### PR TITLE
Fix external launcher startup paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,18 @@ live graph/session.
 
 Supported endpoints:
 
+- `GET /health`
 - `GET /v1/models`
 - `GET /v1/models/deepseek-v4-flash`
 - `POST /v1/chat/completions`
 - `POST /v1/completions`
 - `POST /v1/messages`
+
+`/health` is a lightweight liveness endpoint for process managers and model
+routers. Relative model and Metal source paths are resolved from the current
+working directory first, then from the `ds4` / `ds4-server` executable
+directory, so external launchers can run `/path/to/ds4-server` without `cd` when
+the normal repo layout is next to the binary.
 
 `/v1/chat/completions` accepts the usual OpenAI-style `messages`,
 `max_tokens`/`max_completion_tokens`, `temperature`, `top_p`, `top_k`, `min_p`,

--- a/ds4.c
+++ b/ds4.c
@@ -19,6 +19,7 @@
 #include <float.h>
 #include <inttypes.h>
 #include <ctype.h>
+#include <limits.h>
 #include <math.h>
 #include <pthread.h>
 #include <stdbool.h>
@@ -33,6 +34,10 @@
 #include <stdarg.h>
 #include <time.h>
 #include <unistd.h>
+
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
 
 #include "ds4.h"
 
@@ -506,6 +511,85 @@ static void *xmalloc_zeroed(size_t n, size_t size) {
      */
     memset(p, 0, total);
     return p;
+}
+
+static char *xstrdup(const char *s) {
+    size_t n = strlen(s);
+    char *p = xmalloc(n + 1);
+    memcpy(p, s, n + 1);
+    return p;
+}
+
+static bool path_is_absolute(const char *path) {
+    return path && path[0] == '/';
+}
+
+static bool path_is_readable(const char *path) {
+    return path && access(path, R_OK) == 0;
+}
+
+static char *path_join_dup(const char *dir, const char *path) {
+    size_t dlen = strlen(dir);
+    size_t plen = strlen(path);
+    bool slash = dlen > 0 && dir[dlen - 1] == '/';
+    if (dlen > SIZE_MAX - plen - (slash ? 1u : 2u)) ds4_die("path length overflow");
+    char *out = xmalloc(dlen + (slash ? 0u : 1u) + plen + 1u);
+    memcpy(out, dir, dlen);
+    size_t pos = dlen;
+    if (!slash) out[pos++] = '/';
+    memcpy(out + pos, path, plen + 1u);
+    return out;
+}
+
+static char *executable_dir(void) {
+#if defined(__APPLE__)
+    char stack_path[PATH_MAX];
+    uint32_t size = sizeof(stack_path);
+    char *path = stack_path;
+    if (_NSGetExecutablePath(stack_path, &size) != 0) {
+        path = xmalloc(size);
+        if (_NSGetExecutablePath(path, &size) != 0) {
+            free(path);
+            return NULL;
+        }
+    }
+    char *resolved = realpath(path, NULL);
+    char *owned = resolved ? resolved : xstrdup(path);
+    if (path != stack_path) free(path);
+#elif defined(__linux__)
+    char stack_path[PATH_MAX];
+    ssize_t n = readlink("/proc/self/exe", stack_path, sizeof(stack_path) - 1u);
+    if (n <= 0 || (size_t)n >= sizeof(stack_path)) return NULL;
+    stack_path[n] = '\0';
+    char *resolved = realpath(stack_path, NULL);
+    char *owned = resolved ? resolved : xstrdup(stack_path);
+#else
+    return NULL;
+#endif
+    char *slash = strrchr(owned, '/');
+    if (!slash) {
+        free(owned);
+        return NULL;
+    }
+    if (slash == owned) {
+        slash[1] = '\0';
+    } else {
+        *slash = '\0';
+    }
+    return owned;
+}
+
+static char *resolve_runtime_path(const char *path) {
+    if (!path || !path[0]) return xstrdup(path ? path : "");
+    if (path_is_absolute(path) || path_is_readable(path)) return xstrdup(path);
+
+    char *dir = executable_dir();
+    if (!dir) return xstrdup(path);
+    char *candidate = path_join_dup(dir, path);
+    free(dir);
+    if (path_is_readable(candidate)) return candidate;
+    free(candidate);
+    return xstrdup(path);
 }
 
 static double now_sec(void) {
@@ -16514,7 +16598,9 @@ int ds4_engine_open(ds4_engine **out, const ds4_engine_options *opt) {
     ds4_acquire_instance_lock();
 
     const bool graph_backend = ds4_backend_uses_graph(opt->backend);
-    model_open(&e->model, opt->model_path, graph_backend, true);
+    char *model_path = resolve_runtime_path(opt->model_path);
+    model_open(&e->model, model_path, graph_backend, true);
+    free(model_path);
     if (opt->warm_weights) model_warm_weights(&e->model);
     vocab_load(&e->vocab, &e->model);
     config_validate_model(&e->model);
@@ -16525,12 +16611,14 @@ int ds4_engine_open(ds4_engine **out, const ds4_engine_options *opt) {
         return 1;
     }
     if (opt->mtp_path && opt->mtp_path[0]) {
-        model_open(&e->mtp_model, opt->mtp_path, graph_backend, true);
+        char *mtp_path = resolve_runtime_path(opt->mtp_path);
+        model_open(&e->mtp_model, mtp_path, graph_backend, true);
         mtp_weights_bind(&e->mtp_weights, &e->mtp_model);
         e->mtp_ready = true;
         fprintf(stderr, "ds4: MTP support model loaded: %s (draft=%d)\n",
-                opt->mtp_path,
+                mtp_path,
                 e->mtp_draft_tokens);
+        free(mtp_path);
     }
 
 #ifndef DS4_NO_GPU

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -1226,6 +1226,13 @@ static NSString *ds4_gpu_full_source(void) {
     ];
 
     NSMutableString *source = [NSMutableString stringWithString:base];
+    NSString *exe_path = [[NSBundle mainBundle] executablePath];
+    NSString *exe_dir = [exe_path length] ? [exe_path stringByDeletingLastPathComponent] : nil;
+    NSString *resolved_exe_dir = nil;
+    if ([exe_path length]) {
+        NSString *resolved = [exe_path stringByResolvingSymlinksInPath];
+        resolved_exe_dir = [resolved length] ? [resolved stringByDeletingLastPathComponent] : nil;
+    }
     for (NSArray<NSString *> *spec in required_sources) {
         const char *override_path = getenv([spec[0] UTF8String]);
         NSMutableArray<NSString *> *paths = [NSMutableArray array];
@@ -1234,6 +1241,12 @@ static NSString *ds4_gpu_full_source(void) {
         }
         [paths addObject:spec[1]];
         [paths addObject:[@"./" stringByAppendingString:spec[1]]];
+        if (exe_dir) {
+            [paths addObject:[exe_dir stringByAppendingPathComponent:spec[1]]];
+        }
+        if (resolved_exe_dir && ![resolved_exe_dir isEqualToString:exe_dir]) {
+            [paths addObject:[resolved_exe_dir stringByAppendingPathComponent:spec[1]]];
+        }
 
         NSString *loaded = nil;
         NSString *loaded_path = nil;

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -7653,6 +7653,18 @@ static bool send_models(server *s, int fd) {
     return ok;
 }
 
+static void append_health_json(buf *b) {
+    buf_puts(b, "{\"status\":\"ok\"}\n");
+}
+
+static bool send_health(int fd) {
+    buf b = {0};
+    append_health_json(&b);
+    bool ok = http_response(fd, 200, "application/json", b.ptr);
+    buf_free(&b);
+    return ok;
+}
+
 static void client_done(server *s) {
     pthread_mutex_lock(&s->mu);
     if (s->clients > 0) s->clients--;
@@ -7674,6 +7686,11 @@ static void *client_main(void *arg) {
         goto done;
     }
 
+    if (!strcmp(hr.method, "GET") && !strcmp(hr.path, "/health")) {
+        send_health(fd);
+        http_request_free(&hr);
+        goto done;
+    }
     if (!strcmp(hr.method, "GET") && !strcmp(hr.path, "/v1/models")) {
         send_models(s, fd);
         http_request_free(&hr);
@@ -7944,7 +7961,8 @@ static void usage(FILE *fp) {
         "  ./ds4-server --ctx 100000 --kv-disk-dir /tmp/ds4-kv --kv-disk-space-mb 8192\n"
         "\n"
         "Notes:\n"
-        "  Use /v1/chat/completions, /v1/completions, or /v1/messages.\n"
+        "  Use /health for liveness checks.\n"
+        "  Use /v1/chat/completions, /v1/completions, or /v1/messages for inference.\n"
         "  Larger --ctx values allocate more KV memory at startup; the startup log prints the estimate.\n"
         "  Disk KV caching is best for agents that resend long prompts with stable prefixes.\n"
         "\n"
@@ -9569,6 +9587,13 @@ static void test_model_metadata_clamps_completion_to_context(void) {
     buf_free(&b);
 }
 
+static void test_health_response_json(void) {
+    buf b = {0};
+    append_health_json(&b);
+    TEST_ASSERT(!strcmp(b.ptr, "{\"status\":\"ok\"}\n"));
+    buf_free(&b);
+}
+
 static void test_client_socket_nonblocking_flag(void) {
     int sv[2];
     TEST_ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
@@ -10283,6 +10308,7 @@ static void ds4_server_unit_tests_run(void) {
     test_stop_list_streaming_holds_and_trims_stop_text();
     test_json_skip_has_nesting_limit();
     test_model_metadata_clamps_completion_to_context();
+    test_health_response_json();
     test_client_socket_nonblocking_flag();
     test_thinking_state_tracks_prompt_and_generated_tags();
     test_tool_marker_state_ignores_orphan_end();


### PR DESCRIPTION
## Summary
- Resolve relative model and MTP paths from the current working directory first, then from the executable directory.
- Resolve Metal source files from the current working directory / env overrides first, then from the executable directory.
- Add `GET /health` as a lightweight liveness endpoint for process managers and model routers.

Fixes #49

## Validation
- `git diff --check`
- Not run: `make test` (this Windows environment does not provide the POSIX/macOS headers used by ds4, such as `sys/mman.h` and `arpa/inet.h`)