### PR TITLE
Fix thinking checkpoint rebuild on length stop

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -6624,6 +6624,17 @@ static thinking_state thinking_state_from_prompt(const request *r) {
     return st;
 }
 
+static bool should_canonicalize_thinking_checkpoint(const request *r,
+                                                    const thinking_state *thinking,
+                                                    const char *finish) {
+    if (!r || r->kind != REQ_CHAT || r->has_tools) return false;
+    if (r->prompt_preserves_reasoning) return false;
+    if (!ds4_think_mode_enabled(r->think_mode)) return false;
+    if (finish && (!strcmp(finish, "error") || !strcmp(finish, "length"))) return false;
+    if (thinking && thinking->inside) return false;
+    return true;
+}
+
 static void log_tool_calls_summary(const char *ctx, const tool_calls *calls) {
     if (!calls || calls->len == 0) return;
     buf names = {0};
@@ -7353,10 +7364,8 @@ static void generate_job(server *s, job *j) {
         canonicalize_tool_checkpoint(s, j, ctx_span, trace_id,
                                      parsed_content ? parsed_content : "",
                                      parsed_reasoning, &parsed_calls);
-    } else if (j->req.kind == REQ_CHAT && !parsed_calls.len &&
-               !j->req.prompt_preserves_reasoning &&
-               ds4_think_mode_enabled(j->req.think_mode) &&
-               strcmp(final_finish, "error") != 0) {
+    } else if (!parsed_calls.len &&
+               should_canonicalize_thinking_checkpoint(&j->req, &thinking, final_finish)) {
         canonicalize_thinking_checkpoint(s, j, ctx_span, trace_id,
                                          parsed_content ? parsed_content : "");
     }
@@ -9608,6 +9617,31 @@ static void test_thinking_state_tracks_prompt_and_generated_tags(void) {
     request_free(&r);
 }
 
+static void test_thinking_checkpoint_canonicalization_gate(void) {
+    request r;
+    request_init(&r, REQ_CHAT, 128);
+    r.think_mode = DS4_THINK_HIGH;
+    thinking_state st = {.inside = true};
+
+    TEST_ASSERT(!should_canonicalize_thinking_checkpoint(&r, &st, "length"));
+    TEST_ASSERT(!should_canonicalize_thinking_checkpoint(&r, &st, "stop"));
+
+    st.inside = false;
+    TEST_ASSERT(!should_canonicalize_thinking_checkpoint(&r, &st, "length"));
+    TEST_ASSERT(should_canonicalize_thinking_checkpoint(&r, &st, "stop"));
+
+    r.prompt_preserves_reasoning = true;
+    TEST_ASSERT(!should_canonicalize_thinking_checkpoint(&r, &st, "stop"));
+    r.prompt_preserves_reasoning = false;
+    r.has_tools = true;
+    TEST_ASSERT(!should_canonicalize_thinking_checkpoint(&r, &st, "stop"));
+    r.has_tools = false;
+    r.think_mode = DS4_THINK_NONE;
+    TEST_ASSERT(!should_canonicalize_thinking_checkpoint(&r, &st, "stop"));
+
+    request_free(&r);
+}
+
 static void test_tool_marker_state_ignores_orphan_end(void) {
     bool saw_start = false;
     bool saw_end = false;
@@ -10285,6 +10319,7 @@ static void ds4_server_unit_tests_run(void) {
     test_model_metadata_clamps_completion_to_context();
     test_client_socket_nonblocking_flag();
     test_thinking_state_tracks_prompt_and_generated_tags();
+    test_thinking_checkpoint_canonicalization_gate();
     test_tool_marker_state_ignores_orphan_end();
     test_canonical_rewrite_rebuilds_when_live_tail_changes();
     test_kv_cache_store_len_uses_configured_boundary();


### PR DESCRIPTION
Solving #76 
Length-stopped chat/thinking requests were synchronously rebuilding the thinking checkpoint before returning the response. Skip canonicalization for incomplete thinking turns so client wall time reflects the sampled response.

Client results before the patch:

Context | Prompt TPS | Gen TPS | Gen Tokens | Total Time --------|------------|---------|------------|------------
   0.5k |      230.0 |    23.6 |        128 |       7.3s
     1k |      296.5 |    20.4 |        128 |       9.0s
     2k |      366.3 |    12.4 |        128 |      15.7s
     4k |      308.2 |     7.4 |        128 |      30.0s

Client results after the patch:

Context | Prompt TPS | Gen TPS | Gen Tokens | Total Time --------|------------|---------|------------|------------
   0.5k |      239.1 |    38.8 |        128 |       5.2s
     1k |      295.3 |    38.6 |        128 |       6.0s
     2k |      357.3 |    33.2 |        128 |       9.4s
     4k |      307.9 |    31.0 |        128 |      17.1s

Tested with:
make all ds4_test && make test