### PR TITLE
Fix Metal startup when default device is unavailable

### DIFF
--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -2664,6 +2664,14 @@ int ds4_gpu_init(void) {
     @autoreleasepool {
         g_device = MTLCreateSystemDefaultDevice();
         if (!g_device) {
+            NSArray<id<MTLDevice>> *devices = MTLCopyAllDevices();
+            if ([devices count] > 0) {
+                g_device = devices[0];
+                fprintf(stderr, "ds4: default Metal device unavailable; using enumerated device %s\n",
+                        g_device.name ? [g_device.name UTF8String] : "unknown Metal device");
+            }
+        }
+        if (!g_device) {
             fprintf(stderr, "ds4: Metal device not available\n");
             return 0;
         }


### PR DESCRIPTION
## Summary

Some macOS systems can enumerate a usable Metal device via `MTLCopyAllDevices()` while `MTLCreateSystemDefaultDevice()` still returns nil. In that state ds4 aborts during startup with:

```text
ds4: Metal device not available
ds4: metal backend unavailable; aborting startup
```

This change keeps the existing default-device path, but if it returns nil, falls back to the first device returned by `MTLCopyAllDevices()`. When that fallback is used, ds4 logs the selected device name before continuing normal Metal initialization.

## Why

On an Apple M3 Max machine, `system_profiler` reported Metal support and a standalone probe showed:

```text
device count: 1
default: nil
```

Before this patch, ds4 could not start because it only used `MTLCreateSystemDefaultDevice()`. After the patch, the same machine starts successfully:

```text
ds4: default Metal device unavailable; using enumerated device Apple M3 Max
ds4: Metal device Apple M3 Max, 64.00 GiB RAM
```

## Validation

- Rebuilt `ds4`, `ds4-server`, and `ds4-bench` with `make`
- Ran `./ds4 --ctx 4096 --inspect` successfully on the affected M3 Max machine
