### PR TITLE
download_model.sh: prefer huggingface CLI when available

### DIFF
--- a/download_model.sh
+++ b/download_model.sh
@@ -165,6 +165,22 @@ download_one() {
     echo "from https://huggingface.co/$REPO"
     echo "If the download stops, run the same command again to resume it."
 
+    # Prefer the Hugging Face CLI when available: it is xet-bridge native
+    # and resumable. The plain curl path below 400s on some large files
+    # (e.g. the ~430 GB PRO bundle) because Hugging Face's xet bridge
+    # rejects range-less GETs above a certain size.
+    HF_BIN=$(command -v hf 2>/dev/null || command -v huggingface-cli 2>/dev/null || true)
+    if [ -n "$HF_BIN" ]; then
+        # Pass the token via HF_TOKEN env rather than --token so it does
+        # not appear in `ps` output of the child process.
+        if [ -n "$TOKEN" ]; then
+            HF_TOKEN="$TOKEN" "$HF_BIN" download "$REPO" "$file" --local-dir "$OUT_DIR"
+        else
+            "$HF_BIN" download "$REPO" "$file" --local-dir "$OUT_DIR"
+        fi
+        return
+    fi
+
     if [ -n "$TOKEN" ]; then
         curl -fL --progress-meter -C - -H "Authorization: Bearer $TOKEN" -o "$part" "$url"
     else


### PR DESCRIPTION
Closes #249.

## Problem

`./download_model.sh pro-imatrix` fails when fetching the new ~430 GB PRO bundle:

```
Downloading DeepSeek-V4-Pro-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-Instruct-imatrix.gguf
...
curl: (22) The requested URL returned error: 400
```

Hugging Face's xet bridge rejects range-less GETs above a certain size threshold and returns a generic `<h1>400</h1>` HTML page. Per #249's table, the threshold sits between `q4-imatrix` (164 GB, fine) and `pro-imatrix` (464 GB, 400). Empirically on the PRO file:

- `curl --range 0-67108863` (64 MB chunk) → `206 Partial Content`, downloads fine
- `curl` with no `Range` header → 400 from the xet bridge after two redirects

The redirect chain is HF resolve → xethub bridge → S3 presigned URL with `X-Xet-Cas-Uid`; the bridge itself is what 400s, not S3. `curl -C -` doesn't help on a fresh download because there's no local partial to resume from. The smaller Flash files don't trip the threshold; PRO surfaces it.

## Fix

Prefer the official `hf` CLI (or `huggingface-cli` if it's the older binary on the user's PATH) — it is xet-bridge native and handles chunked / ranged retrieval correctly. Fall through to the existing `curl` flow **unchanged** when no HF CLI is installed, so the existing Flash-download experience is preserved.

The token is passed via the `HF_TOKEN` env rather than `--token` so it doesn't appear in `ps` output of the child process.

## Test

- Patched script on `mtp` (small, cheap to interrupt) → `hf` selected, `.incomplete` staging file created, download begins; killed after a few seconds without side effects.
- Patched script on `pro-imatrix` → in-flight on a 512 GB M3 Ultra at time of writing, against this exact code path.
- Falls back to `curl` cleanly when neither `hf` nor `huggingface-cli` is on PATH.

## Notes

- Minimal patch: 16 additions, 0 deletions, no behavior change to the existing curl path.
- No new hard dependency; the HF CLI is optional and detected at runtime via `command -v`.
- If a pure-curl path is preferred (no HF dep at all), I can replace this with a chunked `curl --range` loop that issues fixed-size chunks and concatenates — happy to take that direction if you'd rather not introduce the HF CLI as an option. The current patch is the smallest fix that works.