### PR TITLE
Makefile: auto-detect Debian/Ubuntu CUDA installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,16 @@ CPU_CORE_OBJS = ds4_cpu.o
 else
 CFLAGS += -D_GNU_SOURCE -fno-finite-math-only
 CUDA_HOME ?= /usr/local/cuda
+
+# Auto-detect Debian/Ubuntu apt-installed CUDA.
+ifeq ($(UNAME_S),Linux)
+ifeq ($(wildcard $(CUDA_HOME)/bin/nvcc),)
+ifneq ($(wildcard /usr/bin/nvcc),)
+CUDA_HOME := /usr
+endif
+endif
+endif
+
 NVCC ?= $(CUDA_HOME)/bin/nvcc
 CUDA_ARCH ?=
 ifneq ($(strip $(CUDA_ARCH)),)


### PR DESCRIPTION
- Auto-detect Debian/Ubuntu apt-installed CUDA on Linux when the default /usr/local/cuda nvcc path is absent.
- Set CUDA_HOME to /usr when /usr/bin/nvcc exists so NVCC resolves to the distro-provided compiler.
- Leave macOS, CPU builds, and existing CUDA linker flags unchanged.