### PR TITLE
fix(agent): restore raw mode

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -9465,7 +9465,17 @@ static bool agent_prompt_yes_no_ex(const char *prompt,
             }
             if (rc < 0) return false;
         }
-        if (!fgets(buf, sizeof(buf), stdin)) return false;
+        /* stdin may be in non-blocking mode (set by editor_start).
+         * Temporarily switch to blocking so fgets can wait for input. */
+        int saved_flags = fcntl(STDIN_FILENO, F_GETFL, 0);
+        if (saved_flags >= 0 && (saved_flags & O_NONBLOCK)) {
+            fcntl(STDIN_FILENO, F_SETFL, saved_flags & ~O_NONBLOCK);
+        }
+        bool got_line = fgets(buf, sizeof(buf), stdin) != NULL;
+        if (saved_flags >= 0 && (saved_flags & O_NONBLOCK)) {
+            fcntl(STDIN_FILENO, F_SETFL, saved_flags);
+        }
+        if (!got_line) return false;
         char *p = buf;
         while (*p == ' ' || *p == '\t') p++;
         if (*p == 'y' || *p == 'Y') return true;
@@ -9963,7 +9973,11 @@ static int run_agent(ds4_engine *engine, agent_config *cfg) {
                 } else if (cmd[0] == '/' && busy) {
                     printf("command requires the model to be idle: %s\n", cmd);
                 } else if (!strcmp(cmd, "/quit") || !strcmp(cmd, "/exit")) {
-                    editor_restore_terminal_layout(&editor);
+                    /* Stop the editor so raw mode and non-blocking stdin are
+                     * disabled before we prompt the user.  If we exit, the
+                     * terminal is already restored.  If the user cancels, we
+                     * restart the editor below. */
+                    editor_stop(&editor);
                     agent_exit_save_result exit_save =
                         agent_maybe_save_before_exiting(&worker);
                     if (exit_save == AGENT_EXIT_NOW) {
@@ -9971,6 +9985,10 @@ static int run_agent(ds4_engine *engine, agent_config *cfg) {
                     } else if (exit_save == AGENT_EXIT_CLEAN) {
                         exit_save_handled = true;
                         running = false;
+                    } else {
+                        /* AGENT_EXIT_CANCEL: user declined to proceed after a
+                         * save failure.  Reopen the editor and continue. */
+                        editor_start(&editor, prompt, statusline, NULL);
                     }
                 } else if (!strcmp(cmd, "/new")) {
                     editor_restore_terminal_layout(&editor);

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -145,6 +145,7 @@ typedef struct {
     bool more_valid;
     agent_bash_job *bash_jobs;
     int next_bash_job_id;
+    bool raw_mode_needs_restore;
 } agent_worker;
 
 static unsigned agent_next_prefill_label(void);
@@ -6586,6 +6587,7 @@ struct agent_bash_job {
     bool running;
     bool timed_out;
     struct agent_bash_job *next;
+    agent_worker *worker;  /* back-pointer for terminal state restoration */
 };
 
 static int agent_bash_display_lines(const agent_bash_job *job) {
@@ -6674,6 +6676,13 @@ static void agent_bash_finalize(agent_bash_job *job, int status) {
     else if (WIFSIGNALED(status)) job->exit_status = 128 + WTERMSIG(status);
     else job->exit_status = -1;
     job->running = false;
+    /* A child process (especially sh) may have changed the terminal mode
+     * from raw to cooked.  Notify the UI thread to restore raw mode. */
+    if (job->worker) {
+        pthread_mutex_lock(&job->worker->mu);
+        job->worker->raw_mode_needs_restore = true;
+        pthread_mutex_unlock(&job->worker->mu);
+    }
 }
 
 /* Drain available output, notice process exit, and enforce timeout.  This is
@@ -6741,6 +6750,17 @@ static agent_bash_job *agent_bash_start(agent_worker *w, const char *cmd,
     if (pid == 0) {
         setpgid(0, 0);
         close(tmpfd);
+        /* Redirect stdin to /dev/null so the shell does not attempt to
+         * change the terminal mode (cooked/raw) on the controlling
+         * terminal.  If the shell sets cooked mode while linenoise has
+         * raw mode active, the terminal becomes unresponsive to user
+         * input until the process exits and linenoise re-enables raw
+         * mode. */
+        int null_fd = open("/dev/null", O_RDONLY);
+        if (null_fd >= 0) {
+            dup2(null_fd, STDIN_FILENO);
+            close(null_fd);
+        }
         close(pipefd[0]);
         dup2(pipefd[1], STDOUT_FILENO);
         dup2(pipefd[1], STDERR_FILENO);
@@ -6767,6 +6787,7 @@ static agent_bash_job *agent_bash_start(agent_worker *w, const char *cmd,
     job->timeout_sec = timeout_sec;
     job->exit_status = -1;
     job->running = true;
+    job->worker = w;
     job->next = w->bash_jobs;
     w->bash_jobs = job;
     return job;
@@ -8028,6 +8049,19 @@ static int set_nonblock(int fd, bool on, int *old_flags) {
     if (old_flags) *old_flags = flags;
     int next = on ? (flags | O_NONBLOCK) : (flags & ~O_NONBLOCK);
     return fcntl(fd, F_SETFL, next);
+}
+
+/* Check and clear the raw_mode_needs_restore flag under the worker mutex.
+ * Returns true if the UI thread should call linenoiseRestoreRawMode(). */
+static bool worker_check_raw_mode_restore(agent_worker *w) {
+    bool needs = false;
+    pthread_mutex_lock(&w->mu);
+    if (w->raw_mode_needs_restore) {
+        w->raw_mode_needs_restore = false;
+        needs = true;
+    }
+    pthread_mutex_unlock(&w->mu);
+    return needs;
 }
 
 static void drain_wake_fd(int fd) {
@@ -9704,6 +9738,11 @@ static int run_agent(ds4_engine *engine, agent_config *cfg) {
     bool force_status_redraw_after_restart = false;
     char *restore_line = NULL;
     while (running) {
+        /* If a bash child process changed the terminal mode (e.g., from raw
+         * to cooked), restore raw mode so linenoise continues to work. */
+        if (worker_check_raw_mode_restore(&worker)) {
+            linenoiseRestoreRawMode();
+        }
         struct pollfd pfd[2] = {
             {.fd = STDIN_FILENO, .events = POLLIN},
             {.fd = worker.wake_fd[0], .events = POLLIN},

--- a/linenoise.c
+++ b/linenoise.c
@@ -631,11 +631,17 @@ static void disableRawMode(int fd) {
 void linenoiseRestoreRawMode(void) {
     if (getenv("LINENOISE_ASSUME_TTY")) return;
     if (!isatty(STDIN_FILENO)) return;
-    /* Re-fetch the original terminal attributes (they may have been changed
-     * by a child process) and re-apply raw mode. */
     struct termios raw;
-    if (tcgetattr(STDIN_FILENO, &orig_termios) == -1) return;
-    raw = orig_termios;
+    if (tcgetattr(STDIN_FILENO, &raw) == -1) return;
+    /* If we are already in raw mode, the current attributes are the raw-mode
+     * settings we set earlier.  Do NOT overwrite orig_termios with them;
+     * orig_termios must remain the original cooked-mode state so that
+     * disableRawMode() can restore it later.  If rawmode is 0, a child
+     * process changed the terminal to cooked mode, so we save the current
+     * (cooked) state as the new orig_termios before applying raw mode. */
+    if (!rawmode) {
+        orig_termios = raw;
+    }
     raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
     raw.c_oflag &= ~(OPOST);
     raw.c_cflag |= (CS8);

--- a/linenoise.c
+++ b/linenoise.c
@@ -624,6 +624,29 @@ static void disableRawMode(int fd) {
     }
 }
 
+/* Re-enable raw mode if a child process changed the terminal state.  This is
+ * useful when the application spawns external processes that may reset the
+ * terminal to cooked mode.  The caller should ensure that no concurrent
+ * linenoise operations are in progress (e.g., not inside a refresh cycle). */
+void linenoiseRestoreRawMode(void) {
+    if (getenv("LINENOISE_ASSUME_TTY")) return;
+    if (!isatty(STDIN_FILENO)) return;
+    /* Re-fetch the original terminal attributes (they may have been changed
+     * by a child process) and re-apply raw mode. */
+    struct termios raw;
+    if (tcgetattr(STDIN_FILENO, &orig_termios) == -1) return;
+    raw = orig_termios;
+    raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+    raw.c_oflag &= ~(OPOST);
+    raw.c_cflag |= (CS8);
+    raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
+    raw.c_cc[VMIN] = 1; raw.c_cc[VTIME] = 0;
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
+    rawmode = 1;
+    /* Re-enable bracketed paste mode. */
+    if (write(rawmode_output, "\x1b[?2004h", 8) == -1) {}
+}
+
 /* Use the ESC [6n escape sequence to query the horizontal cursor position
  * and return it. On error -1 is returned, on success the position of the
  * cursor. */

--- a/linenoise.h
+++ b/linenoise.h
@@ -139,6 +139,8 @@ void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
 void linenoiseMaskModeEnable(void);
 void linenoiseMaskModeDisable(void);
+/* Re-enable raw mode if a child process changed the terminal state. */
+void linenoiseRestoreRawMode(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Fix terminal freeze after bash child processes

### Problem

Running any bash command via the agent's bash tool call (e.g., `tmux list-sessions`) renders the terminal unresponsive to keyboard input. Typed characters don't appear, and the only recovery is to kill the agent process and press `Ctrl-L`.

After killing the agent, the terminal is compressed to the bottom line - the scroll-region escape sequences the agent left behind are still active - confirming the terminal mode was corrupted, not just the agent's input handling.

### Root cause

When the agent spawns `sh -c "<cmd>"`, only `stdout`/`stderr` are redirected to a pipe. `stdin` is left as the original terminal `fd`. The shell detects `stdin` is a tty and calls `tcsetattr()` to set cooked mode (`ICANON`, `ECHO`, etc.), overriding `linenoise`'s raw mode. After the child exits the terminal stays cooked. `linenoise` never re-applies raw mode because `enableRawMode() `is called once at editor startup.

In cooked mode the terminal driver buffers input line-by-line. The agent's non-blocking `read()` sees `EAGAIN` because no complete line is available until Enter is pressed. The user sees nothing happen.

### Fix (two layers)

1. Redirect child `stdin` to `/dev/null` (`ds4_agent.c`:agent_bash_start)

The child now opens `/dev/null` and `dup2`'s it onto `STDIN_FILENO` before exec. This prevents the shell from ever calling `tcsetattr()` on the controlling terminal.

Safety analysis: The bash tool is a non-interactive command runner. The agent never writes to the child's `stdin` – it only reads `stdout`/`stderr` via a pipe. The model supplies all data through command arguments, file writes, or shell pipelines (`printf ... | nc host port`). Commands that expect interactive terminal input (e.g., `ssh`, `sudo`, `git commit` without `-m`) never worked because the agent has no mechanism to forward keystrokes to the child. The redirect only breaks things that were already broken, and it fixes the terminal freeze for everything else.

2. Raw-mode restoration safety net (`linenoise.c`, `ds4_agent.c`)

A new public function `linenoiseRestoreRawMode()` re-applies the same raw-mode flags that `enableRawMode()` sets. It re-fetches `orig_termios` via `tcgetattr()` so it works even if a child process changed the terminal attributes.

The worker thread sets a `raw_mode_needs_restore` flag (under the worker mutex) in `agent_bash_finalize()` whenever a bash job finishes. The UI thread checks this flag at the top of its event loop and calls `linenoiseRestoreRawMode()` if needed. This provides defense-in-depth for any child process that might still touch `/dev/tty` despite the `stdin` redirect (e.g., `ssh` opening `/dev/tty` directly).

### Testing

Before the fix, running tmux list-sessions inside the agent froze the terminal 100% of the time. After the fix, the command runs normally and the terminal stays fully responsive. Repeated testing with various bash commands (including long-running processes and commands that produce ANSI escape sequences) shows no regression.

fix #366

Update: More fixes.

### Fix 1 – `agent_prompt_yes_no_ex` (non‑blocking `stdin`)

`editor_start` sets `stdin` to `O_NONBLOCK`. The prompt function used f`gets(stdin)` which immediately returns `NULL` (`EAGAIN`) when no data is available, causing the function to treat it as "no" and exit without waiting for the user.

Change: Save the `O_NONBLOCK` flag, temporarily disable it before `fgets`, restore it after.

### Fix 2 – `/quit` handler (terminal restoration before exit)

The handler called `editor_restore_terminal_layout` (scroll‑region reset) but never `editor_stop`, which is the function that restores `stdin` flags and disables raw mode. When `AGENT_EXIT_NOW` was taken (user declines save), `exit(0)` was called while raw mode was still active and `stdin` was non‑blocking, leaving the terminal unusable.

Change: Call `editor_stop` before prompting so that raw mode and non‑blocking are already disabled when we prompt or exit. The `AGENT_EXIT_CANCEL` case now restarts the editor instead of leaving it half‑stopped.

### Fix 3 – `linenoiseRestoreRawMode` (corrupted `orig_termios`)

This is the root cause of the garbled /help output. The function unconditionally overwrote the global `orig_termios` with the current terminal attributes via `tcgetattr`. While the editor is active, those are the raw‑mode settings (with `OPOST` cleared). Later, when editor_stop calls `disableRawMode`, it restores that corrupted `orig_termios` — the terminal stays in raw mode. Then put outputs `\n` without carriage return, staggering the lines.

Change: Only update `orig_termios` when `rawmode == 0` (i.e., a child process actually changed the terminal to cooked). If we are already in raw mode, keep the original `orig_termios` intact so `disableRawMode` can still restore proper cooked mode.
