### PR TITLE
Keep the chat session when /ctx fails to recreate it

### DIFF
--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -861,9 +861,6 @@ static void repl_chat_free(repl_chat *chat) {
 }
 
 static int repl_chat_set_ctx(ds4_engine *engine, repl_chat *chat, int ctx_size) {
-    ds4_session_free(chat->session);
-    chat->session = NULL;
-    chat->ctx_size = 0;
     return repl_chat_create_session(engine, chat, ctx_size);
 }
 
@@ -1057,17 +1054,18 @@ static int run_repl(ds4_engine *engine, cli_config *cfg) {
             if (!arg[0]) {
                 fprintf(stderr, "ds4: /ctx needs a positive integer\n");
             } else {
-                cfg->gen.ctx_size = parse_int(arg, "/ctx");
-                log_context_memory(cfg->engine.backend, cfg->gen.ctx_size);
-                rc = repl_chat_set_ctx(engine, &chat, cfg->gen.ctx_size);
-                if (rc != 0) {
-                    linenoiseFree(line);
-                    break;
+                int new_ctx = parse_int(arg, "/ctx");
+                log_context_memory(cfg->engine.backend, new_ctx);
+                if (repl_chat_set_ctx(engine, &chat, new_ctx) == 0) {
+                    cfg->gen.ctx_size = new_ctx;
+                    bool active = ds4_think_mode_for_context(cfg->gen.think_mode,
+                                                             chat.ctx_size) == DS4_THINK_MAX;
+                    repl_chat_apply_max_prefix(engine, &chat, active);
+                    cli_warn_think_max_downgraded(&cfg->gen, "/ctx");
+                } else {
+                    fprintf(stderr, "ds4: /ctx %d failed; keeping current ctx %d\n",
+                            new_ctx, chat.ctx_size);
                 }
-                bool active = ds4_think_mode_for_context(cfg->gen.think_mode,
-                                                         chat.ctx_size) == DS4_THINK_MAX;
-                repl_chat_apply_max_prefix(engine, &chat, active);
-                cli_warn_think_max_downgraded(&cfg->gen, "/ctx");
             }
         } else if (!strcmp(cmd, "/quit") || !strcmp(cmd, "/exit")) {
             linenoiseFree(line);


### PR DESCRIPTION
## Summary

`repl_chat_set_ctx()` freed the existing session before trying to create the replacement:

```c
static int repl_chat_set_ctx(ds4_engine *engine, repl_chat *chat, int ctx_size) {
    ds4_session_free(chat->session);
    chat->session = NULL;
    chat->ctx_size = 0;
    return repl_chat_create_session(engine, chat, ctx_size);
}
```

If the new session failed to allocate (e.g. asking for a context size the backend can't satisfy), the old session was already gone and `run_repl` had no choice but to break out of the loop, ending the chat.

This PR drops the redundant pre-free. `repl_chat_create_session()` already has the safe ordering — it tries to create first and only frees the old session on success — so removing the pre-free restores that protection. The `/ctx` handler is updated to print a warning and keep the current context on failure rather than exiting the REPL.

## Heads up: behavioral change

This is not pure cleanup — it changes user-visible behavior:

- **Before**: `/ctx N` with a valid number that fails to allocate terminates the REPL.
- **After**: prints `ds4: /ctx N failed; keeping current ctx M` and stays at the prompt.

I think keeping the session is the friendlier default (matches every other REPL failure path), but this is a design call and I'm happy to drop the `run_repl` change if you'd rather keep the terminate-on-failure semantics. The `repl_chat_set_ctx()` cleanup still stands on its own — it's a real bug regardless of how the caller responds.

## Relation to #54

Independent of #54. Both touch the `/ctx` handler so they will textually conflict on whichever lands second; happy to rebase. The two PRs address different failure modes:

- #54 — `/ctx abc` (parse error)
- this PR — `/ctx N` where N is valid but creation fails (resource error)

## Test plan

- [x] `make` — clean build, no new warnings
- [x] Piped `/ctx 4096` then `/quit` into `./ds4 -c 4096`: session recreated successfully, exits cleanly. The failure path is hard to exercise reliably without injecting an allocation failure into `ds4_session_create()`; relying on inspection for that branch.