### PR TITLE
Avoid writing local KV cache payloads twice

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -23143,6 +23143,33 @@ int ds4_session_save_payload(ds4_session *s, FILE *fp, char *err, size_t errlen)
 #endif
 }
 
+/* Save the engine-owned payload and report how many bytes were appended.
+ * This intentionally delegates to the single payload serializer so the on-disk
+ * format has only one implementation. */
+int ds4_session_save_payload_counted(ds4_session *s, FILE *fp,
+                                     uint64_t *bytes_written,
+                                     char *err, size_t errlen) {
+    if (!fp || !bytes_written) {
+        payload_set_err(err, errlen, "invalid session payload write request");
+        return 1;
+    }
+    *bytes_written = 0;
+
+    const off_t start = ftello(fp);
+    if (start < 0) {
+        payload_set_err(err, errlen, "failed to get file position before payload write");
+        return 1;
+    }
+    if (ds4_session_save_payload(s, fp, err, errlen) != 0) return 1;
+    const off_t end = ftello(fp);
+    if (end < 0 || end < start) {
+        payload_set_err(err, errlen, "failed to measure session payload write");
+        return 1;
+    }
+    *bytes_written = (uint64_t)(end - start);
+    return 0;
+}
+
 int ds4_session_load_payload(ds4_session *s, FILE *fp, uint64_t payload_bytes, char *err, size_t errlen) {
     if (!s || !fp) {
         payload_set_err(err, errlen, "invalid session payload load");

--- a/ds4.h
+++ b/ds4.h
@@ -315,6 +315,9 @@ int ds4_session_write_staged_payload(const ds4_session_payload_file *payload,
                                      FILE *fp, char *err, size_t errlen);
 void ds4_session_payload_file_free(ds4_session_payload_file *payload);
 int ds4_session_save_payload(ds4_session *s, FILE *fp, char *err, size_t errlen);
+int ds4_session_save_payload_counted(ds4_session *s, FILE *fp,
+                                     uint64_t *bytes_written,
+                                     char *err, size_t errlen);
 int ds4_session_load_payload(ds4_session *s, FILE *fp, uint64_t payload_bytes, char *err, size_t errlen);
 int ds4_session_save_snapshot(ds4_session *s, ds4_session_snapshot *snap, char *err, size_t errlen);
 int ds4_session_load_snapshot(ds4_session *s, const ds4_session_snapshot *snap, char *err, size_t errlen);

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -3910,16 +3910,22 @@ static bool agent_kv_save_path(agent_worker *w, const char *path,
         ds4_kvstore_sha1_bytes_hex(text, text_len, sha);
     if (sha_out) memcpy(sha_out, sha, sizeof(sha));
 
-    ds4_session_payload_file staged = {0};
     char save_err[160] = {0};
-    if (ds4_session_stage_payload(w->session, &staged,
-                                  save_err, sizeof(save_err)) != 0) {
-        snprintf(err, err_len, "%s",
-                 save_err[0] ? save_err : "session has no valid KV payload");
-        free(text);
-        return false;
+    ds4_session_payload_file staged = {0};
+    bool staged_payload = false;
+    uint64_t payload_bytes = ds4_session_payload_bytes(w->session);
+    if (payload_bytes == 0) {
+        if (ds4_session_stage_payload(w->session, &staged,
+                                      save_err, sizeof(save_err)) != 0)
+        {
+            snprintf(err, err_len, "%s",
+                     save_err[0] ? save_err : "session has no valid KV payload");
+            free(text);
+            return false;
+        }
+        staged_payload = true;
+        payload_bytes = staged.bytes;
     }
-    uint64_t payload_bytes = staged.bytes;
 
     agent_buf tmpl = {0};
     agent_buf_puts(&tmpl, path);
@@ -3955,16 +3961,27 @@ static bool agent_kv_save_path(agent_worker *w, const char *path,
     uint8_t tb[4];
     ds4_kvstore_le_put32(tb, (uint32_t)text_len);
 
+    uint64_t written = 0;
     errno = 0;
     bool ok = fwrite(h, 1, sizeof(h), fp) == sizeof(h) &&
               fwrite(tb, 1, sizeof(tb), fp) == sizeof(tb) &&
-              fwrite(text, 1, text_len, fp) == text_len &&
-              ds4_session_write_staged_payload(&staged, fp,
-                                               save_err, sizeof(save_err)) == 0 &&
-              (!session_identity ||
-               agent_kv_write_title_trailer(fp, session_title,
-                                            save_err, sizeof(save_err))) &&
-              fflush(fp) == 0;
+              fwrite(text, 1, text_len, fp) == text_len;
+    if (ok && staged_payload) {
+        ok = ds4_session_write_staged_payload(&staged, fp,
+                                              save_err, sizeof(save_err)) == 0;
+    } else if (ok) {
+        ok = ds4_session_save_payload_counted(w->session, fp, &written,
+                                             save_err, sizeof(save_err)) == 0;
+        if (ok && written != payload_bytes) {
+            snprintf(save_err, sizeof(save_err),
+                     "KV payload size changed while saving");
+            ok = false;
+        }
+    }
+    if (ok && session_identity)
+        ok = agent_kv_write_title_trailer(fp, session_title,
+                                          save_err, sizeof(save_err));
+    if (ok) ok = fflush(fp) == 0;
     int saved_errno = errno;
     if (fclose(fp) != 0) {
         if (!saved_errno) saved_errno = errno;

--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -947,6 +947,7 @@ bool ds4_kvstore_store_live_prefix_text(ds4_kvstore *kc,
     const int model_id = ds4_engine_model_id(engine);
 
     char save_err[160] = {0};
+    uint64_t written = 0;
     const ds4_tokens *live_tokens = ds4_session_tokens(session);
     if (!live_tokens ||
         live_tokens->len != store_tokens.len ||
@@ -1005,22 +1006,28 @@ bool ds4_kvstore_store_live_prefix_text(ds4_kvstore *kc,
     }
 
     ds4_session_payload_file staged = {0};
-    if (ds4_session_stage_payload(session, &staged,
-                                  save_err, sizeof(save_err)) != 0) {
-        kv_logf(kc, DS4_KVSTORE_LOG_KVCACHE,
-                "%s: kv cache skipped tokens=%d reason=%s because KV payload staging failed: %s",
-                kv_log_name(kc),
-                store_tokens.len,
-                reason,
-                save_err[0] ? save_err : "unknown error");
-        if (err && err_len) snprintf(err, err_len, "%s",
-                                     save_err[0] ? save_err : "unknown error");
-        free(text);
-        free(path);
-        ds4_tokens_free(&store_tokens);
-        return false;
+    bool staged_payload = false;
+    uint64_t payload_bytes = ds4_session_payload_bytes(session);
+    if (payload_bytes == 0) {
+        if (ds4_session_stage_payload(session, &staged,
+                                      save_err, sizeof(save_err)) != 0)
+        {
+            kv_logf(kc, DS4_KVSTORE_LOG_KVCACHE,
+                    "%s: kv cache skipped tokens=%d reason=%s because KV payload staging failed: %s",
+                    kv_log_name(kc),
+                    store_tokens.len,
+                    reason,
+                    save_err[0] ? save_err : "unknown error");
+            if (err && err_len) snprintf(err, err_len, "%s",
+                                         save_err[0] ? save_err : "unknown error");
+            free(text);
+            free(path);
+            ds4_tokens_free(&store_tokens);
+            return false;
+        }
+        staged_payload = true;
+        payload_bytes = staged.bytes;
     }
-    uint64_t payload_bytes = staged.bytes;
 
     uint64_t est_file_bytes = 0, est_required_bytes = 0;
     if (!ds4_kvstore_file_size_fits(kc, (uint64_t)text_len, payload_bytes,
@@ -1084,11 +1091,21 @@ bool ds4_kvstore_store_live_prefix_text(ds4_kvstore *kc,
     errno = 0;
     bool ok = fwrite(h, 1, sizeof(h), fp) == sizeof(h) &&
               fwrite(tb, 1, sizeof(tb), fp) == sizeof(tb) &&
-              fwrite(text, 1, text_len, fp) == text_len &&
-              ds4_session_write_staged_payload(&staged, fp,
-                                               save_err, sizeof(save_err)) == 0 &&
-              kv_trailer_write(hooks, fp, text, &trailer_bytes) &&
-              fflush(fp) == 0;
+              fwrite(text, 1, text_len, fp) == text_len;
+    if (ok && staged_payload) {
+        ok = ds4_session_write_staged_payload(&staged, fp,
+                                              save_err, sizeof(save_err)) == 0;
+    } else if (ok) {
+        ok = ds4_session_save_payload_counted(session, fp, &written,
+                                             save_err, sizeof(save_err)) == 0;
+        if (ok && written != payload_bytes) {
+            snprintf(save_err, sizeof(save_err),
+                     "KV payload size changed while saving");
+            ok = false;
+        }
+    }
+    if (ok) ok = kv_trailer_write(hooks, fp, text, &trailer_bytes);
+    if (ok) ok = fflush(fp) == 0;
     int saved_errno = errno;
     if (fclose(fp) != 0) {
         if (!saved_errno) saved_errno = errno;


### PR DESCRIPTION
### Problem

Disk KV saves currently write the session payload twice for local sessions:

1. serialize the DS4 payload to a staged temp file;
   `ds4_session_stage_payload(session, &staged, ...)`
2. copy that staged payload into the final `.kv.tmp...` cache file;
   `ds4_session_write_staged_payload(&staged, fp, ...)`
3. rename the final temp file into place.
   `rename(tmp, path)`

Current path: `session -> staged payload tmp -> final .kv.tmp -> rename`.
This PR: `session -> final .kv.tmp -> rename`.

For long contexts, this payload can be multi-GiB. The extra staged-file copy adds latency to cold/continued/session saves and also raises peak temporary disk usage.

### In this PR

When the engine can predict the payload size with `ds4_session_payload_bytes()`, write the payload directly into the final temporary cache file.

The cache file is still atomic from the reader's point of view: it is written as `.tmp...` and renamed only after the full header, text, payload and trailer are written successfully. If the direct write fails, the temp file is unlinked as before.

Unknown-size payloads still use the old staged path. In practice this preserves the existing distributed-session behavior, since distributed payload size is not predicted by `ds4_session_payload_bytes()`.

Implementation details:

- add `ds4_session_save_payload_counted()`, a small wrapper around the existing `ds4_session_save_payload()` serializer;
- keep the payload format in one implementation instead of duplicating serialization code;
- server and agent save paths use direct writes only when the expected payload size is known;
- after direct write, verify that the measured bytes written match the expected payload size;
- no loader or cache format change.

### Benchmark

I used a long-context server run because this is where disk KV saves are large enough for the extra copy to matter. The benchmark does not try to show faster prefill, just measures the save path around normal long-context checkpoints.

Machine: Apple M2 Max, 64 GiB unified memory, Metal SSD streaming, 32GB routed expert cache.

Command:

```sh
./ds4-server \
  -m ./ds4flash.gguf \
  --ssd-streaming \
  --ssd-streaming-cache-experts 32GB \
  --ctx 524288 \
  --kv-disk-dir "$CACHE" \
  --kv-disk-space-mb 200000 \
  --kv-cache-min-tokens 512 \
  --kv-cache-cold-max-tokens 520192 \
  --kv-cache-continued-interval-tokens 10000 \
  --kv-cache-boundary-trim-tokens 32 \
  --kv-cache-boundary-align-tokens 2048
```

Request:

- prompt: first 405,181 bytes of `speed-bench/promessi_sposi.txt`;
- prompt tokens: 128,190;
- `model=deepseek-chat`, `thinking=false`, `temperature=0`, `max_tokens=1`;
- fresh KV cache dir for each run.

For `main`, I used a temporary timing-only log around `ds4_session_stage_payload()` so the old path can be measured as `serialize to temp + copy temp to cache`. That instrumentation is not part of this PR.

Per-checkpoint save times, excluding shutdown:

| tokens saved | KV file | old: serialize temp | old: copy temp | old total | new direct | delta |
|---:|---:|---:|---:|---:|---:|---:|
| 20,480 | 291.77 MiB | 142.0 ms | 76.3 ms | 218.3 ms | 170.6 ms | -47.7 ms |
| 40,960 | 560.66 MiB | 267.7 ms | 144.2 ms | 411.9 ms | 289.0 ms | -122.9 ms |
| 61,440 | 829.55 MiB | 392.3 ms | 221.8 ms | 614.1 ms | 378.5 ms | -235.6 ms |
| 81,920 | 1098.44 MiB | 526.4 ms | 441.3 ms | 967.7 ms | 515.9 ms | -451.8 ms |
| 102,400 | 1367.33 MiB | 616.5 ms | 955.7 ms | 1572.2 ms | 602.6 ms | -969.6 ms |
| 122,880 | 1636.22 MiB | 740.3 ms | 1049.0 ms | 1789.3 ms | 705.0 ms | -1084.3 ms |
| 126,976 | 1690.00 MiB | 728.4 ms | 1014.2 ms | 1742.6 ms | 716.7 ms | -1025.9 ms |


### Tests

```sh
make clean
make -j4
git diff --check
./ds4_test --server
./ds4-eval --self-test-extractors
make q4k-dot-test
make cpu
```

Additional live cache check on the direct-save branch, reusing the 128k-token benchmark cache:

- cache hit restored 126,976 tokens from disk
- only 1,214 prompt suffix tokens were prefetched
- reported usage: `cached_tokens=126976`, `cache_write_tokens=1214`
- cache load log: `load=355.5 ms` for the 1.69 GiB cold checkpoint
