### PR TITLE
docs(readme): remove off thinking level mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ For **Pi**, add a provider to `~/.pi/agent/models.json`:
           "name": "DeepSeek V4 Flash (ds4.c local)",
           "reasoning": true,
           "thinkingLevelMap": {
-            "off": null,
             "minimal": "low",
             "low": "low",
             "medium": "medium",


### PR DESCRIPTION
Mapping "off" to null does not actually work in pi today. Not setting it actually makes it work.