### PR TITLE
agent: fix title leak, snprintf self-copy and end-line overflow in read tools

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -5073,6 +5073,7 @@ static bool agent_worker_strip_session(agent_worker *w, const char *prefix,
         free(tmp);
         free(text);
         free(path);
+        free(title);
         return false;
     }
 
@@ -5084,6 +5085,7 @@ static bool agent_worker_strip_session(agent_worker *w, const char *prefix,
         free(tmp);
         free(text);
         free(path);
+        free(title);
         return false;
     }
 
@@ -5396,7 +5398,10 @@ static char *agent_edit_result(const char *path,
 
 static void agent_worker_set_more(agent_worker *w, const char *path,
                                   int next_line, bool bare) {
-    snprintf(w->more_path, sizeof(w->more_path), "%s", path ? path : "");
+    /* The `more` tool calls this with path == w->more_path; copying a buffer
+     * onto itself is undefined for snprintf, so skip the self-copy. */
+    if (path != w->more_path)
+        snprintf(w->more_path, sizeof(w->more_path), "%s", path ? path : "");
     w->more_next_line = next_line;
     w->more_bare = bare;
     w->more_valid = path && path[0] && next_line > 0;
@@ -5442,8 +5447,10 @@ static char *agent_read_range(agent_worker *w, const char *path, int start_line,
     } else {
         if (max_lines <= 0) max_lines = AGENT_READ_DEFAULT_LINES;
     }
-    int end_idx = start_idx + max_lines;
-    if (end_idx > spans.len) end_idx = spans.len;
+    /* max_lines can be up to INT_MAX (model-controlled), so compute the end in
+     * 64-bit to avoid signed overflow before clamping to the line count. */
+    long long end_wide = (long long)start_idx + max_lines;
+    int end_idx = end_wide > spans.len ? spans.len : (int)end_wide;
 
     agent_buf out = {0};
     if (bare) {


### PR DESCRIPTION
## What

Three small, independent robustness fixes in the agent file-reading tools (`ds4_agent.c`).

### 1. `title` leak on temp-file error paths (`agent_worker_strip_session`)

When a session was saved with `DS4_KVSTORE_EXT_SESSION_TITLE` (the common case), `title` is a live `xmalloc` allocation. The `mkstemp()` and `fdopen()` failure branches free `tmp`/`text`/`path` but **not** `title`, while every other exit (read failure, SHA mismatch, success) does. Leak on those error paths.

**Fix:** `free(title)` in both branches.

### 2. `snprintf` self-copy in `agent_worker_set_more`

```c
snprintf(w->more_path, sizeof(w->more_path), "%s", path ? path : "");
```

The `more` tool calls `agent_read_range(w, w->more_path, ...)`, which calls `agent_worker_set_more(w, path, ...)` with `path == w->more_path`. Source and destination overlap, which is undefined for `snprintf` (C11 7.21.6). Works on mainstream libc today but is flagged by ASan/UBSan and may break on optimized implementations.

**Fix:** skip the copy when `path` already points at `w->more_path`.

### 3. Signed overflow computing `end_idx` in `agent_read_range`

```c
int end_idx = start_idx + max_lines;
```

`max_lines` comes from `agent_parse_int_default(..., 1, INT_MAX)` (model-controlled), so `start_idx + max_lines` can overflow signed `int` (UB). In practice it wraps negative, the `> spans.len` clamp doesn't fire, and the read silently returns empty.

**Fix:** compute the sum in 64-bit and clamp to the line count before casting back to `int`.

## Testing

- **Machine:** macOS (Apple Silicon).
- `make ds4_agent.o` — clean, **0 warnings / 0 errors** with the project flags (`-Wall -Wextra`).
- No behavioural change on the normal paths; the fixes only affect error/edge cases (temp-file failure, the `more` continuation, and pathological `max_lines`).
