### PR TITLE
test: run logprob vectors through quality path

### DIFF
--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -531,7 +531,7 @@ static void test_official_logprob_vectors(void) {
     TEST_ASSERT(fp != NULL);
     if (!fp) return;
 
-    ds4_engine *engine = test_get_engine(false);
+    ds4_engine *engine = test_get_engine(true);
     if (!engine) {
         fclose(fp);
         return;

--- a/tests/test-vectors/README.md
+++ b/tests/test-vectors/README.md
@@ -33,7 +33,7 @@ API response.
 To inspect a local top-logprob dump manually:
 
 ```sh
-./ds4 --metal --nothink -sys "" --temp 0 -n 4 --ctx 16384 \
+./ds4 --metal --quality --nothink -sys "" --temp 0 -n 4 --ctx 16384 \
   --prompt-file tests/test-vectors/prompts/long_code_audit.txt \
   --dump-logprobs /tmp/long_code_audit.ds4.json \
   --logprobs-top-k 20


### PR DESCRIPTION
## Problem

`./ds4_test --logprob-vectors` was failing on current `main` for the
`long_memory_archive` fixture on Metal. The default fast graph ranked `Based`
above the hosted API's `Component` first token, even though `Component` was
still present in the local top candidates. After that first-token mismatch the
test advanced along the local continuation, so the remaining fixture steps were
compared against the wrong prefix and failed as well.

The fixture is meant to catch tokenizer, prompt-template, attention, and logits
regressions against hosted DeepSeek top-logprob slices. It should therefore use
the exact/quality graph path rather than the default fast path when checking
official vectors.

## Change

Run the official logprob vector test with the quality engine:

```c
test_get_engine(true)
```

Also update the manual `--dump-logprobs` example in
`tests/test-vectors/README.md` to include `--quality`, so the documented
inspection command matches the test path.

## Validation

Machine/backend/model:

- Apple M5 Max
- Metal backend
- default `ds4flash.gguf`

Commands run:

```sh
make -B ds4_test
./ds4_test --logprob-vectors
git diff --cached --check
```

Before this change, `./ds4_test --logprob-vectors` failed with seven
`long_memory_archive` assertions on current `main`. After this change it passes:

```text
logprob-vectors: OK
ds4 tests: ok
```

No runtime inference path changed; this only adjusts which existing engine mode
the official-vector regression uses.
