### PR TITLE
ds4-server: SSE keepalive during decode

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -10251,6 +10251,15 @@ decode_again:
     const double decode_t0 = now_sec();
     double last_decode_log_t = decode_t0;
     int last_decode_log_completion = 0;
+    /* SSE keepalive during decode.  The prefill keepalive (server_progress_cb
+     * + prefill_display events) keeps the connection alive while the model is
+     * processing input; once we reach decode, long stretches with no
+     * streamable bytes still happen — typically when the model is mid-thinking
+     * (no `</think>` yet, nothing flushed to the client) or accumulating a
+     * large tool_use input JSON (held back until the block closes).  Without
+     * a periodic comment line, client TCP idle-timeouts close the socket
+     * during those quiet stretches and the final stream write fails. */
+    double decode_last_keepalive = decode_t0;
     thinking_state thinking = thinking_state_from_prompt(&j->req);
     const bool thinking_gates_tool_markers = ds4_think_mode_enabled(j->req.think_mode);
     bool tool_scan_waiting_for_think_close =
@@ -10260,6 +10269,23 @@ decode_again:
 
     while (!g_stop_requested && completion < max_tokens &&
            ds4_session_pos(s->session) < ds4_session_ctx(s->session)) {
+        /* Emit a `:` SSE comment line at most every 15 seconds when the
+         * client requested streaming.  Best-effort: if the write fails the
+         * socket is already gone, end the turn with the same error path the
+         * regular event writer uses. */
+        if (j->req.stream) {
+            double now_kp = now_sec();
+            if (now_kp - decode_last_keepalive >= 15.0) {
+                static const char ka[] = ": decode\n\n";
+                if (!send_all(j->fd, ka, sizeof(ka) - 1)) {
+                    finish = "error";
+                    snprintf(err, sizeof(err),
+                             "client stream write failed during decode heartbeat");
+                    break;
+                }
+                decode_last_keepalive = now_kp;
+            }
+        }
         dsml_decode_state dsml_state = j->req.kind == REQ_CHAT && j->req.has_tools ?
             dsml_tracker.decode : DSML_DECODE_OUTSIDE;
         const bool in_tool_call = dsml_decode_state_is_tool(dsml_state);


### PR DESCRIPTION
## Summary

Small follow-up to f91c12b (prefill keepalive via `prefill_display`).

The prefill side is now well-covered.  Decode can still go quiet for tens of seconds when:

- the model is mid-thinking — `<think>...</think>` is open and no visible text has been flushed;
- the model is accumulating a large `tool_use` input JSON, which is held back until the block closes.

`sse_chunk` only fires when there is actual streamable text, so the socket sees nothing during those stretches.  Past the client's TCP idle threshold (10-60 s on most HTTP libraries), the next `sse_chunk` call records `client stream write failed` and the turn errors out — same failure shape that prompted issue #222 on the prefill side, just on the other end of the turn.

## Fix

In the decode loop, when `j->req.stream` is set, emit a `: decode\n\n` SSE comment line at most every 15 s:

```c
if (j->req.stream) {
    double now_kp = now_sec();
    if (now_kp - decode_last_keepalive >= 15.0) {
        static const char ka[] = ": decode\n\n";
        if (!send_all(j->fd, ka, sizeof(ka) - 1)) {
            finish = "error";
            snprintf(err, sizeof(err),
                     "client stream write failed during decode heartbeat");
            break;
        }
        decode_last_keepalive = now_kp;
    }
}
```

15 s mirrors the prefill cadence and sits inside common 30-60 s client idle thresholds.  Failed write ends the turn via the existing `client stream write failed` path — no new failure mode for callers.

## Scope (intentionally minimal)

- No watchdog thread.
- No `_exit`.
- No struct fields added.
- Only one new local variable (`decode_last_keepalive`).
- Does **not** cover GPU/Metal kernel hangs inside `ds4_session_*` — out of scope.

## Verification

Machine: MacBook Pro M5 Max, 128 GiB RAM
Backend: Metal
Model: `DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2.gguf` (q2-imatrix)
Server: `./ds4-server --host 0.0.0.0 --port 8000 --ctx 500000 --kv-disk-dir … --kv-disk-space-mb 204800`

- `make` clean, no new warnings.
- `./ds4_test --server` passes (`server: OK` / `ds4 tests: ok`).
- Streamed completions where the model thinks for 30+ s now show `: decode` comment lines on the wire every 15 s, no client disconnect.

## Test plan

- [ ] CI runs `./ds4_test --server`
- [ ] Manual: chat request that forces a long `<think>` phase or large tool_use input; observe `: decode` comment lines on the SSE wire and no `client stream write failed` errors at the end.