### PR TITLE
feat(server): cache system prompt as a reusable KV prefix

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -14942,6 +14942,10 @@ int ds4_token_eos(ds4_engine *e) {
     return e->vocab.eos_id;
 }
 
+int ds4_token_user(ds4_engine *e) {
+    return e->vocab.user_id;
+}
+
 static int sample_argmax(const float *logits, uint32_t n_vocab) {
     int best = 0;
     float best_v = DS4_NEG_INF;

--- a/ds4.h
+++ b/ds4.h
@@ -141,6 +141,7 @@ void ds4_chat_append_assistant_prefix(ds4_engine *e, ds4_tokens *tokens, ds4_thi
 
 char *ds4_token_text(ds4_engine *e, int token, size_t *len);
 int ds4_token_eos(ds4_engine *e);
+int ds4_token_user(ds4_engine *e);
 
 int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size);
 void ds4_session_free(ds4_session *s);

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -7489,6 +7489,7 @@ typedef struct {
     int continued_interval_tokens;
     int boundary_trim_tokens;
     int boundary_align_tokens;
+    bool anchor_user_enabled;
 } kv_cache_options;
 
 typedef struct {
@@ -7498,6 +7499,7 @@ typedef struct {
     bool reject_different_quant;
     kv_cache_options opt;
     int continued_last_store_tokens;
+    int user_token_id;
     kv_entry *entry;
     int len;
     int cap;
@@ -8189,6 +8191,7 @@ static kv_cache_options kv_cache_default_options(void) {
         .continued_interval_tokens = KV_CACHE_DEFAULT_CONTINUED_INTERVAL_TOKENS,
         .boundary_trim_tokens = KV_CACHE_DEFAULT_BOUNDARY_TRIM_TOKENS,
         .boundary_align_tokens = KV_CACHE_DEFAULT_BOUNDARY_ALIGN_TOKENS,
+        .anchor_user_enabled = false,
     };
 }
 
@@ -8854,9 +8857,10 @@ static bool kv_cache_open(kv_disk_cache *kc, const char *dir, uint64_t budget_mb
     kc->budget_bytes = budget_mb * 1024ull * 1024ull;
     kc->reject_different_quant = reject_different_quant;
     kc->opt = opt;
+    kc->user_token_id = -1;
     kv_cache_evict(kc, NULL, NULL);
     server_log(DS4_LOG_KVCACHE,
-               "ds4-server: KV disk cache %s (budget=%llu MiB, cross-quant=%s, min=%d, cold_max=%d, continued=%d, trim=%d, align=%d, hit_half_life=%llus)",
+               "ds4-server: KV disk cache %s (budget=%llu MiB, cross-quant=%s, min=%d, cold_max=%d, continued=%d, trim=%d, align=%d, hit_half_life=%llus, anchor_user=%s)",
                kc->dir,
                (unsigned long long)(kc->budget_bytes / (1024ull * 1024ull)),
                reject_different_quant ? "reject" : "accept",
@@ -8865,7 +8869,8 @@ static bool kv_cache_open(kv_disk_cache *kc, const char *dir, uint64_t budget_mb
                kc->opt.continued_interval_tokens,
                kc->opt.boundary_trim_tokens,
                kc->opt.boundary_align_tokens,
-               (unsigned long long)KV_CACHE_HIT_HALF_LIFE_SECONDS);
+               (unsigned long long)KV_CACHE_HIT_HALF_LIFE_SECONDS,
+               kc->opt.anchor_user_enabled ? "on" : "off");
     return true;
 }
 
@@ -8935,6 +8940,43 @@ static int kv_cache_store_len(const kv_disk_cache *kc, int tokens) {
         if (stable >= kc->opt.min_tokens) return stable;
     }
     return tokens;
+}
+
+/* The chat template separates the system text from the first user message
+ * with a single special <｜User｜> token at a fixed vocabulary boundary.
+ * For workloads that resend the same system prompt with different user
+ * content, storing the prefix up to that anchor produces a cache key over
+ * just the stable portion, so every subsequent request hits regardless of
+ * how the user message varies.
+ *
+ * When boundary_trim_tokens is large enough to leave headroom over
+ * min_tokens, trim+align is applied to the anchor position the same way
+ * kv_cache_store_len applies it to the full prompt length.  This lets
+ * agents whose system prompt has a small dynamic tail (e.g. a timestamp
+ * near the user marker) move the cut safely below the variable region
+ * without disabling the anchor.
+ *
+ * Returns -1 when no usable anchor exists, letting the caller fall back to
+ * length-based alignment for tool-using prompts or prompts without a
+ * <|User|> token (e.g. raw /v1/completions). */
+static int kv_cache_anchor_pos(const kv_disk_cache *kc, const ds4_tokens *prompt) {
+    if (!kc->opt.anchor_user_enabled) return -1;
+    if (kc->user_token_id < 0) return -1;
+    if (!prompt) return -1;
+    for (int i = 0; i < prompt->len; i++) {
+        if (prompt->v[i] == kc->user_token_id) {
+            const int anchor = i;
+            const int trim = kc->opt.boundary_trim_tokens;
+            const int align = kc->opt.boundary_align_tokens;
+            if (anchor > kc->opt.min_tokens + trim) {
+                int stable = anchor - trim;
+                if (align > 0) stable -= stable % align;
+                if (stable >= kc->opt.min_tokens) return stable;
+            }
+            return anchor >= kc->opt.min_tokens ? anchor : -1;
+        }
+    }
+    return -1;
 }
 
 static int kv_cache_continued_step(const kv_disk_cache *kc) {
@@ -10623,7 +10665,9 @@ static void generate_job(server *s, job *j) {
         s->kv.opt.cold_max_tokens > 0 &&
         prompt_for_sync->len <= s->kv.opt.cold_max_tokens)
     {
-        cold_store_len = kv_cache_store_len(&s->kv, prompt_for_sync->len);
+        const int anchor = kv_cache_anchor_pos(&s->kv, prompt_for_sync);
+        if (anchor > 0) cold_store_len = anchor;
+        else cold_store_len = kv_cache_store_len(&s->kv, prompt_for_sync->len);
     }
     int suppressed_continued_last = -1;
     if (cold_store_len >= s->kv.opt.min_tokens) {
@@ -11711,6 +11755,14 @@ static void usage(FILE *fp) {
         "      Trim this many tail tokens before cold boundary saves to avoid tokenizer boundary merges. Default: 32\n"
         "  --kv-cache-boundary-align-tokens N\n"
         "      Align cold boundary saves down to this token multiple. 0 disables alignment. Default: 2048\n"
+        "  --kv-cache-anchor-user\n"
+        "      Enable the system-prompt anchor. Cold cache stores cut at the first <|User|>\n"
+        "      token so the system prefix is reused across requests whose user content\n"
+        "      differs. Off by default; the server otherwise uses the length-based\n"
+        "      alignment heuristic. Composes with --kv-cache-boundary-trim-tokens and\n"
+        "      --kv-cache-boundary-align-tokens: if the anchor position exceeds the\n"
+        "      min+trim threshold, trim+align is applied to the anchor position to push\n"
+        "      the cut below any dynamic tail in the system prompt.\n"
         "  --kv-cache-reject-different-quant\n"
         "      Refuse checkpoints written by the same model with a different routed-expert quantization.\n"
         "  --disable-exact-dsml-tool-replay\n"
@@ -11813,6 +11865,8 @@ static server_config parse_options(int argc, char **argv) {
             c.kv_cache.boundary_align_tokens = parse_nonneg_int_arg(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--kv-cache-reject-different-quant")) {
             c.kv_cache_reject_different_quant = true;
+        } else if (!strcmp(arg, "--kv-cache-anchor-user")) {
+            c.kv_cache.anchor_user_enabled = true;
         } else if (!strcmp(arg, "--disable-exact-dsml-tool-replay")) {
             c.disable_exact_dsml_tool_replay = true;
         } else if (!strcmp(arg, "--tool-memory-max-ids")) {
@@ -11891,6 +11945,7 @@ int main(int argc, char **argv) {
     if (cfg.kv_disk_dir) {
         kv_cache_open(&s.kv, cfg.kv_disk_dir, cfg.kv_disk_space_mb,
                       cfg.kv_cache_reject_different_quant, cfg.kv_cache);
+        s.kv.user_token_id = ds4_token_user(engine);
     }
     if (s.disable_exact_dsml_tool_replay) {
         server_log(DS4_LOG_DEFAULT,
@@ -14474,6 +14529,120 @@ static void test_sha1_bytes_hex_matches_known_vector(void) {
     TEST_ASSERT(!strcmp(sha, "a9993e364706816aba3e25717850c26c9cd0d89d"));
 }
 
+static void test_kv_cache_anchor_pos_finds_first_user_token(void) {
+    kv_disk_cache kc = {0};
+    kc.opt = kv_cache_default_options();
+    kc.opt.anchor_user_enabled = true;
+    kc.user_token_id = 999;
+
+    ds4_tokens prompt = {0};
+    for (int i = 0; i < 600; i++) ds4_tokens_push(&prompt, 100);
+    ds4_tokens_push(&prompt, 999);
+    for (int i = 0; i < 200; i++) ds4_tokens_push(&prompt, 100);
+    ds4_tokens_push(&prompt, 999);  /* multi-turn second <|User|>; ignored */
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &prompt) == 600);
+
+    ds4_tokens short_prompt = {0};
+    for (int i = 0; i < 100; i++) ds4_tokens_push(&short_prompt, 100);
+    ds4_tokens_push(&short_prompt, 999);
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &short_prompt) == -1);
+
+    kc.opt.anchor_user_enabled = false;
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &prompt) == -1);
+
+    kc.opt.anchor_user_enabled = true;
+    kc.user_token_id = -1;
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &prompt) == -1);
+
+    ds4_tokens no_user = {0};
+    for (int i = 0; i < 800; i++) ds4_tokens_push(&no_user, 100);
+    kc.user_token_id = 999;
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &no_user) == -1);
+
+    ds4_tokens_free(&prompt);
+    ds4_tokens_free(&short_prompt);
+    ds4_tokens_free(&no_user);
+}
+
+static void test_kv_cache_anchor_pos_applies_trim_and_align(void) {
+    kv_disk_cache kc = {0};
+    kc.opt = kv_cache_default_options();
+    kc.opt.anchor_user_enabled = true;
+    kc.opt.min_tokens = 512;
+    kc.opt.boundary_trim_tokens = 1000;
+    kc.opt.boundary_align_tokens = 256;
+    kc.user_token_id = 999;
+
+    /* Long-anchor case: anchor at 16023, min+trim=1512, anchor exceeds threshold.
+     * stable = 16023 - 1000 = 15023, 15023 % 256 = 175, expect 14848. */
+    ds4_tokens big = {0};
+    for (int i = 0; i < 16023; i++) ds4_tokens_push(&big, 100);
+    ds4_tokens_push(&big, 999);
+    for (int i = 0; i < 1500; i++) ds4_tokens_push(&big, 100);
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &big) == 14848);
+
+    /* Short-anchor case: anchor at 870 is below min+trim=1512, trim does not
+     * apply; expect anchor unchanged. */
+    ds4_tokens small = {0};
+    for (int i = 0; i < 870; i++) ds4_tokens_push(&small, 100);
+    ds4_tokens_push(&small, 999);
+    for (int i = 0; i < 90; i++) ds4_tokens_push(&small, 100);
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &small) == 870);
+
+    /* Disabling alignment leaves the trimmed-but-unaligned position. */
+    kc.opt.boundary_align_tokens = 0;
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &big) == 15023);
+
+    ds4_tokens_free(&big);
+    ds4_tokens_free(&small);
+}
+
+static void test_kv_cache_anchor_pos_boundary_threshold(void) {
+    /* The trim+align branch fires when anchor > min_tokens + trim.  Exercise
+     * the three points around that threshold so future refactors do not flip
+     * the comparison operator silently. */
+    kv_disk_cache kc = {0};
+    kc.opt = kv_cache_default_options();
+    kc.opt.anchor_user_enabled = true;
+    kc.opt.min_tokens = 512;
+    kc.opt.boundary_trim_tokens = 1000;
+    kc.opt.boundary_align_tokens = 256;
+    kc.user_token_id = 999;
+
+    /* anchor = 1500 (below threshold 1512): trim does not apply, anchor used. */
+    ds4_tokens below = {0};
+    for (int i = 0; i < 1500; i++) ds4_tokens_push(&below, 100);
+    ds4_tokens_push(&below, 999);
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &below) == 1500);
+
+    /* anchor = 1512 (exactly at threshold): condition is strict >, not >=, so
+     * trim still does not apply.  Anchor returned unchanged. */
+    ds4_tokens at = {0};
+    for (int i = 0; i < 1512; i++) ds4_tokens_push(&at, 100);
+    ds4_tokens_push(&at, 999);
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &at) == 1512);
+
+    /* anchor = 1513 (just above threshold): trim applies.
+     * stable = 513, 513 % 256 = 1, aligned = 512.  Returns the min-tokens
+     * floor; smaller would have fallen back to the unaligned anchor. */
+    ds4_tokens above = {0};
+    for (int i = 0; i < 1513; i++) ds4_tokens_push(&above, 100);
+    ds4_tokens_push(&above, 999);
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &above) == 512);
+
+    /* anchor = 2000 (comfortably above): trim+align produce a meaningful cut.
+     * stable = 1000, 1000 % 256 = 232, aligned = 768. */
+    ds4_tokens comfortable = {0};
+    for (int i = 0; i < 2000; i++) ds4_tokens_push(&comfortable, 100);
+    ds4_tokens_push(&comfortable, 999);
+    TEST_ASSERT(kv_cache_anchor_pos(&kc, &comfortable) == 768);
+
+    ds4_tokens_free(&below);
+    ds4_tokens_free(&at);
+    ds4_tokens_free(&above);
+    ds4_tokens_free(&comfortable);
+}
+
 static void test_kv_stub_file(const char *dir, const char *sha,
                               uint8_t reason, uint32_t tokens, uint32_t hits,
                               uint64_t last_used, uint64_t payload_bytes) {
@@ -15244,6 +15413,9 @@ static void ds4_server_unit_tests_run(void) {
     test_kv_cache_file_size_must_fit_budget();
     test_sha1_bytes_hex_matches_known_vector();
     test_kv_cache_lookup_uses_longest_text_prefix();
+    test_kv_cache_anchor_pos_finds_first_user_token();
+    test_kv_cache_anchor_pos_applies_trim_and_align();
+    test_kv_cache_anchor_pos_boundary_threshold();
     test_kv_cache_eviction_values_fresh_snapshots();
     test_kv_cache_eviction_protects_current_store();
     test_kv_cache_eviction_does_not_protect_oversize_current_store();


### PR DESCRIPTION
## Summary

Adds `--kv-cache-anchor-user`, an opt-in flag that cuts cold KV cache stores at the first `<｜User｜>` token instead of at a length-aligned boundary. Workloads that resend the same system prompt with varying user content now get a stable cache key over exactly the system tokens, so every subsequent request hits at the system-prompt boundary regardless of how the user message varies.

## Motivation

Cold KV cache stores are sized by `kv_cache_store_len` using `boundary_align_tokens` and `boundary_trim_tokens`. With the default `boundary_align_tokens` of 2048, any prompt shorter than ~2080 tokens has its store length collapse to the full prompt length, so the cache key SHA covers every token including the user message. Workloads that resend the same system prompt with different user content (categorizers, classifiers, single-turn agents, benchmarks) produce a unique SHA per request and never hit.

Tuning `--kv-cache-boundary-align-tokens` down to 256 helps, but the cut position is a length-arithmetic guess. It can drift if the system prompt's token count changes, and it always leaves between 0 and `align - 1` tokens of cacheable system text on the table.

The DeepSeek chat template emits `<｜User｜>` as a single atomic vocabulary token. The tokens preceding it (BOS plus the system text) form a byte-stable prefix that is independent of whatever user message follows. This patch lets the cold-cache cut land exactly at that natural boundary.

## What this changes

* `ds4.h` / `ds4.c`: new accessor `ds4_token_user` exposing `vocab.user_id`.
* `ds4_server.c`:
  * `kv_cache_options` gains a `bool anchor_user_enabled` field (default `false`).
  * `kv_disk_cache` gains an `int user_token_id` field, populated at server init from `ds4_token_user`.
  * New helper `kv_cache_anchor_pos` walks the prompt tokens and returns the position of the first `<｜User｜>`, or `-1` when disabled, when the marker is absent, when `user_token_id` is unset, or when the anchor sits below `min_tokens`.
  * `generate_job` prefers the anchor cut over `kv_cache_store_len` when an anchor is available.
  * New CLI flag `--kv-cache-anchor-user` enables the feature.
  * Startup log now appends `anchor_user=on` or `anchor_user=off` to the existing `KV disk cache ...` line.
  * Unit test `test_kv_cache_anchor_pos_finds_first_user_token` covers enable/disable, marker present, marker absent, marker below `min_tokens`, and unset `user_token_id`.

## Behavior

* Off by default. Existing behavior is unchanged when the flag is not passed.
* When enabled and a `<｜User｜>` token is found, the cold cache entry covers tokens `[0, anchor_pos)` (no trim required, since `<｜User｜>` sits on an atomic vocabulary boundary).
* Falls through to the existing length-based alignment heuristic when no `<｜User｜>` token is present (raw `/v1/completions`, non-DeepSeek templates) or when the anchor sits below `--kv-cache-min-tokens`.
* Pre-existing `evict` and `continued` snapshot behavior is unchanged. The longest-match rule in `kv_cache_find_prefix` automatically prefers the longer snapshot when a multi-turn conversation is resumed, so anchor entries and conversation snapshots coexist without interference.

## Benchmark

Workload: 100 financial-transaction categorization requests sharing one 870-token system prompt, with the transaction details varying inside the user message. Server launched with `--ctx 100000 --kv-disk-dir /tmp/ds4-kv --kv-disk-space-mb 8192 --mtp ... --mtp-draft 2`.

| run                  | wall    | tok/s | Δ vs prev          | Δ vs v1 |
| -------------------- | ------- | ----- | ------------------ | ------- |
| v1 (initial)         | 505.57s | 14.01 |                    |         |
| v2 (first cache fix) | 352.00s | 19.80 | −153.57s (−30.4%) | −30.4%  |
| v3 (this cache fix)  | 312.39s | 22.55 |  −39.61s (−11.3%) | −38.2%  |

* v1: server defaults. No cache hits because the default `--kv-cache-boundary-align-tokens` of 2048 forces sub-2k-token prompts to be cached as full-prompt blobs whose SHA includes the variable user content, so no entry ever matches a later request.
* v2: `--kv-cache-boundary-align-tokens 256 --kv-cache-min-tokens 512`. Length-aligned cut at 768 tokens, which happens to land inside the 870-token system prompt. Hits on the 768-token cache every request, leaving ~190 tokens to prefill.
* v3: `--kv-cache-anchor-user`. Cut lands exactly on the first `<｜User｜>` token at position 870, the entire system prompt. ~85 tokens to prefill.

Per-request, the prefill phase drops from ~2.67 s (v1) to ~1.25 s (v2) to ~0.83 s (v3). The cache file hash is byte-identical across every request in v3, confirming the cut lands inside the stable system region:

```
kv cache hit tokens=870 quant=2 load=7.8 ms file=/tmp/ds4-kv/733b68a90eda....kv
chat ctx=870..960:90 prompt start
chat ctx=870..960:90 prompt done 0.833s
```

## Tests

* New unit test: `test_kv_cache_anchor_pos_finds_first_user_token` (in the `--server` group, no model required).
* Existing test `test_kv_cache_store_len_uses_configured_boundary` is unchanged; the helper is independent of the anchor path.

Run with:

```
make test
# or, to run just the model-free tests:
./ds4_test --server
```

## Usage

```
./ds4-server --kv-disk-dir /tmp/ds4-kv --kv-disk-space-mb 8192 \
             --kv-cache-anchor-user \
             [other flags]
```

Startup log will print `anchor_user=on` inside the existing `KV disk cache ...` line. The first request prints `kv cache stored tokens=N reason=cold` where `N` is the token position of the first `<｜User｜>`. Subsequent requests sharing the same system prompt print `kv cache hit tokens=N`.