### PR TITLE
docs: explain why README recommends openai-completions for Pi agent client

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,10 @@ For **opencode**, add a provider and agent entry to
 
 For **Pi**, add a provider to `~/.pi/agent/models.json`:
 
+This uses the OpenAI completions API because it is currently the most exercised
+path in `ds4-server`; Responses and Anthropic Messages support will be hardened
+after inference is stabilized.
+
 ```json
 {
   "providers": {


### PR DESCRIPTION
## Summary

Adds a one-paragraph note in the Agent Client Usage section explaining why the recommended Pi provider config uses `"api": "openai-completions"`: it's currently the most-exercised path in `ds4-server`. Responses and Anthropic Messages support will be hardened later, once inference is stabilized.

## Why this matters

@njbrake asked in #113 why the README recommends `openai-completions` when current agentic best practice often points at Messages-style APIs. You answered in-thread on 2026-05-13: it's purely that the completions code path is the most exercised today, with more work coming once inference stabilizes.

This PR puts the explanation in the README so future readers don't need to dig into the issue tracker to find the rationale.

Fixes #113
