### PR TITLE
cuda: always load iq2 dequant LUTs in tile8 MoE gate/up kernels

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -9145,15 +9145,22 @@ __global__ static void moe_gate_up_mid_expert_tile8_row32_kernel(
         slot[np] = pair[np] - tok[np] * n_expert;
         xqb[np] = xq + (uint64_t)tok[np] * xq_blocks;
     }
+    /* The iq2 dequant LUTs are read unconditionally by the dot product below,
+     * so they must be loaded into shared memory for every xq_blocks value. Only
+     * the activation staging into sxq is valid when xq_blocks <= 16 (sxq holds
+     * at most 16 blocks per row); for larger inputs xqb stays in global memory.
+     * The xq_blocks test is block-uniform, so the barrier is hit by all threads. */
+    for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
+    for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
     if (xq_blocks <= 16u) {
         for (uint32_t i = threadIdx.x; i < np * xq_blocks; i += blockDim.x) {
             uint32_t p = i / xq_blocks;
             uint32_t b = i - p * xq_blocks;
             sxq[p][b] = xqb[p][b];
         }
-        for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
-        for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
-        __syncthreads();
+    }
+    __syncthreads();
+    if (xq_blocks <= 16u) {
         for (uint32_t p = 0; p < np; p++) xqb[p] = sxq[p];
     }
     if (row >= expert_mid_dim) return;
@@ -9235,15 +9242,22 @@ __global__ static void moe_gate_up_mid_expert_tile8_row2048_kernel(
         slot[np] = pair[np] - tok[np] * n_expert;
         xqb[np] = xq + (uint64_t)tok[np] * xq_blocks;
     }
+    /* The iq2 dequant LUTs are read unconditionally by the dot product below,
+     * so they must be loaded into shared memory for every xq_blocks value. Only
+     * the activation staging into sxq is valid when xq_blocks <= 16 (sxq holds
+     * at most 16 blocks per row); for larger inputs xqb stays in global memory.
+     * The xq_blocks test is block-uniform, so the barrier is hit by all threads. */
+    for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
+    for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
     if (xq_blocks <= 16u) {
         for (uint32_t i = threadIdx.x; i < np * xq_blocks; i += blockDim.x) {
             uint32_t p = i / xq_blocks;
             uint32_t b = i - p * xq_blocks;
             sxq[p][b] = xqb[p][b];
         }
-        for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
-        for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
-        __syncthreads();
+    }
+    __syncthreads();
+    if (xq_blocks <= 16u) {
         for (uint32_t p = 0; p < np; p++) xqb[p] = sxq[p];
     }
     for (uint32_t rr = 0; rr < 64u; rr++) {
@@ -9329,15 +9343,22 @@ __global__ static void moe_gate_up_mid_expert_tile8_rowspan_kernel(
         slot[np] = pair[np] - tok[np] * n_expert;
         xqb[np] = xq + (uint64_t)tok[np] * xq_blocks;
     }
+    /* The iq2 dequant LUTs are read unconditionally by the dot product below,
+     * so they must be loaded into shared memory for every xq_blocks value. Only
+     * the activation staging into sxq is valid when xq_blocks <= 16 (sxq holds
+     * at most 16 blocks per row); for larger inputs xqb stays in global memory.
+     * The xq_blocks test is block-uniform, so the barrier is hit by all threads. */
+    for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
+    for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
     if (xq_blocks <= 16u) {
         for (uint32_t i = threadIdx.x; i < np * xq_blocks; i += blockDim.x) {
             uint32_t p = i / xq_blocks;
             uint32_t b = i - p * xq_blocks;
             sxq[p][b] = xqb[p][b];
         }
-        for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
-        for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
-        __syncthreads();
+    }
+    __syncthreads();
+    if (xq_blocks <= 16u) {
         for (uint32_t p = 0; p < np; p++) xqb[p] = sxq[p];
     }
     for (uint32_t rr = 0; rr < ROW_SPAN / 32u; rr++) {


### PR DESCRIPTION
## What

Fix uninitialized iq2 dequant lookup tables in the tile8 MoE gate/up CUDA kernels, which silently corrupts MoE output for large iq2_xxs experts.

`moe_gate_up_mid_expert_tile8_row32_kernel`, `...row2048_kernel` and `...rowspan_kernel` declare the iq2 dequant LUTs in shared memory:

```c
__shared__ uint64_t s_iq2_grid[256];
__shared__ uint8_t  s_iq2_signs[128];
```

but populate them **only** inside the `if (xq_blocks <= 16u)` staging block, while the dot product reads them **unconditionally**:

```c
dev_dot_iq2_xxs_q8_K_block8_deq_lut(..., s_iq2_grid, s_iq2_signs);
```

When `xq_blocks > 16` the LUTs are never written (CUDA does not zero shared memory), so the iq2_xxs dequantization reads garbage and the gate/up/mid result is **silently wrong** — no crash, just corrupted numerics. That same `if` block was also the only place issuing `__syncthreads()`, so the barrier was skipped entirely on the `xq_blocks > 16` path.

## Reachability

`xq_blocks = expert_in_dim / 256`, so `xq_blocks > 16` ⇔ `expert_in_dim > 4096`, common for large MoE models. These kernels are reachable in the **default** configuration:

- `rowspan`/`row2048`: `use_gate_row2048` is on by default for `n_tokens >= 128`;
- `row32`: the `2..127` token path.

Neither dispatch site constrains `xq_blocks`. The only `xq_blocks <= 16` gate (`use_decode_lut_gate`) routes to the separate **decode** kernel `moe_gate_up_mid_decode_lut_qwarp32_kernel`, whose `if (xq_blocks <= 16u)` guard is therefore always true — so that kernel is **not** affected and is left unchanged.

## Fix

Load `s_iq2_grid` / `s_iq2_signs` unconditionally and issue a single unconditional `__syncthreads()`. Keep the `sxq` activation staging and the `xqb -> sxq` remap gated on `xq_blocks <= 16` (`sxq` holds at most 16 blocks per row; for larger inputs `xqb` correctly stays in global memory):

```c
for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i]  = cuda_iq2xxs_grid[i];
for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
if (xq_blocks <= 16u) {
    /* stage activations into sxq */
}
__syncthreads();
if (xq_blocks <= 16u) {
    for (uint32_t p = 0; p < np; p++) xqb[p] = sxq[p];
}
```

The `xq_blocks` test is block-uniform and the barrier precedes any row-based early `return`/`continue`, so all threads in a participating block reach it. Behaviour for `xq_blocks <= 16` is unchanged.

## Testing

⚠️ **Not compiled/run here:** the dev machine has no CUDA toolchain (`nvcc` absent), so I could not build `ds4_cuda.cu` or run `make cuda-regression`. The change is mechanical (move two shared-memory load loops out of an existing guard) and reviewed by hand against all three kernels and the dispatch logic.

Per `CONTRIBUTING.md` this needs verification on a CUDA machine:

```sh
make
make cuda-regression
```

A targeted check: run an iq2_xxs MoE model with `expert_in_dim > 4096` (e.g. 7168) at a batch size in the affected ranges and confirm the gate/up/mid output now matches the reference (CPU/Metal) path.
