### PR TITLE
Fix session cache misses for thinking mode (no tools)

### DIFF
--- a/bench/test_thinking_pool.py
+++ b/bench/test_thinking_pool.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+Thinking pool round-trip test.
+
+Verifies that after generating a thinking response, the pool checkpoint
+is canonicalized so the next request gets a pool hit (small suffix) instead
+of a full re-prefill.
+
+Usage:
+    ./bench/test_thinking_pool.py [--port 8211]
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+
+SERVER_BIN = "./ds4-server"
+MODEL = "./ds4flash.gguf"
+
+
+def send_request(port, session_id, messages, model="deepseek-v4-flash", max_tokens=200):
+    url = f"http://127.0.0.1:{port}/v1/chat/completions"
+    payload = json.dumps({
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "stream": False,
+    }).encode()
+
+    req = urllib.request.Request(url, data=payload, headers={
+        "Content-Type": "application/json",
+        "X-Session-Id": session_id,
+    })
+
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        body = json.loads(resp.read())
+        elapsed = time.time() - t0
+        usage = body.get("usage", {})
+        choices = body.get("choices", [])
+        msg = choices[0].get("message", {}) if choices else {}
+        return {
+            "elapsed": elapsed,
+            "prompt_tokens": usage.get("prompt_tokens", 0),
+            "completion_tokens": usage.get("completion_tokens", 0),
+            "content": msg.get("content", ""),
+            "reasoning_content": msg.get("reasoning_content", ""),
+            "finish_reason": choices[0].get("finish_reason", "") if choices else "",
+        }
+
+
+def send_request_with_tools(port, session_id, messages, tools,
+                           model="deepseek-v4-flash", max_tokens=200):
+    """Send a chat completion with tools."""
+    url = f"http://127.0.0.1:{port}/v1/chat/completions"
+    payload = json.dumps({
+        "model": model,
+        "messages": messages,
+        "tools": tools,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "stream": False,
+    }).encode()
+
+    req = urllib.request.Request(url, data=payload, headers={
+        "Content-Type": "application/json",
+        "X-Session-Id": session_id,
+    })
+
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        body = json.loads(resp.read())
+        elapsed = time.time() - t0
+        usage = body.get("usage", {})
+        choices = body.get("choices", [])
+        msg = choices[0].get("message", {}) if choices else {}
+        return {
+            "elapsed": elapsed,
+            "prompt_tokens": usage.get("prompt_tokens", 0),
+            "completion_tokens": usage.get("completion_tokens", 0),
+            "content": msg.get("content", ""),
+            "reasoning_content": msg.get("reasoning_content", ""),
+            "tool_calls": msg.get("tool_calls", []),
+            "finish_reason": choices[0].get("finish_reason", "") if choices else "",
+        }
+
+
+def start_server(port):
+    log_path = f"/tmp/ds4-think-pool-test-{port}.log"
+    log_file = open(log_path, "w")
+    cmd = [
+        SERVER_BIN, "--model", MODEL,
+        "--ctx", "32000",
+        "--port", str(port),
+    ]
+    proc = subprocess.Popen(cmd, stdout=log_file, stderr=log_file)
+    print(f"  Server pid={proc.pid}, log={log_path}")
+    for i in range(120):
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/v1/models", timeout=2)
+            print(f"  Ready in {i+1}s")
+            return proc, log_path
+        except:
+            time.sleep(1)
+            if proc.poll() is not None:
+                print(f"  ERROR: server exited with code {proc.returncode}")
+                sys.exit(1)
+    proc.kill()
+    print("  ERROR: timeout")
+    sys.exit(1)
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=8211)
+    args = parser.parse_args()
+
+    if not os.path.exists(SERVER_BIN) or not os.path.exists(MODEL):
+        print("ERROR: need ds4-server and model file")
+        sys.exit(1)
+
+    print("=" * 60)
+    print("  THINKING POOL ROUND-TRIP TEST")
+    print("=" * 60)
+
+    proc, log_path = start_server(args.port)
+    try:
+        # --- Build a context of ~5K tokens to make prefill cost visible ---
+        system = (
+            "You are a helpful coding assistant. " * 50 +
+            "Always think step by step before answering."
+        )
+        session_id = "think-test-1"
+
+        # --- Turn 1: Generate with thinking ---
+        print("\n  Turn 1: Initial thinking request...")
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": "What is the time complexity of merge sort? Be concise."},
+        ]
+        r1 = send_request(args.port, session_id, messages, model="deepseek-v4-flash")
+        print(f"    elapsed={r1['elapsed']:.2f}s  prompt={r1['prompt_tokens']}  gen={r1['completion_tokens']}")
+        print(f"    reasoning: {r1['reasoning_content'][:80]}...")
+        print(f"    content: {r1['content'][:80]}")
+        print(f"    finish: {r1['finish_reason']}")
+
+        if not r1["content"]:
+            print("    ERROR: no content generated")
+            return
+
+        # --- Turn 2: Follow-up (includes assistant response with reasoning) ---
+        print("\n  Turn 2: Follow-up request (should get pool hit)...")
+        messages.append({
+            "role": "assistant",
+            "content": r1["content"],
+            "reasoning_content": r1["reasoning_content"],
+        })
+        messages.append({
+            "role": "user",
+            "content": "And what about quicksort?",
+        })
+        r2 = send_request(args.port, session_id, messages, model="deepseek-v4-flash")
+        print(f"    elapsed={r2['elapsed']:.2f}s  prompt={r2['prompt_tokens']}  gen={r2['completion_tokens']}")
+        print(f"    reasoning: {r2['reasoning_content'][:80]}...")
+        print(f"    content: {r2['content'][:80]}")
+
+        # --- Turn 3: Another follow-up ---
+        print("\n  Turn 3: Another follow-up (should also get pool hit)...")
+        messages.append({
+            "role": "assistant",
+            "content": r2["content"],
+            "reasoning_content": r2["reasoning_content"],
+        })
+        messages.append({
+            "role": "user",
+            "content": "Compare them.",
+        })
+        r3 = send_request(args.port, session_id, messages, model="deepseek-v4-flash")
+        print(f"    elapsed={r3['elapsed']:.2f}s  prompt={r3['prompt_tokens']}  gen={r3['completion_tokens']}")
+        print(f"    content: {r3['content'][:80]}")
+
+        # --- Also test non-thinking for comparison ---
+        print("\n  Comparison: Non-thinking mode (deepseek-chat)...")
+        session_id2 = "no-think-test-1"
+        msgs2 = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": "What is the time complexity of merge sort? Be concise."},
+        ]
+        r4 = send_request(args.port, session_id2, msgs2, model="deepseek-chat")
+        msgs2.append({"role": "assistant", "content": r4["content"]})
+        msgs2.append({"role": "user", "content": "And what about quicksort?"})
+        r5 = send_request(args.port, session_id2, msgs2, model="deepseek-chat")
+        print(f"    Turn 1: {r4['elapsed']:.2f}s (prompt={r4['prompt_tokens']})")
+        print(f"    Turn 2: {r5['elapsed']:.2f}s (prompt={r5['prompt_tokens']})")
+
+        # --- Golden path: thinking + tools (no tool call in response) ---
+        print("\n  Golden path: Thinking + tools (model answers without calling tools)...")
+        session_id3 = "think-tools-test"
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}}
+                }
+            }
+        }]
+        msgs3 = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": "What is the time complexity of merge sort? Be concise."},
+        ]
+        r6 = send_request_with_tools(args.port, session_id3, msgs3, tools,
+                                      model="deepseek-v4-flash")
+        print(f"    Turn 1: {r6['elapsed']:.2f}s (prompt={r6['prompt_tokens']}, gen={r6['completion_tokens']})")
+        if r6["content"]:
+            msgs3.append({
+                "role": "assistant",
+                "content": r6["content"],
+                "reasoning_content": r6["reasoning_content"],
+            })
+            msgs3.append({"role": "user", "content": "And quicksort?"})
+            r7 = send_request_with_tools(args.port, session_id3, msgs3, tools,
+                                          model="deepseek-v4-flash")
+            print(f"    Turn 2: {r7['elapsed']:.2f}s (prompt={r7['prompt_tokens']}, gen={r7['completion_tokens']})")
+        else:
+            print("    Turn 1 failed or called a tool — skipping")
+            r7 = {"elapsed": 999, "prompt_tokens": 0, "completion_tokens": 0}
+
+        # --- Check server log for canonicalization events ---
+        print("\n  Server log (canonicalization events):")
+        with open(log_path) as f:
+            for line in f:
+                if "canonical" in line or "common=" in line.lower():
+                    print(f"    {line.strip()}")
+
+        # --- Summary ---
+        print(f"\n{'='*60}")
+        print(f"  SUMMARY")
+        print(f"{'='*60}")
+        print(f"  Thinking mode:")
+        print(f"    Turn 1 (cold):    {r1['elapsed']:.2f}s")
+        print(f"    Turn 2 (pool?):   {r2['elapsed']:.2f}s")
+        print(f"    Turn 3 (pool?):   {r3['elapsed']:.2f}s")
+        print(f"  Non-thinking mode:")
+        print(f"    Turn 1 (cold):    {r4['elapsed']:.2f}s")
+        print(f"    Turn 2 (pool):    {r5['elapsed']:.2f}s")
+        print()
+
+        # The key metric: Turn 2 thinking prefill should be fast (pool hit)
+        # We can tell from the prompt_tokens vs elapsed time.
+        # Pool hit: most time is generation. Pool miss: significant prefill time.
+        think_gen_time = r2["completion_tokens"] * 0.05  # thinking is slower (~20 t/s)
+        think_prefill = max(0, r2["elapsed"] - think_gen_time)
+        nothink_gen_time = r5["completion_tokens"] * 0.04
+        nothink_prefill = max(0, r5["elapsed"] - nothink_gen_time)
+
+        print(f"  Estimated prefill times:")
+        print(f"    Thinking Turn 2:  ~{think_prefill:.1f}s (total {r2['elapsed']:.1f}s - gen {think_gen_time:.1f}s)")
+        print(f"    Non-think Turn 2: ~{nothink_prefill:.1f}s (total {r5['elapsed']:.1f}s - gen {nothink_gen_time:.1f}s)")
+
+        # Success criterion: thinking prefill should be < 3s (pool hit)
+        # A full re-prefill of 400 tokens would take ~2-3s on this model
+        if think_prefill < 3.0:
+            print(f"  ✓ PASS: Thinking Turn 2 prefill ~{think_prefill:.1f}s (< 3s = pool hit)")
+        else:
+            print(f"  ✗ FAIL: Thinking Turn 2 prefill ~{think_prefill:.1f}s (>= 3s = likely pool miss)")
+            print(f"          Check log for 'canonicalized' messages")
+
+        # Golden path check
+        if r7.get("prompt_tokens"):
+            tools_gen_time = r7["completion_tokens"] * 0.05
+            tools_prefill = max(0, r7["elapsed"] - tools_gen_time)
+            print(f"\n  Golden path (thinking + tools, no tool call):")
+            print(f"    Turn 1: {r6['elapsed']:.2f}s")
+            print(f"    Turn 2: {r7['elapsed']:.2f}s (~{tools_prefill:.1f}s prefill)")
+            if tools_prefill < 3.0:
+                print(f"  \u2713 PASS: Golden path Turn 2 prefill ~{tools_prefill:.1f}s (< 3s = cache hit)")
+            else:
+                print(f"  \u2717 FAIL: Golden path Turn 2 prefill ~{tools_prefill:.1f}s (>= 3s = cache miss)")
+                print(f"          BPE round-trip may be lossy with tools+thinking")
+
+        print(f"\n  Full log: {log_path}")
+        print(f"{'='*60}\n")
+
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    main()

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -5997,6 +5997,72 @@ static char *build_tool_checkpoint_suffix(const request *r, const char *content,
     return buf_take(&suffix);
 }
 
+/* In thinking mode without tools, the next request drops reasoning from prior
+ * assistant turns (DeepSeek template renders </think> immediately instead of
+ * <think>{reasoning}</think>).  Canonicalize the live checkpoint to match what
+ * the next re-render will produce, enabling pool hits on session switch-back.
+ *
+ * prompt_text ends with "<|Assistant|><think>".  The next render will have
+ * "<|Assistant|></think>{content}<|eos|>" for this turn.  We strip the
+ * trailing <think>, replace with </think>{content}<|eos|>. */
+static void canonicalize_thinking_checkpoint(server *s, const job *j, const char *ctx,
+                                             uint64_t trace_id, const char *content) {
+    if (!j->req.prompt_text) return;
+    if (!ds4_think_mode_enabled(j->req.think_mode)) return;
+
+    /* Build the canonical rendered text: prompt_text minus trailing "<think>"
+     * plus "</think>{content}<|eos|>" */
+    size_t pt_len = strlen(j->req.prompt_text);
+    const char *think_tag = "<think>";
+    size_t tag_len = 7;
+    if (pt_len < tag_len ||
+        memcmp(j->req.prompt_text + pt_len - tag_len, think_tag, tag_len) != 0) {
+        /* prompt_text doesn't end with <think> — unexpected, skip */
+        return;
+    }
+
+    buf rendered = {0};
+    buf_append(&rendered, j->req.prompt_text, pt_len - tag_len);
+    buf_puts(&rendered, "</think>");
+    buf_puts(&rendered, content ? content : "");
+    buf_puts(&rendered, "<｜end▁of▁sentence｜>");
+
+    ds4_tokens canonical = {0};
+    ds4_tokenize_rendered_chat(s->engine, rendered.ptr ? rendered.ptr : "", &canonical);
+    const int live_len = ds4_session_pos(s->session);
+    const int common = ds4_session_common_prefix(s->session, &canonical);
+    if (common == live_len && canonical.len == live_len) goto done;
+    /* The common prefix should be at least prompt_len - 1 (diverges at the
+     * think_start → think_end swap at position prompt_len-1).  If it's
+     * earlier, something unexpected happened. */
+    if (common < j->req.prompt.len - 1) {
+        trace_event(s, trace_id,
+                    "thinking checkpoint canonicalization skipped: common=%d prompt=%d live=%d canonical=%d",
+                    common, j->req.prompt.len, live_len, canonical.len);
+        goto done;
+    }
+
+    char err[160];
+    ds4_session_rewind(s->session, common);
+    if (ds4_session_sync(s->session, &canonical, err, sizeof(err)) == 0) {
+        server_log(DS4_LOG_KVCACHE,
+                   "ds4-server: thinking checkpoint canonicalized ctx=%s common=%d live=%d canonical=%d",
+                   ctx, common, live_len, canonical.len);
+        trace_event(s, trace_id,
+                    "thinking checkpoint canonicalized: common=%d live=%d canonical=%d",
+                    common, live_len, canonical.len);
+    } else {
+        server_log(DS4_LOG_KVCACHE,
+                   "ds4-server: thinking checkpoint canonicalization failed ctx=%s common=%d live=%d canonical=%d error=\"%s\"",
+                   ctx, common, live_len, canonical.len, err);
+        trace_event(s, trace_id, "thinking checkpoint canonicalization failed: %s", err);
+    }
+
+done:
+    ds4_tokens_free(&canonical);
+    buf_free(&rendered);
+}
+
 /* After a successful tool-call finish, make the live checkpoint match what the
  * next request will render.  Usually that is just the exact DSML remembered by
  * tool id.  If a client sends a tool call without an id we know, the fallback
@@ -6497,6 +6563,11 @@ static void generate_job(server *s, job *j) {
         canonicalize_tool_checkpoint(s, j, ctx_span, trace_id,
                                      parsed_content ? parsed_content : "",
                                      parsed_reasoning, &parsed_calls);
+    } else if (j->req.kind == REQ_CHAT && !parsed_calls.len &&
+               !j->req.has_tools && ds4_think_mode_enabled(j->req.think_mode) &&
+               strcmp(final_finish, "error") != 0) {
+        canonicalize_thinking_checkpoint(s, j, ctx_span, trace_id,
+                                         parsed_content ? parsed_content : "");
     }
 
     if (j->req.stream) {
@@ -8852,6 +8923,258 @@ static void test_kv_cache_eviction_penalizes_live_continued_prefixes(void) {
     rmdir(dir);
 }
 
+static void test_thinking_checkpoint_canonical_matches_future_prompt(void) {
+    /* Simulate: user sends a single message, thinking mode on, no tools.
+     * Model generates reasoning + content.  The next request will drop the
+     * reasoning from this turn.  Verify that:
+     *   prompt_text[:-len("<think>")] + "</think>" + content + "<|eos|>"
+     * equals what render_chat_prompt_text produces for the history. */
+
+    chat_msgs prefix_msgs = {0};
+    chat_msg user1 = {0};
+    user1.role = xstrdup("user");
+    user1.content = xstrdup("What is 2+2?");
+    chat_msgs_push(&prefix_msgs, user1);
+
+    /* This is what prompt_text looks like for the first generation */
+    char *prompt_text = render_chat_prompt_text(&prefix_msgs, NULL, NULL, DS4_THINK_HIGH);
+    /* prompt_text should end with <think> */
+    size_t pt_len = strlen(prompt_text);
+    TEST_ASSERT(pt_len >= 7);
+    TEST_ASSERT(!memcmp(prompt_text + pt_len - 7, "<think>", 7));
+
+    /* The model generates: reasoning + </think> + content */
+    const char *reasoning = "Let me think... 2+2 = 4";
+    const char *content = "The answer is 4.";
+
+    /* Build the canonical checkpoint text (what we'd produce after canonicalization) */
+    buf canonical = {0};
+    buf_append(&canonical, prompt_text, pt_len - 7);  /* strip <think> */
+    buf_puts(&canonical, "</think>");
+    buf_puts(&canonical, content);
+    buf_puts(&canonical, "<" "\xef\xbd\x9c" "end" "\xe2\x96\x81" "of" "\xe2\x96\x81" "sentence" "\xef\xbd\x9c" ">");
+
+    /* Now build what the NEXT request would render: history includes this
+     * assistant message, plus a new user message.  Extract just the prefix
+     * up to and including the eos of the assistant turn. */
+    chat_msgs history_msgs = {0};
+    chat_msg h_user1 = {0};
+    h_user1.role = xstrdup("user");
+    h_user1.content = xstrdup("What is 2+2?");
+    chat_msgs_push(&history_msgs, h_user1);
+    chat_msg h_asst = {0};
+    h_asst.role = xstrdup("assistant");
+    h_asst.reasoning = xstrdup(reasoning);
+    h_asst.content = xstrdup(content);
+    chat_msgs_push(&history_msgs, h_asst);
+    chat_msg h_user2 = {0};
+    h_user2.role = xstrdup("user");
+    h_user2.content = xstrdup("Thanks!");
+    chat_msgs_push(&history_msgs, h_user2);
+
+    char *future_prompt = render_chat_prompt_text(&history_msgs, NULL, NULL, DS4_THINK_HIGH);
+
+    /* The future prompt should START with our canonical text */
+    size_t clen = canonical.len;
+    TEST_ASSERT(strlen(future_prompt) > clen);
+    TEST_ASSERT(!memcmp(future_prompt, canonical.ptr, clen));
+
+    /* And what comes after is the new user turn + assistant prefix */
+    const char *rest = future_prompt + clen;
+    TEST_ASSERT(strstr(rest, "Thanks!") != NULL);
+    TEST_ASSERT(strstr(rest, "<think>") != NULL);  /* new turn starts thinking */
+
+    /* Verify reasoning is NOT in the future prompt for this turn */
+    const char *asst_turn = strstr(future_prompt, "<" "\xef\xbd\x9c" "Assistant" "\xef\xbd\x9c" ">");
+    TEST_ASSERT(asst_turn != NULL);
+    TEST_ASSERT(strstr(future_prompt, reasoning) == NULL);  /* reasoning dropped */
+
+    free(future_prompt);
+    buf_free(&canonical);
+    free(prompt_text);
+    chat_msgs_free(&prefix_msgs);
+    chat_msgs_free(&history_msgs);
+}
+
+static void test_thinking_canonical_empty_content(void) {
+    /* Edge case: model thinks but produces empty content (e.g. tool-less
+     * thinking where answer is entirely in reasoning).  Canonical should
+     * still be valid: prompt_text[:-7] + "</think><|eos|>" */
+    chat_msgs msgs = {0};
+    chat_msg user = {0};
+    user.role = xstrdup("user");
+    user.content = xstrdup("Think about life");
+    chat_msgs_push(&msgs, user);
+
+    char *prompt_text = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_HIGH);
+    size_t pt_len = strlen(prompt_text);
+
+    /* Build canonical with empty content */
+    buf canonical = {0};
+    buf_append(&canonical, prompt_text, pt_len - 7);
+    buf_puts(&canonical, "</think>");
+    /* empty content */
+    buf_puts(&canonical, "<" "\xef\xbd\x9c" "end" "\xe2\x96\x81" "of" "\xe2\x96\x81" "sentence" "\xef\xbd\x9c" ">");
+
+    /* Future prompt with empty content assistant message */
+    chat_msgs history = {0};
+    chat_msg h_u = {0};
+    h_u.role = xstrdup("user");
+    h_u.content = xstrdup("Think about life");
+    chat_msgs_push(&history, h_u);
+    chat_msg h_a = {0};
+    h_a.role = xstrdup("assistant");
+    h_a.reasoning = xstrdup("Deep thoughts about existence...");
+    h_a.content = xstrdup("");
+    chat_msgs_push(&history, h_a);
+    chat_msg h_u2 = {0};
+    h_u2.role = xstrdup("user");
+    h_u2.content = xstrdup("Continue");
+    chat_msgs_push(&history, h_u2);
+
+    char *future = render_chat_prompt_text(&history, NULL, NULL, DS4_THINK_HIGH);
+    TEST_ASSERT(strlen(future) > canonical.len);
+    TEST_ASSERT(!memcmp(future, canonical.ptr, canonical.len));
+    /* reasoning dropped */
+    TEST_ASSERT(strstr(future, "Deep thoughts") == NULL);
+
+    free(future);
+    buf_free(&canonical);
+    free(prompt_text);
+    chat_msgs_free(&msgs);
+    chat_msgs_free(&history);
+}
+
+static void test_thinking_canonical_multi_turn(void) {
+    /* Multi-turn: 3 user messages, 2 assistant responses with reasoning.
+     * Both prior assistant turns should have reasoning dropped.
+     * The canonical after the SECOND generation should produce text that
+     * matches the start of a 3rd-turn future prompt. */
+    chat_msgs turn2_prefix = {0};
+    chat_msg u1 = {0};
+    u1.role = xstrdup("user");
+    u1.content = xstrdup("Hello");
+    chat_msgs_push(&turn2_prefix, u1);
+    chat_msg a1 = {0};
+    a1.role = xstrdup("assistant");
+    a1.reasoning = xstrdup("first reasoning");
+    a1.content = xstrdup("Hi there");
+    chat_msgs_push(&turn2_prefix, a1);
+    chat_msg u2 = {0};
+    u2.role = xstrdup("user");
+    u2.content = xstrdup("How are you?");
+    chat_msgs_push(&turn2_prefix, u2);
+
+    /* prompt_text for the 2nd generation (includes 1st assistant turn) */
+    char *prompt_text = render_chat_prompt_text(&turn2_prefix, NULL, NULL, DS4_THINK_HIGH);
+    size_t pt_len = strlen(prompt_text);
+    TEST_ASSERT(!memcmp(prompt_text + pt_len - 7, "<think>", 7));
+
+    /* 1st turn reasoning is already dropped in this prompt_text */
+    TEST_ASSERT(strstr(prompt_text, "first reasoning") == NULL);
+    TEST_ASSERT(strstr(prompt_text, "Hi there") != NULL);
+
+    /* After 2nd generation: canonical drops 2nd reasoning too */
+    const char *content2 = "I'm doing well";
+    buf canonical = {0};
+    buf_append(&canonical, prompt_text, pt_len - 7);
+    buf_puts(&canonical, "</think>");
+    buf_puts(&canonical, content2);
+    buf_puts(&canonical, "<" "\xef\xbd\x9c" "end" "\xe2\x96\x81" "of" "\xe2\x96\x81" "sentence" "\xef\xbd\x9c" ">");
+
+    /* Future: 3rd user message arrives */
+    chat_msgs future_msgs = {0};
+    chat_msg fu1 = {0}; fu1.role = xstrdup("user"); fu1.content = xstrdup("Hello");
+    chat_msgs_push(&future_msgs, fu1);
+    chat_msg fa1 = {0}; fa1.role = xstrdup("assistant");
+    fa1.reasoning = xstrdup("first reasoning");
+    fa1.content = xstrdup("Hi there");
+    chat_msgs_push(&future_msgs, fa1);
+    chat_msg fu2 = {0}; fu2.role = xstrdup("user"); fu2.content = xstrdup("How are you?");
+    chat_msgs_push(&future_msgs, fu2);
+    chat_msg fa2 = {0}; fa2.role = xstrdup("assistant");
+    fa2.reasoning = xstrdup("second reasoning");
+    fa2.content = xstrdup(content2);
+    chat_msgs_push(&future_msgs, fa2);
+    chat_msg fu3 = {0}; fu3.role = xstrdup("user"); fu3.content = xstrdup("Great");
+    chat_msgs_push(&future_msgs, fu3);
+
+    char *future = render_chat_prompt_text(&future_msgs, NULL, NULL, DS4_THINK_HIGH);
+    /* Both reasonings dropped */
+    TEST_ASSERT(strstr(future, "first reasoning") == NULL);
+    TEST_ASSERT(strstr(future, "second reasoning") == NULL);
+    /* Canonical is a prefix of future */
+    TEST_ASSERT(strlen(future) > canonical.len);
+    TEST_ASSERT(!memcmp(future, canonical.ptr, canonical.len));
+
+    free(future);
+    buf_free(&canonical);
+    free(prompt_text);
+    chat_msgs_free(&turn2_prefix);
+    chat_msgs_free(&future_msgs);
+}
+
+static void test_thinking_canonical_with_tools_preserves_reasoning(void) {
+    /* When tools ARE present, reasoning is preserved in re-render.
+     * The thinking canonicalization should NOT fire (has_tools gate),
+     * and the tool canonicalization handles it.  Verify the template
+     * preserves reasoning when tool_context is true. */
+    const char *tool_schemas = "{\"name\":\"bash\"}";
+
+    chat_msgs msgs = {0};
+    chat_msg u = {0};
+    u.role = xstrdup("user");
+    u.content = xstrdup("run ls");
+    chat_msgs_push(&msgs, u);
+
+    char *prompt_text = render_chat_prompt_text(&msgs, tool_schemas, NULL, DS4_THINK_HIGH);
+    size_t pt_len = strlen(prompt_text);
+    TEST_ASSERT(!memcmp(prompt_text + pt_len - 7, "<think>", 7));
+
+    /* With tools, next render KEEPS reasoning */
+    chat_msgs history = {0};
+    chat_msg hu = {0}; hu.role = xstrdup("user"); hu.content = xstrdup("run ls");
+    chat_msgs_push(&history, hu);
+    chat_msg ha = {0}; ha.role = xstrdup("assistant");
+    ha.reasoning = xstrdup("I should run bash");
+    ha.content = xstrdup("Here you go");
+    chat_msgs_push(&history, ha);
+    chat_msg hu2 = {0}; hu2.role = xstrdup("user"); hu2.content = xstrdup("thanks");
+    chat_msgs_push(&history, hu2);
+
+    char *future = render_chat_prompt_text(&history, tool_schemas, NULL, DS4_THINK_HIGH);
+    /* Reasoning IS preserved when tools present */
+    TEST_ASSERT(strstr(future, "I should run bash") != NULL);
+    TEST_ASSERT(strstr(future, "<think>I should run bash</think>") != NULL);
+
+    free(future);
+    free(prompt_text);
+    chat_msgs_free(&msgs);
+    chat_msgs_free(&history);
+}
+
+static void test_thinking_canonical_non_thinking_mode_noop(void) {
+    /* When thinking is disabled (deepseek-chat), prompt_text ends with
+     * </think> not <think>.  The canonicalization should be a no-op
+     * (early return on memcmp check). */
+    chat_msgs msgs = {0};
+    chat_msg u = {0};
+    u.role = xstrdup("user");
+    u.content = xstrdup("Hello");
+    chat_msgs_push(&msgs, u);
+
+    char *prompt_text = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_NONE);
+    size_t pt_len = strlen(prompt_text);
+    /* Should end with </think>, not <think> */
+    TEST_ASSERT(pt_len >= 8);
+    TEST_ASSERT(!memcmp(prompt_text + pt_len - 8, "</think>", 8));
+    /* Does NOT end with <think> */
+    TEST_ASSERT(memcmp(prompt_text + pt_len - 7, "<think>", 7) != 0);
+
+    free(prompt_text);
+    chat_msgs_free(&msgs);
+}
+
 static void ds4_server_unit_tests_run(void) {
     test_request_defaults_match_deepseek_api();
     test_reasoning_effort_mapping();
@@ -8883,6 +9206,11 @@ static void ds4_server_unit_tests_run(void) {
     test_tool_memory_max_ids_prunes_oldest();
     test_kv_tool_map_filters_by_dsml_text();
     test_kv_tool_map_restores_before_prompt_render();
+    test_thinking_checkpoint_canonical_matches_future_prompt();
+    test_thinking_canonical_empty_content();
+    test_thinking_canonical_multi_turn();
+    test_thinking_canonical_with_tools_preserves_reasoning();
+    test_thinking_canonical_non_thinking_mode_noop();
     test_tool_separator_whitespace_is_not_content();
     test_dsml_prompt_escapes_tool_supplied_text();
     test_stop_list_parses_all_sequences();


### PR DESCRIPTION
Problem
-------
With `think=true` and `tool_context=false`, multi-turn conversations never get
KV cache hits. Every request re-prefills the entire context from scratch.

Root cause
----------
After generation, the checkpoint contains the full thinking output:

    <think>reasoning...</think>Answer

On the next turn, the template re-renders the conversation with reasoning
stripped (think_start → think_end with no content between them). The checkpoint
diverges at the think_start/think_end boundary, so `common_prefix()` returns a
position before all prior turns.

Note: with tools enabled this doesn't happen — BPE round-trip through
tool_context is lossless because reasoning is preserved in the template.

Fix
---
Add `canonicalize_thinking_checkpoint()`, called after generation when thinking
is active and tools are not. Mirrors the existing `canonicalize_tool_checkpoint()`
pattern: re-tokenize the expected next-turn representation and overwrite the
checkpoint suffix.

Before: ctx=0..407:407 (full re-prefill)
After:  ctx=397..407:10 (cache hit)

Includes unit tests (5 cases) and an integration test that verifies cache hits
via prefill span logging.