### PR TITLE
Remove hardcoded number of output groups and rank

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -6911,10 +6911,10 @@ static void layer_grouped_out_one(
         const ds4_model   * model,
         const ds4_layer_weights * layer,
         const float       * heads) {
-    const uint32_t n_groups = 8;
+    const uint32_t n_groups = DS4_N_OUT_GROUP;
     const uint32_t group_heads = DS4_N_HEAD / n_groups;
     const uint32_t group_dim = DS4_N_HEAD_DIM * group_heads;
-    const uint32_t rank = 1024;
+    const uint32_t rank = DS4_N_LORA_O;
 
     float *low = xcalloc((size_t)n_groups * rank, sizeof(low[0]));
 
@@ -6930,10 +6930,10 @@ static void layer_grouped_out_one_decode_scratch(
         const ds4_layer_weights * layer,
         const float            * heads,
         ds4_cpu_decode_scratch * scratch) {
-    const uint32_t n_groups = 8;
+    const uint32_t n_groups = DS4_N_OUT_GROUP;
     const uint32_t group_heads = DS4_N_HEAD / n_groups;
     const uint32_t group_dim = DS4_N_HEAD_DIM * group_heads;
-    const uint32_t rank = 1024;
+    const uint32_t rank = DS4_N_LORA_O;
 
     memset(scratch->attn_low, 0, (size_t)n_groups * rank * sizeof(scratch->attn_low[0]));
     matvec_q8_0_grouped_rows_decode_scratch(scratch->attn_low, model, layer->attn_output_a,
@@ -6947,10 +6947,10 @@ static void layer_grouped_out_batch(
         const ds4_layer_weights * layer,
         const float       * heads,
         uint32_t            n_tok) {
-    const uint32_t n_groups = 8;
+    const uint32_t n_groups = DS4_N_OUT_GROUP;
     const uint32_t group_heads = DS4_N_HEAD / n_groups;
     const uint32_t group_dim = DS4_N_HEAD_DIM * group_heads;
-    const uint32_t rank = 1024;
+    const uint32_t rank = DS4_N_LORA_O;
 
     float *low = xcalloc((size_t)n_tok * n_groups * rank, sizeof(low[0]));
 


### PR DESCRIPTION
**What changed:**
Replaced hardcoded values for n_groups and rank with DS4_N_OUT_GROUP and DS4_N_LORA_O.

**Why:**
This allows to run Pro models on CPU. With hardcoded values ds4 will stop with an error: "grouped Q8_0 tensor has an unexpected layout".

```
$ ./ds4 -m DeepSeek-V4-Pro-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-Instruct-imatrix.gguf
ds4: context buffers 631.09 MiB (ctx=32768, backend=cpu, prefill_chunk=0, raw_kv_rows=128, compressed_kv_rows=8194)
Commands:
  /help          Show this help.
  /think         Use normal thinking mode.
  /think-max     Use Think Max only when context is at least 393216 tokens.
  /nothink       Disable thinking mode.
  /ctx N         Set context size for following prompts.
  /power N       Set GPU duty cycle percentage, 1..100.
  /read FILE     Read a prompt from FILE and run it.
  /quit, /exit   Leave the prompt.
  Ctrl+C         Stop generation and return to the prompt.
ds4> /nothink
Thinking mode: none.
ds4> Hi!
processing 11 input tokens: 11/11 (100.0%)
Hello! How can I help you today?
ds4: prefill: 0.62 t/s, generation: 0.57 t/s
```