### PR TITLE
Fix file paths in README for benchmark prompt and SVG generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Q4 requires the larger-memory machine class, so M3 Max Q4 numbers are `N/A`.
 | Mac Studio M3 Ultra, 512 GB | q4 | 12018 tokens | 448.82 t/s | 26.62 t/s |
 | DGX Spark GB10, 128 GB | q2 | 7047 tokens | 343.81 t/s | 13.75 t/s |
 
-![M3 Max t/s](spend-bench/m3_max_ts.svg)
+![M3 Max t/s](speed-bench/m3_max_ts.svg)
 
 ## Benchmarking
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Q4 requires the larger-memory machine class, so M3 Max Q4 numbers are `N/A`.
 | Mac Studio M3 Ultra, 512 GB | q4 | 12018 tokens | 448.82 t/s | 26.62 t/s |
 | DGX Spark GB10, 128 GB | q2 | 7047 tokens | 343.81 t/s | 13.75 t/s |
 
-![M3 Max t/s](bench/m3_max_ts.svg)
+![M3 Max t/s](spend-bench/m3_max_ts.svg)
 
 ## Benchmarking
 
@@ -137,7 +137,7 @@ greedy non-EOS probe, restores the memory snapshot, and continues prefill.
 ```sh
 ./ds4-bench \
   -m ds4flash.gguf \
-  --prompt-file bench/promessi_sposi.txt \
+  --prompt-file speed-bench/promessi_sposi.txt \
   --ctx-start 2048 \
   --ctx-max 65536 \
   --step-incr 2048 \

--- a/speed-bench/README.md
+++ b/speed-bench/README.md
@@ -25,4 +25,4 @@ python3 speed-bench/plot_speed.py speed-bench/m3_max.csv --title "M3 Max t/s"
 ```
 
 The script uses only the Python standard library. By default it writes a file
-next to the CSV using the `_ts.svg` suffix, such as `bench/m3_max_ts.svg`.
+next to the CSV using the `_ts.svg` suffix, such as `speed-bench/m3_max_ts.svg`.

--- a/speed-bench/README.md
+++ b/speed-bench/README.md
@@ -7,7 +7,7 @@ Run `ds4-bench` as:
 ```
 ./ds4-bench \
   -m ds4flash.gguf \
-  --prompt-file bench/promessi_sposi.txt \
+  --prompt-file speed-bench/promessi_sposi.txt \
   --ctx-start 2048 \
   --ctx-max 65536 \
   --step-incr 2048 \
@@ -21,7 +21,7 @@ it is clear what hardware was used for the benchmark.
 To generate an SVG graph from a CSV file:
 
 ```
-python3 bench/plot_speed.py bench/m3_max.csv --title "M3 Max t/s"
+python3 speed-bench/plot_speed.py speed-bench/m3_max.csv --title "M3 Max t/s"
 ```
 
 The script uses only the Python standard library. By default it writes a file


### PR DESCRIPTION
The rename of the folder was not reported in the readme. Although easy to understand, in this way it is immediate to launch the commands
