### PR TITLE
web: cap reassembled WebSocket message size, not just per-frame

### DIFF
--- a/ds4_web.c
+++ b/ds4_web.c
@@ -538,6 +538,14 @@ static char *web_ws_read_message(cdp_ws *ws, char *err, size_t err_len) {
         } else if (opcode == 0x1 || opcode == 0x0) {
             web_buf_append(&msg, (const char *)payload, (size_t)len);
             free(payload);
+            if (msg.len > DS4_WEB_MAX_RESULT_BYTES * 4ULL) {
+                /* Bound the reassembled message too, not just each frame: a peer
+                 * sending endless FIN=0 continuation frames would otherwise grow
+                 * msg without limit until allocation fails (exit). */
+                web_set_err(err, err_len, "websocket message too large");
+                free(msg.ptr);
+                return NULL;
+            }
             if (fin) return web_buf_take(&msg);
         } else {
             free(payload);


### PR DESCRIPTION
## What

`web_ws_read_message` caps the 4 MiB size limit (`DS4_WEB_MAX_RESULT_BYTES * 4`) **per frame** only:

```c
if (len > DS4_WEB_MAX_RESULT_BYTES * 4ULL) { ... return NULL; }   // single frame's len
```

For a fragmented message (continuation frames, opcode `0x1`/`0x0` with `FIN=0`), each payload is appended to `msg` and the loop continues until a frame with `FIN=1`. Nothing bounds the **cumulative** `msg.len`, so a peer that streams many near-4 MiB frames without ever setting `FIN` grows `msg` without limit. `web_buf_append` / `web_xmalloc` call `exit(1)` on allocation failure → process termination (memory exhaustion / DoS).

## Fix

Apply the same 4 MiB ceiling to the reassembled message after each append:

```c
web_buf_append(&msg, (const char *)payload, (size_t)len);
free(payload);
if (msg.len > DS4_WEB_MAX_RESULT_BYTES * 4ULL) { ...too large...; return NULL; }
if (fin) return web_buf_take(&msg);
```

## Testing

- **Machine:** macOS (Apple Silicon).
- `make ds4_web.o` — clean, **0 warnings / 0 errors** (`-Wall -Wextra`).
- Low severity: the WebSocket peer is the CDP endpoint on localhost (the browser debug port the tool drives), so exploitation needs control of that port or a localhost MITM. This is defensive hardening.

## Note (out of scope)

A continuation frame (opcode `0x0`) received as the *first* frame is currently accepted rather than rejected as a protocol error. Left out of this change to keep it focused on the unbounded-accumulation fix.
