### PR TITLE
cuda: ~20% improvement to GB10 prefill throughput

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -8352,10 +8352,7 @@ static void metal_graph_free(ds4_gpu_graph *g) {
 }
 
 static bool metal_tensor_fill_f32(ds4_gpu_tensor *t, float v, uint64_t n) {
-    float *p = ds4_gpu_tensor_contents(t);
-    if (!p || ds4_gpu_tensor_bytes(t) < n * sizeof(float)) return false;
-    for (uint64_t i = 0; i < n; i++) p[i] = v;
-    return true;
+    return ds4_gpu_tensor_fill_f32(t, v, n) != 0;
 }
 
 /* =========================================================================

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -1286,11 +1286,13 @@ extern "C" void ds4_gpu_cleanup(void) {
     }
 }
 
+__global__ static void fill_f32_kernel(float *x, uint64_t n, float v);
+
 extern "C" ds4_gpu_tensor *ds4_gpu_tensor_alloc(uint64_t bytes) {
     if (bytes == 0) bytes = 1;
     ds4_gpu_tensor *t = (ds4_gpu_tensor *)calloc(1, sizeof(*t));
     if (!t) return NULL;
-    if (!cuda_ok(cudaMallocManaged(&t->ptr, (size_t)bytes), "tensor alloc")) {
+    if (!cuda_ok(cudaMalloc(&t->ptr, (size_t)bytes), "tensor alloc")) {
         free(t);
         return NULL;
     }
@@ -1323,6 +1325,13 @@ extern "C" void *ds4_gpu_tensor_contents(ds4_gpu_tensor *tensor) {
     if (!tensor) return NULL;
     (void)cudaDeviceSynchronize();
     return tensor->ptr;
+}
+
+extern "C" int ds4_gpu_tensor_fill_f32(ds4_gpu_tensor *tensor, float value, uint64_t count) {
+    if (!tensor || count > tensor->bytes / sizeof(float)) return 0;
+    if (count == 0) return 1;
+    fill_f32_kernel<<<(count + 255u) / 256u, 256>>>((float *)tensor->ptr, count, value);
+    return cuda_ok(cudaGetLastError(), "tensor fill f32 launch");
 }
 
 extern "C" int ds4_gpu_tensor_write(ds4_gpu_tensor *tensor, uint64_t offset, const void *data, uint64_t bytes) {

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -9366,7 +9366,7 @@ static int routed_moe_launch(
         const uint32_t use_down_tile16 = use_atomic_down && expert_tile_m == 8u &&
             n_tokens >= 128u && getenv("DS4_CUDA_MOE_NO_DOWN_TILE16") == NULL;
         const uint32_t use_down_block16 = use_down_tile16 && midq_blocks <= 8u &&
-            getenv("DS4_CUDA_MOE_NO_DOWN_BLOCK16") == NULL;
+            getenv("DS4_CUDA_MOE_DOWN_BLOCK16") != NULL;
         const uint32_t use_decode_lut_gate =
             n_tokens == 1u && xq_blocks <= 16u &&
             getenv("DS4_CUDA_MOE_NO_DECODE_LUT_GATE") == NULL;

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -5873,8 +5873,8 @@ extern "C" int ds4_gpu_compressor_prefill_tensor(
     if (!ape) return 0;
 
     uint64_t state_n = (uint64_t)state_rows * width;
-    fill_f32_kernel<<<(state_n + 255) / 256, 256>>>((float *)state_kv->ptr, state_n, 0.0f);
-    if (!cuda_ok(cudaGetLastError(), "compressor state kv fill launch")) return 0;
+    if (!cuda_ok(cudaMemsetAsync(state_kv->ptr, 0, (size_t)(state_n * sizeof(float))),
+                 "compressor state kv zero")) return 0;
     fill_f32_kernel<<<(state_n + 255) / 256, 256>>>((float *)state_score->ptr, state_n, -INFINITY);
     if (!cuda_ok(cudaGetLastError(), "compressor state score fill launch")) return 0;
 
@@ -5998,8 +5998,8 @@ extern "C" int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
     if (quantize_fp8 && !ds4_gpu_dsv4_fp8_kv_quantize_tensor(comp_cache, n_comp, head_dim, n_rot)) return 0;
 
     uint64_t state_n = (uint64_t)state_rows * width;
-    fill_f32_kernel<<<(state_n + 255) / 256, 256>>>((float *)state_kv->ptr, state_n, 0.0f);
-    if (!cuda_ok(cudaGetLastError(), "compressor replay state kv fill launch")) return 0;
+    if (!cuda_ok(cudaMemsetAsync(state_kv->ptr, 0, (size_t)(state_n * sizeof(float))),
+                 "compressor replay state kv zero")) return 0;
     fill_f32_kernel<<<(state_n + 255) / 256, 256>>>((float *)state_score->ptr, state_n, -INFINITY);
     if (!cuda_ok(cudaGetLastError(), "compressor replay state score fill launch")) return 0;
     uint32_t prev_start = n_tokens - ratio;
@@ -6041,8 +6041,8 @@ extern "C" int ds4_gpu_compressor_prefill_state_ratio4_tensor(
     const char *ape = cuda_model_range_ptr(model_map, ape_offset, ape_bytes, "compressor_ape");
     if (!ape) return 0;
     uint64_t state_n = (uint64_t)state_rows * width;
-    fill_f32_kernel<<<(state_n + 255) / 256, 256>>>((float *)state_kv->ptr, state_n, 0.0f);
-    if (!cuda_ok(cudaGetLastError(), "compressor state kv fill launch")) return 0;
+    if (!cuda_ok(cudaMemsetAsync(state_kv->ptr, 0, (size_t)(state_n * sizeof(float))),
+                 "compressor state kv zero")) return 0;
     fill_f32_kernel<<<(state_n + 255) / 256, 256>>>((float *)state_score->ptr, state_n, -INFINITY);
     if (!cuda_ok(cudaGetLastError(), "compressor state score fill launch")) return 0;
     uint64_t n = (uint64_t)ratio * width;

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -23,6 +23,7 @@ ds4_gpu_tensor *ds4_gpu_tensor_view(const ds4_gpu_tensor *base, uint64_t offset,
 void ds4_gpu_tensor_free(ds4_gpu_tensor *tensor);
 uint64_t ds4_gpu_tensor_bytes(const ds4_gpu_tensor *tensor);
 void *ds4_gpu_tensor_contents(ds4_gpu_tensor *tensor);
+int ds4_gpu_tensor_fill_f32(ds4_gpu_tensor *tensor, float value, uint64_t count);
 int ds4_gpu_tensor_write(ds4_gpu_tensor *tensor, uint64_t offset, const void *data, uint64_t bytes);
 int ds4_gpu_tensor_read(const ds4_gpu_tensor *tensor, uint64_t offset, void *data, uint64_t bytes);
 int ds4_gpu_tensor_copy(ds4_gpu_tensor *dst, uint64_t dst_offset,

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -3848,6 +3848,14 @@ void *ds4_gpu_tensor_contents(ds4_gpu_tensor *tensor) {
     return (uint8_t *)[obj.buffer contents] + obj.offset;
 }
 
+int ds4_gpu_tensor_fill_f32(ds4_gpu_tensor *tensor, float value, uint64_t count) {
+    if (!tensor || count > ds4_gpu_tensor_bytes(tensor) / sizeof(float)) return 0;
+    float *p = ds4_gpu_tensor_contents(tensor);
+    if (!p && count != 0) return 0;
+    for (uint64_t i = 0; i < count; i++) p[i] = value;
+    return 1;
+}
+
 int ds4_gpu_tensor_write(ds4_gpu_tensor *tensor, uint64_t offset, const void *data, uint64_t bytes) {
     if (!tensor || (!data && bytes != 0)) return 0;
     DS4MetalTensor *obj = ds4_gpu_tensor_obj(tensor);


### PR DESCRIPTION
## Summary

This PR improves CUDA prefill throughput on NVIDIA GB10 / DGX Spark for the DeepSeek V4 Flash q2 imatrix model.

Changes:

- allocate CUDA graph/session tensors with `cudaMalloc()` instead of managed memory
- add a backend `ds4_gpu_tensor_fill_f32()` hook so CUDA can initialize tensors device-side while Metal keeps existing host-visible behavior
- use `cudaMemsetAsync()` for compressor `state_kv` zero fills
- make the slower MoE down `block16` subvariant opt-in via `DS4_CUDA_MOE_DOWN_BLOCK16`; the faster non-block16 tile16 path is now the default

## Results

Benchmark command:

```sh
./ds4-bench \
  -m ds4flash.gguf \
  --cuda \
  --prompt-file speed-bench/promessi_sposi.txt \
  --ctx-start 2048 \
  --ctx-max 2048 \
  --step-incr 2048 \
  --gen-tokens 128
```

Fresh runs on DGX Spark / GB10 (`CUDA_ARCH=sm_121`), comparing this branch against current `origin/main`:

| branch | prefill t/s | generation t/s |
| --- | ---: | ---: |
| this PR | 405.89 | 13.98 |
| this PR | 404.00 | 13.98 |
| origin/main | 328.95 | 13.78 |
| origin/main | 329.70 | 13.87 |

That is roughly a **23% prefill improvement** on this workload, with generation roughly neutral.

A longer-context spot check at 8192 tokens also improved:

| branch | prefill t/s | generation t/s |
| --- | ---: | ---: |
| this PR | 369.90 | 13.58 |
| origin/main | 314.22 | 13.32 |

## Correctness / validation

Built and ran CUDA smoke regression:

```sh
make clean
make -s CUDA_ARCH=sm_121
DS4_CUDA_TOPK_REGRESSION_SEC=10 make -s CUDA_ARCH=sm_121 cuda-regression
```

Output:

```text
cuda-regression: top-k n_comp=32768 n_tokens=32 elapsed=0.004s
cuda long-context regression: OK
```

I also compared a short greedy CUDA logprob dump against `origin/main`; selected token IDs and top selected logits matched exactly for the tested prompt.
