### PR TITLE
cuda: harden public matmul/embed entry points against bad dims

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -5704,7 +5704,7 @@ __global__ static void topk_mask_kernel(float *mask, const uint32_t *topk, uint3
 }
 
 extern "C" int ds4_gpu_embed_token_hc_tensor(ds4_gpu_tensor *out_hc, const void *model_map, uint64_t model_size, uint64_t weight_offset, uint32_t n_vocab, uint32_t token, uint32_t n_embd, uint32_t n_hc) {
-    (void)n_vocab;
+    if (token >= n_vocab) token = 0;
     if (!out_hc || !model_map || weight_offset >= model_size) return 0;
     uint64_t weight_bytes = (uint64_t)n_vocab * n_embd * sizeof(uint16_t);
     if (weight_offset > model_size || weight_bytes > model_size - weight_offset) return 0;
@@ -6059,7 +6059,7 @@ extern "C" int ds4_gpu_dsv4_topk_mask_tensor(
     return cuda_ok(cudaGetLastError(), "topk mask launch");
 }
 static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *model_map, uint64_t model_size, uint64_t weight_offset, uint64_t in_dim, uint64_t out_dim, const ds4_gpu_tensor *x, uint64_t n_tok, const char *label) {
-    if (!out || !x || !model_map) return 0;
+    if (!out || !x || !model_map || in_dim == 0) return 0;
     uint64_t blocks = (in_dim + 31) / 32;
     if (weight_offset > model_size || out_dim > UINT64_MAX / (blocks * 34)) return 0;
     uint64_t weight_bytes = out_dim * blocks * 34;
@@ -6312,7 +6312,7 @@ static int cuda_matmul_q8_0_hc_expand_tensor_labeled(
 }
 
 extern "C" int ds4_gpu_matmul_f16_tensor(ds4_gpu_tensor *out, const void *model_map, uint64_t model_size, uint64_t weight_offset, uint64_t in_dim, uint64_t out_dim, const ds4_gpu_tensor *x, uint64_t n_tok) {
-    if (!out || !x || !model_map) return 0;
+    if (!out || !x || !model_map || in_dim == 0) return 0;
     if (weight_offset > model_size || out_dim > UINT64_MAX / in_dim) return 0;
     uint64_t weight_bytes = out_dim * in_dim * sizeof(uint16_t);
     if (weight_bytes > model_size - weight_offset) return 0;


### PR DESCRIPTION
## What

Three defensive guards on CUDA entry points, each mirroring a check that sibling functions in the same file already perform.

### 1. `embed_token_hc_kernel` — out-of-bounds embedding read (real bug)

The single-token kernel indexes the embedding tensor unconditionally:

```c
out[i] = __half2float(reinterpret_cast<const __half *>(w)[(uint64_t)token * n_embd + e]);
```

with no bound on `token`, and the wrapper `ds4_gpu_embed_token_hc_tensor` explicitly throws `n_vocab` away (`(void)n_vocab;`). A `token >= n_vocab` reads past `token_embd` — corrupted logits on a device-copy mapping, or an async illegal memory access on a registered/UVA mapping. Every sibling enforces this contract: the batch kernel `embed_tokens_hc_kernel` does `if (tok >= n_vocab) tok = 0;`, the Metal implementation rejects `token >= n_vocab`, and the CPU `embed_token_f16` calls `ds4_die()`. **Fix:** clamp `token` to 0 when out of range.

### 2. `cuda_matmul_q8_0_tensor_labeled` — divide-by-zero (hardening)

```c
uint64_t blocks = (in_dim + 31) / 32;
if (weight_offset > model_size || out_dim > UINT64_MAX / (blocks * 34)) return 0;
```

With `in_dim == 0`, `blocks == 0` and `UINT64_MAX / (0 * 34)` is an integer divide-by-zero (SIGFPE on the host) before any tensor-size check. **Fix:** reject `in_dim == 0` up front, like `ds4_gpu_matmul_q8_0_pair_tensor`.

### 3. `ds4_gpu_matmul_f16_tensor` — divide-by-zero (hardening)

```c
if (weight_offset > model_size || out_dim > UINT64_MAX / in_dim) return 0;
```

`in_dim == 0` is a divide-by-zero. **Fix:** reject `in_dim == 0` up front, like `ds4_gpu_matmul_f16_pair_tensor`.

## Impact

In-tree callers pass non-zero model dimensions, so #2 and #3 harden the public `extern "C"` API surface rather than fixing live crashes. #1 closes a real OOB read for any caller that feeds an out-of-vocabulary token id (the single-token GPU embed path has no clamp, unlike all of its siblings).

## Diff

3 one-line changes:

```diff
-    (void)n_vocab;
+    if (token >= n_vocab) token = 0;
-    if (!out || !x || !model_map) return 0;
+    if (!out || !x || !model_map || in_dim == 0) return 0;   // cuda_matmul_q8_0_tensor_labeled
-    if (!out || !x || !model_map) return 0;
+    if (!out || !x || !model_map || in_dim == 0) return 0;   // ds4_gpu_matmul_f16_tensor
```

## Testing

⚠️ **Not compiled/run here:** the dev machine has no CUDA toolchain (`nvcc` absent). These are one-line guards that mirror existing sibling functions, reviewed by hand. Per `CONTRIBUTING.md`, please verify on a CUDA machine:

```sh
make
make cuda-regression
```

## Out of scope (related, intentionally not included)

A separate out-of-bounds shared-memory write exists in `attention_prefill_mixed_kernel` (`__shared__ float scores[512]`, written up to `raw_count + visible_comp` entries, which can exceed 512). It is only reachable in non-default configurations (e.g. `--quality` + `DS4_CUDA_NO_CUBLAS_ATTENTION`), and the correct remedy interacts with the dispatch fallback logic and the shared-memory budget — it should be fixed and validated on CUDA hardware, so it is deliberately left out of this defensive-guards PR.
