### PR TITLE
Add continuous depth-1 MTP speculation (DS4_MTP_CONTINUOUS)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -22212,6 +22212,8 @@ struct ds4_session {
     float *logits;
     float *mtp_logits;
     int mtp_draft_token;
+    uint32_t cont_anchor_row;
+    bool cont_anchor_valid;
     uint64_t mtp_probe_total;
     uint64_t mtp_probe_hit;
     ds4_session_progress_fn progress;
@@ -23785,6 +23787,7 @@ int ds4_session_load_payload(ds4_session *s, FILE *fp, uint64_t payload_bytes, c
     }
     s->checkpoint_valid = true;
     s->mtp_draft_valid = false;
+    s->cont_anchor_valid = false;
     g->mtp_n_raw = 0;
     return 0;
 #endif
@@ -25537,6 +25540,7 @@ int ds4_session_sync(ds4_session *s, const ds4_tokens *prompt, char *err, size_t
         snprintf(err, errlen, "interrupted");
         return DS4_SESSION_SYNC_INTERRUPTED;
     }
+    s->cont_anchor_valid = false;
     if (s->distributed) {
         const ds4_tokens *checkpoint = s->checkpoint_valid ? &s->checkpoint : NULL;
         return ds4_dist_session_sync(s->distributed,
@@ -25965,6 +25969,7 @@ static int ds4_session_eval_internal(ds4_session *s, int token, bool probe_mtp,
         return 1;
     }
     token_vec_push(&s->checkpoint, token);
+    s->cont_anchor_valid = false;
     if (mtp_should_draft) {
         int mtp_top = -1;
         if (metal_graph_eval_mtp_draft(&s->graph,
@@ -26023,6 +26028,113 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
     return -1;
 #else
     ds4_engine *e = s->engine;
+    int n_accept = 0;
+    const bool strict_mtp = e->quality || getenv("DS4_MTP_STRICT") != NULL;
+
+    /* Continuous depth-1 speculation (DS4_MTP_CONTINUOUS).  The default path
+     * below decodes first_token on its own and then batch-verifies the MTP
+     * draft; that standalone decode is a full shared-weight pass the verify
+     * could have amortized.  Continuous mode folds the two together: forward
+     * [first_token, draft] in a single verify, drafting from the anchor row the
+     * previous verify left in batch_cur_hc.  It removes one shared-weight pass
+     * per accepted draft (about 0.50 versus 0.70 reads per token).  Same
+     * near-greedy class as the batched draft-2 verifier, not bit-exact to a
+     * strict decode: a wrong draft is rejected by the verify and never
+     * committed, so a stale anchor only lowers acceptance, never corrupts.
+     * --quality / DS4_MTP_STRICT ask for a strict decode, so defer to the
+     * exact verifier below in that case. */
+    if (!strict_mtp && e->mtp_ready && s->mtp_logits &&
+        e->mtp_draft_tokens > 1 && s->graph.prefill_cap >= 2 &&
+        getenv("DS4_MTP_CONTINUOUS"))
+    {
+        const uint32_t start = (uint32_t)s->checkpoint.len;
+
+        int draft = -1;
+        if (s->cont_anchor_valid) {
+            const uint64_t hc_dim = (uint64_t)DS4_N_HC * DS4_N_EMBD;
+            ds4_gpu_tensor *anchor = metal_graph_tensor_row_view(s->graph.batch_cur_hc,
+                                                                 s->cont_anchor_row, hc_dim);
+            const bool drafted = metal_graph_eval_mtp_draft_from_hc(&s->graph, &e->model, &e->weights,
+                                                                    &e->mtp_model, &e->mtp_weights,
+                                                                    anchor, s->graph.mtp_state_hc,
+                                                                    first_token, start,
+                                                                    NULL, &draft);
+            if (anchor) ds4_gpu_tensor_free(anchor);
+            if (!drafted) draft = -1;
+        }
+
+        /*
+         * No usable draft (first token of a generation, draft unavailable, EOS,
+         * or no room to store or report two tokens): forward first_token alone
+         * and seat the anchor on its row, like an ordinary depth-1 cycle.
+         */
+        if (draft < 0 || first_token == eos_token ||
+            max_tokens == 1 || accepted_cap < 2 ||
+            start + 2u > (uint32_t)s->ctx_size)
+        {
+            token_vec_push(&s->checkpoint, first_token);
+            bool ok = metal_graph_verify_suffix_tops(&s->graph, &e->model, &e->weights,
+                                                     &s->checkpoint, start, 1,
+                                                     false, NULL, NULL) &&
+                      metal_graph_read_spec_logits_row(&s->graph, 0, s->logits);
+            if (!ok) {
+                s->checkpoint.len = start;
+                snprintf(err, errlen, "continuous decode failed");
+                s->checkpoint_valid = false;
+                s->cont_anchor_valid = false;
+                return -1;
+            }
+            accepted[n_accept++] = first_token;
+            s->checkpoint_valid = true;
+            s->mtp_draft_valid = false;
+            s->cont_anchor_row = 0;
+            s->cont_anchor_valid = true;
+            return n_accept;
+        }
+
+        /*
+         * Verify [first_token, draft] together with prefix-1 capture so a
+         * rejected draft rewinds cheaply.  first_token is always committed; the
+         * draft is committed only when the target agrees at row 0.
+         */
+        int row_tops[2] = { -1, -1 };
+        token_vec_push(&s->checkpoint, first_token);
+        token_vec_push(&s->checkpoint, draft);
+        bool ok = metal_graph_verify_suffix_tops(&s->graph, &e->model, &e->weights,
+                                                 &s->checkpoint, start, 2,
+                                                 true, row_tops, NULL);
+        if (ok && row_tops[0] == draft) {
+            ok = metal_graph_read_spec_logits_row(&s->graph, 1, s->logits);
+            if (ok) {
+                accepted[n_accept++] = first_token;
+                if (n_accept < accepted_cap) accepted[n_accept++] = draft;
+                s->cont_anchor_row = 1;
+            }
+        } else if (ok) {
+            if (getenv("DS4_MTP_SPEC_LOG")) {
+                fprintf(stderr, "ds4: mtp cont miss draft=%d top=%d\n", draft, row_tops[0]);
+            }
+            s->checkpoint.len = start;
+            ok = spec_frontier_commit_prefix1(s) &&
+                 metal_graph_read_spec_logits_row(&s->graph, 0, s->logits);
+            if (ok) {
+                accepted[n_accept++] = first_token;
+                token_vec_push(&s->checkpoint, first_token);
+                s->cont_anchor_row = 0;
+            }
+        }
+        if (!ok) {
+            s->checkpoint.len = start;
+            snprintf(err, errlen, "continuous verify failed");
+            s->checkpoint_valid = false;
+            s->cont_anchor_valid = false;
+            return -1;
+        }
+        s->checkpoint_valid = true;
+        s->mtp_draft_valid = false;
+        s->cont_anchor_valid = true;
+        return n_accept;
+    }
 
     /*
      * MTP in DeepSeek V4 is a speculative drafter, not a replacement sampler.
@@ -26033,7 +26145,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
      * draft token is correctness-safe but cannot be faster than baseline.
      */
     if (ds4_session_eval(s, first_token, err, errlen) != 0) return -1;
-    int n_accept = 0;
+    n_accept = 0;
     accepted[n_accept++] = first_token;
     if (first_token == eos_token || max_tokens == 1 || n_accept >= accepted_cap) return n_accept;
 
@@ -26050,7 +26162,6 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
     int draft_n = 1;
     drafts[0] = s->mtp_draft_token;
     s->mtp_draft_valid = false;
-    const bool strict_mtp = e->quality || getenv("DS4_MTP_STRICT") != NULL;
     float mtp_margin_threshold = e->mtp_margin;
     const char *mtp_margin_env = getenv("DS4_MTP_MIN_MARGIN");
     if (mtp_margin_env && mtp_margin_env[0]) {
@@ -26602,6 +26713,7 @@ void ds4_session_invalidate(ds4_session *s) {
     s->checkpoint_valid = false;
     s->checkpoint.len = 0;
     s->mtp_draft_valid = false;
+    s->cont_anchor_valid = false;
 }
 
 void ds4_session_rewind(ds4_session *s, int pos) {
@@ -26609,6 +26721,7 @@ void ds4_session_rewind(ds4_session *s, int pos) {
     if (pos > s->checkpoint.len) pos = s->checkpoint.len;
     s->checkpoint.len = pos;
     s->mtp_draft_valid = false;
+    s->cont_anchor_valid = false;
 }
 
 int ds4_session_pos(ds4_session *s) {

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -1917,6 +1917,8 @@ static void test_mtp_verify_depth(void) {
         return;
     }
     TEST_ASSERT(ds4_engine_mtp_draft_tokens(engine) > 2);
+    char *saved_cont = test_save_env("DS4_MTP_CONTINUOUS");
+    unsetenv("DS4_MTP_CONTINUOUS");
 
     ds4_tokens prompt = {0};
     ds4_chat_begin(engine, &prompt);
@@ -1946,6 +1948,54 @@ static void test_mtp_verify_depth(void) {
 
     free(spec);
     ds4_tokens_free(&prompt);
+    test_restore_env("DS4_MTP_CONTINUOUS", saved_cont);
+}
+
+/* Continuous depth-1 speculation (DS4_MTP_CONTINUOUS) must only commit tokens
+ * the target model would have produced.  Decode the copy task in continuous
+ * mode, then reuse the verify-depth oracle to replay every committed token
+ * through plain decode and require each to be the argmax within tie tolerance.
+ * Self-skips without DS4_TEST_MTP. */
+static void test_cont_argmax_gap(void) {
+    ds4_engine *engine = test_get_engine(false);
+    if (!engine || !ds4_engine_has_mtp(engine)) {
+        fprintf(stderr, "ds4-test: cont-argmax-gap skipped (set DS4_TEST_MTP to an MTP GGUF)\n");
+        return;
+    }
+    char *saved = test_save_env("DS4_MTP_CONTINUOUS");
+    char *saved_strict = test_save_env("DS4_MTP_STRICT");
+    setenv("DS4_MTP_CONTINUOUS", "1", 1);
+    unsetenv("DS4_MTP_STRICT");
+
+    ds4_tokens prompt = {0};
+    ds4_chat_begin(engine, &prompt);
+    ds4_chat_append_message(engine, &prompt, "user", test_mtp_copy_prompt());
+    ds4_chat_append_assistant_prefix(engine, &prompt, DS4_THINK_NONE);
+    TEST_ASSERT(prompt.len > 0);
+
+    int *spec = malloc((size_t)TEST_MTP_MAXGEN * sizeof(*spec));
+    TEST_ASSERT(spec != NULL);
+    if (spec && prompt.len > 0) {
+        int nspec = 0, max_chunk = 0;
+        const bool ok_spec = test_mtp_capture_speculative(engine, &prompt, TEST_MTP_MAXGEN,
+                                                          spec, &nspec, &max_chunk);
+        TEST_ASSERT(ok_spec);
+        TEST_ASSERT(max_chunk == 2);  /* the continuous accept path ran; the draft-4 default
+                                       * path would exceed 2 on this prompt */
+        TEST_ASSERT(nspec > 64);
+        float worst_gap = 0.0f;
+        int worst_at = -1;
+        const bool ok_check = test_mtp_worst_argmax_gap(engine, &prompt, spec, nspec,
+                                                        &worst_gap, &worst_at);
+        TEST_ASSERT(ok_check);
+        fprintf(stderr, "ds4-test: cont-argmax-gap nspec=%d max_chunk=%d worst_argmax_gap=%.3f at=%d\n",
+                nspec, max_chunk, worst_gap, worst_at);
+        TEST_ASSERT(worst_gap <= 2.0f);
+    }
+    free(spec);
+    ds4_tokens_free(&prompt);
+    test_restore_env("DS4_MTP_CONTINUOUS", saved);
+    test_restore_env("DS4_MTP_STRICT", saved_strict);
 }
 #endif
 
@@ -1973,6 +2023,7 @@ static const ds4_test_entry test_entries[] = {
     {"--metal-tensor-equivalence", "metal-tensor-equivalence", "fast/quality Metal prompt-logit and greedy equivalence", test_metal_mpp_equivalence},
     {"--streaming-decode-prefill-correctness", "streaming-decode-prefill-correctness", "streaming decode-style cold prefill drift and repeatability", test_streaming_decode_prefill_correctness},
     {"--mtp-verify-depth", "mtp-verify-depth", "MTP speculative verify commits autoregressive-identical tokens at draft depth > 2", test_mtp_verify_depth},
+    {"--cont-argmax-gap", "cont-argmax-gap", "DS4_MTP_CONTINUOUS commits autoregressive-identical tokens", test_cont_argmax_gap},
 #endif
     {"--server", "server", "server parser/rendering/cache unit tests", test_server_unit_group},
 };


### PR DESCRIPTION
Continuous depth-1 MTP speculation, discussed in #369.

The shipped `--mtp-draft 2` decodes the base token on its own and then batch-verifies the MTP draft; that standalone decode is a full shared-weight pass the verify could have carried. This folds them together: draft from the trunk hidden state the previous verify left in `batch_cur_hc`, and verify `[first_token, draft]` in one batched pass, removing the base decode.

Branch-measured, paired and interleaved on an M4 Max (q2-q4-imatrix base, Q4K/Q8 MTP head): continuous beats `--mtp-draft 2` by +7% to +12% across copy / technical-prose / free-prose, deterministic 0.50 versus 0.70 shared reads per token on copy with the base decode gone. Against plain autoregressive decode the gain is content-dependent, +20% on copy down to roughly flat on free prose, since the speculation benefit itself tracks draft acceptance. Full table and method in #369.

Same near-greedy class as the batched draft-2 verifier, not bit-exact to a strict decode: it only ever commits the verifier's argmax, byte-identical to plain decode on copy-heavy output and diverging only at genuine logit ties on prose. It defers to `--quality` and `DS4_MTP_STRICT`, which select the exact verifier. Depth-1 only; it does not revive deeper drafting (the head's step-2 acceptance drops off a cliff), it makes the depth-1 cycle cheaper.

Env-gated by `DS4_MTP_CONTINUOUS`, about 120 lines, nearly all one block in `ds4_session_eval_speculative_argmax` reusing the existing verify, draft, and prefix-1 helpers. It rides the existing speculative path, so it takes effect under greedy decode with `--mtp-draft 2` or higher; the env var alone does nothing. The anchor is invalidated on sync, rewind, invalidate, payload restore, and plain eval, and draft misses log under `DS4_MTP_SPEC_LOG`. The test reuses the #358 verify-depth oracle (replay the committed stream, require every token within tie tolerance of the argmax):

```
make ds4_test
DS4_TEST_MODEL=<base.gguf> DS4_TEST_MTP=<mtp.gguf> ./ds4_test --cont-argmax-gap
```

Verified on Metal, single-session. The call sites are backend-shared, but I have not tested CUDA or the server.
