### PR TITLE
server: emit U+FFFD for unpaired UTF-16 surrogates in json_string

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -238,6 +238,8 @@ static bool json_string(const char **p, char **out) {
             if (!json_u16(p, &cp)) goto fail;
             if (cp >= 0xd800 && cp <= 0xdbff && json_u16(p, &lo) && lo >= 0xdc00 && lo <= 0xdfff) {
                 cp = 0x10000u + ((cp - 0xd800u) << 10) + (lo - 0xdc00u);
+            } else if (cp >= 0xd800 && cp <= 0xdfff) {
+                cp = 0xfffdu;  /* unpaired UTF-16 surrogate -> U+FFFD, keep output valid UTF-8 */
             }
             utf8_put(&b, cp);
             break;


### PR DESCRIPTION
## What

`json_string` mishandles unpaired UTF-16 surrogates in `\uXXXX` escapes.

When the escape decodes to a surrogate (0xD800-0xDFFF) that does **not** form a valid high+low pair, `cp` keeps the lone surrogate value and:

```c
utf8_put(&b, cp);
```

encodes it as a 3-byte sequence (e.g. `\uD800` -> `ED A0 80`) that decodes back to a surrogate — **invalid UTF-8**. A client sending `"\uD800"` or a stray low surrogate `"\uDC00"` injects malformed UTF-8 into message content.

This contradicts the code's own stated goal (see the comment around the KV prefix-cache logic) of keeping strings valid UTF-8 so prefix matching isn't broken, and can confuse any downstream consumer that assumes valid UTF-8.

## Fix

Map any leftover surrogate to U+FFFD (the standard replacement character for unpaired surrogates) before encoding:

```c
} else if (cp >= 0xd800 && cp <= 0xdfff) {
    cp = 0xfffdu;  /* unpaired UTF-16 surrogate -> U+FFFD */
}
```

Valid surrogate pairs are unchanged; the input-consumption behaviour is untouched (purely additive).

## Testing

- **Machine:** macOS (Apple Silicon).
- `make ds4_server.o` — clean, **0 warnings / 0 errors** (`-Wall -Wextra`).
- Low severity: no crash/memory/security impact, and a conforming JSON encoder always pairs surrogates, so the trigger is malformed/adversarial input — but the result is now well-formed UTF-8.
