### PR TITLE
fix(kv-cache): drop superseded continued snapshots on store

### DIFF
--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -562,6 +562,55 @@ void ds4_kvstore_evict(ds4_kvstore *kc, const ds4_tokens *live,
     }
 }
 
+/* Walk the on-disk index and unlink any continued snapshot whose rendered
+ * text is a strict prefix of the new snapshot's rendered text.  Continued
+ * snapshots are intermediate restart frontiers (see the comment in
+ * ds4_kvstore_entry_eviction_score above); once a longer same-prefix
+ * snapshot exists, the shorter continued entry serves no further purpose
+ * because the longer one dominates it on every prefix lookup.
+ * Cold/evict/shutdown entries on disk are explicit checkpoints (for
+ * example the anchor cold cut at the chat-task boundary) and are left
+ * alone so that workloads which diverge past their length can still hit
+ * them.  Skips the new entry itself.
+ *
+ * Only invoke this when the new store represents a freshly validated
+ * in-progress prefix (continued or cold).  Evict and shutdown stores save
+ * a live state at the moment it has just diverged from an incoming
+ * request, so the saved content may include post-divergence tokens that
+ * no future prompt will match; in that case the shorter continued
+ * snapshots are strict pre-divergence prefixes and remain useful, and the
+ * caller must not call this function.
+ *
+ * The caller is expected to follow up with ds4_kvstore_evict, whose
+ * refresh will rebuild the in-memory index from the post-prune directory
+ * state. */
+void ds4_kvstore_prune_supersedes(ds4_kvstore *kc,
+                                  const char *new_text,
+                                  size_t new_text_len,
+                                  const char *new_sha) {
+    if (!kc->enabled || !new_text || new_text_len == 0 || !new_sha) return;
+    kv_cache_refresh(kc);
+    for (int i = 0; i < kc->len; i++) {
+        const ds4_kvstore_entry *e = &kc->entry[i];
+        if (e->reason != DS4_KVSTORE_REASON_CONTINUED) continue;
+        if (e->text_bytes == 0 || (size_t)e->text_bytes >= new_text_len) continue;
+        if (!strcmp(e->sha, new_sha)) continue;
+        char prefix_sha[41];
+        ds4_kvstore_sha1_bytes_hex(new_text, (size_t)e->text_bytes, prefix_sha);
+        if (strcmp(prefix_sha, e->sha) != 0) continue;
+        if (unlink(e->path) == 0) {
+            kv_logf(kc, DS4_KVSTORE_LOG_KVCACHE,
+                    "%s: kv cache evicted reason=superseded tokens=%u hits=%u size=%.2f MiB file=%s by=%s",
+                    kv_log_name(kc),
+                    e->tokens,
+                    e->hits,
+                    (double)e->file_size / (1024.0 * 1024.0),
+                    e->path ? e->path : "?",
+                    new_sha);
+        }
+    }
+}
+
 bool ds4_kvstore_open(ds4_kvstore *kc, const char *dir, uint64_t budget_mb,
                       bool reject_different_quant, ds4_kvstore_options opt,
                       const char *log_name,
@@ -1074,6 +1123,16 @@ bool ds4_kvstore_store_live_prefix_text(ds4_kvstore *kc,
                 text_override ? (cache_text_key ? cache_text_key : "visible-transcript") : "token-text",
                 (double)(DS4_KVSTORE_FIXED_HEADER + 4ull + text_len + payload_bytes + trailer_bytes) / (1024.0 * 1024.0),
                 save_ms);
+        /* Evict and shutdown stores save a live state that has just diverged
+         * from the next incoming request (or that is about to be discarded);
+         * their full content may include post-divergence tokens that no
+         * future prompt will match.  Shorter same-session continued
+         * snapshots are strict pre-divergence prefixes and remain valuable.
+         * Only run the strict-prefix prune for continued and cold stores,
+         * where the new entry truly dominates its shorter siblings. */
+        if (strcmp(reason, "evict") != 0 && strcmp(reason, "shutdown") != 0) {
+            ds4_kvstore_prune_supersedes(kc, text, text_len, sha);
+        }
         ds4_kvstore_evict(kc, live_tokens, sha);
     }
     free(tmp);

--- a/ds4_kvstore.h
+++ b/ds4_kvstore.h
@@ -147,6 +147,10 @@ double ds4_kvstore_entry_eviction_score(const ds4_kvstore_entry *e,
                                         uint64_t now);
 void ds4_kvstore_evict(ds4_kvstore *kc, const ds4_tokens *live,
                        const char *protected_sha);
+void ds4_kvstore_prune_supersedes(ds4_kvstore *kc,
+                                  const char *new_text,
+                                  size_t new_text_len,
+                                  const char *new_sha);
 int ds4_kvstore_find_text_prefix(ds4_kvstore *kc, const char *prompt_text,
                                  int model_id, int quant_bits, int ctx_size);
 

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -8578,6 +8578,13 @@ static void kv_cache_evict(kv_disk_cache *kc, const ds4_tokens *live,
                            const char *protected_sha) {
     ds4_kvstore_evict(kc, live, protected_sha);
 }
+
+static void kv_cache_prune_supersedes(kv_disk_cache *kc,
+                                      const char *new_text,
+                                      size_t new_text_len,
+                                      const char *new_sha) {
+    ds4_kvstore_prune_supersedes(kc, new_text, new_text_len, new_sha);
+}
 #endif
 
 static void kv_cache_log_cb(void *ud, ds4_kvstore_log_type type, const char *msg) {
@@ -14619,7 +14626,8 @@ static void test_kv_stub_file(const char *dir, const char *sha,
 }
 
 static void test_kv_text_stub_file_model(const char *dir, const char *text,
-                                         uint8_t model_id, uint32_t tokens,
+                                         uint8_t model_id, uint8_t reason,
+                                         uint32_t tokens,
                                          uint64_t payload_bytes) {
     char sha[41];
     sha1_bytes_hex(text, strlen(text), sha);
@@ -14634,7 +14642,7 @@ static void test_kv_text_stub_file_model(const char *dir, const char *text,
     }
 
     uint8_t h[KV_CACHE_FIXED_HEADER];
-    ds4_kvstore_fill_header(h, model_id, 2, KV_REASON_COLD, 0, tokens, 0,
+    ds4_kvstore_fill_header(h, model_id, 2, reason, 0, tokens, 0,
                             32768, 100, 100, payload_bytes);
     uint8_t text_len[4];
     le_put32(text_len, (uint32_t)strlen(text));
@@ -14649,8 +14657,9 @@ static void test_kv_text_stub_file_model(const char *dir, const char *text,
 }
 
 static void test_kv_text_stub_file(const char *dir, const char *text,
+                                   uint8_t reason,
                                    uint32_t tokens, uint64_t payload_bytes) {
-    test_kv_text_stub_file_model(dir, text, 0, tokens, payload_bytes);
+    test_kv_text_stub_file_model(dir, text, 0, reason, tokens, payload_bytes);
 }
 
 static void test_kv_cache_lookup_uses_longest_text_prefix(void) {
@@ -14661,8 +14670,8 @@ static void test_kv_cache_lookup_uses_longest_text_prefix(void) {
 
     const char *short_text = "transcript prefix";
     const char *long_text = "transcript prefix with sampled token bytes";
-    test_kv_text_stub_file(dir, short_text, 512, 0);
-    test_kv_text_stub_file(dir, long_text, 768, 0);
+    test_kv_text_stub_file(dir, short_text, KV_REASON_COLD, 512, 0);
+    test_kv_text_stub_file(dir, long_text, KV_REASON_COLD, 768, 0);
 
     kv_disk_cache kc = {0};
     kc.enabled = true;
@@ -14700,7 +14709,7 @@ static void test_kv_cache_lookup_rejects_wrong_model(void) {
     if (!dir) return;
 
     const char *text = "shared rendered prefix";
-    test_kv_text_stub_file_model(dir, text, 1, 512, 0);
+    test_kv_text_stub_file_model(dir, text, 1, KV_REASON_COLD, 512, 0);
 
     kv_disk_cache kc = {0};
     kc.enabled = true;
@@ -14965,6 +14974,147 @@ static void test_kv_cache_eviction_does_not_protect_oversize_current_store(void)
     unlink(new_path);
     free(old_path);
     free(new_path);
+    rmdir(dir);
+}
+
+static void test_kv_cache_prune_supersedes_unlinks_strict_prefix(void) {
+    char tmpl[] = "/tmp/ds4-kv-supersede-test.XXXXXX";
+    char *dir = mkdtemp(tmpl);
+    TEST_ASSERT(dir != NULL);
+    if (!dir) return;
+
+    const char *short_text = "system: hello world";
+    const char *long_text  = "system: hello world\nuser: prompt";
+    test_kv_text_stub_file(dir, short_text, KV_REASON_CONTINUED, 10, 1024);
+    test_kv_text_stub_file(dir, long_text,  KV_REASON_CONTINUED, 20, 2048);
+
+    char short_sha[41], long_sha[41];
+    sha1_bytes_hex(short_text, strlen(short_text), short_sha);
+    sha1_bytes_hex(long_text,  strlen(long_text),  long_sha);
+    char short_name[44], long_name[44];
+    snprintf(short_name, sizeof(short_name), "%.40s.kv", short_sha);
+    snprintf(long_name,  sizeof(long_name),  "%.40s.kv", long_sha);
+    char *short_path = path_join(dir, short_name);
+    char *long_path  = path_join(dir, long_name);
+
+    kv_disk_cache kc = {0};
+    kc.enabled = true;
+    kc.dir = xstrdup(dir);
+    kc.opt = kv_cache_default_options();
+    kc.budget_bytes = (uint64_t)1 << 30;
+    kv_cache_prune_supersedes(&kc, long_text, strlen(long_text), long_sha);
+
+    TEST_ASSERT(access(short_path, F_OK) != 0);
+    TEST_ASSERT(access(long_path, F_OK) == 0);
+
+    kv_cache_close(&kc);
+    unlink(short_path);
+    unlink(long_path);
+    free(short_path);
+    free(long_path);
+    rmdir(dir);
+}
+
+static void test_kv_cache_prune_supersedes_keeps_unrelated(void) {
+    char tmpl[] = "/tmp/ds4-kv-supersede-keep-test.XXXXXX";
+    char *dir = mkdtemp(tmpl);
+    TEST_ASSERT(dir != NULL);
+    if (!dir) return;
+
+    const char *unrelated_text = "different workload entirely";
+    const char *new_text       = "system: hello world\nuser: prompt";
+    test_kv_text_stub_file(dir, unrelated_text, KV_REASON_CONTINUED, 8, 512);
+
+    char unrelated_sha[41], new_sha[41];
+    sha1_bytes_hex(unrelated_text, strlen(unrelated_text), unrelated_sha);
+    sha1_bytes_hex(new_text,       strlen(new_text),       new_sha);
+    char unrelated_name[44];
+    snprintf(unrelated_name, sizeof(unrelated_name), "%.40s.kv", unrelated_sha);
+    char *unrelated_path = path_join(dir, unrelated_name);
+
+    kv_disk_cache kc = {0};
+    kc.enabled = true;
+    kc.dir = xstrdup(dir);
+    kc.opt = kv_cache_default_options();
+    kc.budget_bytes = (uint64_t)1 << 30;
+    kv_cache_prune_supersedes(&kc, new_text, strlen(new_text), new_sha);
+
+    TEST_ASSERT(access(unrelated_path, F_OK) == 0);
+
+    kv_cache_close(&kc);
+    unlink(unrelated_path);
+    free(unrelated_path);
+    rmdir(dir);
+}
+
+static void test_kv_cache_prune_supersedes_skips_self(void) {
+    char tmpl[] = "/tmp/ds4-kv-supersede-self-test.XXXXXX";
+    char *dir = mkdtemp(tmpl);
+    TEST_ASSERT(dir != NULL);
+    if (!dir) return;
+
+    const char *new_text = "system: hello world";
+    test_kv_text_stub_file(dir, new_text, KV_REASON_CONTINUED, 10, 1024);
+
+    char new_sha[41];
+    sha1_bytes_hex(new_text, strlen(new_text), new_sha);
+    char new_name[44];
+    snprintf(new_name, sizeof(new_name), "%.40s.kv", new_sha);
+    char *new_path = path_join(dir, new_name);
+
+    kv_disk_cache kc = {0};
+    kc.enabled = true;
+    kc.dir = xstrdup(dir);
+    kc.opt = kv_cache_default_options();
+    kc.budget_bytes = (uint64_t)1 << 30;
+    kv_cache_prune_supersedes(&kc, new_text, strlen(new_text), new_sha);
+
+    TEST_ASSERT(access(new_path, F_OK) == 0);
+
+    kv_cache_close(&kc);
+    unlink(new_path);
+    free(new_path);
+    rmdir(dir);
+}
+
+static void test_kv_cache_prune_supersedes_keeps_cold_checkpoint(void) {
+    char tmpl[] = "/tmp/ds4-kv-supersede-cold-test.XXXXXX";
+    char *dir = mkdtemp(tmpl);
+    TEST_ASSERT(dir != NULL);
+    if (!dir) return;
+
+    /* The short entry is a cold checkpoint (e.g. an anchor-user cut at the
+     * system-prompt boundary).  A longer same-prefix snapshot must not delete
+     * it; conversations that diverge past the short prefix still need it. */
+    const char *short_text = "system: hello world";
+    const char *long_text  = "system: hello world\nuser: prompt";
+    test_kv_text_stub_file(dir, short_text, KV_REASON_COLD,      10, 1024);
+    test_kv_text_stub_file(dir, long_text,  KV_REASON_CONTINUED, 20, 2048);
+
+    char short_sha[41], long_sha[41];
+    sha1_bytes_hex(short_text, strlen(short_text), short_sha);
+    sha1_bytes_hex(long_text,  strlen(long_text),  long_sha);
+    char short_name[44], long_name[44];
+    snprintf(short_name, sizeof(short_name), "%.40s.kv", short_sha);
+    snprintf(long_name,  sizeof(long_name),  "%.40s.kv", long_sha);
+    char *short_path = path_join(dir, short_name);
+    char *long_path  = path_join(dir, long_name);
+
+    kv_disk_cache kc = {0};
+    kc.enabled = true;
+    kc.dir = xstrdup(dir);
+    kc.opt = kv_cache_default_options();
+    kc.budget_bytes = (uint64_t)1 << 30;
+    kv_cache_prune_supersedes(&kc, long_text, strlen(long_text), long_sha);
+
+    TEST_ASSERT(access(short_path, F_OK) == 0);
+    TEST_ASSERT(access(long_path, F_OK) == 0);
+
+    kv_cache_close(&kc);
+    unlink(short_path);
+    unlink(long_path);
+    free(short_path);
+    free(long_path);
     rmdir(dir);
 }
 
@@ -15415,6 +15565,10 @@ static void ds4_server_unit_tests_run(void) {
     test_kv_cache_eviction_values_fresh_snapshots();
     test_kv_cache_eviction_protects_current_store();
     test_kv_cache_eviction_does_not_protect_oversize_current_store();
+    test_kv_cache_prune_supersedes_unlinks_strict_prefix();
+    test_kv_cache_prune_supersedes_keeps_unrelated();
+    test_kv_cache_prune_supersedes_skips_self();
+    test_kv_cache_prune_supersedes_keeps_cold_checkpoint();
     test_kv_cache_eviction_score_decays_stale_hits();
     test_kv_cache_eviction_decayed_hits_tie_break_by_age();
     test_kv_cache_eviction_keeps_aligned_continued_frontiers();


### PR DESCRIPTION
Fixes #174

Implements the supersession proposed in #174.
Adds kv_cache_prune_supersedes in the store path, called before kv_cache_evict for cold and continued stores (skipped for evict/shutdown stores where the saved live state may diverge from upcoming requests). Includes four unit tests.