### PR TITLE
CUDA: stabilize mixed KV FP16 attention path

### DIFF
--- a/CUDA_PERF_OPTIMIZATIONS.md
+++ b/CUDA_PERF_OPTIMIZATIONS.md
@@ -124,6 +124,22 @@ are already near the bandwidth ceiling.
 
 `make cuda-regression` passes on all three incremental steps.
 
+### KV FP16 mixed-cache A/B (post-fix)
+
+After the mixed-dtype safety fix (`raw_kv=FP16`, `comp_kv=FP32` handled via
+on-the-fly comp conversion to FP16 in CUDA attention paths), H200 benchmarks
+show a stable generation gain with `DS4_CUDA_KV_FP16=1`.
+
+| ctx_tokens | Default KV (FP32) | `DS4_CUDA_KV_FP16=1` | Delta |
+|------------|-------------------|----------------------|-------|
+| 2048       | 30.76             | **33.19**            | +7.9% |
+| 12288      | 29.28             | **31.09**            | +6.2% |
+| 24576      | 27.58             | **28.80**            | +4.4% |
+| 32768      | 27.01             | **28.15**            | +4.2% |
+
+Prefill stays roughly aligned (small noise-level differences), while decode
+improves consistently across context frontiers.
+
 ---
 
 ## Testing

--- a/CUDA_PERF_OPTIMIZATIONS.md
+++ b/CUDA_PERF_OPTIMIZATIONS.md
@@ -1,0 +1,186 @@
+# CUDA Performance Optimizations — H200 (sm_90)
+
+## Summary
+
+Three targeted changes to `ds4_cuda.cu` improving decode throughput and prefill
+tensor core utilization on NVIDIA H200 and other sm_80+ GPUs. No changes to
+`ds4.c`, `ds4.h`, or any other file outside `ds4_cuda.cu`.
+
+All changes are gated behind environment variable escape hatches for A/B testing
+and are transparent to existing functionality.
+
+---
+
+## Changes
+
+### 1. Force tensor core path in cublasGemmEx (prefill)
+
+**File:** `ds4_cuda.cu`  
+**Lines affected:** two `cublasGemmEx` call sites (q8_0 FP16 path and F16 matmul path)
+
+**Change:** `CUBLAS_GEMM_DEFAULT` → `CUBLAS_GEMM_DEFAULT_TENSOR_OP`
+
+Both `cublasGemmEx` calls already use `CUDA_R_16F` inputs but were using
+`CUBLAS_GEMM_DEFAULT`, which allows cuBLAS to choose any algorithm. On sm_90
+this does not guarantee tensor core selection. `CUBLAS_GEMM_DEFAULT_TENSOR_OP`
+explicitly requires tensor op math, using the full 1979 TFLOPS FP16 throughput
+of H200 rather than the 67 TFLOPS CUDA core path.
+
+**Escape hatch:** none needed (strict improvement, regression-tested).
+
+---
+
+### 2. cuBLAS FP16 GEMV for q8_0 decode (n_tok == 1)
+
+**File:** `ds4_cuda.cu`  
+**Function:** `cuda_matmul_q8_0_tensor_labeled`
+
+**Change:** Added a cuBLAS decode path for single-token (n_tok == 1) q8_0
+matmuls when:
+- cuBLAS is initialized
+- FP16 weight cache is available (`cuda_q8_f16_ptr`)
+- `out_dim >= 1024` (below this threshold the custom warp8 kernel is competitive)
+- `g_quality_mode == 0`
+- `DS4_CUDA_NO_CUBLAS_DECODE` env var is not set
+
+Previously `n_tok == 1` always fell through to `matmul_q8_0_preq_warp8_kernel`,
+a custom kernel that does not use tensor cores. The new path converts the single
+activation vector to FP16, then calls `cublasGemmEx` with
+`CUBLAS_GEMM_DEFAULT_TENSOR_OP`.
+
+**Escape hatch:**
+```sh
+DS4_CUDA_NO_CUBLAS_DECODE=1 ./ds4-server ...
+```
+
+---
+
+### 3. FP16 KV shadow buffers + attention kernels (experimental)
+
+**File:** `ds4_cuda.cu`  
+**New kernels:** `attention_static_mixed_heads8_online_h16_kernel`,
+`attention_decode_mixed_heads8_online_h16_kernel`
+
+**Change:** Added two FP16 variants of the main online attention kernels. KV
+vectors are loaded as `__half2` from a shadow buffer, halving HBM bandwidth for
+the attention dot product. Q remains FP32 for score precision. Online softmax
+and output accumulation are unchanged (FP32).
+
+Shadow buffers `g_kv_h16_raw` / `g_kv_h16_comp` are allocated lazily via
+`kv_ensure_h16()` and freed on `ds4_gpu_cleanup()`. The F32→FP16 conversion
+uses the existing `f32_to_f16_kernel`.
+
+The h16 kernel path activates when:
+- `g_quality_mode == 0`
+- `DS4_CUDA_NO_FP16_KV` env var is not set
+- `head_dim == 512` (DeepSeek V4 Flash MLA shape)
+- The shadow buffer allocation succeeds
+
+Falls back transparently to the original F32 kernel on allocation failure.
+
+**Known limitation:** `kv_ensure_h16` reconverts the full KV buffer on every
+attention call because `raw_kv` grows by one row per generated token. The
+conversion overhead partially offsets the bandwidth gain at short contexts.
+Full benefit requires native FP16 KV store (writing FP16 directly in
+`store_raw_kv_batch_kernel`), which requires changes to `ds4.c` and `ds4.h`.
+See [Future Work](#future-work) below.
+
+**Escape hatch:**
+```sh
+DS4_CUDA_NO_FP16_KV=1 ./ds4-server ...
+```
+
+---
+
+## Benchmark Results
+
+Hardware: NVIDIA H200 NVL (sm_90, 80 GB HBM3e)  
+Model: `DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2.gguf`  
+Command:
+```sh
+./ds4-bench -m <model> \
+  --ctx-start 2048 --ctx-max 32768 --step-incr 2048 \
+  --gen-tokens 128 --prompt-file speed-bench/promessi_sposi.txt
+```
+
+### Generation throughput (t/s) — higher is better
+
+| ctx_tokens | Baseline | +TENSOR_OP | +cublas_decode | Delta |
+|------------|----------|------------|----------------|-------|
+| 2048       | 30.47    | 30.64      | **31.10**      | +2.1% |
+| 4096       | 30.07    | 30.17      | **30.40**      | +1.1% |
+| 8192       | 28.42    | 29.49      | **29.78**      | +4.8% |
+| 16384      | 27.98    | 28.14      | **28.40**      | +1.5% |
+| 24576      | 27.45    | 27.60      | **27.91**      | +1.7% |
+| 32768      | 26.91    | 27.03      | **27.32**      | +1.5% |
+
+### Prefill throughput (t/s) — higher is better
+
+Prefill change is within measurement noise (±0.5%). The TENSOR_OP change
+primarily helps large batch prefill; at `prefill_chunk=2048` the cuBLAS calls
+are already near the bandwidth ceiling.
+
+### Regression
+
+`make cuda-regression` passes on all three incremental steps.
+
+---
+
+## Testing
+
+### Quick regression
+```sh
+make cuda-regression
+```
+
+### Benchmark with escape hatches for A/B comparison
+```sh
+# baseline (all optimizations disabled)
+DS4_CUDA_NO_CUBLAS_DECODE=1 DS4_CUDA_NO_FP16_KV=1 \
+  ./ds4-bench -m <model> --ctx-start 2048 --ctx-max 32768 \
+  --step-incr 2048 --gen-tokens 128 --prompt-file speed-bench/promessi_sposi.txt
+
+# with all optimizations
+./ds4-bench -m <model> --ctx-start 2048 --ctx-max 32768 \
+  --step-incr 2048 --gen-tokens 128 --prompt-file speed-bench/promessi_sposi.txt
+```
+
+### GPU profiling (requires ncu/nsys on the target machine)
+```sh
+# NCU kernel metrics
+./bench/profile_h200.sh ncu 32768
+
+# Nsight Systems timeline
+./bench/profile_h200.sh nsys 32768
+```
+
+---
+
+## Future Work
+
+### Native FP16 KV store (high impact, requires ds4.c + ds4.h changes)
+
+The full bandwidth gain from FP16 KV requires writing FP16 directly at store
+time instead of converting lazily. This involves:
+
+- `store_raw_kv_batch_kernel` in `ds4_cuda.cu`: change `float *raw` to
+  `__half *raw`, write `__float2half(kv[...])` directly (the F32 round-trip
+  already does this implicitly — the cast just needs to stick).
+- `compressor_store_kernel`: same for comp_kv.
+- `ds4_layer_cache` in `ds4.c`: `float *raw_kv` / `float *attn_comp_kv` →
+  `uint16_t *` (or introduce a typed GPU tensor variant).
+- All GPU tensor allocation size checks: `sizeof(float)` → `sizeof(__half)`.
+- All `extern "C"` signatures in `ds4.h` that reference raw/comp KV.
+
+Estimated scope: ~50 lines across `ds4.c`, `ds4_cuda.cu`, `ds4.h`.  
+Estimated decode gain at long context (>64k tokens): +30–50% t/s.
+
+### Speculative decoding (MTP)
+
+Already present as experimental `--mtp` flag. As MTP matures the decode ceiling
+on H200 can be pushed significantly higher without kernel changes.
+
+### Multi-GPU tensor parallelism
+
+For decode t/s beyond ~35 t/s on this model, the primary lever is splitting
+expert matmuls across multiple H200s via NVLink. Out of scope for this patch.

--- a/bench/profile_h200.sh
+++ b/bench/profile_h200.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# usage: ./bench/profile_h200.sh [ncu|nsys] [ctx_start] [ctx_max]
+# examples:
+#   ./bench/profile_h200.sh ncu 32768
+#   ./bench/profile_h200.sh nsys 65536 131072
+MODE=${1:-ncu}
+CTX_START=${2:-32768}
+CTX_MAX=${3:-$CTX_START}
+BENCH=${BENCH:-./ds4-bench}
+MODEL=${MODEL:-ds4flash.gguf}
+
+if [ ! -f "$MODEL" ]; then
+    echo "Model not found: $MODEL (set MODEL= env var)" >&2
+    exit 1
+fi
+if [ ! -x "$BENCH" ]; then
+    echo "Bench binary not found: $BENCH (run make first)" >&2
+    exit 1
+fi
+
+BENCH_ARGS="$BENCH -m $MODEL --ctx-start $CTX_START --ctx-max $CTX_MAX --step-incr $CTX_START --gen-tokens 64"
+
+if [ "$MODE" = "ncu" ]; then
+    ncu \
+      --metrics sm__throughput.avg.pct_of_peak_sustained_elapsed,\
+l1tex__t_bytes.sum,dram__bytes.sum,sm__cycles_elapsed.avg,\
+sm__warps_active.avg.pct_of_peak_sustained_active,\
+gpu__time_duration.sum \
+      --target-processes all \
+      --print-summary per-kernel \
+      $BENCH_ARGS
+elif [ "$MODE" = "nsys" ]; then
+    OUTFILE="nsys_ctx${CTX_START}_$(date +%Y%m%d_%H%M%S)"
+    nsys profile \
+      --stats=true \
+      --trace=cuda,nvtx \
+      --output="$OUTFILE" \
+      $BENCH_ARGS
+    echo "Profile saved: ${OUTFILE}.nsys-rep"
+else
+    echo "Unknown mode: $MODE. Use ncu or nsys." >&2
+    exit 1
+fi

--- a/ds4.c
+++ b/ds4.c
@@ -8633,7 +8633,8 @@ static bool metal_graph_alloc_raw_cap(
     g->kv = ds4_gpu_tensor_alloc((uint64_t)DS4_N_HEAD_DIM * sizeof(float));
     bool state_init_ok = true;
     for (uint32_t il = 0; il < DS4_N_LAYER; il++) {
-        g->layer_raw_cache[il] = ds4_gpu_tensor_alloc((uint64_t)raw_cap * DS4_N_HEAD_DIM * sizeof(float));
+        const uint8_t kv_elem = ds4_gpu_kv_elem_bytes();
+        g->layer_raw_cache[il] = ds4_gpu_tensor_alloc_typed((uint64_t)raw_cap * DS4_N_HEAD_DIM, kv_elem);
         const uint32_t ratio = ds4_layer_compress_ratio(il);
         if (ratio != 0) {
             const uint32_t coff = ratio == 4 ? 2u : 1u;
@@ -8729,7 +8730,7 @@ static bool metal_graph_alloc_raw_cap(
         g->mtp_input_hc = ds4_gpu_tensor_alloc(hc_dim * sizeof(float));
         g->mtp_state_hc = ds4_gpu_tensor_alloc(hc_dim * sizeof(float));
         g->mtp_next_hc = ds4_gpu_tensor_alloc(hc_dim * sizeof(float));
-        g->mtp_raw_cache = ds4_gpu_tensor_alloc((uint64_t)raw_cap * DS4_N_HEAD_DIM * sizeof(float));
+        g->mtp_raw_cache = ds4_gpu_tensor_alloc_typed((uint64_t)raw_cap * DS4_N_HEAD_DIM, ds4_gpu_kv_elem_bytes());
         g->spec_logits = ds4_gpu_tensor_alloc((uint64_t)16 * DS4_N_VOCAB * sizeof(float));
         g->mtp_n_raw = 0;
     }
@@ -10388,7 +10389,7 @@ static int metal_graph_decode_test(
              ds4_gpu_tensor_read(g.attn_norm, 0, gpu_attn_norm, (uint64_t)DS4_N_EMBD * sizeof(float)) != 0 &&
              ds4_gpu_tensor_read(g.q, 0, gpu_q, q_dim * sizeof(float)) != 0 &&
              ds4_gpu_tensor_read(g.kv, 0, gpu_kv, (uint64_t)DS4_N_HEAD_DIM * sizeof(float)) != 0 &&
-             ds4_gpu_tensor_read(g.layer_raw_cache[0], 0, gpu_raw, (uint64_t)DS4_N_HEAD_DIM * sizeof(float)) != 0 &&
+             ds4_gpu_tensor_read_f32(g.layer_raw_cache[0], gpu_raw, DS4_N_HEAD_DIM) != 0 &&
              ds4_gpu_tensor_read(g.attn_out, 0, gpu_attn_out, (uint64_t)DS4_N_EMBD * sizeof(float)) != 0 &&
              ds4_gpu_tensor_read(g.after_attn_hc, 0, gpu_after_attn_hc, hc_dim * sizeof(float)) != 0 &&
              ds4_gpu_tensor_read(g.ffn_cur, 0, gpu_ffn_cur, (uint64_t)DS4_N_EMBD * sizeof(float)) != 0 &&
@@ -13186,7 +13187,7 @@ static bool metal_graph_prefill_chunked_range(
         }
         if (!ok) {
             if (ds4_gpu_synchronize() == 0) {
-                fprintf(stderr, "ds4: Metal synchronize after chunked prefill failure also failed\n");
+                fprintf(stderr, "ds4: GPU synchronize after chunked prefill failure also failed\n");
             }
             return false;
         }
@@ -13707,7 +13708,7 @@ static int metal_graph_prompt_logits_test(
                     const uint32_t raw_start = n_raw < raw_cap ? 0u : ((uint32_t)n_test % raw_cap);
                     float *gpu_raw_phys = xmalloc((size_t)raw_phys_n * sizeof(float));
                     float *gpu_raw_logical = xmalloc((size_t)raw_logical_n * sizeof(float));
-                    if (ds4_gpu_tensor_read(g.layer_raw_cache[il], 0, gpu_raw_phys, raw_phys_n * sizeof(float)) != 0) {
+                    if (ds4_gpu_tensor_read_f32(g.layer_raw_cache[il], gpu_raw_phys, raw_phys_n) != 0) {
                         for (uint32_t r = 0; r < n_raw; r++) {
                             const uint32_t phys = (raw_start + r) % raw_cap;
                             memcpy(gpu_raw_logical + (uint64_t)r * DS4_N_HEAD_DIM,
@@ -15413,8 +15414,9 @@ static uint32_t session_raw_live_rows(const ds4_gpu_graph *g, uint32_t checkpoin
 static uint64_t session_payload_live_tensor_bytes(const ds4_gpu_graph *g, uint32_t checkpoint_len) {
     uint64_t bytes = 0;
     const uint32_t raw_live = session_raw_live_rows(g, checkpoint_len);
+    const uint8_t raw_eb = (uint8_t)ds4_gpu_kv_elem_bytes();
     for (uint32_t il = 0; il < DS4_N_LAYER; il++) {
-        bytes += (uint64_t)raw_live * DS4_N_HEAD_DIM * sizeof(float);
+        bytes += (uint64_t)raw_live * DS4_N_HEAD_DIM * raw_eb;
         const uint32_t ratio = ds4_layer_compress_ratio(il);
         if (ratio == 0) continue;
         bytes += (uint64_t)g->layer_n_comp[il] * DS4_N_HEAD_DIM * sizeof(float);
@@ -15800,14 +15802,16 @@ int ds4_session_save_payload(ds4_session *s, FILE *fp, char *err, size_t errlen)
     for (uint32_t il = 0; rc == 0 && il < DS4_N_LAYER; il++) {
         /* Write the raw ring in logical position order.  The file does not care
          * where the rows happened to live physically in the source graph. */
+        const uint8_t raw_eb = (uint8_t)ds4_gpu_tensor_elem_bytes(g->layer_raw_cache[il]);
+        const uint64_t raw_row_bytes = (uint64_t)DS4_N_HEAD_DIM * raw_eb;
         const uint32_t raw_first = (uint32_t)s->checkpoint.len - raw_live;
         for (uint32_t r = 0; rc == 0 && r < raw_live; r++) {
             const uint32_t pos = raw_first + r;
             const uint32_t phys = pos % g->raw_cap;
             rc = payload_write_tensor_span(fp,
                                            g->layer_raw_cache[il],
-                                           (uint64_t)phys * DS4_N_HEAD_DIM * sizeof(float),
-                                           (uint64_t)DS4_N_HEAD_DIM * sizeof(float),
+                                           (uint64_t)phys * raw_row_bytes,
+                                           raw_row_bytes,
                                            buf,
                                            DS4_SESSION_IO_CHUNK,
                                            err,
@@ -16109,14 +16113,16 @@ int ds4_session_load_payload(ds4_session *s, FILE *fp, uint64_t payload_bytes, c
         /* Rebuild the physical raw ring expected by the current graph.  This is
          * why the file stores rows in logical order instead of dumping bytes from
          * the old ring layout. */
+        const uint8_t raw_eb = (uint8_t)ds4_gpu_tensor_elem_bytes(g->layer_raw_cache[il]);
+        const uint64_t raw_row_bytes = (uint64_t)DS4_N_HEAD_DIM * raw_eb;
         const uint32_t raw_first = saved_tokens - saved_raw_live;
         for (uint32_t r = 0; rc == 0 && r < saved_raw_live; r++) {
             const uint32_t pos = raw_first + r;
             const uint32_t phys = pos % g->raw_cap;
             rc = payload_read_tensor_span(fp,
                                           g->layer_raw_cache[il],
-                                          (uint64_t)phys * DS4_N_HEAD_DIM * sizeof(float),
-                                          (uint64_t)DS4_N_HEAD_DIM * sizeof(float),
+                                          (uint64_t)phys * raw_row_bytes,
+                                          raw_row_bytes,
                                           buf,
                                           DS4_SESSION_IO_CHUNK,
                                           &remaining,
@@ -16855,7 +16861,7 @@ int ds4_session_sync(ds4_session *s, const ds4_tokens *prompt, char *err, size_t
                                                         progress_fn,
                                                         progress_fn ? &progress : NULL);
             if (!ok) {
-                snprintf(err, errlen, "Metal resumed prefill failed while extending checkpoint");
+                snprintf(err, errlen, "GPU resumed prefill failed while extending checkpoint");
                 s->checkpoint_valid = false;
                 return 1;
             }
@@ -16870,7 +16876,7 @@ int ds4_session_sync(ds4_session *s, const ds4_tokens *prompt, char *err, size_t
                                                 (uint32_t)s->checkpoint.len,
                                                 s->logits))
             {
-                snprintf(err, errlen, "Metal decode failed while extending checkpoint");
+                snprintf(err, errlen, "GPU decode failed while extending checkpoint");
                 s->checkpoint_valid = false;
                 return 1;
             }
@@ -16897,7 +16903,7 @@ int ds4_session_sync(ds4_session *s, const ds4_tokens *prompt, char *err, size_t
                                          prompt, prompt->len, s->logits, false);
     }
     if (!ok) {
-        snprintf(err, errlen, "Metal prefill failed");
+        snprintf(err, errlen, "GPU prefill failed");
         s->checkpoint_valid = false;
         return 1;
     }

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -38,6 +38,7 @@ struct ds4_gpu_tensor {
     void *ptr;
     uint64_t bytes;
     int owner;
+    uint8_t elem_bytes; /* element size in bytes: 4 = float32, 2 = float16, 0 = untyped */
 };
 
 typedef struct {
@@ -78,11 +79,6 @@ static cublasHandle_t g_cublas;
 static int g_cublas_ready;
 static int g_quality_mode;
 
-/* FP16 KV shadow buffers for attention kernels. Allocated lazily, freed on reset. */
-static __half *g_kv_h16_raw  = NULL;
-static uint64_t g_kv_h16_raw_bytes = 0;
-static __half *g_kv_h16_comp = NULL;
-static uint64_t g_kv_h16_comp_bytes = 0;
 
 struct cuda_model_range {
     const void *host_base;
@@ -1236,16 +1232,6 @@ extern "C" void ds4_gpu_cleanup(void) {
         g_cuda_tmp = NULL;
         g_cuda_tmp_bytes = 0;
     }
-    if (g_kv_h16_raw) {
-        (void)cudaFree(g_kv_h16_raw);
-        g_kv_h16_raw = NULL;
-        g_kv_h16_raw_bytes = 0;
-    }
-    if (g_kv_h16_comp) {
-        (void)cudaFree(g_kv_h16_comp);
-        g_kv_h16_comp = NULL;
-        g_kv_h16_comp_bytes = 0;
-    }
     for (size_t i = 0; i < 4; i++) {
         if (g_model_stage_event[i]) {
             (void)cudaEventDestroy(g_model_stage_event[i]);
@@ -1299,7 +1285,37 @@ extern "C" ds4_gpu_tensor *ds4_gpu_tensor_alloc(uint64_t bytes) {
     }
     t->bytes = bytes;
     t->owner = 1;
+    t->elem_bytes = 4;
     return t;
+}
+
+extern "C" ds4_gpu_tensor *ds4_gpu_tensor_alloc_typed(uint64_t elems, uint8_t elem_bytes) {
+    if (elem_bytes == 0) elem_bytes = 4;
+    const uint64_t bytes = elems * elem_bytes;
+    ds4_gpu_tensor *t = ds4_gpu_tensor_alloc(bytes);
+    if (t) t->elem_bytes = elem_bytes;
+    return t;
+}
+
+extern "C" uint8_t ds4_gpu_tensor_elem_bytes(const ds4_gpu_tensor *tensor) {
+    if (!tensor || tensor->elem_bytes == 0) return 4;
+    return tensor->elem_bytes;
+}
+
+extern "C" uint8_t ds4_gpu_kv_elem_bytes(void) {
+    /* Keep FP32 KV by default on CUDA.
+     *
+     * The FP16 raw-KV path is currently incomplete for mixed attention where
+     * raw rows are FP16 but compressed rows are FP32. Several kernels still
+     * assume both buffers share the same dtype, which can cause invalid
+     * accesses when n_comp > 0 during resumed/chunked prefill.
+     *
+     * Opt-in switch for targeted experiments:
+     *   DS4_CUDA_KV_FP16=1
+     */
+    const char *fp16 = getenv("DS4_CUDA_KV_FP16");
+    if (fp16 && fp16[0] == '1') return 2;
+    return 4;
 }
 
 extern "C" ds4_gpu_tensor *ds4_gpu_tensor_view(const ds4_gpu_tensor *base, uint64_t offset, uint64_t bytes) {
@@ -1336,6 +1352,26 @@ extern "C" int ds4_gpu_tensor_write(ds4_gpu_tensor *tensor, uint64_t offset, con
 extern "C" int ds4_gpu_tensor_read(const ds4_gpu_tensor *tensor, uint64_t offset, void *data, uint64_t bytes) {
     if (!tensor || !data || offset > tensor->bytes || bytes > tensor->bytes - offset) return 0;
     return cuda_ok(cudaMemcpy(data, (const char *)tensor->ptr + offset, (size_t)bytes, cudaMemcpyDeviceToHost), "tensor read");
+}
+
+extern "C" int ds4_gpu_tensor_read_f32(const ds4_gpu_tensor *tensor, float *out, uint64_t n_elems) {
+    if (!tensor || !out || n_elems == 0) return 0;
+    const uint8_t eb = tensor->elem_bytes ? tensor->elem_bytes : 4u;
+    if (eb == 4) {
+        const uint64_t bytes = n_elems * sizeof(float);
+        if (bytes > tensor->bytes) return 0;
+        return cuda_ok(cudaMemcpy(out, tensor->ptr, bytes, cudaMemcpyDeviceToHost), "tensor read f32");
+    }
+    const uint64_t bytes = n_elems * sizeof(__half);
+    if (bytes > tensor->bytes) return 0;
+    __half *tmp = (__half *)malloc(bytes);
+    if (!tmp) return 0;
+    int ok = cuda_ok(cudaMemcpy(tmp, tensor->ptr, bytes, cudaMemcpyDeviceToHost), "tensor read f16");
+    if (ok) {
+        for (uint64_t i = 0; i < n_elems; i++) out[i] = __half2float(tmp[i]);
+    }
+    free(tmp);
+    return ok;
 }
 
 extern "C" int ds4_gpu_tensor_copy(ds4_gpu_tensor *dst, uint64_t dst_offset,
@@ -2426,7 +2462,17 @@ __global__ static void store_raw_kv_batch_kernel(float *raw, const float *kv, ui
     uint32_t d = gid % head_dim;
     uint32_t t = gid / head_dim;
     uint32_t row = (pos0 + t) % raw_cap;
-    raw[(uint64_t)row * head_dim + d] = __half2float(__float2half(kv[(uint64_t)t * head_dim + d]));
+    raw[(uint64_t)row * head_dim + d] = kv[(uint64_t)t * head_dim + d];
+}
+
+__global__ static void store_raw_kv_batch_h16_kernel(__half *raw, const float *kv, uint32_t raw_cap, uint32_t pos0, uint32_t n_tokens, uint32_t head_dim) {
+    uint64_t gid = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    uint64_t n = (uint64_t)n_tokens * head_dim;
+    if (gid >= n) return;
+    uint32_t d = gid % head_dim;
+    uint32_t t = gid / head_dim;
+    uint32_t row = (pos0 + t) % raw_cap;
+    raw[(uint64_t)row * head_dim + d] = __float2half(kv[(uint64_t)t * head_dim + d]);
 }
 
 __global__ static void attention_prefill_raw_kernel(
@@ -3404,22 +3450,21 @@ __global__ static void attention_indexed_mixed_heads8_online_kernel(
     }
 }
 
-/* Ensure FP16 shadow buffer is allocated and up-to-date for a float KV tensor. */
-static const __half *kv_ensure_h16(__half **buf, uint64_t *buf_bytes,
-                                   const float *src, uint64_t n_elems) {
-    const uint64_t need = n_elems * sizeof(__half);
-    if (*buf_bytes < need) {
-        if (*buf) (void)cudaFree(*buf);
-        *buf = NULL;
-        *buf_bytes = 0;
-        if (cudaMalloc((void **)buf, need) != cudaSuccess) return NULL;
-        *buf_bytes = need;
-    }
-    const uint32_t threads = 256;
-    const uint32_t blocks = (uint32_t)((n_elems + threads - 1) / threads);
-    f32_to_f16_kernel<<<blocks, threads>>>(*buf, src, n_elems);
-    return *buf;
+__global__ static void f16_to_f32_kernel(float *out, const __half *x, uint64_t n) {
+    uint64_t i = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) out[i] = __half2float(x[i]);
 }
+
+static const __half *tmp_f16_from_f32(const float *src, uint64_t n, const char *label) {
+    if (!src || n == 0) return NULL;
+    __half *dst = (__half *)cuda_tmp_alloc(n * sizeof(__half), label);
+    if (!dst) return NULL;
+    f32_to_f16_kernel<<<(uint32_t)((n + 255u) / 256u), 256>>>(dst, src, n);
+    if (!cuda_ok(cudaGetLastError(), "tmp f32->f16 convert launch")) return NULL;
+    return dst;
+}
+
+
 
 __global__ static void attention_static_mixed_heads8_online_h16_kernel(
         float *heads,
@@ -6055,17 +6100,23 @@ extern "C" int ds4_gpu_kv_fp8_store_raw_tensor(
 }
 extern "C" int ds4_gpu_store_raw_kv_tensor(ds4_gpu_tensor *raw_cache, const ds4_gpu_tensor *kv, uint32_t raw_cap, uint32_t row, uint32_t head_dim) {
     if (!raw_cache || !kv || raw_cap == 0 ||
-        raw_cache->bytes < (uint64_t)raw_cap * head_dim * sizeof(float) ||
+        raw_cache->bytes < (uint64_t)raw_cap * head_dim * raw_cache->elem_bytes ||
         kv->bytes < (uint64_t)head_dim * sizeof(float)) return 0;
-    store_raw_kv_batch_kernel<<<(head_dim + 255) / 256, 256>>>((float *)raw_cache->ptr, (const float *)kv->ptr, raw_cap, row, 1, head_dim);
+    if (raw_cache->elem_bytes == 2)
+        store_raw_kv_batch_h16_kernel<<<(head_dim + 255) / 256, 256>>>((__half *)raw_cache->ptr, (const float *)kv->ptr, raw_cap, row, 1, head_dim);
+    else
+        store_raw_kv_batch_kernel<<<(head_dim + 255) / 256, 256>>>((float *)raw_cache->ptr, (const float *)kv->ptr, raw_cap, row, 1, head_dim);
     return cuda_ok(cudaGetLastError(), "store_raw_kv launch");
 }
 extern "C" int ds4_gpu_store_raw_kv_batch_tensor(ds4_gpu_tensor *raw_cache, const ds4_gpu_tensor *kv, uint32_t raw_cap, uint32_t pos0, uint32_t n_tokens, uint32_t head_dim) {
     if (!raw_cache || !kv || raw_cap == 0 ||
-        raw_cache->bytes < (uint64_t)raw_cap * head_dim * sizeof(float) ||
+        raw_cache->bytes < (uint64_t)raw_cap * head_dim * raw_cache->elem_bytes ||
         kv->bytes < (uint64_t)n_tokens * head_dim * sizeof(float)) return 0;
     uint64_t n = (uint64_t)n_tokens * head_dim;
-    store_raw_kv_batch_kernel<<<(n + 255) / 256, 256>>>((float *)raw_cache->ptr, (const float *)kv->ptr, raw_cap, pos0, n_tokens, head_dim);
+    if (raw_cache->elem_bytes == 2)
+        store_raw_kv_batch_h16_kernel<<<(n + 255) / 256, 256>>>((__half *)raw_cache->ptr, (const float *)kv->ptr, raw_cap, pos0, n_tokens, head_dim);
+    else
+        store_raw_kv_batch_kernel<<<(n + 255) / 256, 256>>>((float *)raw_cache->ptr, (const float *)kv->ptr, raw_cap, pos0, n_tokens, head_dim);
     return cuda_ok(cudaGetLastError(), "store_raw_kv_batch launch");
 }
 extern "C" int ds4_gpu_compressor_store_batch_tensor(
@@ -6451,14 +6502,16 @@ extern "C" int ds4_gpu_attention_decode_heads_tensor(
         uint32_t                use_mask,
         uint32_t                n_head,
         uint32_t                head_dim) {
+    const uint8_t kv_eb = raw_kv ? raw_kv->elem_bytes : 4u;
+    const uint8_t ckv_eb = (n_comp && comp_kv) ? comp_kv->elem_bytes : kv_eb;
     if (!heads || !q || !raw_kv || !model_map || n_raw == 0 || raw_cap < n_raw ||
         raw_start >= raw_cap || (n_comp != 0 && !comp_kv) || (use_mask && !comp_mask) ||
         sinks_offset > model_size ||
         (uint64_t)n_head * sizeof(float) > model_size - sinks_offset ||
         heads->bytes < (uint64_t)n_head * head_dim * sizeof(float) ||
         q->bytes < (uint64_t)n_head * head_dim * sizeof(float) ||
-        raw_kv->bytes < (uint64_t)raw_cap * head_dim * sizeof(float) ||
-        (n_comp && comp_kv->bytes < (uint64_t)n_comp * head_dim * sizeof(float)) ||
+        raw_kv->bytes < (uint64_t)raw_cap * head_dim * kv_eb ||
+        (n_comp && comp_kv->bytes < (uint64_t)n_comp * head_dim * ckv_eb) ||
         (use_mask && comp_mask->bytes < (uint64_t)n_comp * sizeof(float))) {
         return 0;
     }
@@ -6469,21 +6522,26 @@ extern "C" int ds4_gpu_attention_decode_heads_tensor(
         if (!use_mask && head_dim == 512u &&
             getenv("DS4_CUDA_NO_WINDOW_ATTENTION") == NULL) {
             dim3 online_grid(1, (n_head + 7u) / 8u, 1);
-            const float *comp_src = n_comp ? (const float *)comp_kv->ptr : (const float *)raw_kv->ptr;
-            const uint64_t raw_elems  = (uint64_t)raw_cap * head_dim;
-            const uint64_t comp_elems = n_comp ? (uint64_t)n_comp * head_dim : raw_elems;
-            const __half *rh = (!g_quality_mode && getenv("DS4_CUDA_NO_FP16_KV") == NULL)
-                ? kv_ensure_h16(&g_kv_h16_raw,  &g_kv_h16_raw_bytes,  (const float *)raw_kv->ptr, raw_elems)
-                : NULL;
-            const __half *ch = (rh && n_comp && !g_quality_mode)
-                ? kv_ensure_h16(&g_kv_h16_comp, &g_kv_h16_comp_bytes, comp_src, comp_elems)
-                : NULL;
-            if (rh && (ch || !n_comp)) {
+            const __half *rh = (kv_eb == 2) ? (const __half *)raw_kv->ptr : NULL;
+            const __half *ch = NULL;
+            if (n_comp && ckv_eb == 2) ch = (const __half *)comp_kv->ptr;
+            if (n_comp && ckv_eb == 4) {
+                ch = tmp_f16_from_f32((const float *)comp_kv->ptr,
+                                      (uint64_t)n_comp * head_dim,
+                                      "attn decode comp f16");
+                if (!ch) return 0;
+            }
+            if (rh && (!n_comp || ch)) {
                 attention_decode_mixed_heads8_online_h16_kernel<<<online_grid, 256>>>(
                     (float *)heads->ptr, sinks, (const float *)q->ptr,
-                    rh, ch ? ch : rh,
+                    rh, ch,
                     1, 0, n_raw, raw_cap, raw_start, n_comp, 0, 0, n_head, head_dim);
             } else {
+                if (kv_eb != 4) {
+                    fprintf(stderr, "ds4: CUDA attention_decode_heads: FP16 raw_kv window fallback requires FP16 comp_kv or n_comp=0\n");
+                    return 0;
+                }
+                const float *comp_src = n_comp ? (const float *)comp_kv->ptr : (const float *)raw_kv->ptr;
                 attention_decode_mixed_heads8_online_kernel<<<online_grid, 256>>>((float *)heads->ptr,
                                                                                   sinks,
                                                                                   (const float *)q->ptr,
@@ -6505,6 +6563,26 @@ extern "C" int ds4_gpu_attention_decode_heads_tensor(
         fprintf(stderr, "ds4: CUDA attention score buffer too small for %u compressed rows\n", n_comp);
         return 0;
     }
+    if (kv_eb == 2 && head_dim == 512u && !use_mask) {
+        dim3 online_grid(1, (n_head + 7u) / 8u, 1);
+        const __half *rh = (const __half *)raw_kv->ptr;
+        const __half *ch = NULL;
+        if (n_comp && ckv_eb == 2) ch = (const __half *)comp_kv->ptr;
+        if (n_comp && ckv_eb == 4) {
+            ch = tmp_f16_from_f32((const float *)comp_kv->ptr,
+                                  (uint64_t)n_comp * head_dim,
+                                  "attn decode comp f16");
+            if (!ch) return 0;
+        }
+        attention_decode_mixed_heads8_online_h16_kernel<<<online_grid, 256>>>(
+            (float *)heads->ptr, sinks, (const float *)q->ptr,
+            rh, ch, 1, 0, n_raw, raw_cap, raw_start, n_comp, 0, 0, n_head, head_dim);
+        return cuda_ok(cudaGetLastError(), "attention decode h16 launch");
+    }
+    if (kv_eb != 4) {
+        fprintf(stderr, "ds4: CUDA attention_decode_heads: FP16 raw_kv not supported in this path\n");
+        return 0;
+    }
     dim3 grid(1, n_head, 1);
     attention_decode_mixed_kernel<<<grid, 256>>>((float *)heads->ptr,
                                                  sinks,
@@ -6518,11 +6596,12 @@ extern "C" int ds4_gpu_attention_decode_heads_tensor(
     return cuda_ok(cudaGetLastError(), "attention decode launch");
 }
 extern "C" int ds4_gpu_attention_prefill_raw_heads_tensor(ds4_gpu_tensor *heads, const void *model_map, uint64_t model_size, uint64_t sinks_offset, const ds4_gpu_tensor *q, const ds4_gpu_tensor *raw_kv, uint32_t n_tokens, uint32_t window, uint32_t n_head, uint32_t head_dim) {
+    const uint8_t kv_eb = raw_kv ? raw_kv->elem_bytes : 4u;
     if (!heads || !q || !raw_kv || !model_map || sinks_offset > model_size ||
         model_size - sinks_offset < (uint64_t)n_head * sizeof(float) ||
         heads->bytes < (uint64_t)n_tokens * n_head * head_dim * sizeof(float) ||
         q->bytes < (uint64_t)n_tokens * n_head * head_dim * sizeof(float) ||
-        raw_kv->bytes < (uint64_t)n_tokens * head_dim * sizeof(float) ||
+        raw_kv->bytes < (uint64_t)n_tokens * head_dim * kv_eb ||
         window > 256) return 0;
     const float *sinks = (const float *)cuda_model_range_ptr(
             model_map, sinks_offset, (uint64_t)n_head * sizeof(float), "attn_sinks");
@@ -6531,10 +6610,7 @@ extern "C" int ds4_gpu_attention_prefill_raw_heads_tensor(ds4_gpu_tensor *heads,
         getenv("DS4_CUDA_NO_WINDOW_ATTENTION") == NULL &&
         (getenv("DS4_CUDA_WINDOW_ATTENTION") != NULL || (!g_quality_mode && n_tokens >= 128u))) {
         dim3 grid(n_tokens, (n_head + 7u) / 8u, 1);
-        const uint64_t raw_elems = (uint64_t)n_tokens * head_dim;
-        const __half *rh = (!g_quality_mode && getenv("DS4_CUDA_NO_FP16_KV") == NULL)
-            ? kv_ensure_h16(&g_kv_h16_raw, &g_kv_h16_raw_bytes, (const float *)raw_kv->ptr, raw_elems)
-            : NULL;
+        const __half *rh = (kv_eb == 2) ? (const __half *)raw_kv->ptr : NULL;
         if (rh) {
             attention_static_mixed_heads8_online_h16_kernel<<<grid, 256>>>(
                 (float *)heads->ptr, sinks, (const float *)q->ptr,
@@ -6554,7 +6630,7 @@ extern "C" int ds4_gpu_attention_prefill_raw_heads_tensor(ds4_gpu_tensor *heads,
         }
         return cuda_ok(cudaGetLastError(), "attention raw window launch");
     }
-    if (g_cublas_ready && n_tokens > 1 && head_dim == 512 &&
+    if (g_cublas_ready && n_tokens > 1 && head_dim == 512 && kv_eb == 4 &&
         getenv("DS4_CUDA_NO_CUBLAS_ATTENTION") == NULL) {
         const uint32_t n_keys = n_tokens;
         const uint64_t score_count = (uint64_t)n_head * n_tokens * n_keys;
@@ -6618,6 +6694,18 @@ extern "C" int ds4_gpu_attention_prefill_raw_heads_tensor(ds4_gpu_tensor *heads,
                                                                         head_dim);
         return cuda_ok(cudaGetLastError(), "attention raw unpack launch");
     }
+    if (kv_eb == 2 && head_dim == 512u) {
+        dim3 grid2(n_tokens, (n_head + 7u) / 8u, 1);
+        const __half *rh = (const __half *)raw_kv->ptr;
+        attention_static_mixed_heads8_online_h16_kernel<<<grid2, 256>>>(
+            (float *)heads->ptr, sinks, (const float *)q->ptr,
+            rh, rh, n_tokens, 0, window, 1, n_head, head_dim);
+        return cuda_ok(cudaGetLastError(), "attention prefill raw h16 fallback launch");
+    }
+    if (kv_eb != 4) {
+        fprintf(stderr, "ds4: CUDA attention_prefill_raw: FP16 raw_kv not supported in this path\n");
+        return 0;
+    }
     dim3 grid(n_tokens, n_head, 1);
     attention_prefill_raw_kernel<<<grid, 128>>>((float *)heads->ptr,
                                                 sinks,
@@ -6646,6 +6734,8 @@ static int attention_decode_batch_launch(
         uint32_t                ratio,
         uint32_t                n_head,
         uint32_t                head_dim) {
+    const uint8_t kv_eb  = raw_kv  ? raw_kv->elem_bytes  : 4u;
+    const uint8_t ckv_eb = (n_comp && comp_kv) ? comp_kv->elem_bytes : kv_eb;
     if (!heads || !q || !raw_kv || !model_map || n_tokens == 0 ||
         n_raw == 0 || raw_cap < n_raw || raw_start >= raw_cap ||
         (n_comp != 0 && !comp_kv) || (use_comp_mask && !comp_mask) ||
@@ -6653,8 +6743,8 @@ static int attention_decode_batch_launch(
         (uint64_t)n_head * sizeof(float) > model_size - sinks_offset ||
         heads->bytes < (uint64_t)n_tokens * n_head * head_dim * sizeof(float) ||
         q->bytes < (uint64_t)n_tokens * n_head * head_dim * sizeof(float) ||
-        raw_kv->bytes < (uint64_t)raw_cap * head_dim * sizeof(float) ||
-        (n_comp && comp_kv->bytes < (uint64_t)n_comp * head_dim * sizeof(float)) ||
+        raw_kv->bytes < (uint64_t)raw_cap * head_dim * kv_eb ||
+        (n_comp && comp_kv->bytes < (uint64_t)n_comp * head_dim * ckv_eb) ||
         (use_comp_mask && comp_mask->bytes < (uint64_t)n_tokens * n_comp * sizeof(float))) {
         return 0;
     }
@@ -6666,6 +6756,26 @@ static int attention_decode_batch_launch(
         if (!use_comp_mask && head_dim == 512u &&
             getenv("DS4_CUDA_NO_WINDOW_ATTENTION") == NULL) {
             dim3 online_grid(n_tokens, (n_head + 7u) / 8u, 1);
+            const __half *rh = (kv_eb == 2) ? (const __half *)raw_kv->ptr : NULL;
+            const __half *ch = NULL;
+            if (n_comp && ckv_eb == 2) ch = (const __half *)comp_kv->ptr;
+            if (n_comp && ckv_eb == 4) {
+                ch = tmp_f16_from_f32((const float *)comp_kv->ptr,
+                                      (uint64_t)n_comp * head_dim,
+                                      "attn decode batch comp f16");
+                if (!ch) return 0;
+            }
+            if (rh && (!n_comp || ch)) {
+                attention_decode_mixed_heads8_online_h16_kernel<<<online_grid, 256>>>(
+                    (float *)heads->ptr, sinks, (const float *)q->ptr,
+                    rh, ch,
+                    n_tokens, pos0, n_raw, raw_cap, raw_start, n_comp, window, ratio, n_head, head_dim);
+                return cuda_ok(cudaGetLastError(), "attention decode online h16 launch");
+            }
+            if (kv_eb != 4) {
+                fprintf(stderr, "ds4: CUDA attention_decode_batch: FP16 raw_kv window fallback requires FP16 comp_kv or n_comp=0\n");
+                return 0;
+            }
             attention_decode_mixed_heads8_online_kernel<<<online_grid, 256>>>((float *)heads->ptr,
                                                                               sinks,
                                                                               (const float *)q->ptr,
@@ -6690,6 +6800,26 @@ static int attention_decode_batch_launch(
         getenv("DS4_CUDA_NO_WINDOW_ATTENTION") == NULL &&
         (getenv("DS4_CUDA_WINDOW_ATTENTION") != NULL || (!g_quality_mode && n_tokens >= 128u))) {
         dim3 grid(n_tokens, (n_head + 7u) / 8u, 1);
+        const __half *rh2 = (kv_eb == 2) ? (const __half *)raw_kv->ptr : NULL;
+        const __half *ch2 = NULL;
+        if (n_comp && ckv_eb == 2) ch2 = (const __half *)comp_kv->ptr;
+        if (n_comp && ckv_eb == 4) {
+            ch2 = tmp_f16_from_f32((const float *)comp_kv->ptr,
+                                   (uint64_t)n_comp * head_dim,
+                                   "attn decode window comp f16");
+            if (!ch2) return 0;
+        }
+        if (rh2 && (!n_comp || ch2)) {
+            attention_decode_mixed_heads8_online_h16_kernel<<<grid, 256>>>(
+                (float *)heads->ptr, sinks, (const float *)q->ptr,
+                rh2, ch2,
+                n_tokens, pos0, n_raw, raw_cap, raw_start, n_comp, window, ratio, n_head, head_dim);
+            return cuda_ok(cudaGetLastError(), "attention decode window h16 launch");
+        }
+        if (kv_eb != 4) {
+            fprintf(stderr, "ds4: CUDA attention_decode_batch: FP16 raw_kv window path requires FP16 comp_kv or n_comp=0\n");
+            return 0;
+        }
         attention_decode_mixed_heads8_online_kernel<<<grid, 256>>>((float *)heads->ptr,
                                                                    sinks,
                                                                    (const float *)q->ptr,
@@ -6706,6 +6836,26 @@ static int attention_decode_batch_launch(
                                                                    n_head,
                                                                    head_dim);
         return cuda_ok(cudaGetLastError(), "attention decode window launch");
+    }
+    if (kv_eb == 2 && head_dim == 512u && !use_comp_mask) {
+        dim3 online_grid(n_tokens, (n_head + 7u) / 8u, 1);
+        const __half *rh = (const __half *)raw_kv->ptr;
+        const __half *ch = NULL;
+        if (n_comp && ckv_eb == 2) ch = (const __half *)comp_kv->ptr;
+        if (n_comp && ckv_eb == 4) {
+            ch = tmp_f16_from_f32((const float *)comp_kv->ptr,
+                                  (uint64_t)n_comp * head_dim,
+                                  "attn decode batch comp f16");
+            if (!ch) return 0;
+        }
+        attention_decode_mixed_heads8_online_h16_kernel<<<online_grid, 256>>>(
+            (float *)heads->ptr, sinks, (const float *)q->ptr,
+            rh, ch, n_tokens, pos0, n_raw, raw_cap, raw_start, n_comp, window, ratio, n_head, head_dim);
+        return cuda_ok(cudaGetLastError(), "attention decode batch h16 launch");
+    }
+    if (kv_eb != 4) {
+        fprintf(stderr, "ds4: CUDA attention_decode_batch: FP16 raw_kv not supported in this path\n");
+        return 0;
     }
     dim3 grid(n_tokens, n_head, 1);
     attention_decode_mixed_kernel<<<grid, 256>>>((float *)heads->ptr,
@@ -6786,6 +6936,7 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
         uint32_t                ratio,
         uint32_t                n_head,
         uint32_t                head_dim) {
+    const uint8_t kv_eb = raw_kv ? raw_kv->elem_bytes : 4u;
     if (!heads || !q || !raw_kv || !comp_kv || !topk || !model_map ||
         n_tokens == 0 || n_raw == 0 || raw_cap < n_raw || raw_start >= raw_cap ||
         n_comp == 0 || top_k == 0 ||
@@ -6793,7 +6944,7 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
         (uint64_t)n_head * sizeof(float) > model_size - sinks_offset ||
         heads->bytes < (uint64_t)n_tokens * n_head * head_dim * sizeof(float) ||
         q->bytes < (uint64_t)n_tokens * n_head * head_dim * sizeof(float) ||
-        raw_kv->bytes < (uint64_t)raw_cap * head_dim * sizeof(float) ||
+        raw_kv->bytes < (uint64_t)raw_cap * head_dim * kv_eb ||
         comp_kv->bytes < (uint64_t)n_comp * head_dim * sizeof(float) ||
         topk->bytes < (uint64_t)n_tokens * top_k * sizeof(int32_t)) {
         return 0;
@@ -6802,6 +6953,17 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
     const float *sinks = (const float *)cuda_model_range_ptr(
             model_map, sinks_offset, (uint64_t)n_head * sizeof(float), "attn_sinks");
     if (!sinks) return 0;
+    /* For FP16 raw_kv, expand to FP32 in scratch then run the float indexed kernel. */
+    float *raw_kv_f32 = NULL;
+    if (kv_eb == 2) {
+        const uint64_t raw_elems = (uint64_t)raw_cap * head_dim;
+        raw_kv_f32 = (float *)cuda_tmp_alloc(raw_elems * sizeof(float), "indexed raw f16->f32");
+        if (!raw_kv_f32) return 0;
+        f16_to_f32_kernel<<<(uint32_t)((raw_elems + 255) / 256), 256>>>(
+            raw_kv_f32, (const __half *)raw_kv->ptr, raw_elems);
+        if (!cuda_ok(cudaGetLastError(), "indexed raw f16->f32")) return 0;
+    }
+    const float *raw_kv_ptr = raw_kv_f32 ? raw_kv_f32 : (const float *)raw_kv->ptr;
     if (n_tokens > 1 && head_dim == 512 && top_k <= 512u &&
         getenv("DS4_CUDA_NO_INDEXED_HEADS8") == NULL) {
         dim3 grid(n_tokens, (n_head + 7u) / 8u, 1);
@@ -6809,7 +6971,7 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
             attention_indexed_mixed_heads8_online_kernel<<<grid, 256>>>((float *)heads->ptr,
                                                                         sinks,
                                                                         (const float *)q->ptr,
-                                                                        (const float *)raw_kv->ptr,
+                                                                        raw_kv_ptr,
                                                                         (const float *)comp_kv->ptr,
                                                                         (const int32_t *)topk->ptr,
                                                                         n_tokens,
@@ -6828,7 +6990,7 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
         attention_indexed_mixed_heads8_rb4_kernel<<<grid, 256>>>((float *)heads->ptr,
                                                                  sinks,
                                                                  (const float *)q->ptr,
-                                                                 (const float *)raw_kv->ptr,
+                                                                 raw_kv_ptr,
                                                                  (const float *)comp_kv->ptr,
                                                                  (const int32_t *)topk->ptr,
                                                                  n_tokens,
@@ -6848,7 +7010,7 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
     attention_indexed_mixed_kernel<<<grid, 256>>>((float *)heads->ptr,
                                                   sinks,
                                                   (const float *)q->ptr,
-                                                  (const float *)raw_kv->ptr,
+                                                  raw_kv_ptr,
                                                   (const float *)comp_kv->ptr,
                                                   (const int32_t *)topk->ptr,
                                                   n_tokens,
@@ -6881,14 +7043,16 @@ static int attention_prefill_mixed_launch(
         uint32_t                ratio,
         uint32_t                n_head,
         uint32_t                head_dim) {
+    const uint8_t kv_eb  = raw_kv  ? raw_kv->elem_bytes  : 4u;
+    const uint8_t ckv_eb = (n_comp && comp_kv) ? comp_kv->elem_bytes : kv_eb;
     if (!heads || !q || !raw_kv || !model_map || n_tokens == 0 || ratio == 0 ||
         (n_comp != 0 && !comp_kv) || (use_comp_mask && !comp_mask) ||
         sinks_offset > model_size ||
         (uint64_t)n_head * sizeof(float) > model_size - sinks_offset ||
         heads->bytes < (uint64_t)n_tokens * n_head * head_dim * sizeof(float) ||
         q->bytes < (uint64_t)n_tokens * n_head * head_dim * sizeof(float) ||
-        raw_kv->bytes < (uint64_t)n_tokens * head_dim * sizeof(float) ||
-        (n_comp && comp_kv->bytes < (uint64_t)n_comp * head_dim * sizeof(float)) ||
+        raw_kv->bytes < (uint64_t)n_tokens * head_dim * kv_eb ||
+        (n_comp && comp_kv->bytes < (uint64_t)n_comp * head_dim * ckv_eb) ||
         (use_comp_mask && comp_mask->bytes < (uint64_t)n_tokens * n_comp * sizeof(float))) {
         return 0;
     }
@@ -6899,20 +7063,25 @@ static int attention_prefill_mixed_launch(
         getenv("DS4_CUDA_NO_WINDOW_ATTENTION") == NULL &&
         (getenv("DS4_CUDA_WINDOW_ATTENTION") != NULL || (!g_quality_mode && n_tokens >= 128u))) {
         dim3 grid(n_tokens, (n_head + 7u) / 8u, 1);
-        const float *comp_src = n_comp ? (const float *)comp_kv->ptr : (const float *)raw_kv->ptr;
-        const uint64_t raw_elems  = (uint64_t)n_tokens * head_dim;
-        const uint64_t comp_elems = n_comp ? (uint64_t)n_comp * head_dim : raw_elems;
-        const __half *rh = (!g_quality_mode && getenv("DS4_CUDA_NO_FP16_KV") == NULL)
-            ? kv_ensure_h16(&g_kv_h16_raw,  &g_kv_h16_raw_bytes,  (const float *)raw_kv->ptr, raw_elems)
-            : NULL;
-        const __half *ch = (rh && n_comp)
-            ? kv_ensure_h16(&g_kv_h16_comp, &g_kv_h16_comp_bytes, comp_src, comp_elems)
-            : NULL;
+        const __half *rh = (kv_eb == 2) ? (const __half *)raw_kv->ptr : NULL;
+        const __half *ch = NULL;
+        if (n_comp && ckv_eb == 2) ch = (const __half *)comp_kv->ptr;
+        if (n_comp && ckv_eb == 4) {
+            ch = tmp_f16_from_f32((const float *)comp_kv->ptr,
+                                  (uint64_t)n_comp * head_dim,
+                                  "attn prefill mixed comp f16");
+            if (!ch) return 0;
+        }
         if (rh && (!n_comp || ch)) {
             attention_static_mixed_heads8_online_h16_kernel<<<grid, 256>>>(
                 (float *)heads->ptr, sinks, (const float *)q->ptr,
-                rh, ch ? ch : rh, n_tokens, n_comp, window, ratio, n_head, head_dim);
+                rh, ch, n_tokens, n_comp, window, ratio, n_head, head_dim);
         } else {
+            if (kv_eb != 4) {
+                fprintf(stderr, "ds4: CUDA attention_prefill_mixed: FP16 raw_kv window fallback requires FP16 comp_kv or n_comp=0\n");
+                return 0;
+            }
+            const float *comp_src = n_comp ? (const float *)comp_kv->ptr : (const float *)raw_kv->ptr;
             attention_static_mixed_heads8_online_kernel<<<grid, 256>>>((float *)heads->ptr,
                                                                        sinks,
                                                                        (const float *)q->ptr,
@@ -6927,7 +7096,7 @@ static int attention_prefill_mixed_launch(
         }
         return cuda_ok(cudaGetLastError(), "attention mixed window launch");
     }
-    if (g_cublas_ready && n_tokens > 1 && head_dim == 512 &&
+    if (g_cublas_ready && n_tokens > 1 && head_dim == 512 && kv_eb == 4 &&
         getenv("DS4_CUDA_NO_CUBLAS_ATTENTION") == NULL) {
         const uint32_t n_keys = n_tokens + n_comp;
         const uint64_t kv_count = (uint64_t)n_keys * head_dim;
@@ -7011,6 +7180,26 @@ static int attention_prefill_mixed_launch(
                                                                         n_head,
                                                                         head_dim);
         return cuda_ok(cudaGetLastError(), "attention mixed unpack launch");
+    }
+    if (kv_eb == 2 && head_dim == 512u && !use_comp_mask) {
+        dim3 grid2(n_tokens, (n_head + 7u) / 8u, 1);
+        const __half *rh = (const __half *)raw_kv->ptr;
+        const __half *ch = NULL;
+        if (n_comp && ckv_eb == 2) ch = (const __half *)comp_kv->ptr;
+        if (n_comp && ckv_eb == 4) {
+            ch = tmp_f16_from_f32((const float *)comp_kv->ptr,
+                                  (uint64_t)n_comp * head_dim,
+                                  "attn prefill h16 fallback comp f16");
+            if (!ch) return 0;
+        }
+        attention_static_mixed_heads8_online_h16_kernel<<<grid2, 256>>>(
+            (float *)heads->ptr, sinks, (const float *)q->ptr,
+            rh, ch, n_tokens, n_comp, window, ratio, n_head, head_dim);
+        return cuda_ok(cudaGetLastError(), "attention prefill mixed h16 fallback launch");
+    }
+    if (kv_eb != 4) {
+        fprintf(stderr, "ds4: CUDA attention_prefill_mixed: FP16 raw_kv not supported in this path\n");
+        return 0;
     }
     dim3 grid(n_tokens, n_head, 1);
     attention_prefill_mixed_kernel<<<grid, 256>>>((float *)heads->ptr,

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -78,6 +78,12 @@ static cublasHandle_t g_cublas;
 static int g_cublas_ready;
 static int g_quality_mode;
 
+/* FP16 KV shadow buffers for attention kernels. Allocated lazily, freed on reset. */
+static __half *g_kv_h16_raw  = NULL;
+static uint64_t g_kv_h16_raw_bytes = 0;
+static __half *g_kv_h16_comp = NULL;
+static uint64_t g_kv_h16_comp_bytes = 0;
+
 struct cuda_model_range {
     const void *host_base;
     uint64_t offset;
@@ -1230,6 +1236,16 @@ extern "C" void ds4_gpu_cleanup(void) {
         g_cuda_tmp = NULL;
         g_cuda_tmp_bytes = 0;
     }
+    if (g_kv_h16_raw) {
+        (void)cudaFree(g_kv_h16_raw);
+        g_kv_h16_raw = NULL;
+        g_kv_h16_raw_bytes = 0;
+    }
+    if (g_kv_h16_comp) {
+        (void)cudaFree(g_kv_h16_comp);
+        g_kv_h16_comp = NULL;
+        g_kv_h16_comp_bytes = 0;
+    }
     for (size_t i = 0; i < 4; i++) {
         if (g_model_stage_event[i]) {
             (void)cudaEventDestroy(g_model_stage_event[i]);
@@ -1711,6 +1727,7 @@ __device__ static float warp_max_f32(float v) {
 __device__ static float dot4_f32(float4 a, float4 b) {
     return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
 }
+
 
 __device__ __forceinline__ static int32_t load_i8x4_i32_aligned(const int8_t *p) {
     return *(const int32_t *)p;
@@ -3336,6 +3353,361 @@ __global__ static void attention_indexed_mixed_heads8_online_kernel(
                               dot4_f32(q3, k3);
                 score = warp_sum_f32(score) * scale;
                 score = __shfl_sync(0xffffffffu, score, 0);
+
+                const float new_m = fmaxf(max_s, score);
+                const float old_scale = expf(max_s - new_m);
+                const float row_scale = expf(score - new_m);
+                sum_s = sum_s * old_scale + row_scale;
+                o0.x = o0.x * old_scale + k0.x * row_scale;
+                o0.y = o0.y * old_scale + k0.y * row_scale;
+                o0.z = o0.z * old_scale + k0.z * row_scale;
+                o0.w = o0.w * old_scale + k0.w * row_scale;
+                o1.x = o1.x * old_scale + k1.x * row_scale;
+                o1.y = o1.y * old_scale + k1.y * row_scale;
+                o1.z = o1.z * old_scale + k1.z * row_scale;
+                o1.w = o1.w * old_scale + k1.w * row_scale;
+                o2.x = o2.x * old_scale + k2.x * row_scale;
+                o2.y = o2.y * old_scale + k2.y * row_scale;
+                o2.z = o2.z * old_scale + k2.z * row_scale;
+                o2.w = o2.w * old_scale + k2.w * row_scale;
+                o3.x = o3.x * old_scale + k3.x * row_scale;
+                o3.y = o3.y * old_scale + k3.y * row_scale;
+                o3.z = o3.z * old_scale + k3.z * row_scale;
+                o3.w = o3.w * old_scale + k3.w * row_scale;
+                max_s = new_m;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (valid_head) {
+        const float sink = sinks[head];
+        const float new_m = fmaxf(max_s, sink);
+        const float old_scale = expf(max_s - new_m);
+        const float sink_scale = expf(sink - new_m);
+        sum_s = sum_s * old_scale + sink_scale;
+        o0.x *= old_scale; o0.y *= old_scale; o0.z *= old_scale; o0.w *= old_scale;
+        o1.x *= old_scale; o1.y *= old_scale; o1.z *= old_scale; o1.w *= old_scale;
+        o2.x *= old_scale; o2.y *= old_scale; o2.z *= old_scale; o2.w *= old_scale;
+        o3.x *= old_scale; o3.y *= old_scale; o3.z *= old_scale; o3.w *= old_scale;
+
+        const float inv_s = sum_s == 0.0f ? 0.0f : 1.0f / sum_s;
+        o0.x *= inv_s; o0.y *= inv_s; o0.z *= inv_s; o0.w *= inv_s;
+        o1.x *= inv_s; o1.y *= inv_s; o1.z *= inv_s; o1.w *= inv_s;
+        o2.x *= inv_s; o2.y *= inv_s; o2.z *= inv_s; o2.w *= inv_s;
+        o3.x *= inv_s; o3.y *= inv_s; o3.z *= inv_s; o3.w *= inv_s;
+        float4 *out4 = (float4 *)(heads + ((uint64_t)t * n_head + head) * head_dim);
+        out4[lane +  0u] = o0;
+        out4[lane + 32u] = o1;
+        out4[lane + 64u] = o2;
+        out4[lane + 96u] = o3;
+    }
+}
+
+/* Ensure FP16 shadow buffer is allocated and up-to-date for a float KV tensor. */
+static const __half *kv_ensure_h16(__half **buf, uint64_t *buf_bytes,
+                                   const float *src, uint64_t n_elems) {
+    const uint64_t need = n_elems * sizeof(__half);
+    if (*buf_bytes < need) {
+        if (*buf) (void)cudaFree(*buf);
+        *buf = NULL;
+        *buf_bytes = 0;
+        if (cudaMalloc((void **)buf, need) != cudaSuccess) return NULL;
+        *buf_bytes = need;
+    }
+    const uint32_t threads = 256;
+    const uint32_t blocks = (uint32_t)((n_elems + threads - 1) / threads);
+    f32_to_f16_kernel<<<blocks, threads>>>(*buf, src, n_elems);
+    return *buf;
+}
+
+__global__ static void attention_static_mixed_heads8_online_h16_kernel(
+        float *heads,
+        const float *sinks,
+        const float *q,
+        const __half *raw_kv_h,
+        const __half *comp_kv_h,
+        uint32_t n_tokens,
+        uint32_t n_comp,
+        uint32_t window,
+        uint32_t ratio,
+        uint32_t n_head,
+        uint32_t head_dim) {
+    uint32_t t = blockIdx.x;
+    uint32_t head_group = blockIdx.y;
+    if (t >= n_tokens || head_dim != 512u) return;
+    const uint32_t lane = threadIdx.x & 31u;
+    const uint32_t warp = threadIdx.x >> 5u;
+    const uint32_t head = head_group * 8u + warp;
+    const bool valid_head = head < n_head;
+
+    /* half2 shared: same 8KB budget as float4 version, holds same 512 KV rows × head_dim/256 elements */
+    __shared__ __half2 kv_shared_h2[4 * 256];
+
+    const uint32_t raw_count = window != 0u && t + 1u > window ? window : t + 1u;
+    const uint32_t raw_start = t + 1u - raw_count;
+    uint32_t comp_count = 0;
+    if (n_comp != 0u && ratio != 0u) {
+        comp_count = (t + 1u) / ratio;
+        if (comp_count > n_comp) comp_count = n_comp;
+    }
+    const uint32_t n_score = raw_count + comp_count;
+    const float scale = rsqrtf((float)head_dim);
+    const float4 *q4 = valid_head
+        ? (const float4 *)(q + ((uint64_t)t * n_head + head) * head_dim)
+        : NULL;
+    float4 q0 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 q1 = q0, q2 = q0, q3 = q0;
+    if (valid_head) {
+        q0 = q4[lane +  0u];
+        q1 = q4[lane + 32u];
+        q2 = q4[lane + 64u];
+        q3 = q4[lane + 96u];
+    }
+
+    float max_s = -INFINITY;
+    float sum_s = 0.0f;
+    float4 o0 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 o1 = o0, o2 = o0, o3 = o0;
+
+    /* head_dim=512 floats = 256 half2 per KV row.
+       Batch 4 rows at a time into shared mem (4 × 256 half2 = 8KB). */
+    for (uint32_t row0 = 0; row0 < n_score; row0 += 4u) {
+        const uint32_t nr = n_score - row0 < 4u ? n_score - row0 : 4u;
+        /* Load KV rows as half2 into shared. 256 threads, 256 half2 per row → 1 pass per row. */
+        for (uint32_t off = threadIdx.x; off < nr * 256u; off += blockDim.x) {
+            const uint32_t rr = off >> 8u;
+            const uint32_t ch = off & 255u;
+            const uint32_t sr = row0 + rr;
+            const __half2 *src = sr < raw_count
+                ? (const __half2 *)(raw_kv_h  + (uint64_t)(raw_start + sr) * head_dim)
+                : (const __half2 *)(comp_kv_h + (uint64_t)(sr - raw_count) * head_dim);
+            kv_shared_h2[rr * 256u + ch] = src[ch];
+        }
+        __syncthreads();
+        if (valid_head) {
+            for (uint32_t rr = 0; rr < nr; rr++) {
+                /* Each warp lane covers 4 floats of Q (float4) and 2 half2 of K per segment. */
+                const __half2 *kh = kv_shared_h2 + rr * 256u + lane * 2u;
+                /* Compute dot(Q, K) across 512 dims = 4 segments × 128 dims.
+                   lane covers 8 half2 (= 16 halfs = 16 dims) per segment,
+                   warp reduces across 32 lanes → 32×16 = 512 dims covered. */
+                const __half2 *kh0 = kv_shared_h2 + rr * 256u + lane * 2u;         /* dims lane*4 .. lane*4+3 in seg0 */
+                const __half2 *kh1 = kv_shared_h2 + rr * 256u + 64u + lane * 2u;   /* seg1 */
+                const __half2 *kh2 = kv_shared_h2 + rr * 256u + 128u + lane * 2u;  /* seg2 */
+                const __half2 *kh3 = kv_shared_h2 + rr * 256u + 192u + lane * 2u;  /* seg3 */
+
+                float score =
+                    q0.x * __half2float(__low2half(kh0[0]))  + q0.y * __half2float(__high2half(kh0[0])) +
+                    q0.z * __half2float(__low2half(kh0[1]))  + q0.w * __half2float(__high2half(kh0[1])) +
+                    q1.x * __half2float(__low2half(kh1[0]))  + q1.y * __half2float(__high2half(kh1[0])) +
+                    q1.z * __half2float(__low2half(kh1[1]))  + q1.w * __half2float(__high2half(kh1[1])) +
+                    q2.x * __half2float(__low2half(kh2[0]))  + q2.y * __half2float(__high2half(kh2[0])) +
+                    q2.z * __half2float(__low2half(kh2[1]))  + q2.w * __half2float(__high2half(kh2[1])) +
+                    q3.x * __half2float(__low2half(kh3[0]))  + q3.y * __half2float(__high2half(kh3[0])) +
+                    q3.z * __half2float(__low2half(kh3[1]))  + q3.w * __half2float(__high2half(kh3[1]));
+                score = warp_sum_f32(score) * scale;
+                score = __shfl_sync(0xffffffffu, score, 0);
+
+                /* Online softmax + output accumulation (FP32, unchanged). */
+                /* Re-read V from shared as float for output accumulation. */
+                const __half2 *vh0 = kv_shared_h2 + rr * 256u + lane * 2u;
+                const __half2 *vh1 = kv_shared_h2 + rr * 256u + 64u + lane * 2u;
+                const __half2 *vh2 = kv_shared_h2 + rr * 256u + 128u + lane * 2u;
+                const __half2 *vh3 = kv_shared_h2 + rr * 256u + 192u + lane * 2u;
+                float4 k0, k1, k2, k3;
+                k0 = make_float4(__half2float(__low2half(vh0[0])), __half2float(__high2half(vh0[0])),
+                                 __half2float(__low2half(vh0[1])), __half2float(__high2half(vh0[1])));
+                k1 = make_float4(__half2float(__low2half(vh1[0])), __half2float(__high2half(vh1[0])),
+                                 __half2float(__low2half(vh1[1])), __half2float(__high2half(vh1[1])));
+                k2 = make_float4(__half2float(__low2half(vh2[0])), __half2float(__high2half(vh2[0])),
+                                 __half2float(__low2half(vh2[1])), __half2float(__high2half(vh2[1])));
+                k3 = make_float4(__half2float(__low2half(vh3[0])), __half2float(__high2half(vh3[0])),
+                                 __half2float(__low2half(vh3[1])), __half2float(__high2half(vh3[1])));
+
+                const float new_m = fmaxf(max_s, score);
+                const float old_scale = expf(max_s - new_m);
+                const float row_scale = expf(score - new_m);
+                sum_s = sum_s * old_scale + row_scale;
+                o0.x = o0.x * old_scale + k0.x * row_scale;
+                o0.y = o0.y * old_scale + k0.y * row_scale;
+                o0.z = o0.z * old_scale + k0.z * row_scale;
+                o0.w = o0.w * old_scale + k0.w * row_scale;
+                o1.x = o1.x * old_scale + k1.x * row_scale;
+                o1.y = o1.y * old_scale + k1.y * row_scale;
+                o1.z = o1.z * old_scale + k1.z * row_scale;
+                o1.w = o1.w * old_scale + k1.w * row_scale;
+                o2.x = o2.x * old_scale + k2.x * row_scale;
+                o2.y = o2.y * old_scale + k2.y * row_scale;
+                o2.z = o2.z * old_scale + k2.z * row_scale;
+                o2.w = o2.w * old_scale + k2.w * row_scale;
+                o3.x = o3.x * old_scale + k3.x * row_scale;
+                o3.y = o3.y * old_scale + k3.y * row_scale;
+                o3.z = o3.z * old_scale + k3.z * row_scale;
+                o3.w = o3.w * old_scale + k3.w * row_scale;
+                max_s = new_m;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (valid_head) {
+        const float sink = sinks[head];
+        const float new_m = fmaxf(max_s, sink);
+        const float old_scale = expf(max_s - new_m);
+        const float sink_scale = expf(sink - new_m);
+        sum_s = sum_s * old_scale + sink_scale;
+        o0.x *= old_scale; o0.y *= old_scale; o0.z *= old_scale; o0.w *= old_scale;
+        o1.x *= old_scale; o1.y *= old_scale; o1.z *= old_scale; o1.w *= old_scale;
+        o2.x *= old_scale; o2.y *= old_scale; o2.z *= old_scale; o2.w *= old_scale;
+        o3.x *= old_scale; o3.y *= old_scale; o3.z *= old_scale; o3.w *= old_scale;
+
+        const float inv_s = sum_s == 0.0f ? 0.0f : 1.0f / sum_s;
+        o0.x *= inv_s; o0.y *= inv_s; o0.z *= inv_s; o0.w *= inv_s;
+        o1.x *= inv_s; o1.y *= inv_s; o1.z *= inv_s; o1.w *= inv_s;
+        o2.x *= inv_s; o2.y *= inv_s; o2.z *= inv_s; o2.w *= inv_s;
+        o3.x *= inv_s; o3.y *= inv_s; o3.z *= inv_s; o3.w *= inv_s;
+        float4 *out4 = (float4 *)(heads + ((uint64_t)t * n_head + head) * head_dim);
+        out4[lane +  0u] = o0;
+        out4[lane + 32u] = o1;
+        out4[lane + 64u] = o2;
+        out4[lane + 96u] = o3;
+    }
+}
+
+__global__ static void attention_decode_mixed_heads8_online_h16_kernel(
+        float *heads,
+        const float *sinks,
+        const float *q,
+        const __half *raw_kv_h,
+        const __half *comp_kv_h,
+        uint32_t n_tokens,
+        uint32_t pos0,
+        uint32_t n_raw,
+        uint32_t raw_cap,
+        uint32_t raw_start,
+        uint32_t n_comp,
+        uint32_t window,
+        uint32_t ratio,
+        uint32_t n_head,
+        uint32_t head_dim) {
+    uint32_t t = blockIdx.x;
+    uint32_t head_group = blockIdx.y;
+    if (t >= n_tokens || head_dim != 512u) return;
+    const uint32_t lane = threadIdx.x & 31u;
+    const uint32_t warp = threadIdx.x >> 5u;
+    const uint32_t head = head_group * 8u + warp;
+    const bool valid_head = head < n_head;
+
+    __shared__ uint32_t raw_rows[256];
+    __shared__ uint32_t raw_count_s;
+    __shared__ uint32_t raw_first_idx_s;
+    __shared__ __half2 kv_shared_h2[4 * 256];
+
+    const uint32_t qpos = pos0 + t;
+    const uint32_t first_raw_pos = pos0 + n_tokens - n_raw;
+    uint32_t comp_count = 0;
+    if (n_comp != 0u) {
+        if (n_tokens == 1u && ratio == 0u) {
+            comp_count = n_comp;
+        } else if (ratio != 0u) {
+            comp_count = (qpos + 1u) / ratio;
+            if (comp_count > n_comp) comp_count = n_comp;
+        }
+    }
+    if (threadIdx.x == 0) {
+        uint32_t raw_count = 0;
+        uint32_t raw_first_idx = 0;
+        if (n_raw != 0u) {
+            const uint32_t raw_last_pos = first_raw_pos + n_raw - 1u;
+            if (qpos >= first_raw_pos) {
+                uint32_t lo = first_raw_pos;
+                if (window != 0u && qpos + 1u > window) {
+                    const uint32_t wlo = qpos + 1u - window;
+                    if (wlo > lo) lo = wlo;
+                }
+                const uint32_t hi = qpos < raw_last_pos ? qpos : raw_last_pos;
+                if (hi >= lo) {
+                    raw_first_idx = lo - first_raw_pos;
+                    raw_count = hi - lo + 1u;
+                    if (raw_count > 256u) raw_count = 256u;
+                }
+            }
+        }
+        raw_count_s = raw_count;
+        raw_first_idx_s = raw_first_idx;
+    }
+    __syncthreads();
+    const uint32_t raw_count = raw_count_s;
+    const uint32_t raw_first_idx = raw_first_idx_s;
+    for (uint32_t r = threadIdx.x; r < raw_count; r += blockDim.x) {
+        raw_rows[r] = (raw_start + raw_first_idx + r) % raw_cap;
+    }
+    __syncthreads();
+
+    const uint32_t n_score = raw_count + comp_count;
+    const float scale = rsqrtf((float)head_dim);
+    const float4 *q4 = valid_head
+        ? (const float4 *)(q + ((uint64_t)t * n_head + head) * head_dim)
+        : NULL;
+    float4 q0 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 q1 = q0, q2 = q0, q3 = q0;
+    if (valid_head) {
+        q0 = q4[lane +  0u];
+        q1 = q4[lane + 32u];
+        q2 = q4[lane + 64u];
+        q3 = q4[lane + 96u];
+    }
+
+    float max_s = -INFINITY;
+    float sum_s = 0.0f;
+    float4 o0 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 o1 = o0, o2 = o0, o3 = o0;
+
+    for (uint32_t row0 = 0; row0 < n_score; row0 += 4u) {
+        const uint32_t nr = n_score - row0 < 4u ? n_score - row0 : 4u;
+        for (uint32_t off = threadIdx.x; off < nr * 256u; off += blockDim.x) {
+            const uint32_t rr = off >> 8u;
+            const uint32_t ch = off & 255u;
+            const uint32_t sr = row0 + rr;
+            const __half2 *src = sr < raw_count
+                ? (const __half2 *)(raw_kv_h  + (uint64_t)raw_rows[sr] * head_dim)
+                : (const __half2 *)(comp_kv_h + (uint64_t)(sr - raw_count) * head_dim);
+            kv_shared_h2[rr * 256u + ch] = src[ch];
+        }
+        __syncthreads();
+        if (valid_head) {
+            for (uint32_t rr = 0; rr < nr; rr++) {
+                const __half2 *kh0 = kv_shared_h2 + rr * 256u + lane * 2u;
+                const __half2 *kh1 = kv_shared_h2 + rr * 256u + 64u + lane * 2u;
+                const __half2 *kh2 = kv_shared_h2 + rr * 256u + 128u + lane * 2u;
+                const __half2 *kh3 = kv_shared_h2 + rr * 256u + 192u + lane * 2u;
+
+                float score =
+                    q0.x * __half2float(__low2half(kh0[0]))  + q0.y * __half2float(__high2half(kh0[0])) +
+                    q0.z * __half2float(__low2half(kh0[1]))  + q0.w * __half2float(__high2half(kh0[1])) +
+                    q1.x * __half2float(__low2half(kh1[0]))  + q1.y * __half2float(__high2half(kh1[0])) +
+                    q1.z * __half2float(__low2half(kh1[1]))  + q1.w * __half2float(__high2half(kh1[1])) +
+                    q2.x * __half2float(__low2half(kh2[0]))  + q2.y * __half2float(__high2half(kh2[0])) +
+                    q2.z * __half2float(__low2half(kh2[1]))  + q2.w * __half2float(__high2half(kh2[1])) +
+                    q3.x * __half2float(__low2half(kh3[0]))  + q3.y * __half2float(__high2half(kh3[0])) +
+                    q3.z * __half2float(__low2half(kh3[1]))  + q3.w * __half2float(__high2half(kh3[1]));
+                score = warp_sum_f32(score) * scale;
+                score = __shfl_sync(0xffffffffu, score, 0);
+
+                const __half2 *vh0 = kv_shared_h2 + rr * 256u + lane * 2u;
+                const __half2 *vh1 = kv_shared_h2 + rr * 256u + 64u + lane * 2u;
+                const __half2 *vh2 = kv_shared_h2 + rr * 256u + 128u + lane * 2u;
+                const __half2 *vh3 = kv_shared_h2 + rr * 256u + 192u + lane * 2u;
+                float4 k0, k1, k2, k3;
+                k0 = make_float4(__half2float(__low2half(vh0[0])), __half2float(__high2half(vh0[0])),
+                                 __half2float(__low2half(vh0[1])), __half2float(__high2half(vh0[1])));
+                k1 = make_float4(__half2float(__low2half(vh1[0])), __half2float(__high2half(vh1[0])),
+                                 __half2float(__low2half(vh1[1])), __half2float(__high2half(vh1[1])));
+                k2 = make_float4(__half2float(__low2half(vh2[0])), __half2float(__high2half(vh2[0])),
+                                 __half2float(__low2half(vh2[1])), __half2float(__high2half(vh2[1])));
+                k3 = make_float4(__half2float(__low2half(vh3[0])), __half2float(__high2half(vh3[0])),
+                                 __half2float(__low2half(vh3[1])), __half2float(__high2half(vh3[1])));
 
                 const float new_m = fmaxf(max_s, score);
                 const float old_scale = expf(max_s - new_m);
@@ -5173,14 +5545,50 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
                                              CUDA_R_32F,
                                              (int)out_dim,
                                              CUDA_R_32F,
-                                             CUBLAS_GEMM_DEFAULT);
+                                             CUBLAS_GEMM_DEFAULT_TENSOR_OP);
             if (st == CUBLAS_STATUS_SUCCESS) return 1;
             fprintf(stderr, "ds4: cuBLAS q8 f16 matmul failed: status %d\n", (int)st);
             cuda_q8_f16_cache_disable_after_failure("cuBLAS f16 matmul failure",
                                                     in_dim * out_dim * sizeof(__half));
-            /* The F16 expansion cache is only an optimization.  If cuBLAS
-             * rejects the cached path under memory pressure, retry the same
-             * operation through the native Q8 kernels below. */
+            /* The F16 expansion cache is only an optimization. If cuBLAS
+             * rejects the cached path under memory pressure, retry through
+             * the native Q8 kernels below. */
+        }
+    }
+    /* Decode path (n_tok==1): use cuBLAS GEMV via FP16 weights if cached and out_dim large enough
+       for tensor core to beat the custom warp8 kernel. Threshold 1024 avoids overhead on small projections. */
+    if (g_cublas_ready && n_tok == 1 && out_dim >= 1024 && !g_quality_mode &&
+        getenv("DS4_CUDA_NO_CUBLAS_DECODE") == NULL) {
+        const __half *w_f16 = cuda_q8_f16_ptr(model_map, weight_offset, weight_bytes, in_dim, out_dim, label);
+        if (w_f16) {
+            __half *xh = (__half *)cuda_tmp_alloc(in_dim * sizeof(__half), "q8 f16 decode gemv activation");
+            if (xh) {
+                f32_to_f16_kernel<<<((unsigned)in_dim + 255u) / 256u, 256>>>(xh, (const float *)x->ptr, in_dim);
+                if (cuda_ok(cudaGetLastError(), "q8 f16 decode activation convert")) {
+                    const float alpha = 1.0f;
+                    const float beta = 0.0f;
+                    cublasStatus_t st = cublasGemmEx(g_cublas,
+                                                     CUBLAS_OP_T,
+                                                     CUBLAS_OP_N,
+                                                     (int)out_dim,
+                                                     1,
+                                                     (int)in_dim,
+                                                     &alpha,
+                                                     w_f16,
+                                                     CUDA_R_16F,
+                                                     (int)in_dim,
+                                                     xh,
+                                                     CUDA_R_16F,
+                                                     (int)in_dim,
+                                                     &beta,
+                                                     out->ptr,
+                                                     CUDA_R_32F,
+                                                     (int)out_dim,
+                                                     CUDA_R_32F,
+                                                     CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+                    if (cublas_ok(st, "q8 f16 decode gemv")) return 1;
+                }
+            }
         }
     }
     const uint64_t xq_bytes = n_tok * blocks * 32u;
@@ -5415,7 +5823,7 @@ extern "C" int ds4_gpu_matmul_f16_tensor(ds4_gpu_tensor *out, const void *model_
                                          CUDA_R_32F,
                                          (int)out_dim,
                                          CUDA_R_32F,
-                                         CUBLAS_GEMM_DEFAULT);
+                                         CUBLAS_GEMM_DEFAULT_TENSOR_OP);
         return cublas_ok(st, "f16 matmul");
     }
     dim3 grid((unsigned)out_dim, (unsigned)n_tok, 1);
@@ -6061,21 +6469,37 @@ extern "C" int ds4_gpu_attention_decode_heads_tensor(
         if (!use_mask && head_dim == 512u &&
             getenv("DS4_CUDA_NO_WINDOW_ATTENTION") == NULL) {
             dim3 online_grid(1, (n_head + 7u) / 8u, 1);
-            attention_decode_mixed_heads8_online_kernel<<<online_grid, 256>>>((float *)heads->ptr,
-                                                                              sinks,
-                                                                              (const float *)q->ptr,
-                                                                              (const float *)raw_kv->ptr,
-                                                                              n_comp ? (const float *)comp_kv->ptr : (const float *)raw_kv->ptr,
-                                                                              1,
-                                                                              0,
-                                                                              n_raw,
-                                                                              raw_cap,
-                                                                              raw_start,
-                                                                              n_comp,
-                                                                              0,
-                                                                              0,
-                                                                              n_head,
-                                                                              head_dim);
+            const float *comp_src = n_comp ? (const float *)comp_kv->ptr : (const float *)raw_kv->ptr;
+            const uint64_t raw_elems  = (uint64_t)raw_cap * head_dim;
+            const uint64_t comp_elems = n_comp ? (uint64_t)n_comp * head_dim : raw_elems;
+            const __half *rh = (!g_quality_mode && getenv("DS4_CUDA_NO_FP16_KV") == NULL)
+                ? kv_ensure_h16(&g_kv_h16_raw,  &g_kv_h16_raw_bytes,  (const float *)raw_kv->ptr, raw_elems)
+                : NULL;
+            const __half *ch = (rh && n_comp && !g_quality_mode)
+                ? kv_ensure_h16(&g_kv_h16_comp, &g_kv_h16_comp_bytes, comp_src, comp_elems)
+                : NULL;
+            if (rh && (ch || !n_comp)) {
+                attention_decode_mixed_heads8_online_h16_kernel<<<online_grid, 256>>>(
+                    (float *)heads->ptr, sinks, (const float *)q->ptr,
+                    rh, ch ? ch : rh,
+                    1, 0, n_raw, raw_cap, raw_start, n_comp, 0, 0, n_head, head_dim);
+            } else {
+                attention_decode_mixed_heads8_online_kernel<<<online_grid, 256>>>((float *)heads->ptr,
+                                                                                  sinks,
+                                                                                  (const float *)q->ptr,
+                                                                                  (const float *)raw_kv->ptr,
+                                                                                  comp_src,
+                                                                                  1,
+                                                                                  0,
+                                                                                  n_raw,
+                                                                                  raw_cap,
+                                                                                  raw_start,
+                                                                                  n_comp,
+                                                                                  0,
+                                                                                  0,
+                                                                                  n_head,
+                                                                                  head_dim);
+            }
             return cuda_ok(cudaGetLastError(), "attention decode online launch");
         }
         fprintf(stderr, "ds4: CUDA attention score buffer too small for %u compressed rows\n", n_comp);
@@ -6107,17 +6531,27 @@ extern "C" int ds4_gpu_attention_prefill_raw_heads_tensor(ds4_gpu_tensor *heads,
         getenv("DS4_CUDA_NO_WINDOW_ATTENTION") == NULL &&
         (getenv("DS4_CUDA_WINDOW_ATTENTION") != NULL || (!g_quality_mode && n_tokens >= 128u))) {
         dim3 grid(n_tokens, (n_head + 7u) / 8u, 1);
-        attention_static_mixed_heads8_online_kernel<<<grid, 256>>>((float *)heads->ptr,
-                                                                   sinks,
-                                                                   (const float *)q->ptr,
-                                                                   (const float *)raw_kv->ptr,
-                                                                   (const float *)raw_kv->ptr,
-                                                                   n_tokens,
-                                                                   0,
-                                                                   window,
-                                                                   1,
-                                                                   n_head,
-                                                                   head_dim);
+        const uint64_t raw_elems = (uint64_t)n_tokens * head_dim;
+        const __half *rh = (!g_quality_mode && getenv("DS4_CUDA_NO_FP16_KV") == NULL)
+            ? kv_ensure_h16(&g_kv_h16_raw, &g_kv_h16_raw_bytes, (const float *)raw_kv->ptr, raw_elems)
+            : NULL;
+        if (rh) {
+            attention_static_mixed_heads8_online_h16_kernel<<<grid, 256>>>(
+                (float *)heads->ptr, sinks, (const float *)q->ptr,
+                rh, rh, n_tokens, 0, window, 1, n_head, head_dim);
+        } else {
+            attention_static_mixed_heads8_online_kernel<<<grid, 256>>>((float *)heads->ptr,
+                                                                       sinks,
+                                                                       (const float *)q->ptr,
+                                                                       (const float *)raw_kv->ptr,
+                                                                       (const float *)raw_kv->ptr,
+                                                                       n_tokens,
+                                                                       0,
+                                                                       window,
+                                                                       1,
+                                                                       n_head,
+                                                                       head_dim);
+        }
         return cuda_ok(cudaGetLastError(), "attention raw window launch");
     }
     if (g_cublas_ready && n_tokens > 1 && head_dim == 512 &&
@@ -6465,17 +6899,32 @@ static int attention_prefill_mixed_launch(
         getenv("DS4_CUDA_NO_WINDOW_ATTENTION") == NULL &&
         (getenv("DS4_CUDA_WINDOW_ATTENTION") != NULL || (!g_quality_mode && n_tokens >= 128u))) {
         dim3 grid(n_tokens, (n_head + 7u) / 8u, 1);
-        attention_static_mixed_heads8_online_kernel<<<grid, 256>>>((float *)heads->ptr,
-                                                                   sinks,
-                                                                   (const float *)q->ptr,
-                                                                   (const float *)raw_kv->ptr,
-                                                                   n_comp ? (const float *)comp_kv->ptr : (const float *)raw_kv->ptr,
-                                                                   n_tokens,
-                                                                   n_comp,
-                                                                   window,
-                                                                   ratio,
-                                                                   n_head,
-                                                                   head_dim);
+        const float *comp_src = n_comp ? (const float *)comp_kv->ptr : (const float *)raw_kv->ptr;
+        const uint64_t raw_elems  = (uint64_t)n_tokens * head_dim;
+        const uint64_t comp_elems = n_comp ? (uint64_t)n_comp * head_dim : raw_elems;
+        const __half *rh = (!g_quality_mode && getenv("DS4_CUDA_NO_FP16_KV") == NULL)
+            ? kv_ensure_h16(&g_kv_h16_raw,  &g_kv_h16_raw_bytes,  (const float *)raw_kv->ptr, raw_elems)
+            : NULL;
+        const __half *ch = (rh && n_comp)
+            ? kv_ensure_h16(&g_kv_h16_comp, &g_kv_h16_comp_bytes, comp_src, comp_elems)
+            : NULL;
+        if (rh && (!n_comp || ch)) {
+            attention_static_mixed_heads8_online_h16_kernel<<<grid, 256>>>(
+                (float *)heads->ptr, sinks, (const float *)q->ptr,
+                rh, ch ? ch : rh, n_tokens, n_comp, window, ratio, n_head, head_dim);
+        } else {
+            attention_static_mixed_heads8_online_kernel<<<grid, 256>>>((float *)heads->ptr,
+                                                                       sinks,
+                                                                       (const float *)q->ptr,
+                                                                       (const float *)raw_kv->ptr,
+                                                                       comp_src,
+                                                                       n_tokens,
+                                                                       n_comp,
+                                                                       window,
+                                                                       ratio,
+                                                                       n_head,
+                                                                       head_dim);
+        }
         return cuda_ok(cudaGetLastError(), "attention mixed window launch");
     }
     if (g_cublas_ready && n_tokens > 1 && head_dim == 512 &&

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -19,12 +19,21 @@ int ds4_gpu_init(void);
 void ds4_gpu_cleanup(void);
 
 ds4_gpu_tensor *ds4_gpu_tensor_alloc(uint64_t bytes);
+ds4_gpu_tensor *ds4_gpu_tensor_alloc_typed(uint64_t elems, uint8_t elem_bytes);
 ds4_gpu_tensor *ds4_gpu_tensor_view(const ds4_gpu_tensor *base, uint64_t offset, uint64_t bytes);
 void ds4_gpu_tensor_free(ds4_gpu_tensor *tensor);
 uint64_t ds4_gpu_tensor_bytes(const ds4_gpu_tensor *tensor);
+uint8_t ds4_gpu_tensor_elem_bytes(const ds4_gpu_tensor *tensor);
+
+/* Returns the native element size used for raw KV cache tensors on this backend.
+   CUDA returns 2 (FP16), Metal returns 4 (FP32). Used by ds4.c to allocate
+   raw/comp KV tensors with the right size without knowing the backend type. */
+uint8_t ds4_gpu_kv_elem_bytes(void);
 void *ds4_gpu_tensor_contents(ds4_gpu_tensor *tensor);
 int ds4_gpu_tensor_write(ds4_gpu_tensor *tensor, uint64_t offset, const void *data, uint64_t bytes);
 int ds4_gpu_tensor_read(const ds4_gpu_tensor *tensor, uint64_t offset, void *data, uint64_t bytes);
+/* Read n_elems elements from offset 0, converting FP16 to float if needed. */
+int ds4_gpu_tensor_read_f32(const ds4_gpu_tensor *tensor, float *out, uint64_t n_elems);
 int ds4_gpu_tensor_copy(ds4_gpu_tensor *dst, uint64_t dst_offset,
                           const ds4_gpu_tensor *src, uint64_t src_offset,
                           uint64_t bytes);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -205,6 +205,7 @@ static uint32_t g_model_view_count;
 @property(nonatomic, assign) uint64_t offset;
 @property(nonatomic, assign) uint64_t bytes;
 @property(nonatomic, assign) uint8_t owner;
+@property(nonatomic, assign) uint8_t elem_bytes;
 @end
 
 @implementation DS4MetalTensor
@@ -3778,6 +3779,7 @@ ds4_gpu_tensor *ds4_gpu_tensor_alloc(uint64_t bytes) {
         tensor.offset = 0;
         tensor.bytes = bytes;
         tensor.owner = 1;
+        tensor.elem_bytes = 4;
         g_tensor_alloc_live_bytes += bytes;
         if (g_tensor_alloc_live_bytes > g_tensor_alloc_peak_bytes) {
             g_tensor_alloc_peak_bytes = g_tensor_alloc_live_bytes;
@@ -3842,6 +3844,26 @@ uint64_t ds4_gpu_tensor_bytes(const ds4_gpu_tensor *tensor) {
     return obj.bytes;
 }
 
+ds4_gpu_tensor *ds4_gpu_tensor_alloc_typed(uint64_t elems, uint8_t elem_bytes) {
+    if (elem_bytes == 0) elem_bytes = 4;
+    ds4_gpu_tensor *t = ds4_gpu_tensor_alloc(elems * (uint64_t)elem_bytes);
+    if (t) {
+        DS4MetalTensor *obj = ds4_gpu_tensor_obj(t);
+        obj.elem_bytes = elem_bytes;
+    }
+    return t;
+}
+
+uint8_t ds4_gpu_tensor_elem_bytes(const ds4_gpu_tensor *tensor) {
+    if (!tensor) return 4;
+    const DS4MetalTensor *obj = ds4_gpu_tensor_const_obj(tensor);
+    return obj.elem_bytes != 0 ? obj.elem_bytes : 4;
+}
+
+uint8_t ds4_gpu_kv_elem_bytes(void) {
+    return 4; /* Metal keeps FP32 KV — Metal shaders read float */
+}
+
 void *ds4_gpu_tensor_contents(ds4_gpu_tensor *tensor) {
     if (!tensor) return NULL;
     DS4MetalTensor *obj = ds4_gpu_tensor_obj(tensor);
@@ -3866,6 +3888,11 @@ int ds4_gpu_tensor_read(const ds4_gpu_tensor *tensor, uint64_t offset, void *dat
         memcpy(data, (const uint8_t *)[obj.buffer contents] + obj.offset + offset, (size_t)bytes);
     }
     return 1;
+}
+
+int ds4_gpu_tensor_read_f32(const ds4_gpu_tensor *tensor, float *out, uint64_t n_elems) {
+    /* Metal KV always FP32; elem_bytes == 4. Simple memcpy suffices. */
+    return ds4_gpu_tensor_read(tensor, 0, out, n_elems * sizeof(float));
 }
 
 int ds4_gpu_tensor_copy(ds4_gpu_tensor *dst, uint64_t dst_offset,


### PR DESCRIPTION
## Summary

This PR improves CUDA stability and decode throughput for DeepSeek V4 Flash on H200, with a focus on mixed KV dtype behavior in long-context/resumed prefill workloads.

It includes:
- safer mixed attention handling for `raw_kv=FP16` and `comp_kv=FP32`,
- typed GPU tensor element-size plumbing across CUDA/Metal backends,
- conservative default behavior (CUDA KV remains FP32 unless explicitly enabled),
- updated H200 benchmark notes and A/B metrics.

## Motivation

During `ds4-bench` long-context runs on H200, the previous FP16 KV path could trigger illegal memory access in resumed/chunked prefill scenarios.

Root cause: mixed attention paths could enter FP16 kernels with inconsistent raw/compressed KV dtype assumptions.

## What changed

### CUDA mixed KV safety and correctness
- Added explicit mixed-dtype handling in CUDA attention paths.
- For FP16 raw KV + FP32 compressed KV, compressed rows are converted on-the-fly to FP16 scratch buffers before H16 kernels.
- Removed ambiguous H16 fallback behavior for mixed paths.

### Tensor typing support
Added typed tensor metadata (`elem_bytes`) and related APIs:
- `ds4_gpu_tensor_alloc_typed`
- `ds4_gpu_tensor_elem_bytes`
- `ds4_gpu_kv_elem_bytes`
- `ds4_gpu_tensor_read_f32`

Wired across both CUDA and Metal backends.

### Conservative default behavior
- CUDA KV remains FP32 by default.
- FP16 KV is opt-in with:
  - `DS4_CUDA_KV_FP16=1`

### Diagnostics
- Updated backend wording in `ds4.c` from Metal-specific messages to backend-agnostic GPU messages.

### Documentation / benchmarking
- Updated `CUDA_PERF_OPTIMIZATIONS.md` with H200 A/B results and observed ranges.

## Benchmark results (H200 NVL)

Command:
```bash
./ds4-bench -m <model> \
  --ctx-start 2048 --ctx-max 32768 --step-incr 2048 \
  --gen-tokens 128 --prompt-file speed-bench/promessi_sposi.txt
  
  # Generation Throughput with `DS4_CUDA_KV_FP16=1` vs Default KV FP32

Observed gain range across repeated runs:

- ~+4% to +8% depending on context frontier and run-to-run jitter.

## Representative Results

- **2048 ctx:** `30.76 -> 33.13..33.19` (~+7.7%..+7.9%)
- **12288 ctx:** `29.28 -> 30.94..31.09` (~+5.7%..+6.2%)
- **24576 ctx:** `27.58 -> 28.80..28.85` (~+4.4%..+4.6%)
- **32768 ctx:** `27.01 -> 28.11..28.15` (~+4.1%..+4.2%)

Prefill is broadly similar, with normal first-point jitter occasionally visible at `2048`.

---

# Validation

- `make cuda-regression` passes.
- `ds4-bench` no longer crashes in the previously failing long-context/resume flow.
- Multiple A/B bench runs completed on H200 with stable qualitative improvement for FP16 KV mode.

---

# Notes

- This PR focuses on correctness + incremental decode speedup for CUDA FP16 KV mixed paths.
- Further gains are expected from decode microbatch/speculative improvements (future work).