### PR TITLE
cuda: fix HMM path on coherent unified-memory systems (GB10 NVLink-C2C)

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -305,6 +305,8 @@ static const char *cuda_model_range_ptr(const void *model_map, uint64_t offset, 
 static int cuda_model_range_is_cached(const void *model_map, uint64_t offset, uint64_t bytes) {
     if (bytes == 0) return 1;
     if (g_model_device_owned || g_model_registered) return 1;
+    /* On the HMM direct path every range is immediately accessible. */
+    if (g_model_hmm_direct) return 1;
 
     const uint64_t end = offset + bytes;
     if (end < offset) return 0;
@@ -1487,6 +1489,12 @@ extern "C" int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size)
     } else {
         fprintf(stderr, "ds4: CUDA host registration skipped: %s\n", cudaGetErrorString(err));
         (void)cudaGetLastError();
+        /* On coherent unified memory systems (e.g. Grace-Blackwell NVLink-C2C) the
+         * host mmap pointer is directly addressable by the GPU via HMM page faults.
+         * Queue an async prefetch of the full model so pages are resident before
+         * inference starts, avoiding per-kernel page-fault stalls.  The function
+         * also sets g_model_hmm_direct=1 on success. */
+        (void)cuda_model_prefetch_range(model_map, model_size, 0, model_size);
     }
     return 1;
 }


### PR DESCRIPTION
## Problem

On systems where `cudaHostRegister()` returns `cudaErrorNotSupported` (e.g.
NVIDIA Grace-Blackwell GB10 / DGX Spark with NVLink-C2C unified memory), the
`else` branch in `ds4_gpu_set_model_map()` only logged the error and returned.
`g_model_hmm_direct` was never set, so `cuda_model_range_is_cached()` returned
0 for every tensor range.

This caused `cuda_model_range_ptr()` to fall through to the per-range
`cudaMalloc` + `cudaMemcpy` path on every first tensor access — silently
allocating ~87 GB of redundant device copies of the 80.76 GiB model:

```
# Without fix, on GB10 running ds4_test:
free -h:       Mem: 121Gi used 98Gi, available 23Gi
nvidia-smi:    ds4_test   87,992 MiB
```

The model weights end up in CUDA device-private pools (not evictable, invisible
to `/proc/PID/smaps`, only visible via `MemFree` shrinking and nvidia-smi's
per-process column). A second model cannot be co-loaded.

## Root cause

`cuda_model_prefetch_range()` was fully implemented and correct — but its only
call site on Linux/CUDA was behind the `DS4_CUDA_COPY_MODEL_CHUNKED` env var.
On a normal GB10 run:
1. `DS4_CUDA_COPY_MODEL_CHUNKED` is not set
2. `cudaHostRegister` fails with `cudaErrorNotSupported`
3. The `else` branch clears the error and returns — prefetch never called
4. `g_model_hmm_direct` stays 0 → per-range copy runs for every tensor

## Fix

Two hunks, 8 lines total:

**Hunk 1** — `ds4_gpu_set_model_map()`: when registration is skipped, call
`cuda_model_prefetch_range()` which issues `cudaMemPrefetchAsync` over the
full mmap region and sets `g_model_hmm_direct = 1` on success.

**Hunk 2** — `cuda_model_range_is_cached()`: short-circuit to 1 when
`g_model_hmm_direct` is set, so the per-range copy path is never reached
(the existing check on line ~200 in `cuda_model_range_ptr` is not reached
because `is_cached` runs first).

## Results on DGX Spark GB10

Hardware: SM_121, 128 GB unified LPDDR5x, NVLink-C2C ~900 GB/s  
Model: DeepSeek V4 Flash IQ2_XXS-w2Q2K (80.76 GiB)  
CUDA 13.0, driver 580.142

| Metric | Before | After |
|--------|--------|-------|
| `free -h` used | ~98 GB | ~26 GB |
| `free -h` available | ~23 GB | ~95 GB |
| nvidia-smi process | 87,992 MiB | ~26,000 MiB |
| Weight memory type | CUDA device allocs (locked) | File page cache (reclaimable) |
| GPU utilization | ~50% (copy stalls) | 94% |
| Throughput | degraded | **13.81 t/s** |
| Second model co-loadable | No | Yes |

## Testing

Manually verified on GB10. Full `make cuda-regression` suite not yet run —
happy to do so if you can confirm there's no known issue running the suite on
SM_121 / CUDA 13.0.