### PR TITLE
feat: support quick instructions

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -13525,6 +13525,12 @@ struct ds4_vocab {
     int think_start_id;
     int think_end_id;
     int dsml_id;
+    int task_action_id;
+    int task_query_id;
+    int task_authority_id;
+    int task_domain_id;
+    int task_title_id;
+    int task_read_url_id;
     str_i32_table token_to_id;
     str_i32_table merge_rank;
 };
@@ -13925,6 +13931,12 @@ static void vocab_load(ds4_vocab *vocab, const ds4_model *model) {
     vocab->think_start_id = vocab_lookup(vocab, "<think>");
     vocab->think_end_id = vocab_lookup(vocab, "</think>");
     vocab->dsml_id = vocab_lookup(vocab, "｜DSML｜");
+    vocab->task_action_id    = vocab_lookup(vocab, "<｜action｜>");
+    vocab->task_query_id     = vocab_lookup(vocab, "<｜query｜>");
+    vocab->task_authority_id = vocab_lookup(vocab, "<｜authority｜>");
+    vocab->task_domain_id    = vocab_lookup(vocab, "<｜domain｜>");
+    vocab->task_title_id     = vocab_lookup(vocab, "<｜title｜>");
+    vocab->task_read_url_id  = vocab_lookup(vocab, "<｜read_url｜>");
 }
 
 static void vocab_free(ds4_vocab *vocab) {
@@ -13976,6 +13988,12 @@ static bool special_token_at(const ds4_vocab *vocab, const char *p, int *token, 
         {"<think>",                vocab->think_start_id},
         {"</think>",               vocab->think_end_id},
         {"｜DSML｜",                vocab->dsml_id},
+        {"<｜action｜>",            vocab->task_action_id},
+        {"<｜query｜>",             vocab->task_query_id},
+        {"<｜authority｜>",         vocab->task_authority_id},
+        {"<｜domain｜>",            vocab->task_domain_id},
+        {"<｜title｜>",             vocab->task_title_id},
+        {"<｜read_url｜>",          vocab->task_read_url_id},
     };
 
     for (size_t i = 0; i < sizeof(specials) / sizeof(specials[0]); i++) {

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -476,6 +476,7 @@ typedef struct {
     char *content;
     char *reasoning;
     char *tool_call_id;
+    char *task;
     tool_calls calls;
 } chat_msg;
 
@@ -539,6 +540,7 @@ static void chat_msg_free(chat_msg *m) {
     free(m->content);
     free(m->reasoning);
     free(m->tool_call_id);
+    free(m->task);
     tool_calls_free(&m->calls);
     memset(m, 0, sizeof(*m));
 }
@@ -1218,6 +1220,12 @@ static bool parse_messages(const char **p, chat_msgs *msgs) {
                     free(key);
                     goto fail;
                 }
+            } else if (!strcmp(key, "task")) {
+                free(msg.task);
+                if (!json_string(p, &msg.task)) {
+                    free(key);
+                    goto fail;
+                }
             } else if (!json_skip_value(p)) {
                 free(key);
                 goto fail;
@@ -1448,6 +1456,12 @@ static bool parse_anthropic_messages(const char **p, chat_msgs *msgs) {
                 free(msg.content);
                 msg.content = NULL;
                 if (!parse_anthropic_content(p, &msg)) {
+                    free(key);
+                    goto fail;
+                }
+            } else if (!strcmp(key, "task")) {
+                free(msg.task);
+                if (!json_string(p, &msg.task)) {
                     free(key);
                     goto fail;
                 }
@@ -1842,7 +1856,26 @@ static char *render_chat_prompt_text(const chat_msgs *msgs, const char *tool_sch
         } else if (!strcmp(m->role, "user")) {
             buf_puts(&out, "<｜User｜>");
             buf_puts(&out, m->content ? m->content : "");
-            pending_assistant = true;
+            if (m->task && m->task[0]) {
+                if (!strcmp(m->task, "action")) {
+                    buf_puts(&out, "<｜Assistant｜>");
+                    buf_puts(&out, think ? "<think>" : "</think>");
+                    buf_puts(&out, "<｜action｜>");
+                } else if (!strcmp(m->task, "title")) {
+                    buf_puts(&out, "<｜title｜>");
+                } else if (!strcmp(m->task, "query")) {
+                    buf_puts(&out, "<｜query｜>");
+                } else if (!strcmp(m->task, "authority")) {
+                    buf_puts(&out, "<｜authority｜>");
+                } else if (!strcmp(m->task, "domain")) {
+                    buf_puts(&out, "<｜domain｜>");
+                } else if (!strcmp(m->task, "read_url")) {
+                    buf_puts(&out, "<｜read_url｜>");
+                }
+                pending_assistant = false;
+            } else {
+                pending_assistant = true;
+            }
             pending_tool_result = false;
         } else if (!strcmp(m->role, "tool") || !strcmp(m->role, "function")) {
             if (!pending_tool_result) buf_puts(&out, "<｜User｜>");


### PR DESCRIPTION
Ref: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/encoding/README.md

## Changes Summary

### 1. `ds4.c` — Engine layer (3 changes)

**A. `ds4_vocab` struct** — Added 6 task token ID fields:
```c
int task_action_id;     // <｜action｜>    (token #128829)
int task_query_id;      // <｜query｜>     (token #128830)
int task_authority_id;  // <｜authority｜> (token #128831)
int task_domain_id;     // <｜domain｜>    (token #128832)
int task_title_id;      // <｜title｜>     (token #128836)
int task_read_url_id;   // <｜read_url｜>  (token #128845)
```

**B. `vocab_load()`** — Looks up all 6 token IDs from the GGUF vocabulary (same pattern as existing special tokens).

**C. `special_token_at()`** — All 6 tokens are now recognized during `ds4_tokenize_rendered_chat()`, so they're correctly tokenized as single special tokens rather than being BPE-split into subword pieces.

### 2. `ds4_server.c` — Server layer (4 changes)

**A. `chat_msg` struct** — Added `char *task` field.

**B. `chat_msg_free()`** — Frees the `task` string.

**C. OpenAI message parser** — Accepts `"task"` field on message objects.

**D. Anthropic message parser** — Accepts `"task"` field on message objects.

**E. `render_chat_prompt_text()`** — After rendering a user message with a `task` field:
- **`"action"`**: Renders `<｜User｜>content<｜Assistant｜><think|/think><｜action｜>`. Sets `pending_assistant = false` (the Assistant prefix is already emitted).
- **Other tasks** (`title`, `query`, `authority`, `domain`, `read_url`): Renders `<｜User｜>content<｜task_token｜>`. Sets `pending_assistant = false` — the model generates the task output directly, no `<｜Assistant｜>` prefix follows.
- **No task**: Original behavior preserved (`pending_assistant = true`).

### Usage

After rebuilding, clients can include a `"task"` field on user messages:

```sh
curl http://127.0.0.1:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "deepseek-v4-flash",
    "messages": [
      {"role": "user", "content": "What is Redis?", "task": "title"}
    ],
    "max_tokens": 10,
    "stream": true
  }'
```

The rendered prompt becomes:
```
<｜begin▁of▁sentence｜><｜User｜>What is Redis?<｜title｜>
```

And the model will generate just the title without the normal Assistant thinking preamble.