### PR TITLE
mtp: make speculation disable skip draft work

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -17728,9 +17728,10 @@ static int ds4_session_eval_internal(ds4_session *s, int token, bool probe_mtp,
 #else
     ds4_engine *e = s->engine;
     const bool mtp_probe_log = getenv("DS4_MTP_PROBE") != NULL;
+    const bool mtp_spec_disabled = getenv("DS4_MTP_SPEC_DISABLE") != NULL;
     const bool mtp_should_draft =
         probe_mtp && e->mtp_ready && s->mtp_logits &&
-        (e->mtp_draft_tokens > 1 || mtp_probe_log);
+        ((e->mtp_draft_tokens > 1 && !mtp_spec_disabled) || mtp_probe_log);
     if (probe_mtp && s->mtp_draft_valid) {
         if (mtp_probe_log) {
             s->mtp_probe_total++;

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -280,6 +280,11 @@ static double cli_now_sec(void) {
     return (double)ts.tv_sec + (double)ts.tv_nsec * 1.0e-9;
 }
 
+static bool cli_mtp_spec_enabled(ds4_engine *engine) {
+    return ds4_engine_mtp_draft_tokens(engine) > 1 &&
+           getenv("DS4_MTP_SPEC_DISABLE") == NULL;
+}
+
 static char *read_prompt_file(const char *path, bool fatal);
 
 typedef struct {
@@ -509,8 +514,7 @@ static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, con
 
         int toks[17];
         int ntok = 0;
-        if (cfg->gen.temperature <= 0.0f && ds4_engine_mtp_draft_tokens(engine) > 1 &&
-            getenv("DS4_MTP_SPEC_DISABLE") == NULL) {
+        if (cfg->gen.temperature <= 0.0f && cli_mtp_spec_enabled(engine)) {
             ntok = ds4_session_eval_speculative_argmax(session,
                                                        token,
                                                        max_tokens - generated,
@@ -758,7 +762,7 @@ static int run_generation(ds4_engine *engine, const cli_config *cfg) {
             fprintf(stderr, "ds4: diagnostic run completed on the native %s path.\n",
                     ds4_backend_name(cfg->engine.backend));
         }
-    } else if (cfg->gen.temperature > 0.0f || ds4_engine_mtp_draft_tokens(engine) > 1) {
+    } else if (cfg->gen.temperature > 0.0f || cli_mtp_spec_enabled(engine)) {
         rc = run_sampled_generation(engine, cfg, &prompt);
     } else {
         token_printer printer = {
@@ -971,8 +975,7 @@ static int run_chat_turn(ds4_engine *engine, cli_config *cfg, repl_chat *chat, c
 
         int toks[17];
         int ntok = 0;
-        if (cfg->gen.temperature <= 0.0f && ds4_engine_mtp_draft_tokens(engine) > 1 &&
-            getenv("DS4_MTP_SPEC_DISABLE") == NULL) {
+        if (cfg->gen.temperature <= 0.0f && cli_mtp_spec_enabled(engine)) {
             ntok = ds4_session_eval_speculative_argmax(chat->session,
                                                        token,
                                                        max_tokens - generated,


### PR DESCRIPTION
## Summary

`DS4_MTP_SPEC_DISABLE` should leave greedy generation on the ordinary
non-speculative path. Before this change, the flag bypassed speculative
acceptance, but two pieces of speculative plumbing still ran:

- one-shot CLI generation still selected the session sampling path when MTP was
  configured
- `ds4_session_eval()` still prepared MTP draft tokens after each decode step

This patch honors the flag at those remaining decision points. `DS4_MTP_PROBE`
remains independent, so explicit draft-probe diagnostics still work without
enabling speculative generation.

## Why This Is A Correctness Fix

The disable flag previously meant "do not accept speculative tokens" rather
than "do not run speculative work." That made the disabled mode surprising and
kept extra MTP work in a path meant to be ordinary greedy generation. After this
change, the flag has the expected behavior: configured MTP support can remain
loaded, but speculative generation work is skipped unless speculation or probe
diagnostics are explicitly enabled.

## Testing

Machine/backend/model:

- Apple M5 Max, Metal backend, 128 GiB RAM
- main model: `DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix.gguf`
- MTP model: `DeepSeek-V4-Flash-MTP-Q4K-Q8_0-F32.gguf`

Commands run on this branch:

```sh
make clean
make
make test
```

`make` passed.

`make test` ran with Metal access. The `long-context`, `tool-call-quality`,
`metal-kernels`, and `server` tracks passed. The `logprob-vectors` track failed
on `long_memory_archive` with 7 failures.

I checked the same logprob-vector track on `main`:

```sh
DS4_TEST_MODEL=/Users/abhay/Dev/ds4/ds4flash.gguf ./ds4_test --logprob-vectors
```

It failed the same `long_memory_archive` vector on `main` with the same 7
failures, so this branch does not appear to introduce that regression. That
pre-existing vector failure is addressed separately in
https://github.com/antirez/ds4/pull/204, which runs the official logprob-vector
check through the quality path.

## Targeted Disabled-MTP Smoke Check

I also compared the exact affected mode against `main`:

```sh
env DS4_MTP_SPEC_DISABLE=1 ./ds4 \
  -m /Users/abhay/Dev/ds4/ds4flash.gguf \
  --mtp /Users/abhay/Dev/ds4/gguf/DeepSeek-V4-Flash-MTP-Q4K-Q8_0-F32.gguf \
  --mtp-draft 2 \
  --temp 0 \
  --nothink \
  --ctx 1024 \
  -n 32 \
  -p 'Write one concise sentence about testing.'
```

Both `main` and this branch produced the same greedy output. Generation speed in
this narrow smoke check was:

- `main`: 35.67 t/s
- this branch: 38.98 t/s

This is not a broad throughput claim. It only shows that the disabled-MTP mode
now avoids the extra draft-path overhead this patch removes.