### PR TITLE
[Agent Fix]: Old tail anchor not found after old head

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -5868,6 +5868,15 @@ static bool agent_edit_find_old_span(const char *data, size_t len,
     size_t head_len = (size_t)(upto - old);
     const char *tail = upto + strlen(marker);
     size_t tail_len = old_len - head_len - strlen(marker);
+    /* Strip leading newline/CR from tail before searching.  The head already
+     * includes the newline at its end, so the extra \n that follows [upto] in
+     * the old text (whether injected by the forcer or written by the model)
+     * must not be part of the tail needle -- the file after the head has no
+     * duplicate newline. */
+    while (tail_len > 0 && (*tail == '\n' || *tail == '\r')) {
+        tail++;
+        tail_len--;
+    }
     if (!agent_span_has_nonspace(tail, tail_len)) {
         snprintf(err, err_len,
                  "old text after [upto] must include a unique tail anchor");


### PR DESCRIPTION
# PR Summary: Fix anchored edit tail anchor search

**Bug**: `edit` with `[upto]` always fails with `old tail anchor not found after old head`, blocking large anchored replacements.

**Root Cause**: In `agent_edit_find_old_span()`, the tail string includes a leading `\n` (from `[upto]\n`), but the file after the head match has no such newline — so the tail needle never matches.

**Fix**: Strip leading `\n`/`\r` from the tail before searching. The head already ends with that newline.

**Changes** (`ds4_agent.c` lines 5871–5879):
- Added a while-loop to remove leading `\n`/`\r` from `tail` / `tail_len`.
- Works for both Unix (`\n`) and Windows (`\r\n`) line endings.
- Handles both the forcer-injected `\n` and model-written `\n` after `[upto]`.
- The `agent_span_has_nonspace` guard (moved after the strip) still rejects empty/whitespace-only tails.
- `match_len` remains correct because the head's trailing newline is counted in `head_len`.

**Testing**: Compiles cleanly with `-Wall -Wextra`, all edge cases verified. [upto] edits actually work. I had to go back to a sha from 2 weeks ago to find an agent that could properly use the edit tool again to make this change: d447bdb - but tested with newest build and agent is able to edit reliably again!