### PR TITLE
flock: unlink lock file on release

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -109,6 +109,7 @@ enum {
 };
 
 static int g_ds4_lock_fd = -1;
+static const char *g_ds4_lock_path = NULL;
 
 #if defined(__GNUC__) || defined(__clang__)
 #define DS4_MAYBE_UNUSED __attribute__((unused))
@@ -15449,6 +15450,9 @@ static void ds4_release_instance_lock(void) {
     if (g_ds4_lock_fd >= 0) {
         close(g_ds4_lock_fd);
         g_ds4_lock_fd = -1;
+        if (g_ds4_lock_path) {
+            (void)unlink(g_ds4_lock_path);
+        }
     }
 }
 
@@ -15495,6 +15499,7 @@ static void ds4_acquire_instance_lock(void) {
     }
     dprintf(fd, "%ld\n", (long)getpid());
     g_ds4_lock_fd = fd;
+    g_ds4_lock_path = path;
     atexit(ds4_release_instance_lock);
 }
 


### PR DESCRIPTION
Store the lock path globally so we can unlink() after close. Prevents EACCES when a subsequent run executes under a different uid (root vs non-root) and the stale file from the previous owner can't be reopened.