### PR TITLE
ds4_server: silence the warning

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -959,7 +959,7 @@ static bool stop_list_find_from(const stop_list *stops, const char *text,
     bool found = false;
     size_t best_pos = 0, best_len = 0;
     for (int i = 0; i < stops->len; i++) {
-        char *p = strstr(text + from, stops->v[i]);
+        const char *p = strstr(text + from, stops->v[i]);
         if (!p) continue;
         size_t ppos = (size_t)(p - text);
         size_t plen = strlen(stops->v[i]);


### PR DESCRIPTION
to silence the warning
```
ds4_server.c: In function ‘stop_list_find_from’:
ds4_server.c:962:19: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  962 |         char *p = strstr(text + from, stops->v[i]);
      |                   ^~~~~~
In file included from tests/ds4_test.c:3:
tests/../ds4_server.c: In function ‘stop_list_find_from’:
tests/../ds4_server.c:962:19: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  962 |         char *p = strstr(text + from, stops->v[i]);
      |                   ^~~~~~
```