### PR TITLE
ds4_server: Add /health endpoint that returns HTTP 200 once model is fully loaded

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -7708,6 +7708,7 @@ struct server {
     visible_live_state thinking_live;
     bool disable_exact_dsml_tool_replay;
     bool enable_cors;
+    volatile bool model_ready;
     pthread_mutex_t tool_mu;
     pthread_mutex_t mu;
     pthread_cond_t cv;
@@ -11147,6 +11148,16 @@ static void *client_main(void *arg) {
         goto done;
     }
 
+    if (!strcmp(hr.method, "GET") && !strcmp(hr.path, "/health")) {
+        if (s->model_ready) {
+            http_response(fd, s->enable_cors, 200, "text/plain", "ok");
+        } else {
+            http_error(fd, s->enable_cors, 503, "model not yet loaded");
+        }
+        http_request_free(&hr);
+        goto done;
+    }
+
     if (!strcmp(hr.method, "GET") && !strcmp(hr.path, "/v1/models")) {
         send_models(s, fd);
         http_request_free(&hr);
@@ -11625,6 +11636,7 @@ int main(int argc, char **argv) {
     s.disable_exact_dsml_tool_replay = cfg.disable_exact_dsml_tool_replay;
     s.tool_mem.max_entries = cfg.tool_memory_max_ids;
     s.enable_cors = cfg.enable_cors;
+    s.model_ready = true;
     if (cfg.kv_disk_dir) {
         kv_cache_open(&s.kv, cfg.kv_disk_dir, cfg.kv_disk_space_mb,
                       cfg.kv_cache_reject_different_quant, cfg.kv_cache);


### PR DESCRIPTION
### Summary
Adds a simple `/health` HTTP endpoint  to ds4_server.c, which returns `200 OK` once a model is fully loaded, and `503 Service Unavailable` otherwise.

### References to existing issues and pull requests
This fixes issue https://github.com/antirez/ds4/issues/334, so that tools such as llama-swap can start `ds4-server` and detect when it is ready to receive requests.

I note that there is open PR https://github.com/antirez/ds4/pull/326 which implements a more full-featured `/health` endpoint along with other endpoints. If that PR is favoured and merged I'm more than happy to close this one. 


### Test evidence
Manually tested with llama-swap and ds4-server on Strix Halo.

`ds4-server` logs:
```
ds4: ROCm startup model preparation covered 80.76 GiB of tensor spans in 0.642s
ds4: ROCm preparing model tensor mappings
ds4: ROCm startup model preparation covered 3.55 GiB of tensor spans in 0.012s
ds4: rocm backend initialized for graph diagnostics
0609 21:46:11 ds4-server: context buffers 4460.31 MiB (ctx=131072, backend=rocm, prefill_chunk=8192, raw_kv_rows=8192, compressed_kv_rows=32770)
0609 21:46:12 ds4-server: KV disk cache /tmp/ds4-kv (budget=8192 MiB, cross-quant=accept, min=512, cold_max=30000, continued=10000, trim=32, align=2048, hit_half_life=21600s)
0609 21:46:12 ds4-server: listening on http://127.0.0.1:5816
```

`llama-swap` logs:
```
2026-06-09T21:46:12+01:00 [INFO] <deepseek-v4-flash-ds4> Health check passed on http://localhost:5816/health
```