### PR TITLE
fix: accept F32 ffn_gate_inp in MTP validator

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -2202,7 +2202,7 @@ static void mtp_weights_validate_layout(const ds4_mtp_weights *w) {
     tensor_expect_layout(l->hc_ffn_scale,   DS4_TENSOR_F32,  1, 3, 0, 0);
     tensor_expect_layout(l->hc_ffn_base,    DS4_TENSOR_F32,  1, hc_mix_dim, 0, 0);
     tensor_expect_layout(l->ffn_norm,       DS4_TENSOR_F32,  1, DS4_N_EMBD, 0, 0);
-    tensor_expect_layout(l->ffn_gate_inp,   DS4_TENSOR_F16,  2, DS4_N_EMBD, DS4_N_EXPERT, 0);
+    tensor_expect_plain_layout(l->ffn_gate_inp, 2, DS4_N_EMBD, DS4_N_EXPERT, 0);
     tensor_expect_layout(l->ffn_exp_probs_b, DS4_TENSOR_F32, 1, DS4_N_EXPERT, 0, 0);
     tensor_expect_routed_expert(l->ffn_gate_exps, 3, DS4_N_EMBD, DS4_N_FF_EXP, DS4_N_EXPERT);
     tensor_expect_routed_expert(l->ffn_up_exps,   3, DS4_N_EMBD, DS4_N_FF_EXP, DS4_N_EXPERT);


### PR DESCRIPTION
## Summary

Fixes #4 — `./ds4 --mtp gguf/DeepSeek-V4-Flash-MTP-Q4K-Q8_0-F32.gguf --mtp-draft 2` failing with `tensor mtp.0.ffn_gate_inp.weight has type f32, expected f16`.

The MTP weights validator at `mtp_weights_validate_layout` strictly required `mtp.0.ffn_gate_inp.weight` to be F16, but the bundled MTP GGUF (note the `-F32` suffix) ships this tensor as F32. The runtime kernel that actually consumes the tensor — `metal_graph_matmul_plain_tensor`, reached via the shared `metal_graph_encode_decode_layer` from `metal_graph_eval_mtp_draft_from_hc` — already dispatches to either `ds4_metal_matmul_f16_tensor` or `ds4_metal_matmul_f32_tensor` based on `w->type`, so the validator was gratuitously stricter than the kernel.

The fix switches the check to `tensor_expect_plain_layout`, mirroring the same relaxation already applied a few lines above for `hc_head_fn`, `hc_attn_fn`, and `hc_ffn_fn` — the other tensors in the MTP block whose only consumer is the dtype-dispatching plain matmul.

The base-model layer validator (`weights_validate_layout`) is **deliberately left strict**: the base-model prefill batch path in `metal_graph_encode_layer_ffn_batch` calls `ds4_metal_matmul_f16_tensor` directly on `layer->ffn_gate_inp` (no F32 branch), and would silently produce garbage with F32 weights. MTP only does single-token decode, so it never reaches that kernel.

## Diff

```diff
-    tensor_expect_layout(l->ffn_gate_inp,   DS4_TENSOR_F16,  2, DS4_N_EMBD, DS4_N_EXPERT, 0);
+    tensor_expect_plain_layout(l->ffn_gate_inp, 2, DS4_N_EMBD, DS4_N_EXPERT, 0);
```

## Test plan

- [x] `make` rebuilds clean
- [x] `./ds4 --mtp gguf/DeepSeek-V4-Flash-MTP-Q4K-Q8_0-F32.gguf --mtp-draft 2` now boots; previously failed at validation
- [x] Smoke prompt `hello` produces a coherent response with MTP draft active (prefill 23.11 t/s, generation 31.98 t/s on this machine)
- [x] Base-model run without `--mtp` unaffected (validator path for `weights->layer[il]` unchanged)