### PR TITLE
fix(metal): infer model view overlap from tensors to support q4 on 192GB Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Download one main model:
 
 ```sh
 ./download_model.sh q2   # 128 GB RAM machines
-./download_model.sh q4   # >= 256 GB RAM machines
+./download_model.sh q4   # >= 256 GB RAM machines, or 192 GB with the Metal setup below
 ```
 
 The script downloads from `https://huggingface.co/antirez/deepseek-v4-gguf`,
@@ -94,12 +94,25 @@ make
 select another supported GGUF from `./gguf/`. Run `./ds4 --help` and
 `./ds4-server --help` for the full flag list.
 
+### Q4 on 192 GB Macs
+
+On 192 GB Apple Silicon machines, the q4 model needs a higher wired-memory
+limit than the macOS default before Metal can keep the model and runtime
+buffers resident. Set it after each reboot before starting `ds4` or
+`ds4-server`:
+
+```sh
+sudo sysctl iogpu.wired_limit_mb=188000
+```
+
 ## Speed
 
-These are single-run Metal CLI numbers with `--ctx 32768`, `--nothink`, greedy
-decoding, and `-n 256`. The short prompt is a normal small Italian story
-prompt. The long prompts exercise chunked prefill plus long-context decode.
-Q4 requires the larger-memory machine class, so M3 Max Q4 numbers are `N/A`.
+These are single-run Metal CLI numbers with `--ctx 32768`, `--nothink`,
+`-sys ""`, greedy decoding, and `-n 256`. The short prompt is a normal small
+Italian story prompt. The M2 Ultra long prompt uses
+`tests/test-vectors/prompts/long_code_audit.txt`, which reports 3844 prompt
+tokens and exercises chunked prefill plus long-context decode. Q4 requires the
+larger-memory machine class, so M3 Max Q4 numbers are `N/A`.
 
 | Machine | Quant | Prompt | Prefill | Generation |
 | --- | ---: | ---: | ---: | ---: |
@@ -107,6 +120,8 @@ Q4 requires the larger-memory machine class, so M3 Max Q4 numbers are `N/A`.
 | MacBook Pro M3 Max, 128 GB | q2 | 11709 tokens | 250.11 t/s | 21.47 t/s |
 | MacBook Pro M3 Max, 128 GB | q4 | short | N/A | N/A |
 | MacBook Pro M3 Max, 128 GB | q4 | long | N/A | N/A |
+| Mac Studio M2 Ultra, 192 GB | q4 | short | 50.42 t/s | 29.88 t/s |
+| Mac Studio M2 Ultra, 192 GB | q4 | 3844 tokens | 394.66 t/s | 21.69 t/s |
 | Mac Studio M3 Ultra, 512 GB | q2 | short | 84.43 t/s | 36.86 t/s |
 | Mac Studio M3 Ultra, 512 GB | q2 | 11709 tokens | 468.03 t/s | 27.39 t/s |
 | Mac Studio M3 Ultra, 512 GB | q4 | short | 78.95 t/s | 35.50 t/s |

--- a/ds4.c
+++ b/ds4.c
@@ -922,6 +922,7 @@ typedef struct {
     uint64_t n_tensors;
     uint64_t alignment;
     uint64_t tensor_data_pos;
+    uint64_t max_tensor_bytes;
 
     ds4_kv *kv;
     ds4_tensor *tensors;
@@ -1171,6 +1172,7 @@ static void parse_tensors(ds4_model *m, ds4_cursor *c) {
                 "ds4: warning: tensor %.*s has unsupported GGUF type %u\n",
                 (int)t->name.len, t->name.ptr, t->type);
         }
+        if (t->bytes > m->max_tensor_bytes) m->max_tensor_bytes = t->bytes;
     }
 
     m->tensor_data_pos = align_up(c->pos, m->alignment);
@@ -1246,6 +1248,37 @@ static void print_size(uint64_t bytes) {
     printf("%.2f GiB", (double)bytes / gib);
 }
 
+static uint64_t model_metal_max_tensor_bytes(const ds4_model *m,
+                                             uint64_t min_tensor_bytes) {
+    uint64_t max_tensor_bytes = m->max_tensor_bytes;
+    if (min_tensor_bytes > max_tensor_bytes) max_tensor_bytes = min_tensor_bytes;
+    return max_tensor_bytes;
+}
+
+#ifndef DS4_NO_GPU
+static int accelerator_set_model_map_range(ds4_backend backend,
+                                           const ds4_model *m,
+                                           uint64_t metal_min_tensor_bytes) {
+#ifdef __APPLE__
+    if (backend == DS4_BACKEND_METAL) {
+        return ds4_gpu_set_model_map_range_with_max_tensor(
+            m->map,
+            m->size,
+            m->tensor_data_pos,
+            m->size - m->tensor_data_pos,
+            model_metal_max_tensor_bytes(m, metal_min_tensor_bytes));
+    }
+#else
+    (void)backend;
+    (void)metal_min_tensor_bytes;
+#endif
+    return ds4_gpu_set_model_map_range(m->map,
+                                       m->size,
+                                       m->tensor_data_pos,
+                                       m->size - m->tensor_data_pos);
+}
+#endif
+
 static void model_summary(const ds4_model *m) {
     ds4_str name = {0};
     ds4_str arch = {0};
@@ -1309,6 +1342,9 @@ static void model_summary(const ds4_model *m) {
     printf("\n");
     printf("tensor bytes described by GGUF: ");
     print_size(tensor_bytes);
+    printf("\n");
+    printf("largest tensor: ");
+    print_size(m->max_tensor_bytes);
     printf("\n");
     printf("logical parameters: %.2f B\n", (double)params / 1000000000.0);
 
@@ -16493,10 +16529,9 @@ int ds4_engine_open(ds4_engine **out, const ds4_engine_options *opt) {
         }
         ds4_gpu_set_quality(e->quality);
         (void)ds4_gpu_set_model_fd(e->model.fd);
-        if (!ds4_gpu_set_model_map_range(e->model.map,
-                                           e->model.size,
-                                           e->model.tensor_data_pos,
-                                           e->model.size - e->model.tensor_data_pos))
+        if (!accelerator_set_model_map_range(e->backend,
+                                             &e->model,
+                                             opt->metal_model_max_tensor_bytes))
         {
             fprintf(stderr,
                     "ds4: %s failed to map model views; aborting startup. "
@@ -16507,10 +16542,9 @@ int ds4_engine_open(ds4_engine **out, const ds4_engine_options *opt) {
             return 1;
         }
         if (e->mtp_ready &&
-            !ds4_gpu_set_model_map_range(e->mtp_model.map,
-                                           e->mtp_model.size,
-                                           e->mtp_model.tensor_data_pos,
-                                           e->mtp_model.size - e->mtp_model.tensor_data_pos))
+            !accelerator_set_model_map_range(e->backend,
+                                             &e->mtp_model,
+                                             opt->metal_model_max_tensor_bytes))
         {
             fprintf(stderr,
                     "ds4: %s failed to map MTP model views; aborting startup. "

--- a/ds4.h
+++ b/ds4.h
@@ -65,6 +65,7 @@ typedef struct {
     const char *directional_steering_file;
     float directional_steering_attn;
     float directional_steering_ffn;
+    uint64_t metal_model_max_tensor_bytes;
     bool warm_weights;
     bool quality;
 } ds4_engine_options;

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -107,6 +107,8 @@ static void usage(FILE *fp) {
         "      Apply steering after attention outputs. Default: 0\n"
         "  --warm-weights\n"
         "      Touch mapped tensor pages before generation. Slower startup, fewer first-use stalls.\n"
+        "  --metal-model-max-tensor-mb N\n"
+        "      Minimum tensor size used for Metal model-view overlap. Default: inferred from GGUF.\n"
         "\n"
         "Prompt and generation:\n"
         "  -p, --prompt TEXT\n"
@@ -197,6 +199,15 @@ static uint64_t parse_u64(const char *s, const char *opt) {
         exit(2);
     }
     return (uint64_t)v;
+}
+
+static uint64_t parse_mib_bytes(const char *s, const char *opt) {
+    uint64_t mib = parse_u64(s, opt);
+    if (mib > UINT64_MAX / (1024ull * 1024ull)) {
+        fprintf(stderr, "ds4: invalid value for %s: %s\n", opt, s);
+        exit(2);
+    }
+    return mib * 1024ull * 1024ull;
 }
 
 static float parse_float_range(const char *s, const char *opt, float min, float max) {
@@ -1282,6 +1293,9 @@ static cli_config parse_options(int argc, char **argv) {
             c.inspect = true;
         } else if (!strcmp(arg, "--warm-weights")) {
             c.engine.warm_weights = true;
+        } else if (!strcmp(arg, "--metal-model-max-tensor-mb")) {
+            c.engine.metal_model_max_tensor_bytes =
+                parse_mib_bytes(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--server")) {
             fprintf(stderr, "ds4: use ds4-server for the HTTP server\n");
             exit(2);

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -37,6 +37,15 @@ int ds4_gpu_synchronize(void);
 int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size);
 int ds4_gpu_set_model_fd(int fd);
 int ds4_gpu_set_model_map_range(const void *model_map, uint64_t model_size, uint64_t map_offset, uint64_t map_size);
+#ifdef __APPLE__
+/* Metal wraps large GGUF tensor data as overlapping no-copy MTLBuffers.  This
+ * extension lets the engine size the overlap from the actual largest tensor. */
+int ds4_gpu_set_model_map_range_with_max_tensor(const void *model_map,
+                                                uint64_t model_size,
+                                                uint64_t map_offset,
+                                                uint64_t map_size,
+                                                uint64_t max_tensor_bytes);
+#endif
 int ds4_gpu_cache_model_range(const void *model_map, uint64_t model_size, uint64_t offset, uint64_t bytes, const char *label);
 int ds4_gpu_cache_q8_f16_range(const void *model_map, uint64_t model_size, uint64_t offset, uint64_t bytes, uint64_t in_dim, uint64_t out_dim, const char *label);
 void ds4_gpu_set_quality(bool quality);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -187,7 +187,7 @@ static void ds4_gpu_print_device_summary(void) {
 }
 
 #define DS4_METAL_MAX_MODEL_VIEWS 16
-#define DS4_METAL_MODEL_MAX_TENSOR_BYTES 704643072ull
+#define DS4_METAL_MODEL_VIEW_FALLBACK_TENSOR_BYTES 704643072ull
 
 typedef struct {
     __strong id<MTLBuffer> buffer;
@@ -195,6 +195,7 @@ typedef struct {
     uint64_t model_size;
     uint64_t model_offset;
     uint64_t bytes;
+    uint64_t max_tensor_bytes;
 } ds4_gpu_model_view;
 
 static ds4_gpu_model_view g_model_views[DS4_METAL_MAX_MODEL_VIEWS];
@@ -351,6 +352,7 @@ static void ds4_gpu_model_views_clear(void) {
         g_model_views[i].model_size = 0;
         g_model_views[i].model_offset = 0;
         g_model_views[i].bytes = 0;
+        g_model_views[i].max_tensor_bytes = 0;
     }
     g_model_view_count = 0;
 }
@@ -409,7 +411,8 @@ static int ds4_gpu_map_model_views(
         const void *model_map,
         uint64_t    model_size,
         uint64_t    map_offset,
-        uint64_t    map_size) {
+        uint64_t    map_size,
+        uint64_t    max_tensor_bytes) {
     const double t0 = ds4_gpu_now_ms();
     const uint64_t page = (uint64_t)getpagesize();
     const uintptr_t model_addr = (uintptr_t)model_map;
@@ -445,9 +448,19 @@ static int ds4_gpu_map_model_views(
      * inside at least one view, so hot paths pass one buffer and one inner byte
      * offset. We never split a weight tensor across command encoders.
      */
-    const uint64_t overlap = round_up_u64(DS4_METAL_MODEL_MAX_TENSOR_BYTES, page) + page;
+    if (max_tensor_bytes < DS4_METAL_MODEL_VIEW_FALLBACK_TENSOR_BYTES) {
+        max_tensor_bytes = DS4_METAL_MODEL_VIEW_FALLBACK_TENSOR_BYTES;
+    }
+    if (max_tensor_bytes > UINT64_MAX - page) {
+        fprintf(stderr, "ds4: Metal model tensor size is too large for model views\n");
+        return 0;
+    }
+    const uint64_t overlap = round_up_u64(max_tensor_bytes, page) + page;
     if (max_buffer == 0 || max_buffer <= overlap) {
-        fprintf(stderr, "ds4: Metal maxBufferLength is too small for DS4 model views\n");
+        fprintf(stderr,
+                "ds4: Metal maxBufferLength %.2f GiB is too small for largest model tensor %.2f GiB\n",
+                (double)max_buffer / (1024.0 * 1024.0 * 1024.0),
+                (double)max_tensor_bytes / (1024.0 * 1024.0 * 1024.0));
         return 0;
     }
 
@@ -480,6 +493,7 @@ static int ds4_gpu_map_model_views(
         g_model_views[g_model_view_count].model_size = model_size;
         g_model_views[g_model_view_count].model_offset = page_model_offset + off;
         g_model_views[g_model_view_count].bytes = view_bytes;
+        g_model_views[g_model_view_count].max_tensor_bytes = max_tensor_bytes;
         g_model_view_count++;
 
         g_model_wrap_count++;
@@ -520,12 +534,14 @@ static int ds4_gpu_map_model_views(
     }
     const double t_warm = ds4_gpu_now_ms();
     fprintf(stderr,
-            "ds4: Metal model views created in %.3f ms, residency requested in %.3f ms, warmup %.3f ms (mapped %.2f MiB from offset %.2f MiB)\n",
+            "ds4: Metal model views created in %.3f ms, residency requested in %.3f ms, warmup %.3f ms (mapped %.2f MiB from offset %.2f MiB, largest tensor %.2f MiB, overlap %.2f MiB)\n",
             t_mapped - t0,
             t_resident - t_mapped,
             t_warm - t_warm0,
             mapped_model_size / 1024.0 / 1024.0,
-            page_model_offset / 1024.0 / 1024.0);
+            page_model_offset / 1024.0 / 1024.0,
+            max_tensor_bytes / 1024.0 / 1024.0,
+            overlap / 1024.0 / 1024.0);
     if (!warmed) return 0;
     return 1;
 }
@@ -4357,7 +4373,11 @@ int ds4_gpu_embed_tokens_hc_tensor(
     return 1;
 }
 
-int ds4_gpu_set_model_map_range(const void *model_map, uint64_t model_size, uint64_t map_offset, uint64_t map_size) {
+int ds4_gpu_set_model_map_range_with_max_tensor(const void *model_map,
+                                                uint64_t model_size,
+                                                uint64_t map_offset,
+                                                uint64_t map_size,
+                                                uint64_t max_tensor_bytes) {
     if (!g_initialized && !ds4_gpu_init()) return 0;
     if (!model_map || model_size == 0) return 0;
     if (map_offset > model_size || map_size == 0 || map_size > model_size - map_offset) return 0;
@@ -4366,6 +4386,7 @@ int ds4_gpu_set_model_map_range(const void *model_map, uint64_t model_size, uint
         for (uint32_t i = 0; i < g_model_view_count; i++) {
             if (g_model_views[i].model_map == model_map &&
                 g_model_views[i].model_size == model_size &&
+                g_model_views[i].max_tensor_bytes >= max_tensor_bytes &&
                 map_offset >= g_model_views[i].model_offset &&
                 map_offset + map_size <= g_model_views[i].model_offset + g_model_views[i].bytes) {
                 return 1;
@@ -4377,7 +4398,7 @@ int ds4_gpu_set_model_map_range(const void *model_map, uint64_t model_size, uint
         g_model_map_size = model_size;
         g_model_mapped_offset = map_offset;
         g_model_mapped_size = map_size;
-        if (!ds4_gpu_map_model_views(model_map, model_size, map_offset, map_size)) {
+        if (!ds4_gpu_map_model_views(model_map, model_size, map_offset, map_size, max_tensor_bytes)) {
             ds4_gpu_model_residency_clear();
             return 0;
         }
@@ -4386,6 +4407,10 @@ int ds4_gpu_set_model_map_range(const void *model_map, uint64_t model_size, uint
                 g_model_view_count);
         return 1;
     }
+}
+
+int ds4_gpu_set_model_map_range(const void *model_map, uint64_t model_size, uint64_t map_offset, uint64_t map_size) {
+    return ds4_gpu_set_model_map_range_with_max_tensor(model_map, model_size, map_offset, map_size, 0);
 }
 
 int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size) {

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -7817,6 +7817,11 @@ static int parse_nonneg_int_arg(const char *s, const char *opt) {
     return (int)v;
 }
 
+static uint64_t parse_mib_bytes_arg(const char *s, const char *opt) {
+    uint64_t mib = (uint64_t)parse_int_arg(s, opt);
+    return mib * 1024ull * 1024ull;
+}
+
 static float parse_float_arg(const char *s, const char *opt, float minv, float maxv) {
     char *end = NULL;
     float v = strtof(s, &end);
@@ -7895,6 +7900,8 @@ static void usage(FILE *fp) {
         "      Touch mapped tensor pages before serving. Slower startup, fewer first-use stalls.\n"
         "  --metal | --cuda | --cpu | --backend NAME\n"
         "      Select backend explicitly. Defaults to Metal on macOS and CUDA on CUDA builds.\n"
+        "  --metal-model-max-tensor-mb N\n"
+        "      Minimum tensor size used for Metal model-view overlap. Default: inferred from GGUF.\n"
         "\n"
         "HTTP API:\n"
         "  --host HOST\n"
@@ -8053,6 +8060,9 @@ static server_config parse_options(int argc, char **argv) {
             c.engine.backend = parse_backend_arg(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--cpu")) {
             c.engine.backend = DS4_BACKEND_CPU;
+        } else if (!strcmp(arg, "--metal-model-max-tensor-mb")) {
+            c.engine.metal_model_max_tensor_bytes =
+                parse_mib_bytes_arg(need_arg(&i, argc, argv, arg), arg);
         } else {
             server_log(DS4_LOG_DEFAULT, "ds4-server: unknown option: %s", arg);
             usage(stderr);


### PR DESCRIPTION
## Summary

Fixes q4 startup on machines where the model crosses Metal's per-buffer `maxBufferLength`, then documents q4 usage and benchmark results for a Mac Studio M2 Ultra with 192 GB RAM.

The original implementation used a fixed 672 MiB model-view overlap. The q4 GGUF has 1152 MiB expert tensors, so on this machine one tensor can straddle two mapped Metal views and fail startup with:

`ds4: Metal model range 106.89..108.01 GiB is not covered by mapped model views`

This PR fixes that by deriving the Metal model-view overlap from the largest tensor described by the GGUF metadata, with a CLI/server override kept as a diagnostic lower-bound escape hatch.

## 192 GB q4 setup

On the tested Mac Studio M2 Ultra with 192 GB RAM, q4 runs at `--ctx 32768` after raising the iGPU wired-memory limit:

```sh
sudo sysctl iogpu.wired_limit_mb=188000
```

## Benchmark

Single-run Metal CLI numbers using:

- `--ctx 32768`
- `--nothink`
- `-sys ""`
- `--temp 0`
- `-n 256`

| Machine | Quant | Prompt | Prefill | Generation |
| --- | ---: | ---: | ---: | ---: |
| Mac Studio M2 Ultra, 192 GB | q4 | short | 50.42 t/s | 29.88 t/s |
| Mac Studio M2 Ultra, 192 GB | q4 | 3844 tokens | 394.66 t/s | 21.69 t/s |

The long benchmark uses `tests/test-vectors/prompts/long_code_audit.txt`.

## Test plan

- `make ds4 ds4-server ds4_test`
- `./ds4 --inspect -m ds4flash.gguf`
- `./ds4_test --server`
- q4 short benchmark command above
- q4 long benchmark command above