### PR TITLE
Document wide MoE prefill tile setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ Chunked Metal prefill reuses the same range-capable layer-major graph for each
 chunk, preserving absolute compressor/indexer boundaries while avoiding the old
 per-layer chunk dispatch path.
 
+Metal routed-MoE prefill defaults to wider token tiles for aligned chunks: 128
+tokens when possible, otherwise 64, with 32 as the fallback. This applies to
+`Q2_K`, `IQ2_XXS`, and `Q4_K` routed expert matmuls and is primarily a prefill
+optimization. For A/B testing, set `DS4_METAL_MOE_TILE_MAX=32` to force the old
+32-token path, or `64` to cap the new path at 64-token tiles.
+
 ## Capability Evaluation
 
 `ds4-eval` is a small real-model integration benchmark. It is not a leaderboard


### PR DESCRIPTION
Documents the wide routed-MoE prefill tile behavior added by PR #264 and the DS4_METAL_MOE_TILE_MAX A/B knob.\n\nDocs-only change.