### PR TITLE
[codex] Fix CUDA object rebuild on config changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ OBJCFLAGS ?= -O3 -ffast-math $(NATIVE_CPU_FLAG) -Wall -Wextra -fobjc-arc
 
 LDLIBS ?= -lm -pthread
 METAL_SRCS := $(wildcard metal/*.metal)
+CUDA_CONFIG := .ds4_cuda.config
 
 ifeq ($(UNAME_S),Darwin)
 METAL_LDLIBS := $(LDLIBS) -framework Foundation -framework Metal
@@ -32,7 +33,7 @@ CPU_CORE_OBJS = ds4_cpu.o
 METAL_LDLIBS := $(LDLIBS)
 endif
 
-.PHONY: all help clean test cpu cuda cuda-spark cuda-generic cuda-regression
+.PHONY: all help clean test cpu cuda cuda-spark cuda-generic cuda-regression FORCE
 
 ifeq ($(UNAME_S),Darwin)
 all: ds4 ds4-server ds4-bench ds4-eval
@@ -110,6 +111,20 @@ cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_eval_cpu.o linenoise.o r
 
 cuda-regression: tests/cuda_long_context_smoke
 	./tests/cuda_long_context_smoke
+
+$(CUDA_CONFIG): FORCE
+	@tmp="$@.tmp"; \
+	{ \
+		printf '%s\n' "CUDA_ARCH=$(CUDA_ARCH)"; \
+		printf '%s\n' "NVCC=$(NVCC)"; \
+		printf '%s\n' "NVCCFLAGS=$(NVCCFLAGS)"; \
+	} > "$$tmp"; \
+	if test -r "$@" && cmp -s "$$tmp" "$@"; then \
+		rm -f "$$tmp"; \
+	else \
+		mv "$$tmp" "$@"; \
+		rm -f ds4_cuda.o; \
+	fi
 endif
 
 ds4.o: ds4.c ds4.h ds4_gpu.h
@@ -157,7 +172,7 @@ ds4_eval_cpu.o: ds4_eval.c ds4.h
 ds4_metal.o: ds4_metal.m ds4_gpu.h $(METAL_SRCS)
 	$(CC) $(OBJCFLAGS) -c -o $@ ds4_metal.m
 
-ds4_cuda.o: ds4_cuda.cu ds4_gpu.h ds4_iq2_tables_cuda.inc
+ds4_cuda.o: ds4_cuda.cu ds4_gpu.h ds4_iq2_tables_cuda.inc $(CUDA_CONFIG)
 	$(NVCC) $(NVCCFLAGS) -c -o $@ ds4_cuda.cu
 
 tests/cuda_long_context_smoke: tests/cuda_long_context_smoke.o ds4_cuda.o
@@ -174,4 +189,4 @@ test: ds4_test
 	./ds4_test
 
 clean:
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4_cpu ds4_native ds4_server_test ds4_test *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4_cpu ds4_native ds4_server_test ds4_test *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o $(CUDA_CONFIG) $(CUDA_CONFIG).tmp


### PR DESCRIPTION
## Summary

Fixes stale CUDA object reuse when switching CUDA build settings in the same checkout.

The Makefile now writes a small CUDA config stamp containing `CUDA_ARCH`, `NVCC`, and `NVCCFLAGS`. `ds4_cuda.o` depends on that stamp, and the stamp rule removes the old CUDA object only when those recorded settings change. `make clean` also removes the stamp and temporary stamp file.

## Why

GNU Make does not rebuild a target just because the expanded recipe command changes. A build such as `make cuda CUDA_ARCH=sm_90` followed by `make cuda CUDA_ARCH=sm_120` could relink with the old `ds4_cuda.o`, producing a binary built for the wrong CUDA target.

## Validation

- `git diff --check`
- `make -n UNAME_S=Linux cuda CUDA_ARCH=sm_90`
- Focused stamp check: same CUDA settings preserve `ds4_cuda.o`; changed CUDA settings remove it so Make rebuilds it.
- `make test` was run on Apple M5 Max. It passed long-context, tool-call-quality, metal-kernels, and server sections, but the existing logprob-vectors fixture failed on `short_code_completion` token mismatches.
