### PR TITLE
ds4: use shape macros for grouped attention output on the CPU path (fixes Pro on CPU)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -5603,10 +5603,10 @@ static void layer_grouped_out_one(
         const ds4_model   * model,
         const ds4_layer_weights * layer,
         const float       * heads) {
-    const uint32_t n_groups = 8;
+    const uint32_t n_groups = DS4_N_OUT_GROUP;
     const uint32_t group_heads = DS4_N_HEAD / n_groups;
     const uint32_t group_dim = DS4_N_HEAD_DIM * group_heads;
-    const uint32_t rank = 1024;
+    const uint32_t rank = DS4_N_LORA_O;
 
     float *low = xcalloc((size_t)n_groups * rank, sizeof(low[0]));
 
@@ -5622,10 +5622,10 @@ static void layer_grouped_out_one_decode_scratch(
         const ds4_layer_weights * layer,
         const float            * heads,
         ds4_cpu_decode_scratch * scratch) {
-    const uint32_t n_groups = 8;
+    const uint32_t n_groups = DS4_N_OUT_GROUP;
     const uint32_t group_heads = DS4_N_HEAD / n_groups;
     const uint32_t group_dim = DS4_N_HEAD_DIM * group_heads;
-    const uint32_t rank = 1024;
+    const uint32_t rank = DS4_N_LORA_O;
 
     memset(scratch->attn_low, 0, (size_t)n_groups * rank * sizeof(scratch->attn_low[0]));
     matvec_q8_0_grouped_rows_decode_scratch(scratch->attn_low, model, layer->attn_output_a,
@@ -5639,10 +5639,10 @@ static void layer_grouped_out_batch(
         const ds4_layer_weights * layer,
         const float       * heads,
         uint32_t            n_tok) {
-    const uint32_t n_groups = 8;
+    const uint32_t n_groups = DS4_N_OUT_GROUP;
     const uint32_t group_heads = DS4_N_HEAD / n_groups;
     const uint32_t group_dim = DS4_N_HEAD_DIM * group_heads;
-    const uint32_t rank = 1024;
+    const uint32_t rank = DS4_N_LORA_O;
 
     float *low = xcalloc((size_t)n_tok * n_groups * rank, sizeof(low[0]));
 


### PR DESCRIPTION
## What

Fix the CPU attention output-projection so the **Pro** shape works on the CPU backend.

The three CPU helpers — `layer_grouped_out_one`, `layer_grouped_out_one_decode_scratch` and `layer_grouped_out_batch` — hardcoded the grouping constants:

```c
const uint32_t n_groups = 8;
const uint32_t group_heads = DS4_N_HEAD / n_groups;
const uint32_t group_dim = DS4_N_HEAD_DIM * group_heads;
const uint32_t rank = 1024;
```

These only match the **Flash** shape (`n_out_group = 8`). For the **Pro** shape (`n_out_group = 16`):

- the CPU path computes `group_dim = DS4_N_HEAD_DIM * (DS4_N_HEAD / 8) = 8192`,
- but `attn_output_a` is validated at load with `dim[0] = DS4_N_HEAD_DIM * (DS4_N_HEAD / DS4_N_OUT_GROUP) = 4096` (`tensor_expect_layout`, ds4.c:2695 / 2765).

`matvec_q8_0_grouped_rows`, `matvec_q8_0_grouped_rows_decode_scratch` and `matmul_q8_0_grouped_batch` check `w->dim[0] != group_dim` and call `ds4_die()`, so **every attention layer aborts**: the Pro model is unusable on the CPU backend, and the projection math would be wrong for Pro even without the guard (wrong group count / `group_dim`).

## Fix

Use the shape macros, exactly like the GPU path already does (ds4.c:10037-10040 and 12040-12043):

```c
const uint32_t n_groups = DS4_N_OUT_GROUP;
...
const uint32_t rank = DS4_N_LORA_O;
```

`group_heads` and `group_dim` recompute from `n_groups`, so:
- **Flash** is unchanged (`8 == 8`, `1024 == 1024`),
- **Pro** now matches the validated tensor layout (`group_dim = 4096`, `rank = 1024`).

## Testing

Per `CONTRIBUTING.md`:

- **Machine / backend:** macOS (Apple Silicon).
- **CPU target builds:** `make clean && make cpu` — links all CPU binaries cleanly, **no new warnings** introduced by this change (the change is at ds4.c:5606-5645; the only warnings in the build are pre-existing `-Wunused-but-set-variable` reports at ds4.c:18787+, unrelated to this diff).
- I do not have a Pro `.gguf` locally, so I could not run end-to-end Pro inference. The fix is verified by construction: it aligns the CPU constants with the GPU path and with the tensor-layout validation (`DS4_N_HEAD_DIM * (DS4_N_HEAD / DS4_N_OUT_GROUP)` / `DS4_N_OUT_GROUP * DS4_N_LORA_O`) already enforced at model load.

## Notes

- Flash behaviour is byte-for-byte unchanged (the macros evaluate to the previous literals for that shape).
