### PR TITLE
feat(server): optionally prepend tool schemas to the system prompt

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -2260,6 +2260,12 @@ static char *render_chat_prompt_text(const chat_msgs *msgs, const char *tool_sch
     const bool tool_context = chat_history_uses_tool_context(msgs, tool_schemas);
     int last_user_idx = -1;
     buf system = {0};
+    /* Render tool schemas before the client system content so
+     * --kv-cache-boundary-trim-tokens chops a dynamic tail from the client
+     * message instead of the much larger tool-schema region. */
+    if (tool_schemas && tool_schemas[0]) {
+        append_tools_prompt_text(&system, tool_schemas);
+    }
     for (int i = 0; i < msgs->len; i++) {
         const chat_msg *m = &msgs->v[i];
         if (!role_is_system(m->role)) continue;
@@ -2269,11 +2275,6 @@ static char *render_chat_prompt_text(const chat_msgs *msgs, const char *tool_sch
     for (int i = 0; i < msgs->len; i++) {
         const chat_msg *m = &msgs->v[i];
         if (role_is_user_like(m->role)) last_user_idx = i;
-    }
-
-    if (tool_schemas && tool_schemas[0]) {
-        if (system.len) buf_puts(&system, "\n\n");
-        append_tools_prompt_text(&system, tool_schemas);
     }
 
     buf out = {0};
@@ -12992,6 +12993,34 @@ static void test_render_preserves_reasoning_with_tools(void) {
     chat_msgs_free(&msgs);
 }
 
+static void test_render_chat_prompt_text_renders_tools_before_system(void) {
+    /* The tool-schema block must sit at the head of the system region so the
+     * client's system content stays at the tail, right before <｜User｜>.
+     * That keeps a per-request dynamic tail (e.g. a timestamp) out of the
+     * cached prefix without losing the tool schemas to the trim. */
+    chat_msgs msgs = {0};
+    chat_msg sys = {0};
+    sys.role = xstrdup("system");
+    sys.content = xstrdup("CLIENT_SYSTEM_MARKER");
+    chat_msgs_push(&msgs, sys);
+    chat_msg user = {0};
+    user.role = xstrdup("user");
+    user.content = xstrdup("hello");
+    chat_msgs_push(&msgs, user);
+
+    char *prompt = render_chat_prompt_text(&msgs, "TOOL_SCHEMA_MARKER", NULL,
+                                           DS4_THINK_HIGH);
+    TEST_ASSERT(prompt != NULL);
+    const char *tools  = strstr(prompt, "## Tools");
+    const char *client = strstr(prompt, "CLIENT_SYSTEM_MARKER");
+    const char *user_m = strstr(prompt, "<｜User｜>");
+    TEST_ASSERT(tools && client && user_m);
+    TEST_ASSERT(tools  < client);
+    TEST_ASSERT(client < user_m);
+    free(prompt);
+    chat_msgs_free(&msgs);
+}
+
 static void test_dsml_tool_args_preserve_call_order(void) {
     tool_calls calls = make_swapped_bash_call();
     buf b = {0};
@@ -14859,6 +14888,7 @@ static void ds4_server_unit_tests_run(void) {
     test_render_non_thinking_prompt_closes_think();
     test_render_drops_old_reasoning_without_tools();
     test_render_preserves_reasoning_with_tools();
+    test_render_chat_prompt_text_renders_tools_before_system();
     test_tool_schema_order_from_anthropic_schema();
     test_tool_schema_order_from_openai_tools();
     test_tool_schema_order_from_responses_tool_search();


### PR DESCRIPTION
## Summary

Adds `--tools-prepend-system`, an opt-in flag that renders ds4's auto-injected tool boilerplate at the start of the system prompt instead of after the client's system content. The model sees the same content in the same role; only the order changes. With the flag enabled, the client's system content (including any dynamic tail it contains) sits immediately before `<｜User｜>`, so the existing `--kv-cache-boundary-trim-tokens` knob can chop just those bytes and keep the tool-schema region in the cached prefix.

## Motivation

`render_chat_prompt_text` injects `## Tools` and `### Available Tool Schemas` instructions into every prompt whose request carries a `tools` field. Today that block is appended after the client's own system content, producing this layout:

```
<｜begin▁of▁sentence｜>
[client's system content, possibly with a small dynamic tail]
[ds4-injected tool schemas + boilerplate]
<｜User｜>
[user message]
```

For tool-using agents whose system message has a small dynamic field, the variable bytes sit *between* two stable regions. There is no length-based cache cut that excludes the dynamic content while including any of the tool schemas. Every cross-session lookup misses for the same structural reason regardless of how `--kv-cache-boundary-trim-tokens` is tuned.

For example, a Hermes-style agent typically emits a few lines at the end of its system prompt summarizing the session context:

```
Conversation started: Sunday, Oct 31, 2008 03:00 PM
Model: deepseek-v4-flash
Provider: custom

Host: macOS (26.4.1)
User home directory: /Users/snaka
Current working directory: /Users/snaka/Documents
```

The first line varies between sessions (timestamp) while the rest is stable. Under the current layout that block lives in the middle of the rendered system region, with the much larger tool-schema region after it. There is no horizontal cut that captures any tool schemas without also capturing the variable timestamp, so the KV cache cannot be reused across sessions.

With `--tools-prepend-system`, the layout becomes:

```
<｜begin▁of▁sentence｜>
[ds4-injected tool schemas + boilerplate]   <-- byte-stable across requests
[client's system content, dynamic tail intact]
<｜User｜>
[user message]
```

The dynamic content is now at the tail of the system block. The length-based heuristic in `kv_cache_store_len` produces a cut below the variable bytes, and cross-session cache hits start working without any other knob changes.

## What this changes

* New CLI flag `--tools-prepend-system`. Off by default. Adds a `bool tools_prepend_system` field on `server_config` and `struct server`.
* `render_chat_prompt_text` gains a `bool tools_prepend_system` parameter that selects whether the tool block is appended (default) or prepended.
* Named macros `TOOLS_AFTER_SYSTEM` and `TOOLS_BEFORE_SYSTEM` are used at call sites so the position argument reads naturally next to the existing `DS4_THINK_*` constants instead of as a bare boolean.
* A forward-declared accessor `server_tools_prepend_system(const server *s)` lets parsers read the flag before the full `struct server` definition is in scope, matching the existing pattern used by `tool_memory_attach_to_messages` and friends.
* Startup logs `tool schemas rendered before client system content` when the flag is active, so operators can confirm the flag took effect without running a request first.

## Behavior

* Off by default. Existing behavior is unchanged when the flag is not passed.
* When enabled, the auto-injected tool block is placed at the start of the system content. All other rendering (BOS, role markers, thinking tags, tool-result rendering) is unchanged.
* Has no effect on requests without tools (no tool block to position).
* Has no effect on raw `/v1/completions` requests (no chat-template tool injection runs).

## Benchmark

Workload: an agent with a 16K-token system prompt that ends with a small dynamic tail (a `Conversation started: …` block of roughly 50 tokens immediately before the user message). Two back-to-back sessions with clean context.

Server launched with `--kv-cache-boundary-trim-tokens 1000 --kv-cache-boundary-align-tokens 2048 --tools-prepend-system` and the disk cache directory unmodified between the two sessions.

| Metric | First request (cold) | Second request (cache hit) | Saved |
| --- | --- | --- | --- |
| Prefill wall | 45.7 s | 6.9 s | 38.8 s |
| Prefill tokens | 16081 | 1703 | 14378 tokens served from cache |
| Total request | ~47 s | ~26 s | ~21 s |
| Cache file | written | reused | one file serves every subsequent session |

Without `--tools-prepend-system`, the same two-session test produces zero cross-session cache hits. The cold cut lands above the dynamic tail (because the appended tool block sits between the tail and the user marker), the SHA always differs across sessions, and `prompt done` reports the full ~45 s on every request.

## Tests

* `test_render_chat_prompt_text_tools_prepend_system` (new) asserts both renderings contain the same set of marker strings and that the tool block precedes the client system content when the flag is true and follows it when the flag is false.
* All existing tests pass; call sites updated to pass `TOOLS_AFTER_SYSTEM` explicitly so behavior is unchanged when the flag is off.

Run with:

```
make test
# or, to run just the model-free tests:
./ds4_test --server
```

## Usage

```
./ds4-server [other flags] --tools-prepend-system
```

Startup will print:

```
ds4-server: tool schemas rendered before client system content
```

Recommended companion flags for tool-using agents with a small dynamic tail:

```
./ds4-server [other flags] \
  --kv-disk-dir /path/to/cache \
  --kv-disk-space-mb 8192 \
  --kv-cache-boundary-align-tokens 2048 \
  --kv-cache-boundary-trim-tokens 1000 \
  --tools-prepend-system
```

The trim of 1000 with align of 2048 lands the cold cut at a prefill-batch-aligned position safely below typical dynamic tails. Adjust trim downward if the dynamic tail is smaller, or upward if it is larger.
