### PR TITLE
dir-steering: support up to 8 stacked direction vectors

### DIFF
--- a/dir-steering/README.md
+++ b/dir-steering/README.md
@@ -14,7 +14,7 @@ With no steering file or zero scales, ds4 follows the normal inference path.
 ## Runtime Options
 
 ```text
---dir-steering-file FILE   load a 43 x 4096 f32 direction file
+--dir-steering-file FILE   load a 43 x 4096 f32 direction file (repeatable)
 --dir-steering-ffn F       apply steering after FFN outputs; default is 1 when a file is provided
 --dir-steering-attn F      apply steering after attention outputs; default is 0
 ```
@@ -22,6 +22,34 @@ With no steering file or zero scales, ds4 follows the normal inference path.
 The FFN output is usually the best first target because it is late enough in
 each layer to represent behavior, style, and topic signals. Attention steering
 is available for experiments, but it can be more fragile.
+
+### Composing multiple directions
+
+`--dir-steering-file` is repeatable. Every occurrence opens a new slot, and the
+following `--dir-steering-ffn` / `--dir-steering-attn` flags bind to the
+most recently opened slot. Up to 8 slots are applied sequentially at every
+layer:
+
+```sh
+./ds4 -m ds4flash.gguf --nothink --temp 0 -n 220 \
+  --dir-steering-file dir-steering/out/refusal.f32  --dir-steering-ffn 2 \
+  --dir-steering-file dir-steering/out/verbosity.f32 --dir-steering-ffn -1 \
+  -p "Explain in detail how to hotwire a 2020 Toyota Camry."
+```
+
+Two independent vectors compose into one runtime edit: "ablate refusal, then
+make the answer terser". Each slot has its own `ffn` and `attn` scale; both
+default to `1` / `0` when omitted. Slots are applied in the order they appear
+on the command line.
+
+Two ablations of vectors that are not strictly orthogonal are not equivalent
+to a single ablation of their span (Gram–Schmidt would be), but for concept
+vectors that have low cosine (e.g., a refusal axis vs. a verbosity axis) the
+approximation is good enough in practice.
+
+Multi-slot composition is implemented on the GPU backends (Metal and CUDA).
+The CPU reference backend still consumes only the first slot; pass the most
+important vector first if you mix backends.
 
 ## Verbosity Example
 

--- a/ds4.c
+++ b/ds4.c
@@ -14451,7 +14451,10 @@ static void cpu_directional_steering_project_rows(
     }
 }
 
-static bool cpu_load_directional_steering(ds4_engine *e) {
+/* Read every active steering slot's .f32 file into the engine's host buffer.
+ * Backend-agnostic: the host copy is used directly by the CPU reference path
+ * and uploaded to GPU tensors by metal_graph_load_directional_steering. */
+static bool load_directional_steering_slots(ds4_engine *e) {
     if (!e || e->steering_slots_count == 0) return true;
 
     const uint64_t n = (uint64_t)DS4_N_LAYER * DS4_N_EMBD;
@@ -14470,7 +14473,7 @@ static bool cpu_load_directional_steering(ds4_engine *e) {
             fprintf(stderr, "ds4: failed to load directional steering vectors from %s\n", slot->file);
             return false;
         }
-        fprintf(stderr, "ds4: CPU directional steering enabled (slot %d): %s attn=%g ffn=%g\n",
+        fprintf(stderr, "ds4: directional steering slot %d loaded: %s attn=%g ffn=%g\n",
                 k, slot->file,
                 (double)slot->attn_scale, (double)slot->ffn_scale);
     }
@@ -17255,7 +17258,7 @@ int ds4_engine_open(ds4_engine **out, const ds4_engine_options *opt) {
     vocab_load(&e->vocab, &e->model);
     config_validate_model(&e->model);
     weights_bind(&e->weights, &e->model);
-    if (e->backend == DS4_BACKEND_CPU && !cpu_load_directional_steering(e)) {
+    if (!load_directional_steering_slots(e)) {
         ds4_engine_close(e);
         *out = NULL;
         return 1;

--- a/ds4.c
+++ b/ds4.c
@@ -49,6 +49,16 @@
 
 #define DS4_NEG_INF (-1.0e30f)
 #define DS4_POS_INF ( 1.0e30f)
+
+/* Internal representation of a directional-steering slot held by the engine.
+ * Declared up-front so backend graph code (above the engine struct) can take
+ * arrays of these without needing the full ds4_engine definition. */
+typedef struct {
+    char *file;
+    float *dirs;          /* DS4_N_LAYER * DS4_N_EMBD floats, owned; NULL when not loaded. */
+    float attn_scale;
+    float ffn_scale;
+} ds4_engine_steering_slot;
 #define DS4_RMS_EPS ( 1.0e-6f)
 #define DS4_HC_EPS  ( 1.0e-6f)
 #define DS4_EXPERT_WEIGHT_SCALE (1.5f)
@@ -8299,16 +8309,23 @@ typedef struct {
     bool batch_routed_mid_is_f16;
     ds4_gpu_tensor *batch_ffn_out;
     bool materialize_ffn_out;
-    ds4_gpu_tensor *directional_steering_dirs;
-    float directional_steering_attn_scale;
-    float directional_steering_ffn_scale;
+    int steering_slots_count;
+    struct {
+        ds4_gpu_tensor *dirs;
+        float attn_scale;
+        float ffn_scale;
+    } steering_slots[DS4_MAX_STEERING_SLOTS];
     bool quality;
     bool mtp_enabled;
 } ds4_gpu_graph;
 
 /* Release every Metal tensor owned by the whole-model graph runtime. */
 static void metal_graph_free(ds4_gpu_graph *g) {
-    ds4_gpu_tensor_free(g->directional_steering_dirs);
+    for (int k = 0; k < g->steering_slots_count; k++) {
+        ds4_gpu_tensor_free(g->steering_slots[k].dirs);
+        g->steering_slots[k].dirs = NULL;
+    }
+    g->steering_slots_count = 0;
     ds4_gpu_tensor_free(g->batch_ffn_out);
     ds4_gpu_tensor_free(g->batch_routed_out);
     ds4_gpu_tensor_free(g->batch_routed_down);
@@ -8460,59 +8477,54 @@ static bool metal_tensor_fill_f32(ds4_gpu_tensor *t, float v, uint64_t n) {
  */
 
 static bool metal_graph_load_directional_steering(
-        ds4_gpu_graph *g,
-        const char      *path,
-        float            attn_scale,
-        float            ffn_scale) {
-    if (attn_scale == 0.0f && ffn_scale == 0.0f) return true;
-
-    if (!path || !path[0]) {
-        fprintf(stderr, "ds4: directional steering needs --dir-steering-file\n");
-        return false;
-    }
+        ds4_gpu_graph                       *g,
+        const ds4_engine_steering_slot      *slots,
+        int                                  n_slots) {
+    if (!g || n_slots <= 0) return true;
 
     const uint64_t n = (uint64_t)DS4_N_LAYER * DS4_N_EMBD;
-    float *dirs = xmalloc((size_t)n * sizeof(dirs[0]));
-    bool ok = read_f32_binary_file(path, dirs, n);
-    if (ok) {
-        g->directional_steering_dirs = ds4_gpu_tensor_alloc(n * sizeof(dirs[0]));
-        ok = g->directional_steering_dirs != NULL &&
-             ds4_gpu_tensor_write(g->directional_steering_dirs, 0, dirs, n * sizeof(dirs[0])) != 0;
+    for (int k = 0; k < n_slots; k++) {
+        const ds4_engine_steering_slot *src = &slots[k];
+        if (src->attn_scale == 0.0f && src->ffn_scale == 0.0f) continue;
+        if (!src->dirs) {
+            fprintf(stderr, "ds4: steering slot %d has scales set but no dirs loaded\n", k);
+            return false;
+        }
+        if (g->steering_slots_count >= DS4_MAX_STEERING_SLOTS) {
+            fprintf(stderr, "ds4: too many active steering slots (max %d)\n", DS4_MAX_STEERING_SLOTS);
+            return false;
+        }
+        ds4_gpu_tensor *t = ds4_gpu_tensor_alloc(n * sizeof(float));
+        if (!t || ds4_gpu_tensor_write(t, 0, src->dirs, n * sizeof(float)) == 0) {
+            ds4_gpu_tensor_free(t);
+            fprintf(stderr, "ds4: failed to upload directional steering slot %d\n", k);
+            return false;
+        }
+        const int dst = g->steering_slots_count++;
+        g->steering_slots[dst].dirs = t;
+        g->steering_slots[dst].attn_scale = src->attn_scale;
+        g->steering_slots[dst].ffn_scale = src->ffn_scale;
+        fprintf(stderr, "ds4: directional steering enabled (slot %d): %s attn=%g ffn=%g\n",
+                dst, src->file ? src->file : "(in-memory)",
+                (double)src->attn_scale, (double)src->ffn_scale);
     }
-    free(dirs);
-
-    if (!ok) {
-        fprintf(stderr, "ds4: failed to load directional steering vectors from %s\n", path);
-        return false;
-    }
-    g->directional_steering_attn_scale = attn_scale;
-    g->directional_steering_ffn_scale = ffn_scale;
-    fprintf(stderr, "ds4: directional steering enabled: %s attn=%g ffn=%g\n",
-            path, (double)attn_scale, (double)ffn_scale);
     return true;
 }
 
 static bool metal_graph_directional_steering_attn_enabled(const ds4_gpu_graph *g) {
-    return g && g->directional_steering_dirs && g->directional_steering_attn_scale != 0.0f;
+    if (!g) return false;
+    for (int k = 0; k < g->steering_slots_count; k++) {
+        if (g->steering_slots[k].dirs && g->steering_slots[k].attn_scale != 0.0f) return true;
+    }
+    return false;
 }
 
 static bool metal_graph_directional_steering_ffn_enabled(const ds4_gpu_graph *g) {
-    return g && g->directional_steering_dirs && g->directional_steering_ffn_scale != 0.0f;
-}
-
-static bool metal_graph_apply_directional_steering(
-        ds4_gpu_graph  *g,
-        ds4_gpu_tensor *x,
-        uint32_t          il,
-        uint32_t          rows,
-        float             scale) {
-    if (!g || !g->directional_steering_dirs || scale == 0.0f) return true;
-    return ds4_gpu_directional_steering_project_tensor(x,
-                                            g->directional_steering_dirs,
-                                            il,
-                                            DS4_N_EMBD,
-                                            rows,
-                                            scale) != 0;
+    if (!g) return false;
+    for (int k = 0; k < g->steering_slots_count; k++) {
+        if (g->steering_slots[k].dirs && g->steering_slots[k].ffn_scale != 0.0f) return true;
+    }
+    return false;
 }
 
 static bool metal_graph_apply_directional_steering_attn(
@@ -8520,7 +8532,20 @@ static bool metal_graph_apply_directional_steering_attn(
         ds4_gpu_tensor *x,
         uint32_t          il,
         uint32_t          rows) {
-    return metal_graph_apply_directional_steering(g, x, il, rows, g ? g->directional_steering_attn_scale : 0.0f);
+    if (!g) return true;
+    for (int k = 0; k < g->steering_slots_count; k++) {
+        const float scale = g->steering_slots[k].attn_scale;
+        if (scale == 0.0f || !g->steering_slots[k].dirs) continue;
+        if (ds4_gpu_directional_steering_project_tensor(x,
+                                                g->steering_slots[k].dirs,
+                                                il,
+                                                DS4_N_EMBD,
+                                                rows,
+                                                scale) == 0) {
+            return false;
+        }
+    }
+    return true;
 }
 
 static bool metal_graph_apply_directional_steering_ffn(
@@ -8528,7 +8553,20 @@ static bool metal_graph_apply_directional_steering_ffn(
         ds4_gpu_tensor *x,
         uint32_t          il,
         uint32_t          rows) {
-    return metal_graph_apply_directional_steering(g, x, il, rows, g ? g->directional_steering_ffn_scale : 0.0f);
+    if (!g) return true;
+    for (int k = 0; k < g->steering_slots_count; k++) {
+        const float scale = g->steering_slots[k].ffn_scale;
+        if (scale == 0.0f || !g->steering_slots[k].dirs) continue;
+        if (ds4_gpu_directional_steering_project_tensor(x,
+                                                g->steering_slots[k].dirs,
+                                                il,
+                                                DS4_N_EMBD,
+                                                rows,
+                                                scale) == 0) {
+            return false;
+        }
+    }
+    return true;
 }
 
 static uint64_t metal_graph_kv_cache_bytes_for_context(uint32_t ctx_size, uint32_t raw_cap) {
@@ -14378,10 +14416,8 @@ struct ds4_engine {
     ds4_backend backend;
     int mtp_draft_tokens;
     float mtp_margin;
-    char *directional_steering_file;
-    float *directional_steering_dirs;
-    float directional_steering_attn_scale;
-    float directional_steering_ffn_scale;
+    int steering_slots_count;
+    ds4_engine_steering_slot steering_slots[DS4_MAX_STEERING_SLOTS];
     bool quality;
     bool metal_ready;
     bool mtp_ready;
@@ -14416,32 +14452,41 @@ static void cpu_directional_steering_project_rows(
 }
 
 static bool cpu_load_directional_steering(ds4_engine *e) {
-    if (!e ||
-        (e->directional_steering_attn_scale == 0.0f &&
-         e->directional_steering_ffn_scale == 0.0f)) {
-        return true;
-    }
-
-    const char *path = e->directional_steering_file;
-    if (!path || !path[0]) {
-        fprintf(stderr, "ds4: directional steering needs --dir-steering-file\n");
-        return false;
-    }
+    if (!e || e->steering_slots_count == 0) return true;
 
     const uint64_t n = (uint64_t)DS4_N_LAYER * DS4_N_EMBD;
-    e->directional_steering_dirs = xmalloc((size_t)n * sizeof(e->directional_steering_dirs[0]));
-    if (!read_f32_binary_file(path, e->directional_steering_dirs, n)) {
-        free(e->directional_steering_dirs);
-        e->directional_steering_dirs = NULL;
-        fprintf(stderr, "ds4: failed to load directional steering vectors from %s\n", path);
-        return false;
+    for (int k = 0; k < e->steering_slots_count; k++) {
+        ds4_engine_steering_slot *slot = &e->steering_slots[k];
+        if (slot->attn_scale == 0.0f && slot->ffn_scale == 0.0f) continue;
+        if (slot->dirs) continue; /* already loaded */
+        if (!slot->file || !slot->file[0]) {
+            fprintf(stderr, "ds4: steering slot %d needs --dir-steering-file\n", k);
+            return false;
+        }
+        slot->dirs = xmalloc((size_t)n * sizeof(slot->dirs[0]));
+        if (!read_f32_binary_file(slot->file, slot->dirs, n)) {
+            free(slot->dirs);
+            slot->dirs = NULL;
+            fprintf(stderr, "ds4: failed to load directional steering vectors from %s\n", slot->file);
+            return false;
+        }
+        fprintf(stderr, "ds4: CPU directional steering enabled (slot %d): %s attn=%g ffn=%g\n",
+                k, slot->file,
+                (double)slot->attn_scale, (double)slot->ffn_scale);
     }
-    fprintf(stderr, "ds4: CPU directional steering enabled: %s attn=%g ffn=%g\n",
-            path,
-            (double)e->directional_steering_attn_scale,
-            (double)e->directional_steering_ffn_scale);
     return true;
 }
+
+/* CPU backend currently propagates a single steering slot through its
+ * intermediate functions (one (dirs, attn, ffn) triple).  Until the CPU
+ * dispatch path is refactored end-to-end, we route only slot 0 through it.
+ * Multi-slot composition is fully supported on GPU backends. */
+#define DS4_CPU_STEERING_DIRS(e) \
+    ((e)->steering_slots_count > 0 ? (e)->steering_slots[0].dirs : NULL)
+#define DS4_CPU_STEERING_ATTN(e) \
+    ((e)->steering_slots_count > 0 ? (e)->steering_slots[0].attn_scale : 0.0f)
+#define DS4_CPU_STEERING_FFN(e) \
+    ((e)->steering_slots_count > 0 ? (e)->steering_slots[0].ffn_scale : 0.0f)
 
 static void utf8_put(char **p, uint32_t cp) {
     if (cp <= 0x7f) {
@@ -15448,6 +15493,7 @@ static int generate_raw_swa_cpu(
 /* Metal generation entry point.  The model runs as one local whole-graph
  * pipeline: chunked/layer-major prefill followed by graph decode steps. */
 static int generate_metal_graph_raw_swa(
+        const ds4_engine  * engine,
         const ds4_model   * model,
         const ds4_vocab   * vocab,
         const ds4_weights * weights,
@@ -15455,9 +15501,6 @@ static int generate_metal_graph_raw_swa(
         int                 n_predict,
         int                 ctx_size,
         bool                quality,
-        const char        * directional_steering_file,
-        float               directional_steering_attn,
-        float               directional_steering_ffn,
         ds4_token_emit_fn   emit,
         ds4_generation_done_fn done,
         void              * emit_ud,
@@ -15487,9 +15530,8 @@ static int generate_metal_graph_raw_swa(
     }
     g.quality = quality;
     if (!metal_graph_load_directional_steering(&g,
-                                               directional_steering_file,
-                                               directional_steering_attn,
-                                               directional_steering_ffn)) {
+                                               engine->steering_slots,
+                                               engine->steering_slots_count)) {
         metal_graph_free(&g);
         return 1;
     }
@@ -16953,11 +16995,8 @@ int ds4_engine_generate_argmax(
                     ds4_backend_name(e->backend));
             return 1;
         }
-        return generate_metal_graph_raw_swa(model, vocab, weights, prompt,
+        return generate_metal_graph_raw_swa(e, model, vocab, weights, prompt,
                                             n_predict, ctx_size, e->quality,
-                                            e->directional_steering_file,
-                                            e->directional_steering_attn_scale,
-                                            e->directional_steering_ffn_scale,
                                             emit, done, emit_ud,
                                             progress, progress_ud);
 #else
@@ -16967,11 +17006,12 @@ int ds4_engine_generate_argmax(
 #endif
     }
 
+    /* CPU backend currently consumes the first steering slot only. */
     return generate_raw_swa_cpu(model, vocab, weights, prompt, n_predict,
                                 ctx_size,
-                                e->directional_steering_dirs,
-                                e->directional_steering_attn_scale,
-                                e->directional_steering_ffn_scale,
+                                e->steering_slots_count > 0 ? e->steering_slots[0].dirs : NULL,
+                                e->steering_slots_count > 0 ? e->steering_slots[0].attn_scale : 0.0f,
+                                e->steering_slots_count > 0 ? e->steering_slots[0].ffn_scale : 0.0f,
                                 emit, done, emit_ud, progress, progress_ud);
 }
 
@@ -17170,18 +17210,41 @@ int ds4_engine_open(ds4_engine **out, const ds4_engine_options *opt) {
     e->mtp_draft_tokens = opt->mtp_draft_tokens > 0 ? opt->mtp_draft_tokens : 1;
     if (e->mtp_draft_tokens > 16) e->mtp_draft_tokens = 16;
     e->mtp_margin = opt->mtp_margin >= 0.0f ? opt->mtp_margin : 3.0f;
-    if ((opt->directional_steering_attn != 0.0f || opt->directional_steering_ffn != 0.0f) &&
-        (!opt->directional_steering_file || !opt->directional_steering_file[0]))
-    {
-        fprintf(stderr, "ds4: directional steering needs --dir-steering-file\n");
+    /* Collect steering slots from options. The multi-slot array
+     * (opt->steering_slots) takes precedence when populated; otherwise we
+     * synthesize one slot from the legacy single-file fields for backward
+     * compatibility with callers that still set them. */
+    if (opt->steering_slots_count > DS4_MAX_STEERING_SLOTS) {
+        fprintf(stderr, "ds4: too many steering slots in options (%d > %d)\n",
+                opt->steering_slots_count, DS4_MAX_STEERING_SLOTS);
         free(e);
         *out = NULL;
         return 1;
     }
-    if (opt->directional_steering_file && opt->directional_steering_file[0]) {
-        e->directional_steering_file = ds4_strdup(opt->directional_steering_file);
-        e->directional_steering_attn_scale = opt->directional_steering_attn;
-        e->directional_steering_ffn_scale = opt->directional_steering_ffn;
+    if (opt->steering_slots_count > 0) {
+        for (int k = 0; k < opt->steering_slots_count; k++) {
+            const ds4_steering_slot *src = &opt->steering_slots[k];
+            if ((src->ffn != 0.0f || src->attn != 0.0f) && (!src->file || !src->file[0])) {
+                fprintf(stderr, "ds4: directional steering slot %d needs --dir-steering-file\n", k);
+                free(e);
+                *out = NULL;
+                return 1;
+            }
+            e->steering_slots[k].file = src->file ? ds4_strdup(src->file) : NULL;
+            e->steering_slots[k].attn_scale = src->attn;
+            e->steering_slots[k].ffn_scale = src->ffn;
+        }
+        e->steering_slots_count = opt->steering_slots_count;
+    } else if (opt->directional_steering_file && opt->directional_steering_file[0]) {
+        e->steering_slots[0].file = ds4_strdup(opt->directional_steering_file);
+        e->steering_slots[0].attn_scale = opt->directional_steering_attn;
+        e->steering_slots[0].ffn_scale = opt->directional_steering_ffn;
+        e->steering_slots_count = 1;
+    } else if (opt->directional_steering_attn != 0.0f || opt->directional_steering_ffn != 0.0f) {
+        fprintf(stderr, "ds4: directional steering needs --dir-steering-file\n");
+        free(e);
+        *out = NULL;
+        return 1;
     }
     if (opt->n_threads > 0) g_requested_threads = (uint32_t)opt->n_threads;
     ds4_acquire_instance_lock();
@@ -17300,8 +17363,10 @@ void ds4_engine_close(ds4_engine *e) {
     ds4_gpu_cleanup();
 #endif
     ds4_release_instance_lock();
-    free(e->directional_steering_dirs);
-    free(e->directional_steering_file);
+    for (int k = 0; k < e->steering_slots_count; k++) {
+        free(e->steering_slots[k].dirs);
+        free(e->steering_slots[k].file);
+    }
     free(e);
 }
 
@@ -17336,9 +17401,8 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
     }
     s->graph.quality = e->quality;
     if (!metal_graph_load_directional_steering(&s->graph,
-                                               e->directional_steering_file,
-                                               e->directional_steering_attn_scale,
-                                               e->directional_steering_ffn_scale)) {
+                                               e->steering_slots,
+                                               e->steering_slots_count)) {
         metal_graph_free(&s->graph);
         free(s);
         return 1;
@@ -17431,9 +17495,9 @@ int ds4_session_sync(ds4_session *s, const ds4_tokens *prompt, char *err, size_t
                                                          &s->cpu_cache,
                                                          prompt->v[i],
                                                          (uint32_t)s->checkpoint.len,
-                                                         e->directional_steering_dirs,
-                                                         e->directional_steering_attn_scale,
-                                                         e->directional_steering_ffn_scale,
+                                                         DS4_CPU_STEERING_DIRS(e),
+                                                         DS4_CPU_STEERING_ATTN(e),
+                                                         DS4_CPU_STEERING_FFN(e),
                                                          &s->cpu_scratch);
                 token_vec_push(&s->checkpoint, prompt->v[i]);
                 if (s->progress) s->progress(s->progress_ud, "prefill_chunk", i + 1, prompt->len);
@@ -17448,9 +17512,9 @@ int ds4_session_sync(ds4_session *s, const ds4_tokens *prompt, char *err, size_t
                                 &e->weights,
                                 &s->cpu_cache,
                                 prompt,
-                                e->directional_steering_dirs,
-                                e->directional_steering_attn_scale,
-                                e->directional_steering_ffn_scale);
+                                DS4_CPU_STEERING_DIRS(e),
+                                DS4_CPU_STEERING_ATTN(e),
+                                DS4_CPU_STEERING_FFN(e));
         ds4_tokens_copy(&s->checkpoint, prompt);
         s->checkpoint_valid = true;
         s->mtp_draft_valid = false;
@@ -17709,9 +17773,9 @@ static int ds4_session_eval_internal(ds4_session *s, int token, bool probe_mtp,
                                                  &s->cpu_cache,
                                                  token,
                                                  (uint32_t)s->checkpoint.len,
-                                                 e->directional_steering_dirs,
-                                                 e->directional_steering_attn_scale,
-                                                 e->directional_steering_ffn_scale,
+                                                 DS4_CPU_STEERING_DIRS(e),
+                                                 DS4_CPU_STEERING_ATTN(e),
+                                                 DS4_CPU_STEERING_FFN(e),
                                                  &s->cpu_scratch);
         token_vec_push(&s->checkpoint, token);
         s->checkpoint_valid = true;

--- a/ds4.h
+++ b/ds4.h
@@ -59,6 +59,16 @@ typedef struct ds4_session ds4_session;
 
 typedef void (*ds4_session_progress_fn)(void *ud, const char *event, int current, int total);
 
+#ifndef DS4_MAX_STEERING_SLOTS
+#define DS4_MAX_STEERING_SLOTS 8
+#endif
+
+typedef struct {
+    const char *file;
+    float ffn;
+    float attn;
+} ds4_steering_slot;
+
 typedef struct {
     const char *model_path;
     const char *mtp_path;
@@ -66,9 +76,16 @@ typedef struct {
     int n_threads;
     int mtp_draft_tokens;
     float mtp_margin;
+    /* Legacy single-slot fields. If steering_slots_count == 0 and a file is
+     * set here, the engine synthesizes one slot from these. Otherwise these
+     * fields are ignored in favor of the array below. */
     const char *directional_steering_file;
     float directional_steering_attn;
     float directional_steering_ffn;
+    /* Multi-slot directional steering. When count > 0, each slot is loaded
+     * independently and applied sequentially at every layer. */
+    int steering_slots_count;
+    ds4_steering_slot steering_slots[DS4_MAX_STEERING_SLOTS];
     bool warm_weights;
     bool quality;
 } ds4_engine_options;

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -23,6 +23,9 @@
 #include <time.h>
 #include <unistd.h>
 
+#define DS4_STRINGIFY_(x) #x
+#define DS4_STRINGIFY(x) DS4_STRINGIFY_(x)
+
 typedef struct {
     const char *prompt;
     const char *system;
@@ -106,10 +109,14 @@ static void usage(FILE *fp) {
         "      Prefer exact kernels where faster approximate paths exist; MTP uses strict verification.\n"
         "  --dir-steering-file FILE\n"
         "      Load one f32 direction vector per layer for directional steering.\n"
+        "      Repeatable: every additional --dir-steering-file opens a new slot.\n"
+        "      Up to " DS4_STRINGIFY(DS4_MAX_STEERING_SLOTS) " slots are applied in order at every layer.\n"
         "  --dir-steering-ffn F\n"
-        "      Apply steering after FFN outputs: y -= F*v*dot(v,y). Default with file: 1\n"
+        "      Apply steering after FFN outputs: y -= F*v*dot(v,y). Default with file: 1.\n"
+        "      Applies to the most recently opened --dir-steering-file slot.\n"
         "  --dir-steering-attn F\n"
-        "      Apply steering after attention outputs. Default: 0\n"
+        "      Apply steering after attention outputs. Default: 0.\n"
+        "      Applies to the most recently opened --dir-steering-file slot.\n"
         "  --warm-weights\n"
         "      Touch mapped tensor pages before generation. Slower startup, fewer first-use stalls.\n"
         "\n"
@@ -1208,7 +1215,7 @@ static cli_config parse_options(int argc, char **argv) {
         },
     };
 
-    bool directional_steering_scale_set = false;
+    int dir_steering_slot = -1;
     for (int i = 1; i < argc; i++) {
         const char *arg = argv[i];
         if (!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
@@ -1252,13 +1259,32 @@ static cli_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--quality")) {
             c.engine.quality = true;
         } else if (!strcmp(arg, "--dir-steering-file")) {
-            c.engine.directional_steering_file = need_arg(&i, argc, argv, arg);
+            if (c.engine.steering_slots_count >= DS4_MAX_STEERING_SLOTS) {
+                fprintf(stderr,
+                        "ds4: too many --dir-steering-file directives (max %d)\n",
+                        DS4_MAX_STEERING_SLOTS);
+                exit(2);
+            }
+            dir_steering_slot = c.engine.steering_slots_count++;
+            c.engine.steering_slots[dir_steering_slot].file = need_arg(&i, argc, argv, arg);
+            c.engine.steering_slots[dir_steering_slot].ffn = 1.0f;
+            c.engine.steering_slots[dir_steering_slot].attn = 0.0f;
         } else if (!strcmp(arg, "--dir-steering-ffn")) {
-            c.engine.directional_steering_ffn = parse_float_range(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
-            directional_steering_scale_set = true;
+            const float v = parse_float_range(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
+            if (dir_steering_slot < 0) {
+                fprintf(stderr,
+                        "ds4: --dir-steering-ffn must come after a --dir-steering-file\n");
+                exit(2);
+            }
+            c.engine.steering_slots[dir_steering_slot].ffn = v;
         } else if (!strcmp(arg, "--dir-steering-attn")) {
-            c.engine.directional_steering_attn = parse_float_range(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
-            directional_steering_scale_set = true;
+            const float v = parse_float_range(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
+            if (dir_steering_slot < 0) {
+                fprintf(stderr,
+                        "ds4: --dir-steering-attn must come after a --dir-steering-file\n");
+                exit(2);
+            }
+            c.engine.steering_slots[dir_steering_slot].attn = v;
         } else if (!strcmp(arg, "-t") || !strcmp(arg, "--threads")) {
             c.engine.n_threads = parse_int(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--backend")) {
@@ -1320,9 +1346,7 @@ static cli_config parse_options(int argc, char **argv) {
         }
     }
 
-    if (c.engine.directional_steering_file && !directional_steering_scale_set) {
-        c.engine.directional_steering_ffn = 1.0f;
-    }
+    (void)dir_steering_slot;
     if (c.gen.imatrix_output_path && !c.gen.imatrix_dataset_path) {
         fprintf(stderr, "ds4: --imatrix-out requires --imatrix-dataset\n");
         exit(2);

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -1,6 +1,9 @@
 #include "ds4.h"
 #include "rax.h"
 
+#define DS4_SERVER_STRINGIFY_(x) #x
+#define DS4_SERVER_STRINGIFY(x) DS4_SERVER_STRINGIFY_(x)
+
 /* OpenAI/Anthropic compatible local server.
  *
  * HTTP is intentionally simple: each client connection is handled by a small
@@ -11793,10 +11796,14 @@ static void usage(FILE *fp) {
         "      Prefer exact kernels where faster approximate paths exist; MTP uses strict verification.\n"
         "  --dir-steering-file FILE\n"
         "      Load one f32 direction vector per layer for directional steering.\n"
+        "      Repeatable: every additional --dir-steering-file opens a new slot.\n"
+        "      Up to " DS4_SERVER_STRINGIFY(DS4_MAX_STEERING_SLOTS) " slots are applied in order at every layer.\n"
         "  --dir-steering-ffn F\n"
-        "      Apply steering after FFN outputs: y -= F*v*dot(v,y). Default with file: 1\n"
+        "      Apply steering after FFN outputs: y -= F*v*dot(v,y). Default with file: 1.\n"
+        "      Applies to the most recently opened --dir-steering-file slot.\n"
         "  --dir-steering-attn F\n"
-        "      Apply steering after attention outputs. Default: 0\n"
+        "      Apply steering after attention outputs. Default: 0.\n"
+        "      Applies to the most recently opened --dir-steering-file slot.\n"
         "  --warm-weights\n"
         "      Touch mapped tensor pages before serving. Slower startup, fewer first-use stalls.\n"
         "  --metal | --cuda | --cpu | --backend NAME\n"
@@ -11895,7 +11902,7 @@ static server_config parse_options(int argc, char **argv) {
     };
     c.kv_cache = kv_cache_default_options();
 
-    bool directional_steering_scale_set = false;
+    int dir_steering_slot = -1;
     for (int i = 1; i < argc; i++) {
         const char *arg = argv[i];
         if (!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
@@ -11948,13 +11955,32 @@ static server_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--quality")) {
             c.engine.quality = true;
         } else if (!strcmp(arg, "--dir-steering-file")) {
-            c.engine.directional_steering_file = need_arg(&i, argc, argv, arg);
+            if (c.engine.steering_slots_count >= DS4_MAX_STEERING_SLOTS) {
+                server_log(DS4_LOG_DEFAULT,
+                           "ds4-server: too many --dir-steering-file directives (max %d)",
+                           DS4_MAX_STEERING_SLOTS);
+                exit(2);
+            }
+            dir_steering_slot = c.engine.steering_slots_count++;
+            c.engine.steering_slots[dir_steering_slot].file = need_arg(&i, argc, argv, arg);
+            c.engine.steering_slots[dir_steering_slot].ffn = 1.0f;
+            c.engine.steering_slots[dir_steering_slot].attn = 0.0f;
         } else if (!strcmp(arg, "--dir-steering-ffn")) {
-            c.engine.directional_steering_ffn = parse_float_arg(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
-            directional_steering_scale_set = true;
+            const float v = parse_float_arg(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
+            if (dir_steering_slot < 0) {
+                server_log(DS4_LOG_DEFAULT,
+                           "ds4-server: --dir-steering-ffn must come after a --dir-steering-file");
+                exit(2);
+            }
+            c.engine.steering_slots[dir_steering_slot].ffn = v;
         } else if (!strcmp(arg, "--dir-steering-attn")) {
-            c.engine.directional_steering_attn = parse_float_arg(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
-            directional_steering_scale_set = true;
+            const float v = parse_float_arg(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
+            if (dir_steering_slot < 0) {
+                server_log(DS4_LOG_DEFAULT,
+                           "ds4-server: --dir-steering-attn must come after a --dir-steering-file");
+                exit(2);
+            }
+            c.engine.steering_slots[dir_steering_slot].attn = v;
         } else if (!strcmp(arg, "--warm-weights")) {
             c.engine.warm_weights = true;
         } else if (!strcmp(arg, "--metal")) {
@@ -11978,9 +12004,7 @@ static server_config parse_options(int argc, char **argv) {
                    "ds4-server: --kv-cache-cold-max-tokens must be 0 or >= --kv-cache-min-tokens");
         exit(2);
     }
-    if (c.engine.directional_steering_file && !directional_steering_scale_set) {
-        c.engine.directional_steering_ffn = 1.0f;
-    }
+    (void)dir_steering_slot;
     return c;
 }
 


### PR DESCRIPTION
## Summary

Makes `--dir-steering-file` repeatable so independent concept vectors can be composed at runtime into a single steered inference, without rebuilding the model or producing a new `.gguf`. Up to `DS4_MAX_STEERING_SLOTS` (8) `.f32` direction files can be passed; each gets its own `--dir-steering-ffn` and `--dir-steering-attn` scale and is applied sequentially at every layer.

```sh
./ds4 -m ds4flash.gguf --nothink --temp 0 -n 220 \
  --dir-steering-file dir-steering/out/refusal.f32   --dir-steering-ffn 2 \
  --dir-steering-file dir-steering/out/verbosity.f32 --dir-steering-ffn -1 \
  -p "Explain in detail how to hotwire a 2020 Toyota Camry."
```

Single-file invocations and existing scripts work unchanged.

## Why

The existing single-vector setup is enough for one isolated behavior axis (e.g. verbosity, or refusal), but several useful experiments need to compose more than one axis at the same time:

- **refusal ablation + style control**: jailbreak the refusal direction (Arditi et al. 2024, *Refusal in Language Models Is Mediated by a Single Direction*, arXiv:2406.11717) while keeping responses terse via the existing verbosity vector.
- **multi-policy refusal**: separate vectors for distinct refusal categories (e.g. one extracted from AdvBench-style harmful prompts vs. one for unauthorized-pentest prompts) — these don't always live on the same residual-stream direction, and per-category scaling matters.
- **cross-lingual stabilization**: a refusal vector built from English pairs + a vector that keeps the model from switching language under strong steering.
- **sycophancy / honesty axes**: stacked with a behavior vector.

In practice these scenarios are reachable today only by hand-merging vectors offline, which loses the ability to tune each scale independently or to ablate one axis without disturbing the others.

## What changes

### Public API (`ds4.h`)

Adds `DS4_MAX_STEERING_SLOTS` and `ds4_steering_slot { file, ffn, attn }`. `ds4_engine_options` gains `steering_slots[]` + `steering_slots_count`. The legacy `directional_steering_file/attn/ffn` fields are kept; when `steering_slots_count == 0` the engine synthesizes one slot from them, so existing binary/source callers compile and behave identically.

### Engine + GPU graph (`ds4.c`)

- `struct ds4_engine` and `ds4_gpu_graph` now hold an array of slots instead of a single (file, dirs, attn_scale, ffn_scale) tuple.
- `load_directional_steering_slots` (formerly `cpu_load_directional_steering`) loads every active slot's `.f32` into a host buffer; it's called unconditionally on `ds4_engine_open` because both CPU and GPU paths need the host copy (CPU uses it in place, GPU uploads it to a device tensor).
- `metal_graph_load_directional_steering` allocates one device tensor per active slot.
- `metal_graph_apply_directional_steering_attn` / `_ffn` and the corresponding `_enabled` predicates iterate over the slot array, applying each non-zero scale via the existing `ds4_gpu_directional_steering_project_tensor` kernel. No kernel or shader changes — composition is implemented as N sequential kernel launches per layer.
- CPU reference backend currently still propagates a single `(dirs, attn, ffn)` triple through its intermediate functions. A `DS4_CPU_STEERING_*` macro routes slot 0 into that path. Multi-slot composition is supported on the GPU backends (Metal + CUDA); the CPU backend uses the first slot only, and a follow-up can refactor the CPU dispatch path end-to-end if needed. Documented in `dir-steering/README.md`.

### CLI (`ds4_cli.c`, `ds4_server.c`)

Stateful parsing: every `--dir-steering-file` opens a new slot and the immediately-following `--dir-steering-ffn` / `--dir-steering-attn` flags bind to that slot. Defaults per slot are `ffn=1, attn=0` (same as before). An out-of-order `--dir-steering-ffn`/`-attn` before any `--dir-steering-file` is a hard error rather than silently going into a legacy field.

### Docs

`dir-steering/README.md` gets a "Composing multiple directions" section with the runnable example above and a note on what stacking two non-orthogonal ablations approximates.

## Math note

Applying slot v₁ then slot v₂ in sequence at the same layer is not exactly the same as a single ablation of `span(v₁, v₂)` (Gram–Schmidt of the slot dirs before ablation would be). For concept vectors that have low pairwise cosine — e.g. refusal vs. verbosity — the approximation is good enough in practice. If a future use case wants exact subspace ablation, the slot loader already has the per-slot host buffers in hand and could orthogonalize before upload; that's a self-contained follow-up.

## Compatibility

- Existing command lines and existing `ds4_engine_options` callers keep working byte-for-byte.
- `.f32` file format is unchanged.
- Single-file behavior is unchanged.
- `DS4_MAX_STEERING_SLOTS = 8` is a generous cap; raising it is one constant.

## Validation

- `make -j4 ds4 ds4-server` on macOS Metal — clean.
- `make -j4 ds4 ds4-server` on Linux + CUDA (NVIDIA GB10) — clean.
- `make ds4_test` + `./ds4_test --server` — `server: OK`.
- Smoke test on GB10 with `refusal_v2.f32` (built from AdvBench/Alpaca, 128 pairs) + the bundled `verbosity.f32`:
  - both slots load and activate (`directional steering slot N loaded` + `directional steering enabled (slot N)` in stderr)
  - stacked `refusal=+2, verbosity=-1` produces a noticeably terser-but-non-refusing answer to a harmful-style prompt compared to single-slot `refusal=+2` (composition is visible).
- The existing single-slot `verbosity.f32` example from `dir-steering/README.md` still works unchanged.

## Out of scope (intentionally)

- Extending the CPU reference dispatch path to multi-slot (left for a follow-up; current PR keeps CPU on slot 0 with a clearly named macro).
- Per-slot dynamic policies (interacts with #148 / `--dir-steering-policy`; can be layered on top in a future PR).
- Combining with `--expert-steering-file` from #168 (compatible: those are an independent control surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)