### PR TITLE
Fix agent edit: accept [upto] markers indented or padded with blanks (+ golden cases)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,11 @@ The C test runner is `ds4_test`. Running it without arguments is equivalent to
 make test
 ```
 
+`make test` also runs the model-free unit tests first: `./ds4-eval
+--self-test-extractors` (answer-extractor golden cases) and `./ds4_agent_test`
+(edit anchor matcher golden cases). Both run without loading a model, so they
+work with no GGUF present.
+
 Useful narrower checks:
 
 ```sh

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -6738,6 +6738,25 @@ static bool agent_edit_upto_forcer_should_replace(agent_edit_upto_forcer *forcer
     return false;
 }
 
+static bool agent_edit_match_anchors(const char *data, size_t len,
+                                     const char *old, size_t head_len,
+                                     const char *tail, size_t tail_len,
+                                     const char **match, size_t *match_len,
+                                     char *err, size_t err_len) {
+    const char *head_pos = NULL;
+    const char *tail_pos = NULL;
+    if (!agent_find_unique(data, len, old, head_len, &head_pos, "old head",
+                           err, err_len))
+        return false;
+    if (!agent_find_unique_after(data, len, head_pos + head_len,
+                                 tail, tail_len, &tail_pos, "old tail",
+                                 err, err_len))
+        return false;
+    *match = head_pos;
+    *match_len = (size_t)(tail_pos - head_pos) + tail_len;
+    return true;
+}
+
 static bool agent_edit_find_old_span(const char *data, size_t len,
                                      const char *old, bool allow_upto,
                                      const char **match,
@@ -6780,19 +6799,51 @@ static bool agent_edit_find_old_span(const char *data, size_t len,
                  "old text after [upto] must include a unique tail anchor");
         return false;
     }
-    const char *head_pos = NULL;
-    const char *tail_pos = NULL;
-    if (!agent_find_unique(data, len, old, head_len, &head_pos, "old head",
-                           err, err_len))
-        return false;
-    if (!agent_find_unique_after(data, len, head_pos + head_len,
-                                 tail, tail_len, &tail_pos, "old tail",
-                                 err, err_len))
-        return false;
-    *anchored = true;
-    *match = head_pos;
-    *match_len = (size_t)(tail_pos - head_pos) + tail_len;
-    return true;
+    if (agent_edit_match_anchors(data, len, old, head_len, tail, tail_len,
+                                 match, match_len, err, err_len)) {
+        *anchored = true;
+        return true;
+    }
+    /* The model may indent [upto] like the surrounding code, or pad it with
+     * blanks before its newline.  Those blanks belong to the marker line,
+     * not to the anchors, so retry once treating the whole line as the
+     * marker: drop the head's line-trailing blanks and the blank padding
+     * after the marker.  The exact needles must run first: a forcer-injected
+     * marker can sit after partial indentation whose blanks are what makes
+     * the head unique, so edits that match today must keep matching as-is. */
+    size_t lenient_head_len = head_len;
+    while (lenient_head_len > 0 && (old[lenient_head_len - 1] == ' ' ||
+                                    old[lenient_head_len - 1] == '\t'))
+        lenient_head_len--;
+    if (lenient_head_len > 0 && old[lenient_head_len - 1] != '\n')
+        lenient_head_len = head_len; /* inline head: blanks are content */
+    const char *lenient_tail = upto + strlen(marker);
+    size_t lenient_tail_len = old_len - head_len - strlen(marker);
+    size_t pad = 0;
+    while (pad < lenient_tail_len && (lenient_tail[pad] == ' ' ||
+                                      lenient_tail[pad] == '\t'))
+        pad++;
+    if (pad < lenient_tail_len && (lenient_tail[pad] == '\n' ||
+                                   lenient_tail[pad] == '\r')) {
+        lenient_tail += pad;
+        lenient_tail_len -= pad;
+    }
+    while (lenient_tail_len > 0 &&
+           (*lenient_tail == '\n' || *lenient_tail == '\r')) {
+        lenient_tail++;
+        lenient_tail_len--;
+    }
+    if (lenient_head_len == head_len && lenient_tail == tail)
+        return false; /* nothing to relax: keep the exact-match error */
+    char lenient_err[256];
+    if (agent_edit_match_anchors(data, len, old, lenient_head_len,
+                                 lenient_tail, lenient_tail_len,
+                                 match, match_len,
+                                 lenient_err, sizeof(lenient_err))) {
+        *anchored = true;
+        return true;
+    }
+    return false; /* report the exact-match error */
 }
 
 #ifdef DS4_AGENT_TEST

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -7323,6 +7323,101 @@ static void test_agent_steering_command(void) {
 
 static void test_agent_terminal_wrap_output_is_deferred(void);
 
+/* Golden cases for [upto] anchor matching, mostly around the
+ * whitespace-lenient retry: the model can emit the marker indented like the
+ * surrounding code or padded with blanks before its newline.  A NULL span
+ * means the case must fail with an error containing err_part. */
+typedef struct {
+    const char *name;
+    const char *file;     /* file content the edit runs against */
+    const char *old;      /* edit old argument */
+    const char *span;     /* expected matched span, NULL if it must fail */
+    const char *err_part; /* expected error substring when span is NULL */
+} agent_edit_golden_case;
+
+static const agent_edit_golden_case agent_edit_golden_cases[] = {
+    { "plain unique old without [upto]",
+      "int a;\nint b;\nint c;\n",
+      "int b;\n",
+      "int b;\n", NULL },
+    { "[upto] indented with a tab while the file uses spaces",
+      "static int parse(void) {\n    int ok = compute();\n    return ok;\n}\n",
+      "static int parse(void) {\n\t[upto]\n    return ok;\n}\n",
+      "static int parse(void) {\n    int ok = compute();\n    return ok;\n}\n",
+      NULL },
+    { "indented [upto] before a dedenting line",
+      "void a(void) {\n    x();\n}\n\nvoid b(void) {\n    y();\n}\n",
+      "    x();\n    [upto]\nvoid b(void) {\n",
+      "    x();\n}\n\nvoid b(void) {\n", NULL },
+    { "trailing blanks between [upto] and the newline",
+      "int a;\nint b;\nint c;\n",
+      "int a;\n[upto]  \nint c;\n",
+      "int a;\nint b;\nint c;\n", NULL },
+    { "trailing blank then CRLF after [upto]",
+      "int a;\r\nint b;\r\nint c;\r\n",
+      "int a;\r\n[upto] \r\nint c;\r\n",
+      "int a;\r\nint b;\r\nint c;\r\n", NULL },
+    /* Locks the exact-needles-first order: the auto-upto forcer can inject
+     * '[upto]\n' after partial indentation whose blanks are what makes the
+     * head prefix unique, so the head must not be trimmed unconditionally. */
+    { "head whose uniqueness depends on its trailing blanks",
+      "x();\n  y();\nx();\nz();\n",
+      "x();\n  [upto]\ny();\n",
+      "x();\n  y();\n", NULL },
+    { "inline head [upto] tail keeps its exact spacing",
+      "alpha middle omega\n",
+      "alpha [upto] omega\n",
+      "alpha middle omega\n", NULL },
+    { "indented [upto] whose next file line shares the prefix",
+      "static int parse(void) {\n    int ok = 0;\n    use(ok);\n"
+      "    return ok;\n}\n",
+      "    int ok = 0;\n    [upto]\n    return ok;\n}\n",
+      "    int ok = 0;\n    use(ok);\n    return ok;\n}\n", NULL },
+    { "two [upto] markers stay an error",
+      "int a;\nint b;\n",
+      "int a;\n[upto]\n[upto]\nint b;\n",
+      NULL, "more than one [upto]" },
+    { "blanks-only tail stays an error",
+      "int a;\nint b;\n",
+      "int a;\n[upto]  ",
+      NULL, "must include a unique tail anchor" },
+    { "absent head still reports the exact-match error",
+      "int a;\nint b;\n",
+      "int zz;\n    [upto]\nint b;\n",
+      NULL, "old head anchor not found" },
+};
+
+static void test_agent_edit_upto_whitespace_golden_cases(void) {
+    size_t ncases = sizeof(agent_edit_golden_cases) /
+                    sizeof(agent_edit_golden_cases[0]);
+    for (size_t i = 0; i < ncases; i++) {
+        const agent_edit_golden_case *t = &agent_edit_golden_cases[i];
+        const char *match = NULL;
+        size_t match_len = 0;
+        bool anchored = false;
+        char err[256] = "";
+        bool ok = agent_edit_find_old_span(t->file, strlen(t->file), t->old,
+                                           true, &match, &match_len, &anchored,
+                                           err, sizeof(err));
+        if (t->span) {
+            if (ok && match_len == strlen(t->span) &&
+                memcmp(match, t->span, match_len) == 0) continue;
+            if (ok)
+                fprintf(stderr, "golden case failed: %s (got span '%.*s')\n",
+                        t->name, (int)match_len, match);
+            else
+                fprintf(stderr, "golden case failed: %s (got error '%s')\n",
+                        t->name, err);
+        } else {
+            if (!ok && strstr(err, t->err_part) != NULL) continue;
+            fprintf(stderr,
+                    "golden case failed: %s (expected error '%s', got %s)\n",
+                    t->name, t->err_part, ok ? "a match" : err);
+        }
+        agent_test_failures++;
+    }
+}
+
 static void ds4_agent_unit_tests_run(void) {
     test_agent_edit_upto_tail_newline_is_not_part_of_anchor();
     test_agent_edit_upto_requires_tail_after_newline_strip();
@@ -7343,6 +7438,7 @@ static void ds4_agent_unit_tests_run(void) {
     test_agent_dsml_stream_tool_call_chunked();
     test_agent_glm_tool_parser_rejects_missing_value();
     test_agent_terminal_wrap_output_is_deferred();
+    test_agent_edit_upto_whitespace_golden_cases();
 }
 #endif
 


### PR DESCRIPTION
Follow-up to #338, one step further in the same failure class. Rebased on top of 7624c68 (the new `tests/ds4_agent_test.c` harness): the golden cases now live there instead of behind the `--self-test-edit` flag the first version of this PR added.

## The failure

The model sometimes writes the `[upto]` marker of an anchored edit indented like the surrounding code, or leaves trailing blanks before the newline:

```
<｜DSML｜parameter name="old" string="true">    x();
    [upto]
void b(void) {</｜DSML｜parameter>
```

`agent_edit_find_old_span()` folds that whitespace into the anchors: the head needle becomes `"    x();\n    "` and fails with `old head anchor not found` whenever the next file line doesn't share the marker's indentation prefix (dedenting line, closing brace, tabs-vs-spaces — the common shapes). `[upto]  ` with trailing blanks fails the same way on the tail (`old tail anchor not found after old head`). Since `agent_preflight_edit_old()` runs the same matcher, the stream aborts early and the model retries or rewrites the whole file — same UX as the newline case #338 fixed.

## Why not just trim the whitespace

The auto-upto forcer can inject `[upto]\n` after **partial indentation**: `agent_edit_old_is_only_space()` holds it back while the model streams blanks, so when it fires, the emitted prefix can end mid-indentation — and the forcer verified that *full* prefix, **including those blanks**, is unique in the file. Trimming unconditionally would make such a head match more places and break edits that work today.

So the fix matches the exact needles first (bit-for-bit today's behavior) and only on failure retries once with the marker line's blanks folded into the marker. Working edits are untouched; only current failures can be rescued. When both passes fail, the exact-match error is reported, as today. This invariant is locked as a golden case (`head whose uniqueness depends on its trailing blanks`).

## Commit 2: golden cases in the new test harness

Eleven table-driven golden cases for `agent_edit_find_old_span()` added to `ds4_agent_unit_tests_run()`, next to the two tests 7624c68 introduced: the indented/padded/CRLF variants this PR fixes, inline anchors, the forcer-injected mid-indentation case, the plain non-anchored path, and the error paths (double marker, blanks-only tail, absent head). The two commits are independent so the fix can be cherry-picked alone.

## Red → green

With commit 1 reverted and the tests kept, `./ds4_agent_test` fails exactly the four whitespace cases:

```
golden case failed: [upto] indented with a tab while the file uses spaces (got error 'old head anchor not found')
golden case failed: indented [upto] before a dedenting line (got error 'old head anchor not found')
golden case failed: trailing blanks between [upto] and the newline (got error 'old tail anchor not found after old head')
golden case failed: trailing blank then CRLF after [upto] (got error 'old tail anchor not found after old head')
ds4-agent tests: 4 failure(s)
```

With the fix, all thirteen pass (`ds4-agent tests: ok`), including the no-behavior-change cases (same-indent accidental match, inline `head [upto] tail`, forcer mid-indentation head, error paths).

## Testing

MacBook Pro M5 Max, 128 GB, macOS (Darwin 25.5), default Metal backend; model `DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix.gguf`.

```
make clean && make             # 0 warnings (-Wall -Wextra)
make ds4_agent_test && ./ds4_agent_test   # ds4-agent tests: ok
./ds4-eval --self-test-extractors
./ds4_test --server            # server: OK / ds4 tests: ok
make cpu                       # builds clean, 0 warnings
```

Live smoke on the same machine: a non-interactive `ds4-agent` session asked to replace a function body performed an anchored edit end-to-end, and the session itself demonstrated the forcer constraint above — the trace shows `edit old auto-upto replaced token=6042 text= double`, i.e. the marker was injected after partial indentation (the rendered old text shows the marker line as `   [upto]`, three blanks prefix-matching the file's four-blank indent), and the exact-needles-first path matched it. The edit applied correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
