### PR TITLE
Fix Metal short prompt prefill

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -10915,8 +10915,11 @@ static bool metal_graph_refresh_ratio4_compressor_state(
         uint32_t          width,
         uint32_t          pos0,
         uint32_t          n_tokens) {
+    if (n_tokens < 4) {
+        return true;
+    }
     if (!g || !model || !state_kv || !state_score || !kv_weight || !score_weight || !ape ||
-        head_dim == 0 || width == 0 || n_tokens < 4) {
+        head_dim == 0 || width == 0) {
         return false;
     }
 

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -150,6 +150,47 @@ static void test_metal_f16_matvec_fast_nr0_4(void) {
     free(weights_raw);
 }
 
+static void test_metal_short_prefill_ratio4(void) {
+    ds4_engine *engine = test_get_engine(false);
+    if (!engine) return;
+
+    const int tokens[] = {
+        ds4_token_user(engine),
+        ds4_token_assistant(engine),
+        ds4_token_eos(engine),
+    };
+    for (size_t i = 0; i < sizeof(tokens) / sizeof(tokens[0]); i++) {
+        TEST_ASSERT(tokens[i] >= 0);
+        if (tokens[i] < 0) return;
+    }
+
+    for (size_t n = 1; n <= 3; n++) {
+        ds4_tokens prompt = {0};
+        for (size_t i = 0; i < n; i++) {
+            ds4_tokens_push(&prompt, tokens[i]);
+        }
+        TEST_ASSERT(prompt.len == (int)n);
+
+        ds4_session *session = NULL;
+        TEST_ASSERT(ds4_session_create(&session, engine, 2048) == 0);
+        if (!session) {
+            ds4_tokens_free(&prompt);
+            return;
+        }
+
+        char err[160] = {0};
+        const int rc = ds4_session_sync(session, &prompt, err, sizeof(err));
+        if (rc != 0) {
+            fprintf(stderr, "ds4-test: short prefill failed for %zu token(s): %s\n",
+                    n, err);
+        }
+        TEST_ASSERT(rc == 0);
+
+        ds4_session_free(session);
+        ds4_tokens_free(&prompt);
+    }
+}
+
 static char *test_read_file(const char *path) {
     FILE *fp = fopen(path, "rb");
     if (!fp) return NULL;
@@ -666,6 +707,7 @@ static const ds4_test_entry test_entries[] = {
     {"--long-context", "long-context", "long-context story fact-recall regression", test_long_story_fact_recall},
     {"--tool-call-quality", "tool-call-quality", "model emits valid DSML tool calls", test_tool_call_quality},
     {"--logprob-vectors", "logprob-vectors", "official API top-logprob vector comparison", test_official_logprob_vectors},
+    {"--metal-short-prefill", "metal-short-prefill", "Metal ratio-4 short prefill regression", test_metal_short_prefill_ratio4},
     {"--metal-kernels", "metal-kernels", "isolated Metal kernel numeric regressions", test_metal_f16_matvec_fast_nr0_4},
 #endif
     {"--server", "server", "server parser/rendering/cache unit tests", test_server_unit_group},


### PR DESCRIPTION
This PR fixes a Metal prefill regression for prompts shorter than four tokens.

`metal_graph_refresh_ratio4_compressor_state()` treated `n_tokens < 4` as an error, even though no ratio-4 compressor state refresh is needed until a complete group of four tokens exists. For 1-3 token prompts, the partial state produced by normal prefill is already the correct state to keep.

The fix returns success for 1-3 token prompts and keeps the existing validation for real ratio-4 refreshes. The PR also adds a dedicated Metal regression test, `--metal-short-prefill`, that synchronizes prompts of 1, 2, and 3 tokens through the normal session path.

Verification:

```text
make ds4_test
./ds4_test --server
./ds4_test --metal-short-prefill
```

Before the fix, `./ds4_test --metal-short-prefill` fails for 1, 2, and 3 token prompts with `metal prefill failed`. After the fix, the same test passes.

Grazie Salvatore, e veramente un piacere seguirti sui social.