### PR TITLE
fix: handle CR in agent yes/no prompts

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -8918,7 +8918,6 @@ static const char *agent_yes_no_auto_name(agent_yes_no_auto answer) {
 static bool agent_prompt_yes_no_ex(const char *prompt,
                                    const agent_yes_no_options *opts,
                                    bool *timed_out) {
-    char buf[32];
     int timeout_sec = opts ? opts->timeout_sec : 0;
     agent_yes_no_auto auto_answer = opts ?
         opts->timeout_answer : AGENT_YES_NO_AUTO_NONE;
@@ -8934,31 +8933,41 @@ static bool agent_prompt_yes_no_ex(const char *prompt,
             printf("[auto-%s in %ds] ", agent_yes_no_auto_name(auto_answer), rem);
         }
         fflush(stdout);
-        if (use_timeout) {
-            double rem_sec = deadline - now_sec();
-            if (rem_sec <= 0.0) {
-                if (timed_out) *timed_out = true;
-                printf("\n");
-                return auto_answer == AGENT_YES_NO_AUTO_YES;
+        int answer = 0;
+        for (;;) {
+            if (use_timeout) {
+                double rem_sec = deadline - now_sec();
+                if (rem_sec <= 0.0) {
+                    if (timed_out) *timed_out = true;
+                    printf("\n");
+                    return auto_answer == AGENT_YES_NO_AUTO_YES;
+                }
+                struct pollfd pfd = {.fd = STDIN_FILENO, .events = POLLIN};
+                int timeout_ms = (int)(rem_sec * 1000.0) + 1;
+                int rc;
+                do {
+                    rc = poll(&pfd, 1, timeout_ms);
+                } while (rc < 0 && errno == EINTR);
+                if (rc == 0) {
+                    if (timed_out) *timed_out = true;
+                    printf("\n");
+                    return auto_answer == AGENT_YES_NO_AUTO_YES;
+                }
+                if (rc < 0) return false;
             }
-            struct pollfd pfd = {.fd = STDIN_FILENO, .events = POLLIN};
-            int timeout_ms = (int)(rem_sec * 1000.0) + 1;
-            int rc;
-            do {
-                rc = poll(&pfd, 1, timeout_ms);
-            } while (rc < 0 && errno == EINTR);
-            if (rc == 0) {
-                if (timed_out) *timed_out = true;
+            int c = getchar();
+            if (c == EOF || c == 4) {
                 printf("\n");
-                return auto_answer == AGENT_YES_NO_AUTO_YES;
+                return false;
             }
-            if (rc < 0) return false;
+            if (c == '\n' || c == '\r') {
+                printf("\n");
+                if (answer == 'y' || answer == 'Y') return true;
+                if (answer == 'n' || answer == 'N' || !answer) return false;
+                break;
+            }
+            if (!answer && c != ' ' && c != '\t') answer = c;
         }
-        if (!fgets(buf, sizeof(buf), stdin)) return false;
-        char *p = buf;
-        while (*p == ' ' || *p == '\t') p++;
-        if (*p == 'y' || *p == 'Y') return true;
-        if (*p == 'n' || *p == 'N') return false;
     }
 }
 


### PR DESCRIPTION
## Summary

`ds4-agent` now treats carriage return as a valid line terminator in its yes/no prompts.

This fixes an interactive exit path where a terminal can send `\r` after replying to:

```text
Save current session? (y/n)
```

With the old line-buffered parser, that response could remain visually stuck as `y^M` instead of being accepted cleanly.

## Root cause

The prompt helper parsed complete newline-delimited lines with `fgets()`. Some terminal paths can deliver carriage return for Enter in this restored-terminal prompt path.

The same helper is also used for timed approval prompts, so the fix keeps that timeout behavior while switching the answer parser to read one byte at a time.

## Change

`agent_prompt_yes_no_ex()` now:

- records the first non-space answer byte;
- accepts either `\n` or `\r` as the end of the response;
- preserves EOF / Ctrl+D as a negative answer;
- preserves automatic timeout answers for callers that opt into them.

## Validation

Current branch after rebase onto `origin/main` (`072bc0f`):

```sh
git diff --check origin/main..HEAD
make ds4-agent
./ds4_test --server
```

Results:

- `git diff --check origin/main..HEAD`: passed.
- `make ds4-agent`: passed.
- `./ds4_test --server`: passed.

Earlier, the same fix was also validated with a full `make test` from a normal macOS Terminal on Apple M5 Max / Metal backend. The Codex execution context cannot always access a Metal device directly, so the current post-rebase verification uses the non-Metal server regression check.
