### PR TITLE
Don't kill the REPL on /ctx with invalid input

### DIFF
--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -180,6 +180,17 @@ static int parse_int(const char *s, const char *opt) {
     return (int)v;
 }
 
+static bool parse_int_repl(const char *s, const char *opt, int *out) {
+    char *end = NULL;
+    long v = strtol(s, &end, 10);
+    if (s[0] == '\0' || *end != '\0' || v <= 0 || v > INT32_MAX) {
+        fprintf(stderr, "ds4: invalid value for %s: %s\n", opt, s);
+        return false;
+    }
+    *out = (int)v;
+    return true;
+}
+
 static uint64_t parse_u64(const char *s, const char *opt) {
     char *end = NULL;
     unsigned long long v = strtoull(s, &end, 10);
@@ -1057,17 +1068,20 @@ static int run_repl(ds4_engine *engine, cli_config *cfg) {
             if (!arg[0]) {
                 fprintf(stderr, "ds4: /ctx needs a positive integer\n");
             } else {
-                cfg->gen.ctx_size = parse_int(arg, "/ctx");
-                log_context_memory(cfg->engine.backend, cfg->gen.ctx_size);
-                rc = repl_chat_set_ctx(engine, &chat, cfg->gen.ctx_size);
-                if (rc != 0) {
-                    linenoiseFree(line);
-                    break;
+                int new_ctx;
+                if (parse_int_repl(arg, "/ctx", &new_ctx)) {
+                    cfg->gen.ctx_size = new_ctx;
+                    log_context_memory(cfg->engine.backend, cfg->gen.ctx_size);
+                    rc = repl_chat_set_ctx(engine, &chat, cfg->gen.ctx_size);
+                    if (rc != 0) {
+                        linenoiseFree(line);
+                        break;
+                    }
+                    bool active = ds4_think_mode_for_context(cfg->gen.think_mode,
+                                                             chat.ctx_size) == DS4_THINK_MAX;
+                    repl_chat_apply_max_prefix(engine, &chat, active);
+                    cli_warn_think_max_downgraded(&cfg->gen, "/ctx");
                 }
-                bool active = ds4_think_mode_for_context(cfg->gen.think_mode,
-                                                         chat.ctx_size) == DS4_THINK_MAX;
-                repl_chat_apply_max_prefix(engine, &chat, active);
-                cli_warn_think_max_downgraded(&cfg->gen, "/ctx");
             }
         } else if (!strcmp(cmd, "/quit") || !strcmp(cmd, "/exit")) {
             linenoiseFree(line);


### PR DESCRIPTION
## Summary

The `/ctx` command in the interactive REPL called `parse_int()`, which exits the process via `exit(2)` on bad input. That is correct for command-line argument parsing at startup, but in the REPL it kills the entire `ds4` process — dropping the KV cache and the conversation — on a typo like `/ctx abc`.

All other failure paths in the REPL already print and continue: `/ctx` with no argument, `/read` on a missing file, an unknown command. Only invalid `/ctx` numeric values exited.

This PR adds a `parse_int_repl()` twin of `parse_int()` that prints the same error and returns `false` instead, and switches the `/ctx` handler to use it. Behavior on every other path — including a valid `/ctx N` that fails inside `repl_chat_set_ctx()` — is unchanged from `main`.

## Test plan

- [x] `make` — clean build, no new warnings
- [x] Piped commands into `./ds4 -c 4096`:
  - `/ctx abc` → prints `ds4: invalid value for /ctx: abc`, REPL continues (previously: process exit)
  - `/ctx 4096` → still works, recreates the session
  - `/quit` → exits cleanly

## Note

There is a sibling PR — focused on a separate, independent failure mode (the chat losing its session when `repl_chat_set_ctx()` itself fails) — that I will open right after this one. It is intentionally split because it includes a behavioral change worth its own review.