### PR TITLE
session payload: reject KV checkpoints saved against a different model/quant (v3 fingerprint)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -22264,6 +22264,60 @@ static uint32_t payload_get_u32(const uint8_t in[4]) {
            ((uint32_t)in[3] << 24);
 }
 
+/* Cheap, stable model/quant identity fingerprint for the session payload.
+ *
+ * A payload only restores correctly into an engine running the *same* model and
+ * quantization: the serialized KV rows are produced by that exact weight set.
+ * The structural header words (layers/head dims/vocab) catch a different DS4
+ * build, but two different GGUFs or quants can share that layout, so we also
+ * fold in identity that varies with the actual model and quant:
+ *   - the routed expert quant bits (Q2_K vs Q4_K),
+ *   - the output and token_embd tensor quant types,
+ *   - every per-layer ffn_gate_exps quant type (the quant "mix"),
+ *   - the full vocab token byte strings (differs across tokenizers/models).
+ * This reads only metadata and host-resident vocab bytes -- it never touches the
+ * (potentially 80 GB) weight data -- so it is cheap to compute on every save and
+ * load.  FNV-1a/64 keeps it dependency-free; collisions are astronomically
+ * unlikely for this use and a collision only fails to reject a mismatch, never
+ * corrupts a matching restore.  Exposed at engine scope so the distributed KV
+ * checkpoint path (ds4_distributed.c) can stamp/validate the same identity. */
+uint64_t ds4_engine_model_fingerprint(ds4_engine *e) {
+    uint64_t h = UINT64_C(1469598103934665603); /* FNV offset basis */
+    const uint64_t prime = UINT64_C(1099511628211);
+#define DS4_FP_MIX_U64(v) do { \
+        uint64_t _v = (uint64_t)(v); \
+        for (int _b = 0; _b < 8; _b++) { \
+            h ^= (uint64_t)((_v >> (_b * 8)) & 0xffu); \
+            h *= prime; \
+        } \
+    } while (0)
+    if (!e) return h;
+    DS4_FP_MIX_U64((uint64_t)ds4_engine_routed_quant_bits(e));
+    if (e->weights.output) DS4_FP_MIX_U64(e->weights.output->type);
+    if (e->weights.token_embd) DS4_FP_MIX_U64(e->weights.token_embd->type);
+    for (uint32_t il = 0; il < DS4_N_LAYER; il++) {
+        const ds4_tensor *g = e->weights.layer[il].ffn_gate_exps;
+        DS4_FP_MIX_U64(g ? g->type : 0u);
+    }
+    DS4_FP_MIX_U64((uint64_t)e->vocab.n_vocab);
+    for (int i = 0; i < e->vocab.n_vocab; i++) {
+        const ds4_str *t = &e->vocab.token[i];
+        const unsigned char *p = (const unsigned char *)t->ptr;
+        DS4_FP_MIX_U64(t->len);
+        for (uint64_t b = 0; p && b < t->len; b++) {
+            h ^= (uint64_t)p[b];
+            h *= prime;
+        }
+    }
+#undef DS4_FP_MIX_U64
+    return h;
+}
+
+static uint64_t ds4_session_model_fingerprint(const ds4_session *s) {
+    if (!s || !s->engine) return ds4_engine_model_fingerprint(NULL);
+    return ds4_engine_model_fingerprint(s->engine);
+}
+
 static int payload_write_bytes(FILE *fp, const void *ptr, uint64_t bytes, char *err, size_t errlen) {
     const uint8_t *p = ptr;
     while (bytes != 0) {
@@ -23223,6 +23277,7 @@ int ds4_session_save_payload(ds4_session *s, FILE *fp, char *err, size_t errlen)
         const uint32_t raw_live = session_cpu_raw_live_rows(s);
         const uint32_t raw_cap = ds4_default_raw_cap((uint32_t)s->ctx_size);
         const uint32_t comp_cap = session_cpu_comp_cap(s);
+        const uint64_t model_fp = ds4_session_model_fingerprint(s);
         uint32_t header[DS4_SESSION_PAYLOAD_U32_FIELDS] = {
             DS4_SESSION_PAYLOAD_MAGIC,
             DS4_SESSION_PAYLOAD_VERSION,
@@ -23237,6 +23292,8 @@ int ds4_session_save_payload(ds4_session *s, FILE *fp, char *err, size_t errlen)
             DS4_N_INDEXER_HEAD_DIM,
             DS4_N_VOCAB,
             raw_live,
+            (uint32_t)(model_fp & 0xffffffffu),       /* model fingerprint low  */
+            (uint32_t)(model_fp >> 32),               /* model fingerprint high */
         };
         for (uint32_t i = 0; i < DS4_SESSION_PAYLOAD_U32_FIELDS; i++) {
             if (payload_write_u32(fp, header[i], err, errlen) != 0) return 1;
@@ -23299,8 +23356,10 @@ int ds4_session_save_payload(ds4_session *s, FILE *fp, char *err, size_t errlen)
      *   0 magic, 1 version, 2 ctx, 3 prefill chunk, 4 raw cap,
      *   5 raw window, 6 compressed cap, 7 token count,
      *   8 layers, 9 raw head dim, 10 indexer head dim, 11 vocab,
-     *   12 live raw rows serialized below.
+     *   12 live raw rows serialized below,
+     *   13 model fingerprint low, 14 model fingerprint high.
      */
+    const uint64_t model_fp = ds4_session_model_fingerprint(s);
     uint32_t header[DS4_SESSION_PAYLOAD_U32_FIELDS] = {
         DS4_SESSION_PAYLOAD_MAGIC,
         DS4_SESSION_PAYLOAD_VERSION,
@@ -23315,6 +23374,8 @@ int ds4_session_save_payload(ds4_session *s, FILE *fp, char *err, size_t errlen)
         DS4_N_INDEXER_HEAD_DIM,
         DS4_N_VOCAB,
         raw_live,
+        (uint32_t)(model_fp & 0xffffffffu),       /* model fingerprint low  */
+        (uint32_t)(model_fp >> 32),               /* model fingerprint high */
     };
     for (uint32_t i = 0; i < DS4_SESSION_PAYLOAD_U32_FIELDS; i++) {
         if (payload_write_u32(fp, header[i], err, errlen) != 0) return 1;
@@ -23436,6 +23497,20 @@ int ds4_session_load_payload(ds4_session *s, FILE *fp, uint64_t payload_bytes, c
     if (h[0] != DS4_SESSION_PAYLOAD_MAGIC || h[1] != DS4_SESSION_PAYLOAD_VERSION) {
         payload_set_err(err, errlen, "unsupported session payload version");
         return 1;
+    }
+    /* Reject a payload saved against a different model/quant (same structural
+     * layout but different weights would silently decode to garbage).  Header
+     * words 13/14 hold the 64-bit fingerprint; recompute it for the engine this
+     * session is bound to and reject before reading any KV bytes.  v<3 payloads
+     * lack these words and are already rejected by the version check above. */
+    {
+        const uint64_t saved_fp = (uint64_t)h[13] | ((uint64_t)h[14] << 32);
+        const uint64_t live_fp = ds4_session_model_fingerprint(s);
+        if (saved_fp != live_fp) {
+            payload_set_err(err, errlen,
+                "KV checkpoint was saved against a different model or quantization");
+            return 1;
+        }
     }
     if (ds4_session_is_cpu(s)) {
         const uint32_t saved_ctx = h[2];

--- a/ds4.h
+++ b/ds4.h
@@ -158,6 +158,11 @@ uint64_t ds4_engine_hidden_f32_values(ds4_engine *e);
  * KV files with the previously-zero reserved byte remain Flash-compatible;
  * Pro and later shapes must use nonzero ids. */
 int ds4_engine_model_id(ds4_engine *e);
+/* Cheap, stable 64-bit model/quant identity over structural+quant metadata and
+ * vocab bytes (never the weights).  Stamped into the session payload header so a
+ * KV checkpoint saved against a different GGUF/quant of the same shape is
+ * rejected on load instead of silently decoding garbage. */
+uint64_t ds4_engine_model_fingerprint(ds4_engine *e);
 const char *ds4_backend_name(ds4_backend backend);
 bool ds4_think_mode_enabled(ds4_think_mode mode);
 const char *ds4_think_mode_name(ds4_think_mode mode);
@@ -302,8 +307,16 @@ int ds4_session_eval_output_head_from_hc(ds4_session *s,
 /* Disk KV payload helpers.  HTTP/agent code owns the outer file header and
  * persistence policy; the engine owns the DS4-specific serialized graph state. */
 #define DS4_SESSION_PAYLOAD_MAGIC UINT32_C(0x34565344) /* "DSV4" */
-#define DS4_SESSION_PAYLOAD_VERSION UINT32_C(2)
-#define DS4_SESSION_PAYLOAD_U32_FIELDS 13u
+/* Version 3 appends a 64-bit model/quant fingerprint (header words 13,14) so a
+ * payload saved against a different GGUF or quant with the same structural
+ * layout is rejected on load instead of silently decoding garbage.  The coarse
+ * structural words (layers/head dims/vocab) cannot tell two different models of
+ * the same variant+quant apart; the fingerprint folds in routed-expert quant
+ * bits, output/token_embd tensor quant types, the per-layer ffn_gate_exps quant
+ * mix, and the vocab token bytes (metadata only, never the weights).  Older v<3
+ * payloads (13 header words, no fingerprint) are rejected cleanly on load. */
+#define DS4_SESSION_PAYLOAD_VERSION UINT32_C(3)
+#define DS4_SESSION_PAYLOAD_U32_FIELDS 15u
 #define DS4_SESSION_LAYER_PAYLOAD_MAGIC UINT32_C(0x4c565344) /* "DSVL" */
 #define DS4_SESSION_LAYER_PAYLOAD_VERSION UINT32_C(1)
 #define DS4_SESSION_LAYER_PAYLOAD_U32_FIELDS 14u

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -372,6 +372,7 @@ typedef struct {
     uint32_t indexer_head_dim;
     uint32_t vocab;
     uint32_t raw_live;
+    uint64_t model_fp;   /* model/quant fingerprint (payload v3 header words 13,14) */
 } ds4_dist_kv_layout;
 
 typedef struct {
@@ -4809,6 +4810,8 @@ static int dist_kv_write_session_header(
         layout->indexer_head_dim,
         layout->vocab,
         layout->raw_live,
+        (uint32_t)(layout->model_fp & 0xffffffffu),  /* model fingerprint low  */
+        (uint32_t)(layout->model_fp >> 32),          /* model fingerprint high */
     };
     for (uint32_t i = 0; i < DS4_SESSION_PAYLOAD_U32_FIELDS; i++) {
         if (dist_payload_write_u32(fp, h[i], err, errlen) != 0) return 1;
@@ -5170,6 +5173,9 @@ int ds4_dist_session_save_payload(
         if (errlen) snprintf(err, errlen, "distributed KV shard metadata mismatch");
         goto cleanup;
     }
+    /* Stamp the model/quant fingerprint (payload v3) so a checkpoint restored
+     * against a different GGUF/quant of the same shape is rejected on load. */
+    layout.model_fp = ds4_engine_model_fingerprint(d->state.engine);
 
     if (dist_kv_write_session_header(fp, &layout, err, errlen) != 0)
         goto cleanup;
@@ -5246,7 +5252,16 @@ int ds4_dist_session_load_payload(
         .indexer_head_dim = h[10],
         .vocab = h[11],
         .raw_live = h[12],
+        .model_fp = (uint64_t)h[13] | ((uint64_t)h[14] << 32),
     };
+    /* Reject a checkpoint saved against a different model/quant before reading
+     * any KV bytes; the same structural layout with different weights would
+     * silently decode to garbage. */
+    if (layout.model_fp != ds4_engine_model_fingerprint(d->state.engine)) {
+        if (errlen) snprintf(err, errlen,
+            "KV checkpoint was saved against a different model or quantization");
+        return 1;
+    }
     if (layout.n_layers != d->state.n_layers ||
         layout.ctx > (uint32_t)ds4_session_ctx(owner) ||
         layout.token_count >= (uint32_t)ds4_session_ctx(owner) ||


### PR DESCRIPTION
Small robustness hardening for the session-payload format.

`ds4_session_save_payload` / `load_payload` validate ctx, chunk layout, structural dims, and a coarse `model_id` (= `DS4_MODEL_VARIANT`) + quant bits. That catches most mismatches, but **not two different GGUFs of the same variant + same quant + same layout** (e.g. a re-quantized model, a different fine-tune, a swapped checkpoint): such a payload loads and silently decodes to garbage.

This adds a cheap **64-bit model/quant fingerprint** (FNV-1a/64) to the payload header, written on save and checked on load — rejecting a mismatch with a clear error (`KV checkpoint was saved against a different model or quantization`) **before any KV bytes are read**. The fingerprint folds in routed-expert quant bits, the `output`/`token_embd` tensor quant types, every per-layer `ffn_gate_exps` quant type, and the vocab token bytes — **metadata only, never the weight data**, so it's effectively free.

- `DS4_SESSION_PAYLOAD_VERSION` 2 → 3 (two extra header words); v<3 payloads are rejected cleanly by the existing version gate, not misparsed.
- Both the local (`ds4.c`) and distributed-KV (`ds4_distributed.c`) save/load paths updated symmetrically; CUDA/CPU/Metal/ROCm builds unaffected (backend-agnostic host C). Build-verified on the gfx1151 Windows HIP build.

Honest scope: this is defensive hardening, not a feature — the existing validation already covers most cases, and `ds4_kvstore.c` handles the persistence itself. It closes one narrow but real silent-garbage footgun. Happy to drop it if you consider it unnecessary.