### PR TITLE
bench: add MTP options to ds4-bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ native tooling can be added later.
 GGUF for Flash. It can be used with q2-imatrix, q4-imatrix, q2, and q4, but must be
 enabled explicitly with `--mtp`. The current MTP/speculative decoding path is
 still experimental: it is correctness-gated and currently provides at most a
-slight speedup, not a meaningful generation-speed win.
+slight speedup, not a meaningful generation-speed win. The performance target
+is to make the target-model suffix verifier much cheaper than repeated normal
+decode; the MTP draft model itself is already a small part of the cycle.
 
 Then build:
 
@@ -271,6 +273,20 @@ greedy non-EOS probe, restores the memory snapshot, and continues prefill.
   --ctx-start 2048 \
   --ctx-max 65536 \
   --step-incr 2048 \
+  --gen-tokens 128
+```
+
+For MTP measurements, pass the support GGUF and a draft depth greater than one:
+
+```sh
+./ds4-bench \
+  -m ds4flash.gguf \
+  --mtp ds4flash-mtp.gguf \
+  --mtp-draft 2 \
+  --mtp-margin 0 \
+  --prompt-file speed-bench/promessi_sposi.txt \
+  --ctx-start 2048 \
+  --ctx-max 2048 \
   --gen-tokens 128
 ```
 

--- a/ds4.c
+++ b/ds4.c
@@ -14400,6 +14400,8 @@ static bool metal_graph_verify_suffix_tops(
     const uint32_t top_rows = n_tokens > 1 ? n_tokens - 1 : 0;
     if (top_rows && !row_tops) return false;
 
+    const bool timing = getenv("DS4_MTP_VERIFY_TIMING") != NULL;
+    const double t0 = timing ? now_sec() : 0.0;
     bool ok = metal_graph_upload_prompt_tokens(g->prefill_tokens, prompt, start, n_tokens);
     if (ok) ok = metal_graph_upload_prompt_embeddings_hc(g->batch_cur_hc,
                                                          g->prefill_tokens,
@@ -14408,11 +14410,13 @@ static bool metal_graph_verify_suffix_tops(
                                                          prompt,
                                                          start,
                                                          n_tokens);
+    const double t_uploaded = timing ? now_sec() : 0.0;
     if (!ok) return false;
 
     const bool saved_capture = g->spec_capture_prefix1;
     g->spec_capture_prefix1 = capture_prefix1 && n_tokens == 2;
 
+    const double t_layers_encode0 = timing ? now_sec() : 0.0;
     ok = ds4_gpu_begin_commands() != 0;
     for (uint32_t il = 0; ok && il < DS4_N_LAYER; il++) {
         ok = metal_graph_encode_layer_batch(g,
@@ -14422,11 +14426,17 @@ static bool metal_graph_verify_suffix_tops(
                                             start,
                                             n_tokens);
     }
-    if (ok) ok = ds4_gpu_end_commands() != 0;
-    else (void)ds4_gpu_synchronize();
+    const double t_layers_encoded = timing ? now_sec() : 0.0;
+    if (ok) {
+        ok = ds4_gpu_end_commands() != 0;
+    } else {
+        (void)ds4_gpu_synchronize();
+    }
+    const double t_layers_done = timing ? now_sec() : 0.0;
     g->spec_capture_prefix1 = saved_capture;
     if (!ok) return false;
 
+    const double t_head_encode0 = timing ? now_sec() : 0.0;
     ok = ds4_gpu_begin_commands() != 0;
     if (ok) ok = metal_graph_encode_output_head_batch(g,
                                                       model,
@@ -14442,8 +14452,14 @@ static bool metal_graph_verify_suffix_tops(
                                                top_rows) != 0;
         }
     }
-    if (ok) ok = ds4_gpu_end_commands() != 0;
-    else (void)ds4_gpu_synchronize();
+    const double t_head_encoded = timing ? now_sec() : 0.0;
+    if (ok) {
+        ok = ds4_gpu_end_commands() != 0;
+    } else {
+        (void)ds4_gpu_synchronize();
+    }
+    const double t_head_done = timing ? now_sec() : 0.0;
+    const double t_read0 = timing ? now_sec() : 0.0;
     if (ok && top_rows) {
         ok = ds4_gpu_tensor_read(g->comp_selected,
                                    0,
@@ -14455,6 +14471,22 @@ static bool metal_graph_verify_suffix_tops(
                                    0,
                                    row_logits,
                                    (uint64_t)n_tokens * DS4_N_VOCAB * sizeof(row_logits[0])) != 0;
+    }
+    if (timing) {
+        const double t_done = now_sec();
+        fprintf(stderr,
+                "ds4: mtp verify suffix tokens=%u start=%u capture_prefix1=%d upload=%.3f ms layers_encode=%.3f ms layers_execute=%.3f ms head_encode=%.3f ms head_execute=%.3f ms read=%.3f ms total=%.3f ms ok=%d\n",
+                n_tokens,
+                start,
+                capture_prefix1 ? 1 : 0,
+                (t_uploaded - t0) * 1000.0,
+                (t_layers_encoded - t_layers_encode0) * 1000.0,
+                (t_layers_done - t_layers_encoded) * 1000.0,
+                (t_head_encoded - t_head_encode0) * 1000.0,
+                (t_head_done - t_head_encoded) * 1000.0,
+                (t_done - t_read0) * 1000.0,
+                (t_done - t0) * 1000.0,
+                ok ? 1 : 0);
     }
     return ok;
 }

--- a/ds4_bench.c
+++ b/ds4_bench.c
@@ -22,6 +22,7 @@
 
 typedef struct {
     const char *model_path;
+    const char *mtp_path;
     const char *prompt_path;
     const char *chat_prompt_path;
     const char *system;
@@ -34,6 +35,8 @@ typedef struct {
     int step_incr;
     int gen_tokens;
     int power_percent;
+    int mtp_draft_tokens;
+    float mtp_margin;
     double step_mul;
     const char *dump_frontier_logits_dir;
     bool warm_weights;
@@ -65,6 +68,9 @@ static void usage(FILE *fp) {
         "\n"
         "Model and backend:\n"
         "  -m, --model FILE       GGUF model path. Default: ds4flash.gguf\n"
+        "  --mtp FILE             Optional MTP support GGUF.\n"
+        "  --mtp-draft N          MTP draft tokens for greedy speculation. Use 2 to enable.\n"
+        "  --mtp-margin F         Minimum recursive-draft confidence. Default: 3\n"
         "  --metal | --cuda | --cpu | --backend NAME\n"
         "      Select backend explicitly. Defaults to Metal on macOS, CUDA elsewhere.\n"
         "  -t, --threads N        CPU helper threads.\n"
@@ -182,6 +188,8 @@ static bench_config parse_options(int argc, char **argv) {
         .ctx_max = 32768,
         .step_incr = 2048,
         .gen_tokens = 128,
+        .mtp_draft_tokens = 1,
+        .mtp_margin = 3.0f,
         .step_mul = 1.0,
     };
 
@@ -192,6 +200,12 @@ static bench_config parse_options(int argc, char **argv) {
             exit(0);
         } else if (!strcmp(arg, "-m") || !strcmp(arg, "--model")) {
             c.model_path = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--mtp")) {
+            c.mtp_path = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--mtp-draft")) {
+            c.mtp_draft_tokens = parse_int(need_arg(&i, argc, argv, arg), arg);
+        } else if (!strcmp(arg, "--mtp-margin")) {
+            c.mtp_margin = (float)parse_double_arg(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--prompt-file")) {
             c.prompt_path = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--chat-prompt-file")) {
@@ -397,9 +411,12 @@ int main(int argc, char **argv) {
 
     ds4_engine_options opt = {
         .model_path = cfg.model_path,
+        .mtp_path = cfg.mtp_path,
         .backend = cfg.backend,
         .n_threads = cfg.threads,
         .power_percent = cfg.power_percent,
+        .mtp_draft_tokens = cfg.mtp_draft_tokens,
+        .mtp_margin = cfg.mtp_margin,
         .warm_weights = cfg.warm_weights,
         .quality = cfg.quality,
     };
@@ -483,7 +500,8 @@ int main(int argc, char **argv) {
         }
 
         const double gen_t0 = bench_now_sec();
-        for (int i = 0; i < cfg.gen_tokens; i++) {
+        int generated = 0;
+        while (generated < cfg.gen_tokens) {
             if (ds4_session_pos(session) + 1 >= ds4_session_ctx(session)) {
                 fprintf(stderr, "ds4-bench: generation would exceed allocated context at frontier %d\n", frontier);
                 rc = 1;
@@ -495,11 +513,32 @@ int main(int argc, char **argv) {
                 rc = 1;
                 break;
             }
-            if (ds4_session_eval(session, token, err, sizeof(err)) != 0) {
-                fprintf(stderr, "ds4-bench: decode at frontier %d failed: %s\n", frontier, err);
-                rc = 1;
-                break;
+            int toks[17];
+            int ntok = 0;
+            if (ds4_engine_mtp_draft_tokens(engine) > 1 &&
+                getenv("DS4_MTP_SPEC_DISABLE") == NULL) {
+                ntok = ds4_session_eval_speculative_argmax(session,
+                                                           token,
+                                                           cfg.gen_tokens - generated,
+                                                           eos,
+                                                           toks,
+                                                           (int)(sizeof(toks) / sizeof(toks[0])),
+                                                           err,
+                                                           sizeof(err));
+                if (ntok < 0) {
+                    fprintf(stderr, "ds4-bench: MTP decode at frontier %d failed: %s\n", frontier, err);
+                    rc = 1;
+                    break;
+                }
+            } else {
+                if (ds4_session_eval(session, token, err, sizeof(err)) != 0) {
+                    fprintf(stderr, "ds4-bench: decode at frontier %d failed: %s\n", frontier, err);
+                    rc = 1;
+                    break;
+                }
+                ntok = 1;
             }
+            generated += ntok;
         }
         const double gen_t1 = bench_now_sec();
         if (rc != 0) break;


### PR DESCRIPTION
## Summary

- add `--mtp`, `--mtp-draft`, and `--mtp-margin` to `ds4-bench`
- route the benchmark generation loop through the existing greedy MTP path when draft depth is greater than one
- document a minimal normal-vs-MTP benchmark invocation and add an opt-in `DS4_MTP_VERIFY_TIMING` breakdown for verifier profiling

## Overlap check

I checked the current issue/PR list before opening this. Related discussions exist around speculative decoding (#80, #63) and the large CUDA/backend PR #187 also mentions speculative-decoding plumbing, but I did not find a focused PR that makes `ds4-bench` directly benchmark the existing MTP path on main. This PR is intentionally small and measurement-oriented; it does not change default runtime behavior.

## Testing

- `make`
- `git diff --check origin/main..HEAD`
- `./ds4-bench --help` shows the new MTP options

