### PR TITLE
Satisfy debug-layer buffer validation

### DIFF
--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -12231,21 +12231,42 @@ static int ds4_metal_encode_router_select(
                                              0.0f);
         if (!ok) return 0;
 
+        const bool use_token_buffer = single_token == NULL;
         ds4_metal_dsv4_router_select_one_args args = {
             .has_bias = has_bias ? 1u : 0u,
             .hash_mode = hash_mode ? 1u : 0u,
-            .use_token_buffer = single_token ? 0u : 1u,
+            .use_token_buffer = use_token_buffer ? 1u : 0u,
             .token = single_token ? (uint32_t)*single_token : 0u,
             .hash_rows = hash_rows,
         };
+
+        const float zero_f32 = 0.0f;
+        const int32_t zero_i32 = 0;
+        if ((has_bias && !biasbuf) ||
+            (hash_mode && !hashbuf) ||
+            (use_token_buffer && !tokensbuf)) {
+            return 0;
+        }
 
         id<MTLComputeCommandEncoder> enc = ds4_metal_compute_encoder(cb);
         [enc setComputePipelineState:router_finalize_pipeline];
         [enc setBytes:&args length:sizeof(args) atIndex:0];
         [enc setBuffer:probsbuf offset:probs_off atIndex:1];
-        [enc setBuffer:biasbuf offset:bias_off atIndex:2];
-        [enc setBuffer:hashbuf offset:hash_off atIndex:3];
-        [enc setBuffer:tokensbuf offset:tokens_off atIndex:4];
+        if (has_bias) {
+            [enc setBuffer:biasbuf offset:bias_off atIndex:2];
+        } else {
+            [enc setBytes:&zero_f32 length:sizeof(zero_f32) atIndex:2];
+        }
+        if (hash_mode) {
+            [enc setBuffer:hashbuf offset:hash_off atIndex:3];
+        } else {
+            [enc setBytes:&zero_i32 length:sizeof(zero_i32) atIndex:3];
+        }
+        if (use_token_buffer) {
+            [enc setBuffer:tokensbuf offset:tokens_off atIndex:4];
+        } else {
+            [enc setBytes:&zero_i32 length:sizeof(zero_i32) atIndex:4];
+        }
         [enc setBuffer:selectedbuf offset:selected_off atIndex:5];
         [enc setThreadgroupMemoryLength:256u * sizeof(float) + 256u * sizeof(int32_t) atIndex:0];
         [enc dispatchThreadgroups:MTLSizeMake(1, 1, 1)

--- a/metal/get_rows.metal
+++ b/metal/get_rows.metal
@@ -20,9 +20,9 @@ struct ds4_metal_args_get_rows {
 template<typename T0, typename T>
 kernel void kernel_get_rows_f(
         constant ds4_metal_args_get_rows & args,
-        device const void * src0,
-        device const void * src1,
-        device       void * dst,
+        device const char * src0,
+        device const char * src1,
+        device       char * dst,
         uint3               tgpig[[threadgroup_position_in_grid]],
         ushort              tiitg[[thread_index_in_threadgroup]],
         ushort3             ntg [[threads_per_threadgroup]]) {
@@ -31,13 +31,13 @@ kernel void kernel_get_rows_f(
     const int32_t i11 = tgpig.y;
     const int32_t i12 = tgpig.z;
 
-    const int32_t r = ((const device int32_t *) ((const device char *) src1 + i12*args.nb12 + i11*args.nb11 + i10*args.nb10))[0];
+    const int32_t r = ((const device int32_t *) (src1 + i12*args.nb12 + i11*args.nb11 + i10*args.nb10))[0];
 
     const int32_t i02 = i11;
     const int32_t i03 = i12;
 
-    auto psrc = (const device T0 *) ((const device char *) src0 + i03*args.nb03 + i02*args.nb02 +   r*args.nb01);
-    auto pdst = (      device T  *) ((      device char *)  dst + i12*args.nb3  + i11*args.nb2  + i10*args.nb1);
+    auto psrc = (const device T0 *) (src0 + i03*args.nb03 + i02*args.nb02 + r*args.nb01);
+    auto pdst = (      device T  *) (dst  + i12*args.nb3  + i11*args.nb2  + i10*args.nb1);
 
     for (int ind = iw0*ntg.x + tiitg; ind < args.ne00t;) {
         pdst[ind] = psrc[ind];

--- a/metal/set_rows.metal
+++ b/metal/set_rows.metal
@@ -21,8 +21,8 @@ struct ds4_metal_args_set_rows {
 template<typename T, typename TI>
 kernel void kernel_set_rows_f(
         constant ds4_metal_args_set_rows & args,
-        device const  void * src0,
-        device const  void * src1,
+        device const char  * src0,
+        device const char  * src1,
         device       float * dst,
         uint3                tgpig[[threadgroup_position_in_grid]],
         uint                 tiitg[[thread_index_in_threadgroup]],
@@ -39,10 +39,10 @@ kernel void kernel_set_rows_f(
     }
 
     const int32_t i10 = i01;
-    const TI      i1  = ((const device TI *) ((const device char *) src1 + i10*args.nb10 + i11*args.nb11 + i12*args.nb12))[0];
+    const TI      i1  = ((const device TI *) (src1 + i10*args.nb10 + i11*args.nb11 + i12*args.nb12))[0];
 
-          device T     * dst_row = (      device T     *) ((      device char *) dst  +  i1*args.nb1  + i02*args.nb2  + i03*args.nb3);
-    const device float * src_row = (const device float *) ((const device char *) src0 + i01*args.nb01 + i02*args.nb02 + i03*args.nb03);
+          device T     * dst_row = (      device T     *) ((device char *) dst  + i1*args.nb1   + i02*args.nb2  + i03*args.nb3);
+    const device float * src_row = (const device float *) (                src0 + i01*args.nb01 + i02*args.nb02 + i03*args.nb03);
 
     for (int ind = tiitg%tptg.x; ind < args.nk0; ind += tptg.x) {
         dst_row[ind] = (T) src_row[ind];


### PR DESCRIPTION
This PR allows you to run ds4 with `MTL_DEBUG_LAYER=1`.  Without this I got a failure like so:

```
validateComputeFunctionArguments:1066: failed assertion `Compute Function(kernel_set_rows_f32_i32): Read-only bytes are being bound at index 2 to a shader argument with write access enabled (did you mean to use const or constant in the shader?).'
[1]    8708 abort      MTL_DEBUG_LAYER=1 ./ds4 -p "What's the capital of France"
```