### PR TITLE
Guard KV cache against page-cache pressure

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -5557,6 +5557,23 @@ static void kv_fill_header(uint8_t h[KV_CACHE_FIXED_HEADER], uint8_t quant_bits,
     le_put64(h + 40, payload_bytes);
 }
 
+/* Hint the kernel to drop clean page-cache pages for an open .kv file.
+ * The KV cache deliberately avoids mmap so cache restore does not add VM
+ * mappings to a process that already maps a very large GGUF; after a
+ * payload read or write the page-cache copy is dead weight that competes
+ * with the mmapped weights for RAM.  POSIX_FADV_DONTNEED only drops clean
+ * pages, so the effect on a fresh write is best-effort until the kernel
+ * has finished writeback.  Set DS4_KV_KEEP_PAGES=1 to disable for
+ * diagnostic comparisons. */
+static void kv_disk_drop_file_pages(int fd) {
+#if defined(POSIX_FADV_DONTNEED)
+    if (fd < 0 || getenv("DS4_KV_KEEP_PAGES") != NULL) return;
+    (void)posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+#else
+    (void)fd;
+#endif
+}
+
 static bool kv_read_header(FILE *fp, kv_entry *e, uint32_t *text_bytes) {
     uint8_t h[KV_CACHE_FIXED_HEADER];
     if (fread(h, 1, sizeof(h), fp) != sizeof(h)) return false;
@@ -6011,6 +6028,7 @@ static bool kv_cache_store_live_prefix(server *s, const ds4_tokens *tokens,
               kv_tool_map_write(s, fp, text, &tool_map_bytes) &&
               fflush(fp) == 0;
     int saved_errno = errno;
+    if (ok) kv_disk_drop_file_pages(fileno(fp));
     if (fclose(fp) != 0) {
         if (!saved_errno) saved_errno = errno;
         ok = false;
@@ -6169,6 +6187,7 @@ static int kv_cache_try_load_text(server *s, const char *prompt_text,
                    header_ok ? err : fail_reason,
                    (now_sec() - load_t0) * 1000.0);
     }
+    kv_disk_drop_file_pages(fileno(fp));
     fclose(fp);
 
     if (loaded > 0) {
@@ -8218,6 +8237,8 @@ int main(int argc, char **argv) {
 }
 #else
 
+#include <sys/mman.h>
+
 static int test_failures = 0;
 
 static void test_assert(bool cond, const char *file, int line, const char *expr) {
@@ -10024,6 +10045,114 @@ static void test_kv_cache_eviction_keeps_aligned_continued_frontiers(void) {
     rmdir(dir);
 }
 
+#if defined(__linux__) && defined(POSIX_FADV_DONTNEED)
+static size_t test_kv_count_resident_pages(const unsigned char *vec, size_t npages) {
+    size_t n = 0;
+    for (size_t i = 0; i < npages; i++) if (vec[i] & 1u) n++;
+    return n;
+}
+
+static size_t test_kv_resident_pages(int fd, size_t total, size_t npages,
+                                     unsigned char *vec) {
+    void *map = mmap(NULL, total, PROT_READ, MAP_SHARED, fd, 0);
+    if (map == MAP_FAILED) return SIZE_MAX;
+    size_t n = (mincore(map, total, vec) == 0)
+        ? test_kv_count_resident_pages(vec, npages)
+        : SIZE_MAX;
+    (void)munmap(map, total);
+    return n;
+}
+
+static void test_kv_disk_drop_file_pages_inner(bool keep_pages_env) {
+    const char *keep_env_name = "DS4_KV_KEEP_PAGES";
+    /* 4 MiB is enough for mincore signal/noise to be unambiguous while
+     * keeping the per-test write+fsync cheap on `make test`. */
+    const size_t total = (size_t)4 * 1024 * 1024;
+
+    char tmpl[] = "/tmp/ds4-kv-fadvise-test.XXXXXX";
+    char *dir = NULL;
+    char *path = NULL;
+    int fd = -1;
+    unsigned char *block = NULL;
+    unsigned char *vec = NULL;
+
+    dir = mkdtemp(tmpl);
+    TEST_ASSERT(dir != NULL);
+    if (!dir) goto done;
+
+    path = path_join(dir, "payload.bin");
+    fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    TEST_ASSERT(fd >= 0);
+    if (fd < 0) goto done;
+
+    const size_t page_sz = (size_t)getpagesize();
+    const size_t npages = total / page_sz;
+
+    block = xmalloc(page_sz);
+    for (size_t i = 0; i < page_sz; i++) block[i] = (unsigned char)(i & 0xff);
+    bool wrote_ok = true;
+    for (size_t off = 0; off < total; off += page_sz) {
+        if (write(fd, block, page_sz) != (ssize_t)page_sz) {
+            wrote_ok = false;
+            break;
+        }
+    }
+    TEST_ASSERT(wrote_ok);
+    if (!wrote_ok) goto done;
+
+    /* Force dirty pages clean so POSIX_FADV_DONTNEED can actually drop them. */
+    TEST_ASSERT(fsync(fd) == 0);
+
+    /* Linux only invalidates page-cache pages with zero mappings, so each
+     * residency measurement opens and releases its own mmap. */
+    vec = xmalloc(npages);
+    size_t v_before = test_kv_resident_pages(fd, total, npages, vec);
+    TEST_ASSERT(v_before != SIZE_MAX);
+    if (v_before == SIZE_MAX) goto done;
+    TEST_ASSERT(v_before >= (npages * 9) / 10);
+
+    if (keep_pages_env) {
+        TEST_ASSERT(setenv(keep_env_name, "1", 1) == 0);
+    } else {
+        unsetenv(keep_env_name);
+    }
+    kv_disk_drop_file_pages(fd);
+    if (keep_pages_env) {
+        TEST_ASSERT(unsetenv(keep_env_name) == 0);
+    }
+
+    size_t v_after = test_kv_resident_pages(fd, total, npages, vec);
+    TEST_ASSERT(v_after != SIZE_MAX);
+    if (v_after == SIZE_MAX) goto done;
+    if (keep_pages_env) {
+        TEST_ASSERT(v_after >= (v_before * 9) / 10);
+    } else {
+        TEST_ASSERT(v_after <= v_before / 4);
+    }
+
+done:
+    free(vec);
+    free(block);
+    if (fd >= 0) close(fd);
+    if (path) {
+        unlink(path);
+        free(path);
+    }
+    if (dir) rmdir(dir);
+}
+
+static void test_kv_disk_drop_file_pages_releases_page_cache(void) {
+    test_kv_disk_drop_file_pages_inner(false);
+}
+
+static void test_kv_disk_drop_file_pages_respects_keep_pages_env(void) {
+    test_kv_disk_drop_file_pages_inner(true);
+}
+#else
+static void test_kv_disk_drop_file_pages_releases_page_cache(void) { /* no-op without POSIX_FADV_DONTNEED */ }
+static void test_kv_disk_drop_file_pages_respects_keep_pages_env(void) { /* no-op without POSIX_FADV_DONTNEED */ }
+#endif
+
 static void test_thinking_checkpoint_canonical_matches_future_prompt(void) {
     /* Simulate: user sends a single message, thinking mode on, no tools.
      * Model generates reasoning + content.  The next request will drop the
@@ -10332,6 +10461,8 @@ static void ds4_server_unit_tests_run(void) {
     test_kv_cache_lookup_uses_longest_text_prefix();
     test_kv_cache_eviction_values_fresh_snapshots();
     test_kv_cache_eviction_keeps_aligned_continued_frontiers();
+    test_kv_disk_drop_file_pages_releases_page_cache();
+    test_kv_disk_drop_file_pages_respects_keep_pages_env();
 }
 
 #ifndef DS4_SERVER_TEST_NO_MAIN


### PR DESCRIPTION
The disk KV cache uses plain read/write to avoid mapping more VM into a process that already maps a large GGUF, but the bytes still land in the Linux page cache where they compete with the mmapped weights for resident memory. A 30k-token cold save leaves hundreds of MiB sitting in Cached: after the save returns, exactly the RAM pressure the no-mmap decision was meant to avoid.

Hint the kernel to invalidate those pages with
posix_fadvise(POSIX_FADV_DONTNEED) right after each full payload write and read. Header-only scans are deliberately untouched, since repeated small header reads still benefit from page-cache reuse. Expose DS4_KV_KEEP_PAGES=1 as an escape hatch for diagnostic comparisons, mirroring the existing cuda_model_drop_file_pages and its DS4_CUDA_KEEP_MODEL_PAGES toggle.

Correctness: make test; ./ds4_test --server.
Two new mincore-based tests assert that resident pages of a 4 MiB temp file drop from ~all to under 25% after the hint, and that DS4_KV_KEEP_PAGES=1 keeps them in place.