### PR TITLE
ds4-server: keep SSE connection alive during long prefill

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -10069,6 +10069,15 @@ typedef struct {
     double last_t;
     int last_current;
     bool seen;
+    /* SSE keepalive during long prefill: send HTTP/SSE headers ahead of
+     * generation and emit a `:` comment line every few seconds so HTTP/TCP
+     * idle timeouts on the client side don't close the connection while the
+     * server is busy doing prefill. */
+    int fd;
+    bool stream;
+    bool enable_cors;
+    bool headers_sent;
+    double last_keepalive;
 } server_prefill_progress;
 
 static void request_ctx_span(char *buf, size_t len, int cached, int prompt) {
@@ -10203,6 +10212,23 @@ static void server_progress_cb(void *ud, const char *event, int current, int tot
     if (!p || !event || strcmp(event, "prefill_chunk")) return;
 
     double now = now_sec();
+    /* Keep the HTTP/SSE connection alive while prefill runs.  We write the SSE
+     * response headers the first time the callback fires and then emit a
+     * comment line (`:` prefix, ignored by SSE clients) every few seconds.
+     * Best-effort: if the client has already gone away, the writes fail
+     * silently and the outer code will discover the closed socket the next
+     * time it tries to stream a real event. */
+    if (p->stream && p->fd >= 0) {
+        if (!p->headers_sent) {
+            (void)sse_headers(p->fd, p->enable_cors);
+            p->headers_sent = true;
+            p->last_keepalive = now;
+        } else if (now - p->last_keepalive >= 5.0) {
+            static const char ka[] = ": prefill\n\n";
+            (void)send_all(p->fd, ka, sizeof(ka) - 1);
+            p->last_keepalive = now;
+        }
+    }
     double elapsed = now - p->t0;
     if (p->seen && current == p->last_current) {
         if (p->srv && current > p->cached_tokens) {
@@ -10436,6 +10462,14 @@ static void canonicalize_tool_checkpoint(server *s, const job *j, const char *ct
             .phase = "tool checkpoint rebuild",
             .has_tools = j->req.has_tools,
             .t0 = rebuild_t0,
+            .fd = j->fd,
+            .stream = j->req.stream,
+            .enable_cors = s->enable_cors,
+            /* Tool checkpoint rebuild only runs after the response stream is
+             * already in flight, so the SSE headers were sent long ago.
+             * Pre-arm the flag so the progress callback only emits keepalive
+             * comments and never tries to write a second set of headers. */
+            .headers_sent = true,
         };
         snprintf(rebuild_progress.ctx, sizeof(rebuild_progress.ctx), "%s", rebuild_ctx);
         ds4_session_set_progress(s->session, server_progress_cb, &rebuild_progress);
@@ -10655,6 +10689,9 @@ static void generate_job(server *s, job *j) {
         .has_tools = j->req.has_tools,
         .responses_protocol = responses_protocol,
         .t0 = t0,
+        .fd = j->fd,
+        .stream = j->req.stream,
+        .enable_cors = s->enable_cors,
     };
     snprintf(progress.ctx, sizeof(progress.ctx), "%s", ctx_span);
     char req_flags[64];
@@ -10801,7 +10838,10 @@ static void generate_job(server *s, job *j) {
     const bool responses_live_chat = request_uses_responses_live_stream(&j->req);
     long responses_created_at = (long)time(NULL);
     if (j->req.stream) {
-        if (!sse_headers(j->fd, s->enable_cors)) {
+        /* The prefill progress callback may have already sent the SSE headers
+         * to keep the connection alive during a long prefill. Only emit them
+         * here when prefill never fired (e.g. fully cached prompt). */
+        if (!progress.headers_sent && !sse_headers(j->fd, s->enable_cors)) {
             server_log(DS4_LOG_GENERATION,
                        "ds4-server: %s ctx=%s%s%s sse headers failed",
                        j->req.kind == REQ_CHAT ? "chat" : "completion",
@@ -10811,6 +10851,7 @@ static void generate_job(server *s, job *j) {
             ds4_tokens_free(&effective_prompt);
             return;
         }
+        progress.headers_sent = true;
         if (j->req.api == API_ANTHROPIC &&
             !anthropic_sse_start_live(j->fd, &j->req, id,
                                       prompt_tokens, &anthropic_live)) {


### PR DESCRIPTION
## Summary

Long prefills (large prompts with no cache hit) can take minutes on local hardware. Today ds4-server is silent on the socket for that entire window, so HTTP/TCP idle timeouts on the client side will close the connection before the first response byte. The existing log line `"sse headers failed"` is what fires at the *end* of a multi-minute prefill in real agent runs — the headers literally fail to write because the client already gave up.

This PR makes the existing `prefill_chunk` progress callback also act as an SSE keepalive source:

1. The first time the callback fires, it writes the SSE response headers immediately so the client sees an HTTP 200 + `Content-Type: text/event-stream` within the first chunk.
2. On subsequent callback fires it emits a `":"` SSE comment line at most every 5 seconds. Per the SSE spec these lines are required to be ignored by conforming clients, so they keep the TCP/HTTP path alive without injecting fake events into the stream.
3. The existing call to `sse_headers()` in the request handler becomes idempotent — it only fires when prefill never ran (e.g. fully cached prompt), so non-streaming and short paths are unchanged.
4. The tool-checkpoint rebuild path pre-arms `headers_sent = true` because by the time that rebuild runs, the response stream is already in flight, so we only want the keepalive ticks and never a second header line.

Writes are best-effort: if the client has already gone away, `send_all` returns false and the outer code discovers the closed socket the next time it tries to stream a real event, matching the existing error path.

## Reproduction of the original bug

```
0518 21:04:34 ds4-server: chat ctx=0..81722:81722 TOOLS prefill chunk 81722/81722 (100.0%) chunk=204.64 t/s avg=270.77 t/s 301.808s
0518 21:04:34 ds4-server: chat ctx=0..81722:81722 TOOLS prompt done 301.810s
0518 21:04:34 ds4-server: chat ctx=0..81722:81722 TOOLS sse headers failed
```

5 minutes of complete socket silence during prefill, then `sse headers failed` because the client RST'd the connection long ago. This is on `--ctx 200000`, Anthropic-API endpoint, agent client (Claude Code style) with a ~80k system+tools+CLAUDE.md prompt — i.e. a normal first turn against a local model.

## Verification

Machine: MacBook Pro M5 Max, 128 GiB RAM
Backend: Metal
Model: `DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2.gguf` (q2-imatrix)
Server: `./ds4-server --host 0.0.0.0 --port 8000 --ctx 200000 --kv-disk-dir … --kv-disk-space-mb 204800`

- `make clean && make` — clean build, no new warnings
- `./ds4_test --server` — `server: OK` / `ds4 tests: ok`
- Fresh ~10.5k-token streaming request (cache miss), client-side timing:
  ```
  + 6.27s  : prefill
  +12.46s  : prefill
  +18.73s  : prefill
  +25.08s  : prefill
  +31.70s  : prefill
  +34.99s  data: {"id":"chatcmpl-3", … role: assistant}
  +35.04s  data: {"id":"chatcmpl-3", … content: "嗯"}
  +35.04s  data: [DONE]
  ```
  The corresponding server log shows `prompt done 33.594s`, so the keepalive cadence really is real-time over the long prefill — the client just sees pipe-buffered output collapse without it.
- Short 5-token prompt: `0.76s` total round trip, unchanged.
- Verified the no-prefill path (fully cached prompt) still writes headers from the request handler, not the callback (because the callback never fires).

## Test plan

- [ ] CI runs `./ds4_test --server`
- [ ] Manual streaming smoke test with a long unique prompt to confirm `: prefill` comment lines appear during prefill
- [ ] Confirm short / cached prompts unaffected