### PR TITLE
ds4_server: check if client disconnected to abort inference early

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -10268,6 +10268,34 @@ decode_again:
         if (in_tool_call && !dsml_decode_state_uses_payload_sampling(dsml_state)) {
             temperature = 0.0f;
         }
+        /* Check if client disconnected before sampling the next token.
+         * For streaming requests the write-side checks already catch a dropped
+         * connection, but for non-streaming there is no fd interaction during
+         * generation and the worker would waste time completing the full
+         * response for a client that is no longer listening.
+         * On macOS POLLHUP is not raised for a graceful TCP close (FIN);
+         * instead the socket becomes readable and recv() returns 0.
+         * We therefore also check POLLIN and peek for EOF. */
+        if (!j->req.stream) {
+            struct pollfd pfd = {.fd = j->fd, .events = POLLIN};
+            int prc = poll(&pfd, 1, 0);
+            if (prc > 0) {
+                bool disconnected = false;
+                if (pfd.revents & (POLLHUP | POLLERR | POLLNVAL)) {
+                    disconnected = true;
+                } else if (pfd.revents & POLLIN) {
+                    char tmp;
+                    ssize_t n = recv(j->fd, &tmp, 1, MSG_PEEK | MSG_DONTWAIT);
+                    if (n == 0) disconnected = true;
+                }
+                if (disconnected) {
+                    server_log(DS4_LOG_WARNING, "ds4-server: client disconnected during generation, aborting job");
+                    finish = "error";
+                    snprintf(err, sizeof(err), "client disconnected");
+                    break;
+                }
+            }
+        }
         int token = ds4_session_sample(s->session, temperature, top_k, top_p, min_p, &rng);
         if (token == ds4_token_eos(s->engine)) {
             finish = "stop";


### PR DESCRIPTION
## Title
Detect client disconnection during non-streaming inference and abort generation early to allow the next queued worker to begin

## Description

### Problem
The ds4-server uses a single-worker-thread architecture. When a client disconnects mid-request (drops their HTTP connection), the worker continues generating tokens until the response is fully complete before noticing the failure. For non-streaming requests, there is no interaction with the client socket during the decode loop, so a dropped connection is never detected until the final send(). This wastes GPU time an more importantly, blocks the single worker thread from processing any subsequent queued requests.

### Solution
Add a lightweight, per-token health check on the client socket inside the decode loop for non-streaming requests. Before sampling each tokepoll() the fd with a zero timeout. If the peer has closed the connection, abort generation immediately with finish = "error".

### Cross-platform notes
- On Linux, POLLHUP (and POLLRDHUP with _GNU_SOURCE) is raised for a graceful TCP FIN, so the check is straightforward.
- On macOS, POLLHUP is not raised for a TCP FIN �~@~T the socket becomes readable instead, and recv() returns 0. The implementation handles bot paths: it checks POLLHUP | POLLERR | POLLNVAL first, and if only POLLIN is set, it peeks with recv(fd, ..., MSG_PEEK | MSG_DONTWAIT) to detect EOF.

### Changes
- ds4_server.c: ~28 lines added in the decode loop of generate_job(), guarded by if (!j->req.stream) (streaming requests already detect disconnection via write failures).
- No new includes, no new build flags, no new dependencies.

### Testing
- Compiles cleanly on both macOS (clang) and Linux (gcc).
- Manual test performed: send a non-streaming request and kill the client mid-generation the server logs "ds4-server: client disconnected during generation, aborting job" and immediately picks up the next queued job.