### PR TITLE
feat(server): support llama.cpp-style raw completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,6 +768,20 @@ For browser JavaScript clients served from another origin, start the server with
 headers; it does not expose the server on the LAN. Use `--host 0.0.0.0`
 explicitly when remote machines should be able to connect.
 
+By default, `/v1/completions` wraps the `prompt` as a DS4 user message for
+compatibility with simple OpenAI completions clients. Start the server with
+`--raw-completions` to align with llama.cpp-style raw completions, where the
+client-provided `prompt` is treated as an already-rendered model prompt and the
+server only continues it:
+
+```sh
+./ds4-server --ctx 32768 --raw-completions
+```
+
+This mode is useful for clients that own their prompt templates, text
+completion/instruct frontends, and custom experiments that send model-specific
+templates directly.
+
 ### Tool call handling and canonicalization
 
 DeepSeek V4 emits tool calls as [DSML text](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/encoding/README.md). Agent clients do not send that

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -305,6 +305,7 @@ static void print_server_api(FILE *fp, const help_colors *c) {
     opt(fp, c, "--port N", "Bind port. Default: 8000");
     opt(fp, c, "--cors", "Add Access-Control-Allow-* headers for browser JS clients.");
     opt(fp, c, "--trace FILE", "Write prompts, cache decisions, output, and tool calls.");
+    opt(fp, c, "--raw-completions", "Treat /v1/completions prompts as already-rendered model prompts.");
     para(fp, c, "Endpoints: /v1/chat/completions, /v1/responses, /v1/completions, and /v1/messages.");
     para(fp, c, "Model endpoint aliases include deepseek-v4-flash and deepseek-v4-pro; both serve the loaded GGUF.");
     fputc('\n', fp);

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -3975,8 +3975,23 @@ static bool parse_prompt(const char **p, char **out) {
     return true;
 }
 
+static char *render_completion_prompt_text(const char *prompt, ds4_think_mode think_mode,
+                                           bool raw_completion) {
+    if (raw_completion) return xstrdup(prompt ? prompt : "");
+
+    buf rendered = {0};
+    buf_puts(&rendered, "<｜begin▁of▁sentence｜>");
+    if (think_mode == DS4_THINK_MAX) buf_puts(&rendered, ds4_think_max_prefix());
+    buf_puts(&rendered, "You are a helpful assistant<｜User｜>");
+    buf_puts(&rendered, prompt ? prompt : "");
+    buf_puts(&rendered, "<｜Assistant｜>");
+    buf_puts(&rendered, ds4_think_mode_enabled(think_mode) ? "<think>" : "</think>");
+    return buf_take(&rendered);
+}
+
 static bool parse_completion_request(ds4_engine *e, const char *body, int def_tokens,
-                                     int ctx_size, request *r, char *err, size_t errlen) {
+                                     int ctx_size, bool raw_completions, request *r,
+                                     char *err, size_t errlen) {
     request_init(r, REQ_COMPLETION, def_tokens);
     const char *p = body;
     char *prompt = NULL;
@@ -4095,18 +4110,18 @@ static bool parse_completion_request(ds4_engine *e, const char *body, int def_to
         request_free(r);
         return false;
     }
+    if (raw_completions) {
+        r->think_mode = DS4_THINK_NONE;
+        r->prompt_text = render_completion_prompt_text(prompt, r->think_mode, true);
+        ds4_tokenize_rendered_chat(e, r->prompt_text, &r->prompt);
+        free(prompt);
+        return true;
+    }
     if (!got_thinking && model_alias_disables_thinking(r->model)) thinking_enabled = false;
     if (!got_thinking && model_alias_enables_thinking(r->model)) thinking_enabled = true;
     r->think_mode = ds4_think_mode_for_context(
         think_mode_from_enabled(thinking_enabled, reasoning_effort), ctx_size);
-    buf rendered = {0};
-    buf_puts(&rendered, "<｜begin▁of▁sentence｜>");
-    if (r->think_mode == DS4_THINK_MAX) buf_puts(&rendered, ds4_think_max_prefix());
-    buf_puts(&rendered, "You are a helpful assistant<｜User｜>");
-    buf_puts(&rendered, prompt);
-    buf_puts(&rendered, "<｜Assistant｜>");
-    buf_puts(&rendered, ds4_think_mode_enabled(r->think_mode) ? "<think>" : "</think>");
-    r->prompt_text = buf_take(&rendered);
+    r->prompt_text = render_completion_prompt_text(prompt, r->think_mode, false);
     ds4_tokenize_rendered_chat(e, r->prompt_text, &r->prompt);
     free(prompt);
     return true;
@@ -7708,6 +7723,7 @@ struct server {
     visible_live_state thinking_live;
     bool disable_exact_dsml_tool_replay;
     bool enable_cors;
+    bool raw_completions;
     pthread_mutex_t tool_mu;
     pthread_mutex_t mu;
     pthread_cond_t cv;
@@ -11280,7 +11296,8 @@ static void *client_main(void *arg) {
                                      ctx_size, &req, err, sizeof(err));
     } else if (!strcmp(hr.method, "POST") && !strcmp(hr.path, "/v1/completions")) {
         ok = parse_completion_request(s->engine, hr.body, s->default_tokens,
-                                      ctx_size, &req, err, sizeof(err));
+                                      ctx_size, s->raw_completions, &req,
+                                      err, sizeof(err));
     } else {
         http_error(fd, s->enable_cors, 404, "unknown endpoint");
         http_request_free(&hr);
@@ -11387,6 +11404,7 @@ typedef struct {
     kv_cache_options kv_cache;
     bool kv_cache_reject_different_quant;
     bool disable_exact_dsml_tool_replay;
+    bool raw_completions;
     int tool_memory_max_ids;
     bool enable_cors;
 } server_config;
@@ -11563,6 +11581,8 @@ static server_config parse_options(int argc, char **argv) {
             c.enable_cors = true;
         } else if (!strcmp(arg, "--trace")) {
             c.trace_path = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--raw-completions")) {
+            c.raw_completions = true;
         } else if (!strcmp(arg, "--kv-disk-dir")) {
             c.kv_disk_dir = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--kv-disk-space-mb")) {
@@ -11725,6 +11745,7 @@ int main(int argc, char **argv) {
     s.session = session;
     s.default_tokens = cfg.default_tokens;
     s.disable_exact_dsml_tool_replay = cfg.disable_exact_dsml_tool_replay;
+    s.raw_completions = cfg.raw_completions;
     s.tool_mem.max_entries = cfg.tool_memory_max_ids;
     s.enable_cors = cfg.enable_cors;
     if (cfg.kv_disk_dir) {
@@ -13207,6 +13228,28 @@ static void test_anthropic_thinking_and_tool_args_preserve_call_order(void) {
     buf_free(&b);
     tool_calls_free(&calls);
     request_free(&r);
+}
+
+static void test_completion_prompt_wraps_by_default(void) {
+    char *prompt = render_completion_prompt_text("Return JSON", DS4_THINK_HIGH, false);
+    TEST_ASSERT(prompt != NULL);
+    TEST_ASSERT(strstr(prompt,
+        "<｜begin▁of▁sentence｜>You are a helpful assistant<｜User｜>"
+        "Return JSON<｜Assistant｜><think>") != NULL);
+
+    free(prompt);
+}
+
+static void test_completion_prompt_can_be_raw(void) {
+    const char *raw =
+        "<｜begin▁of▁sentence｜>System text<｜User｜>hello<｜Assistant｜>"
+        "<think>\npartial reasoning";
+    char *prompt = render_completion_prompt_text(raw, DS4_THINK_HIGH, true);
+    TEST_ASSERT(prompt != NULL);
+    TEST_ASSERT(!strcmp(prompt, raw));
+    TEST_ASSERT(strstr(prompt, "You are a helpful assistant") == NULL);
+
+    free(prompt);
 }
 
 static void test_parse_short_dsml_and_canonical_suffix(void) {
@@ -15655,6 +15698,8 @@ static void ds4_server_unit_tests_run(void) {
     test_openai_tool_stream_holds_partial_utf8_arguments();
     test_openai_tool_stream_handles_multiple_calls();
     test_streaming_holds_partial_utf8();
+    test_completion_prompt_wraps_by_default();
+    test_completion_prompt_can_be_raw();
     test_parse_short_dsml_and_canonical_suffix();
     test_dsml_parser_recovers_loose_nested_parameters();
     test_dsml_repair_produces_parseable_calls();


### PR DESCRIPTION
## Summary

This adds an opt-in `--raw-completions` mode for `ds4-server`.

When enabled, `POST /v1/completions` treats the request `prompt` as an already-rendered model prompt and continues it directly, instead of wrapping it in the built-in DS4 chat template. The default behavior is unchanged.

## Why

This aligns ds4 with llama.cpp-style raw completions for clients that own prompt rendering and expect the server to perform only continuation.

That unlocks prompt-template-owning clients, text-completion/instruct frontends, and raw prompt experiments that send model-specific templates directly.

## Notes

- `POST /v1/chat/completions`, `/v1/responses`, and `/v1/messages` are unchanged.
- Default `/v1/completions` behavior is unchanged unless `--raw-completions` is passed.
- In raw mode, thinking markers and other model control tokens should be included by the client as part of the rendered prompt.
- This branch was freshly ported onto current `origin/main` after the Responses API changes.

## Testing

- `make ds4-server ds4_test`
- `./ds4_test --server`
- `./ds4-server --help | rg -n "raw-completions|/v1/completions|responses"`