### PR TITLE
feat(server): optional SSE keepalive during long prefills

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -4679,6 +4679,20 @@ static bool sse_headers(int fd) {
     return send_all(fd, h, strlen(h));
 }
 
+/* Sent when --sse-keepalive-prefill flushed the response headers before prefill
+ * and prefill subsequently failed. The stream is already committed to 200 OK,
+ * so we cannot use http_error; emit a single SSE error event plus [DONE] so
+ * the client surfaces a useful message instead of an unterminated stream. */
+static void sse_error_event(int fd, const char *msg) {
+    buf b = {0};
+    buf_puts(&b, "data: {\"error\":{\"message\":");
+    json_escape(&b, msg ? msg : "prefill failed");
+    buf_puts(&b, ",\"type\":\"server_error\"}}\n\n");
+    (void)send_all(fd, b.ptr, b.len);
+    buf_free(&b);
+    (void)send_all(fd, "data: [DONE]\n\n", 14);
+}
+
 static bool sse_chunk(int fd, const request *r, const char *id, const char *text, const char *finish) {
     buf b = {0};
     long now = (long)time(NULL);
@@ -7476,6 +7490,7 @@ struct server {
     live_tool_state anthropic_live;
     visible_live_state thinking_live;
     bool disable_exact_dsml_tool_replay;
+    bool sse_keepalive_prefill;
     pthread_mutex_t tool_mu;
     pthread_mutex_t mu;
     pthread_cond_t cv;
@@ -9686,6 +9701,9 @@ typedef struct {
     double last_t;
     int last_current;
     bool seen;
+    int fd;
+    bool emit_keepalive;
+    bool client_gone;
 } server_prefill_progress;
 
 static void request_ctx_span(char *buf, size_t len, int cached, int prompt) {
@@ -9865,6 +9883,13 @@ static void server_progress_cb(void *ud, const char *event, int current, int tot
                elapsed);
     if (p->srv && current > p->cached_tokens) {
         kv_cache_maybe_store_continued(p->srv);
+    }
+    if (p->emit_keepalive && !p->client_gone) {
+        /* SSE comment lines (lines starting with ':') are ignored by parsers but
+         * keep the TCP connection warm so a client read timeout does not fire
+         * during a very long prefill. */
+        static const char ka[] = ": ds4 prefill keepalive\n\n";
+        if (!send_all(p->fd, ka, sizeof(ka) - 1)) p->client_gone = true;
     }
 }
 
@@ -10315,6 +10340,24 @@ static void generate_job(server *s, job *j) {
                req_flags);
     ds4_session_set_progress(s->session, server_progress_cb, &progress);
 
+    bool sse_headers_sent = false;
+    if (j->req.stream && s->sse_keepalive_prefill) {
+        if (!sse_headers(j->fd)) {
+            server_log(DS4_LOG_GENERATION,
+                       "ds4-server: %s ctx=%s%s%s sse headers failed",
+                       j->req.kind == REQ_CHAT ? "chat" : "completion",
+                       ctx_span,
+                       req_flags[0] ? " " : "",
+                       req_flags);
+            ds4_session_set_progress(s->session, NULL, NULL);
+            ds4_tokens_free(&effective_prompt);
+            return;
+        }
+        sse_headers_sent = true;
+        progress.fd = j->fd;
+        progress.emit_keepalive = true;
+    }
+
     int cold_store_len = 0;
     if (cached == 0 &&
         s->kv.enabled &&
@@ -10336,7 +10379,8 @@ static void generate_job(server *s, job *j) {
             ds4_tokens_free(&effective_prompt);
             ds4_session_set_progress(s->session, NULL, NULL);
             trace_event(s, trace_id, "prefill failed: %s", err);
-            http_error(j->fd, 500, err);
+            if (sse_headers_sent) sse_error_event(j->fd, err);
+            else http_error(j->fd, 500, err);
             return;
         }
         if (kv_cache_store_live_prefix(s, prompt_for_sync, cold_store_len, "cold")) {
@@ -10349,7 +10393,20 @@ static void generate_job(server *s, job *j) {
         ds4_tokens_free(&effective_prompt);
         ds4_session_set_progress(s->session, NULL, NULL);
         trace_event(s, trace_id, "prefill failed: %s", err);
-        http_error(j->fd, 500, err);
+        if (sse_headers_sent) sse_error_event(j->fd, err);
+        else http_error(j->fd, 500, err);
+        return;
+    }
+    if (progress.client_gone) {
+        ds4_tokens_free(&effective_prompt);
+        ds4_session_set_progress(s->session, NULL, NULL);
+        trace_event(s, trace_id, "client disconnected during prefill");
+        server_log(DS4_LOG_GENERATION,
+                   "ds4-server: %s ctx=%s%s%s client gone after prefill",
+                   j->req.kind == REQ_CHAT ? "chat" : "completion",
+                   ctx_span,
+                   req_flags[0] ? " " : "",
+                   req_flags);
         return;
     }
     /* Once a non-live request wins, old protocol live bindings are stale. Keep
@@ -10384,7 +10441,7 @@ static void generate_job(server *s, job *j) {
     const bool responses_live_chat = request_uses_responses_live_stream(&j->req);
     long responses_created_at = (long)time(NULL);
     if (j->req.stream) {
-        if (!sse_headers(j->fd)) {
+        if (!sse_headers_sent && !sse_headers(j->fd)) {
             server_log(DS4_LOG_GENERATION,
                        "ds4-server: %s ctx=%s%s%s sse headers failed",
                        j->req.kind == REQ_CHAT ? "chat" : "completion",
@@ -11245,6 +11302,7 @@ typedef struct {
     kv_cache_options kv_cache;
     bool kv_cache_reject_different_quant;
     bool disable_exact_dsml_tool_replay;
+    bool sse_keepalive_prefill;
     int tool_memory_max_ids;
 } server_config;
 
@@ -11385,6 +11443,13 @@ static void usage(FILE *fp) {
         "      Refuse checkpoints written by the same model with a different routed-expert quantization.\n"
         "  --disable-exact-dsml-tool-replay\n"
         "      Disable the tool-id -> exact sampled DSML map. Tool history falls back to canonical JSON rendering.\n"
+        "  --sse-keepalive-prefill\n"
+        "      For streaming requests, flush SSE response headers before prefill and\n"
+        "      emit a comment line per prefill chunk so the client TCP connection\n"
+        "      stays warm during very long prompts. Off by default. Useful when a\n"
+        "      large --ctx allows prefill to exceed typical HTTP client read\n"
+        "      timeouts; without it, the client may disconnect before the server\n"
+        "      finishes prefill and writes its first SSE byte.\n"
         "  --tool-memory-max-ids N\n"
         "      Maximum exact tool-call IDs kept in RAM for replay. Default: 100000\n"
         "\n"
@@ -11485,6 +11550,8 @@ static server_config parse_options(int argc, char **argv) {
             c.kv_cache_reject_different_quant = true;
         } else if (!strcmp(arg, "--disable-exact-dsml-tool-replay")) {
             c.disable_exact_dsml_tool_replay = true;
+        } else if (!strcmp(arg, "--sse-keepalive-prefill")) {
+            c.sse_keepalive_prefill = true;
         } else if (!strcmp(arg, "--tool-memory-max-ids")) {
             c.tool_memory_max_ids = parse_int_arg(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--quality")) {
@@ -11557,6 +11624,7 @@ int main(int argc, char **argv) {
     s.session = session;
     s.default_tokens = cfg.default_tokens;
     s.disable_exact_dsml_tool_replay = cfg.disable_exact_dsml_tool_replay;
+    s.sse_keepalive_prefill = cfg.sse_keepalive_prefill;
     s.tool_mem.max_entries = cfg.tool_memory_max_ids;
     if (cfg.kv_disk_dir) {
         kv_cache_open(&s.kv, cfg.kv_disk_dir, cfg.kv_disk_space_mb,


### PR DESCRIPTION
## Problem

For streaming requests, `ds4-server` writes the SSE response headers only after
`ds4_session_sync()` finishes prefill. With a large `--ctx` and a long prompt,
prefill can run for many minutes. Standard HTTP client read timeouts (typically
30-300 seconds) fire before the first SSE byte reaches the wire, so the client
disconnects and the server log shows `sse headers failed` after `prompt done`.

Reproduced on an Apple M3 Ultra with `--ctx 512000` and a streaming chat
request with a ~150K-token prompt against a cold cache:

```
chat ctx=0..150349:138061 TOOLS prefill chunk 150349/150349 (100.0%) chunk=158.41 t/s avg=245.44 t/s 562.508s
chat ctx=0..150349:138061 TOOLS prompt done 562.509s
chat ctx=0..150349:138061 sse headers failed
```

The client received zero bytes for 562 seconds, timed out, and disconnected.
The server completed prefill (and wrote continued/cold disk checkpoints) but
the response went nowhere.

## Change

A new opt-in flag `--sse-keepalive-prefill`. When set, for streaming requests:

1. SSE response headers are flushed before prefill starts.
2. A `: ds4 prefill keepalive` comment line is emitted on every prefill
   progress callback (one per ~2048-token chunk) via the existing
   `server_prefill_progress` path. Comment lines (`:` prefix) are part of the
   SSE spec and ignored by compliant parsers, but they keep the TCP connection
   active so a client read timeout does not fire.
3. If a keepalive write fails, the per-request progress struct sets
   `client_gone`. After prefill completes, the request handler logs
   `client gone after prefill` and returns without running decode.
4. If prefill itself fails after the early flush, a new `sse_error_event()`
   helper sends a single SSE `data: {"error":{"message":"...","type":"server_error"}}`
   event followed by `data: [DONE]`, since the response is already committed
   to `200 OK` and cannot be downgraded to `500`.

The flag is off by default. With the flag off, the request handler is
byte-identical to the prior code: the late `sse_headers()` call still fires
after `prompt done`, and prefill failure still goes through
`http_error(500, ...)`.

## Behavior difference reviewers should know about

When the flag is **on** and prefill fails, the response is delivered as an
SSE error event under a `200 OK` status, not as `500 Internal Server Error`
with a JSON body. This affects clients differently depending on how they
classify errors:

- **SSE-aware SDKs (OpenAI Python/JS, Anthropic, LiteLLM, vercel/ai):** parse
  the `error` key in event payloads and surface the failure as expected.
- **Clients keyed on HTTP status code:** see `200` and treat the response as
  success. Retry logic gated on `5xx` will not trigger. The error message is
  still on the wire as the first SSE event, but a client that does not parse
  SSE payloads will miss it.

Making this opt-in avoids changing failure semantics for existing deployments
where prefill is fast enough that the original ordering is not a problem.

## Scope boundaries

The change touches only the HTTP layer of `generate_job()` and the prefill
progress callback. Specifically untouched:

- Metal compute kernels, MTP draft logic, attention/compressor state.
- KV cache file format, cache-key derivation, cold/continued/evict triggers.
- `--quality`, `--mtp-*`, and all sampling/decoding parameters.
- The flag-off code path through `generate_job()` is identical to upstream.
- Disk cache `continued` saves still fire during prefill regardless of flag
  state, so an abandoned-by-client request still populates the cache and a
  retry will hit it.

There is no cancellation path through `ds4_session_sync()`. A client that
disconnects mid-prefill still costs the GPU the full prefill time before the
server returns; the change just skips decode in that case. Adding real
cancellation would be a larger refactor of the engine API.

## Cost when the flag is on

- One ~25-byte SSE comment per prefill chunk on the wire, plus the usual
  TCP/IP headers per packet. At ~one chunk every several seconds, this is on
  the order of 30 KB per hour of prefill.
- One `send_all()` syscall per progress callback. The write goes into the
  kernel send buffer and returns immediately on a healthy socket.
  Microseconds against ~8-10 seconds of GPU work per chunk.
- One `bool` on `server_config` and `server` each. Three additional fields
  (`int fd`, `bool emit_keepalive`, `bool client_gone`) on the stack-allocated
  per-request `server_prefill_progress`.

## Testing

- `make ds4-server` builds clean with no new warnings.
- Server-side unit tests under `DS4_SERVER_TEST` pass:
  `ds4-server tests: ok`.
- End-to-end verified on a 256 GB Apple M3 Ultra with `--ctx 512000`: a
  streaming chat request with a ~150K-token prompt completes successfully
  with `--sse-keepalive-prefill` set, where the same request reproducibly
  failed with `sse headers failed` without the flag.

## How to enable

Add `--sse-keepalive-prefill` to the server command line. For example:

```
./ds4-server --ctx 512000 --kv-disk-dir /tmp/ds4-kv --sse-keepalive-prefill
```

## Help text

```
  --sse-keepalive-prefill
      For streaming requests, flush SSE response headers before prefill and
      emit a comment line per prefill chunk so the client TCP connection
      stays warm during very long prompts. Off by default. Useful when a
      large --ctx allows prefill to exceed typical HTTP client read
      timeouts; without it, the client may disconnect before the server
      finishes prefill and writes its first SSE byte.
```
