### PR TITLE
Keep wide MoE tiles opt-in

### DIFF
--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -12660,7 +12660,11 @@ static id<MTLComputePipelineState> ds4_gpu_routed_mm_pipeline_for_tile(uint32_t 
 }
 
 static uint32_t ds4_gpu_moe_mm_tile_n(uint32_t gate_type, uint32_t n_tokens) {
-    const uint32_t tile_max = ds4_gpu_env_u32("DS4_METAL_MOE_TILE_MAX", 128u);
+    /*
+     * Keep the wide MoE tiles opt-in until their output exactness matches the
+     * 32-token path. DS4_METAL_MOE_TILE_MAX=64/128 still enables them.
+     */
+    const uint32_t tile_max = ds4_gpu_env_u32("DS4_METAL_MOE_TILE_MAX", 32u);
     if (tile_max <= 32u) {
         return 32u;
     }


### PR DESCRIPTION
## Summary
- Restore the default routed MoE Metal tile cap to 32 tokens.
- Keep the 64/128-token wide MoE kernels available via `DS4_METAL_MOE_TILE_MAX=64` or `128`.

## Why
The wide routed-MoE `mul_mm_id` kernels currently diverge from the validated 32-token path on `origin/main` (`9ca9013`). Local comparison of `ffn_moe_out` for layer 0, position 0 on `ds4flash.gguf` showed `13,762,559 / 16,777,216` differing floats, `RMS=0.165865076351`, and `max_abs=2.18316340446`.

This keeps the faster wide kernels available for opt-in testing while avoiding a default correctness regression.

## Test
- `make ds4-bench`
- `git diff --check`