### PR TITLE
Allow building on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 CC ?= cc
+ifeq ($(UNAME_S),Darwin)
 CFLAGS ?= -O3 -ffast-math -mcpu=native -Wall -Wextra -std=c99
 OBJCFLAGS ?= -O3 -ffast-math -mcpu=native -Wall -Wextra -fobjc-arc
+else
+CFLAGS ?= -O3 -fno-finite-math-only -march=native -Wall -Wextra -std=c99 -D_GNU_SOURCE
+endif
 
 LDLIBS ?= -lm -pthread
 UNAME_S := $(shell uname -s)


### PR DESCRIPTION
The smallest change to allow building on Linux with CC set to either gcc or clang (I see there's already a non-Darwin branch in the Makefile)
Probably fixes #21 