### PR TITLE
metal: implement ds4_gpu_argmax_tensor (fix Metal build break)

### DIFF
--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -87,6 +87,7 @@ static id<MTLComputePipelineState> g_dsv4_softmax_pool_pipeline;
 static id<MTLComputePipelineState> g_soft_max_f32_pipeline;
 static id<MTLComputePipelineState> g_soft_max_f32_4_pipeline;
 static id<MTLComputePipelineState> g_argsort_f32_i32_desc_pipeline;
+static id<MTLComputePipelineState> g_argmax_f32_i32_pipeline;
 static id<MTLComputePipelineState> g_argsort_merge_f32_i32_desc_pipeline;
 static id<MTLComputePipelineState> g_sum_rows_f32_f32_pipeline;
 static id<MTLComputePipelineState> g_dsv4_topk_mask_pipeline;
@@ -3763,6 +3764,22 @@ int ds4_gpu_init(void) {
             return 0;
         }
 
+        fn = [library newFunctionWithName:@"kernel_argmax_f32_i32"];
+        if (!fn) {
+            fprintf(stderr, "ds4: Metal kernel_argmax_f32_i32 function not found\n");
+            g_queue = nil;
+            g_device = nil;
+            return 0;
+        }
+        g_argmax_f32_i32_pipeline = [g_device newComputePipelineStateWithFunction:fn error:&error];
+        if (!g_argmax_f32_i32_pipeline) {
+            fprintf(stderr, "ds4: Metal kernel_argmax_f32_i32 pipeline failed: %s\n",
+                    [[error localizedDescription] UTF8String]);
+            g_queue = nil;
+            g_device = nil;
+            return 0;
+        }
+
         fn = [library newFunctionWithName:@"kernel_argsort_merge_f32_i32_desc"];
         if (!fn) {
             fprintf(stderr, "ds4: Metal kernel_argsort_merge_f32_i32_desc function not found\n");
@@ -4508,6 +4525,7 @@ void ds4_gpu_cleanup(void) {
         g_soft_max_f32_pipeline = nil;
         g_soft_max_f32_4_pipeline = nil;
         g_argsort_f32_i32_desc_pipeline = nil;
+        g_argmax_f32_i32_pipeline = nil;
         g_argsort_merge_f32_i32_desc_pipeline = nil;
         g_sum_rows_f32_f32_pipeline = nil;
         g_dsv4_topk_mask_pipeline = nil;
@@ -5377,6 +5395,54 @@ int ds4_gpu_indexer_topk_tensor(
         }
 
         if (!ds4_gpu_finish_command_buffer(cb, owned, "indexer top-k")) return 0;
+    }
+
+    return 1;
+}
+
+int ds4_gpu_argmax_tensor(
+        ds4_gpu_tensor       *out_idx,
+        const ds4_gpu_tensor *logits,
+        uint32_t                n_vocab) {
+    if (!g_initialized && !ds4_gpu_init()) return 0;
+    if (!out_idx || !logits || n_vocab == 0) return 0;
+
+    @autoreleasepool {
+        id<MTLBuffer> logitbuf = ds4_gpu_tensor_buffer(logits);
+        id<MTLBuffer> outbuf = ds4_gpu_tensor_buffer(out_idx);
+        if (!logitbuf || !outbuf ||
+            ds4_gpu_tensor_bytes(logits) < (uint64_t)n_vocab * sizeof(float) ||
+            ds4_gpu_tensor_bytes(out_idx) < sizeof(int32_t)) {
+            fprintf(stderr, "ds4: Metal argmax received undersized buffers\n");
+            return 0;
+        }
+
+        /* Single threadgroup, power-of-two width so the reduction is exact. */
+        NSUInteger max_threads = g_argmax_f32_i32_pipeline.maxTotalThreadsPerThreadgroup;
+        if (max_threads == 0) max_threads = 1024;
+        NSUInteger nth = 1;
+        while (2u * nth <= max_threads && 2u * nth <= 1024u) nth *= 2;
+
+        const NSUInteger smem_val = ((nth * sizeof(float)) + 15u) & ~(NSUInteger)15u;
+        const NSUInteger smem_idx = ((nth * sizeof(int32_t)) + 15u) & ~(NSUInteger)15u;
+        const uint32_t nv = n_vocab;
+
+        int owned = 0;
+        id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
+        if (!cb) return 0;
+
+        id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
+        [enc setComputePipelineState:g_argmax_f32_i32_pipeline];
+        [enc setBytes:&nv length:sizeof(nv) atIndex:0];
+        [enc setBuffer:logitbuf offset:ds4_gpu_tensor_offset(logits) atIndex:1];
+        [enc setBuffer:outbuf offset:ds4_gpu_tensor_offset(out_idx) atIndex:2];
+        [enc setThreadgroupMemoryLength:smem_val atIndex:0];
+        [enc setThreadgroupMemoryLength:smem_idx atIndex:1];
+        [enc dispatchThreadgroups:MTLSizeMake(1, 1, 1)
+             threadsPerThreadgroup:MTLSizeMake(nth, 1, 1)];
+        ds4_gpu_end_compute_encoder(cb, enc);
+
+        if (!ds4_gpu_finish_command_buffer(cb, owned, "argmax")) return 0;
     }
 
     return 1;

--- a/metal/argsort.metal
+++ b/metal/argsort.metal
@@ -264,3 +264,49 @@ kernel void kernel_argsort_merge_f32_i32(
 
 // Host-visible merge variant used by DS4 top-k selection.
 template [[host_name("kernel_argsort_merge_f32_i32_desc")]] kernel argsort_merge_t kernel_argsort_merge_f32_i32<DS4_SORT_ORDER_DESC>;
+
+// GPU argmax over n_vocab F32 logits, computed by a single threadgroup with a
+// power-of-two width reduction. Writes the winning index as int32 at out_idx[0].
+// Tie-break: lower index wins (matches host sample_argmax and the CUDA
+// argmax_kernel). threads_per_threadgroup MUST be a power of two.
+kernel void kernel_argmax_f32_i32(
+        constant     uint  & n_vocab,
+        device const float * logits,
+        device       int32_t * out_idx,
+        threadgroup  float * sm_val [[threadgroup(0)]],
+        threadgroup  int32_t * sm_idx [[threadgroup(1)]],
+        uint tid [[thread_position_in_threadgroup]],
+        uint ntg [[threads_per_threadgroup]]) {
+    float   local_v = -INFINITY;
+    int32_t local_i = 0;
+    for (uint i = tid; i < n_vocab; i += ntg) {
+        const float v = logits[i];
+        if (v > local_v) {
+            local_v = v;
+            local_i = (int32_t) i;
+        }
+    }
+    sm_val[tid] = local_v;
+    sm_idx[tid] = local_i;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint s = ntg / 2u; s > 0u; s >>= 1) {
+        if (tid < s) {
+            const float   vr = sm_val[tid + s];
+            const int32_t ir = sm_idx[tid + s];
+            const float   vl = sm_val[tid];
+            const int32_t il = sm_idx[tid];
+            // Larger value wins; on exact ties prefer the lower index.
+            const bool take_right = (vr > vl) || (vr == vl && ir < il);
+            if (take_right) {
+                sm_val[tid] = vr;
+                sm_idx[tid] = ir;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tid == 0) {
+        out_idx[0] = sm_idx[0];
+    }
+}


### PR DESCRIPTION
## Problem

`make` on macOS (Metal, the primary target per the README) currently fails to link on `main`:

```
Undefined symbols for architecture arm64:
  "_ds4_gpu_argmax_tensor", referenced from:
      _metal_graph_eval_mtp_draft_from_hc in ds4.o
      _metal_graph_verify_decode2_exact in ds4.o
      _metal_graph_verify_suffix_tops in ds4.o
      _metal_graph_eval_token_raw_swa_top in ds4.o
ld: symbol(s) not found for architecture arm64
```

Commit 15f42aa (*DGX Spark / GB10 backend support*) added `ds4_gpu_argmax_tensor` to `ds4_gpu.h`, the CUDA backend (`ds4_cuda.cu`), and four Metal call sites in `ds4.c` — but did not add the Metal implementation, so the Metal build no longer links.

## Fix

- **`metal/argsort.metal`**: new `kernel_argmax_f32_i32` — a single-threadgroup, power-of-two width reduction over the F32 logits. Tie-break prefers the **lower index**, matching the CUDA `argmax_kernel` and host `sample_argmax`.
- **`ds4_metal.m`**: `ds4_gpu_argmax_tensor` plus its pipeline state (created in init, released on teardown). It encodes into the active command buffer so the argmax runs *after* the logits kernel, avoiding a stale CPU readback (the call sites sit between `ds4_gpu_begin_commands` / `ds4_gpu_end_commands`).

## Verification

- Pristine `bf3ff6d` fails `make ds4`; with this change all targets build.
- `make test` passes — tensor-equivalence reports top1 match on all cases (`top1_mismatch=0`).

Tested on Apple M5 Max, 128 GiB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)