### PR TITLE
Makefile: use -march=native on x86_64 Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 CC ?= cc
 UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
 
 ifeq ($(UNAME_S),Darwin)
+ifeq ($(UNAME_M),arm64)
 NATIVE_CPU_FLAG ?= -mcpu=native
+else
+NATIVE_CPU_FLAG ?= -march=native
+endif
 else
 NATIVE_CPU_FLAG ?= -march=native
 endif


### PR DESCRIPTION
## Summary

`make cpu` fails on x86_64 macOS because Apple Clang rejects `-mcpu=native`:

```
clang: error: unsupported option '-mcpu=' for target 'x86_64-apple-darwin25.4.0'
```

Fix: use `-mcpu=native` only on `arm64` Darwin (Apple Silicon), fall back to `-march=native` on `x86_64` Darwin. Linux behavior unchanged.

## What Changed

**`Makefile`** (+5 lines)

Adds `UNAME_M` detection and a nested `ifeq` for Darwin:
- Darwin arm64 → `-mcpu=native` (Apple Silicon, works)
- Darwin x86_64 → `-march=native` (Intel Mac, works)
- Linux → `-march=native` (unchanged)

## Verification

Before (x86_64 macOS):
```
$ make cpu
clang: error: unsupported option '-mcpu=' for target 'x86_64-apple-darwin25.4.0'
```

After:
```
$ make clean && make cpu
# all targets build cleanly
$ ./ds4_test --server
server: OK
```