### PR TITLE
feat: add runtime file discovery chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ DS4_LINK_LIBS ?= $(CUDA_LDLIBS)
 METAL_LDLIBS := $(LDLIBS)
 endif
 
-.PHONY: all help clean test cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
+.PHONY: all help clean test cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm install-user
 
 ifeq ($(UNAME_S),Darwin)
 all: ds4 ds4-server ds4-bench ds4-eval ds4-agent
@@ -51,6 +51,7 @@ help:
 	@echo "  make cpu          Build CPU-only ./ds4, ./ds4-server, ./ds4-bench, ./ds4-eval, and ./ds4-agent"
 	@echo "  make test         Build and run tests"
 	@echo "  make clean        Remove build outputs"
+	@echo "  make install-user Install ds4 and ds4-agent to ~/.local/bin and runtime files to ~/.ds4/runtime"
 
 ds4: ds4_cli.o ds4_help.o linenoise.o $(CORE_OBJS)
 	$(CC) $(CFLAGS) -o $@ ds4_cli.o ds4_help.o linenoise.o $(CORE_OBJS) $(METAL_LDLIBS)
@@ -89,6 +90,7 @@ help:
 	@echo "  make cpu                 Build CPU-only ./ds4, ./ds4-server, ./ds4-bench, ./ds4-eval, and ./ds4-agent"
 	@echo "  make test                Build and run tests"
 	@echo "  make clean               Remove build outputs"
+	@echo "  make install-user        Install ds4 and ds4-agent to ~/.local/bin and runtime files to ~/.ds4/runtime"
 
 cuda-spark:
 	$(MAKE) -B ds4 ds4-server ds4-bench ds4-eval ds4-agent CUDA_ARCH=
@@ -239,6 +241,51 @@ test: ds4_test ds4_agent_test ds4-eval q4k-dot-test
 q4k-dot-test: tests/test_q4k_dot.c
 	$(CC) -O2 -Wall -Wextra -std=c99 -o tests/test_q4k_dot tests/test_q4k_dot.c -lm -pthread
 	./tests/test_q4k_dot
+
+# -----------------------------------------------------------------------
+# User-local install — no system directories touched.
+#
+# INSTALL_BIN_DIR  — where to copy ds4 and ds4-agent binaries
+#                     (default: ~/.local/bin)
+# RUNTIME_DIR      — where to place runtime files for ds4_find_runtime_file()
+#                     (default: ~/.ds4/runtime)
+#
+# The model file is NOT copied (multi-GB).  If ds4flash.gguf exists in the
+# build directory a symlink command is suggested; otherwise the download
+# script path is printed.
+# -----------------------------------------------------------------------
+INSTALL_BIN_DIR ?= $(HOME)/.local/bin
+RUNTIME_DIR     ?= $(HOME)/.ds4/runtime
+
+install-user: ds4 ds4-agent
+	@echo "==> Installing binaries to $(INSTALL_BIN_DIR)"
+	mkdir -p $(INSTALL_BIN_DIR)
+	install -m 0755 ds4        $(INSTALL_BIN_DIR)/ds4
+	install -m 0755 ds4-agent  $(INSTALL_BIN_DIR)/ds4-agent
+	@echo "==> Installing runtime files to $(RUNTIME_DIR)"
+	mkdir -p $(RUNTIME_DIR)/metal
+	for f in metal/*.metal; do \
+		install -m 0644 "$$f" $(RUNTIME_DIR)/metal/; \
+	done
+	@echo ""
+	@echo "==> Model file"
+	@if [ -f ds4flash.gguf ]; then \
+		M="$$(realpath ds4flash.gguf)"; \
+		echo "  ds4flash.gguf found at: $$M"; \
+		if [ ! -L $(RUNTIME_DIR)/ds4flash.gguf ] || [ "$$(readlink $(RUNTIME_DIR)/ds4flash.gguf)" != "$$M" ]; then \
+			echo ""; \
+			echo "  To use it from any CWD, create a symlink:"; \
+			echo "    ln -s '$$M' $(RUNTIME_DIR)/ds4flash.gguf"; \
+		else \
+			echo "  Symlink $(RUNTIME_DIR)/ds4flash.gguf already points to it."; \
+		fi; \
+	else \
+		echo "  No ds4flash.gguf found in the build directory."; \
+		echo "  To download a model, run:"; \
+		echo "    ./download_model.sh"; \
+	fi
+	@echo ""
+	@echo "==> Done.  Run ds4 or ds4-agent from anywhere."
 
 clean:
 	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test tests/test_q4k_dot *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o

--- a/ds4.c
+++ b/ds4.c
@@ -23876,7 +23876,16 @@ int ds4_dump_text_tokenization(const char *model_path, const char *text, FILE *f
     token_vec tokens = {0};
 
     if (!fp) fp = stdout;
-    model_open(&model, model_path, false, false);
+
+    /* Resolve model path through runtime file discovery chain. */
+    char *resolved = NULL;
+    const char *path = model_path;
+    if (path && path[0] && path[0] != '/') {
+        resolved = ds4_find_runtime_file(path);
+        if (resolved) path = resolved;
+    }
+    model_open(&model, path, false, false);
+    free(resolved);
     vocab_load(&vocab, &model);
     tokenize_rendered_chat_vocab(&vocab, text ? text : "", &tokens);
 

--- a/ds4.c
+++ b/ds4.c
@@ -24542,7 +24542,17 @@ int ds4_engine_open(ds4_engine **out, const ds4_engine_options *opt) {
     }
 
     const bool graph_backend = ds4_backend_uses_graph(opt->backend);
-    model_open(&e->model, opt->model_path, graph_backend, !opt->inspect_only);
+
+    /* Resolve model path through runtime file discovery chain unless the
+     * path is already absolute (user passed -m /full/path or env var). */
+    char *resolved_model = NULL;
+    const char *model_path = opt->model_path;
+    if (model_path && model_path[0] && model_path[0] != '/') {
+        resolved_model = ds4_find_runtime_file(model_path);
+        if (resolved_model) model_path = resolved_model;
+    }
+    model_open(&e->model, model_path, graph_backend, !opt->inspect_only);
+    free(resolved_model);
     if (opt->warm_weights) model_warm_weights(&e->model);
     if (!opt->inspect_only) vocab_load(&e->vocab, &e->model);
     config_validate_model(&e->model);
@@ -24624,7 +24634,14 @@ int ds4_engine_open(ds4_engine **out, const ds4_engine_options *opt) {
             *out = NULL;
             return 1;
         }
-        model_open(&e->mtp_model, opt->mtp_path, graph_backend, true);
+        char *resolved_mtp = NULL;
+        const char *mtp_path = opt->mtp_path;
+        if (mtp_path && mtp_path[0] && mtp_path[0] != '/') {
+            resolved_mtp = ds4_find_runtime_file(mtp_path);
+            if (resolved_mtp) mtp_path = resolved_mtp;
+        }
+        model_open(&e->mtp_model, mtp_path, graph_backend, true);
+        free(resolved_mtp);
         mtp_weights_bind(&e->mtp_weights, &e->mtp_model);
         e->mtp_ready = true;
         fprintf(stderr, "ds4: MTP support model loaded: %s (draft=%d)\n",
@@ -26596,6 +26613,89 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
     }
     return n_accept;
 #endif
+}
+
+/* ============================================================================
+ * Runtime file discovery
+ *
+ * ds4_find_runtime_file() searches for a runtime file (e.g. model weights,
+ * Metal kernel sources) using the following lookup chain:
+ *
+ *   1. Already absolute (starts with '/') → use as-is
+ *   2. $DS4_RUNTIME_DIR env var          → check there
+ *   3. Binary-relative (dirname of exe)   → check there
+ *   4. ~/.ds4/runtime/                   → check there
+ *   5. CWD-relative                       → current fallback
+ *
+ * Returns an allocated path or NULL.  Caller frees.
+ * ========================================================================= */
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#include <libgen.h>
+bool ds4_get_executable_path(char *buf, size_t len) {
+    uint32_t size = (uint32_t)len;
+    return _NSGetExecutablePath(buf, &size) == 0;
+}
+#elif defined(__linux__)
+bool ds4_get_executable_path(char *buf, size_t len) {
+    ssize_t n = readlink("/proc/self/exe", buf, len - 1);
+    if (n <= 0) return false;
+    buf[n] = '\0';
+    return true;
+}
+#else
+bool ds4_get_executable_path(char *buf, size_t len) {
+    (void)buf; (void)len;
+    return false;  /* fallback to CWD */
+}
+#endif
+
+char *ds4_find_runtime_file(const char *name) {
+    /* 1. Already absolute? */
+    if (name[0] == '/') return strdup(name);
+
+    /* 2. DS4_RUNTIME_DIR env var */
+    const char *rt = getenv("DS4_RUNTIME_DIR");
+    if (rt && rt[0]) {
+        char *p = NULL;
+        if (asprintf(&p, "%s/%s", rt, name) > 0) {
+            if (p && access(p, F_OK) == 0) return p;
+            free(p);
+        }
+    }
+
+    /* 3. Binary-relative */
+    char exe_path[PATH_MAX];
+    if (ds4_get_executable_path(exe_path, sizeof(exe_path))) {
+        /* dirname may modify in-place; make a copy */
+        char *copy = strdup(exe_path);
+        if (copy) {
+            char *dir = dirname(copy);
+            char *p = NULL;
+            if (asprintf(&p, "%s/%s", dir, name) > 0) {
+                if (p && access(p, F_OK) == 0) {
+                    free(copy);
+                    return p;
+                }
+                free(p);
+            }
+            free(copy);
+        }
+    }
+
+    /* 4. ~/.ds4/runtime/ */
+    const char *home = getenv("HOME");
+    if (home) {
+        char *p = NULL;
+        if (asprintf(&p, "%s/.ds4/runtime/%s", home, name) > 0) {
+            if (p && access(p, F_OK) == 0) return p;
+            free(p);
+        }
+    }
+
+    /* 5. Fall back to name as relative-from-CWD */
+    return access(name, F_OK) == 0 ? strdup(name) : NULL;
 }
 
 void ds4_session_invalidate(ds4_session *s) {

--- a/ds4.h
+++ b/ds4.h
@@ -144,6 +144,12 @@ typedef struct {
     uint64_t bytes;
 } ds4_session_payload_file;
 
+/* Runtime file discovery — see ds4_find_runtime_file() in ds4.c for the
+ * lookup chain: absolute path → $DS4_RUNTIME_DIR → binary-relative →
+ * ~/.ds4/runtime/ → CWD-relative (current fallback). */
+bool ds4_get_executable_path(char *buf, size_t len);
+char *ds4_find_runtime_file(const char *name);
+
 int ds4_engine_open(ds4_engine **out, const ds4_engine_options *opt);
 void ds4_engine_close(ds4_engine *e);
 void ds4_engine_summary(ds4_engine *e);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -2860,7 +2860,6 @@ static const char *ds4_gpu_source =
 
 static NSString *ds4_gpu_full_source(void) {
     NSString *base = [NSString stringWithUTF8String:ds4_gpu_source];
-    NSFileManager *fm = [NSFileManager defaultManager];
     /*
      * Kernels are kept as separate files for review, then concatenated into one
      * Metal library.  Environment overrides are still honored so a diagnostic
@@ -2891,29 +2890,41 @@ static NSString *ds4_gpu_full_source(void) {
     NSMutableString *source = [NSMutableString stringWithString:base];
     for (NSArray<NSString *> *spec in required_sources) {
         const char *override_path = getenv([spec[0] UTF8String]);
-        NSMutableArray<NSString *> *paths = [NSMutableArray array];
-        if (override_path && override_path[0]) {
-            [paths addObject:[NSString stringWithUTF8String:override_path]];
-        }
-        [paths addObject:spec[1]];
-        [paths addObject:[@"./" stringByAppendingString:spec[1]]];
-
         NSString *loaded = nil;
         NSString *loaded_path = nil;
-        for (NSString *path in paths) {
-            if (![fm fileExistsAtPath:path]) continue;
 
+        if (override_path && override_path[0]) {
+            loaded_path = [NSString stringWithUTF8String:override_path];
             NSError *error = nil;
-            loaded = [NSString stringWithContentsOfFile:path
+            loaded = [NSString stringWithContentsOfFile:loaded_path
                                                encoding:NSUTF8StringEncoding
                                                   error:&error];
             if (!loaded) {
                 fprintf(stderr, "ds4: failed to read Metal source %s: %s\n",
-                        [path UTF8String], [[error localizedDescription] UTF8String]);
+                        [loaded_path UTF8String],
+                        [[error localizedDescription] UTF8String]);
                 return nil;
             }
-            loaded_path = path;
-            break;
+        } else {
+            /* Use runtime file discovery chain: $DS4_RUNTIME_DIR →
+             * binary-relative → ~/.ds4/runtime/ → CWD. */
+            char *found = ds4_find_runtime_file([spec[1] UTF8String]);
+            if (found) {
+                loaded_path = [NSString stringWithUTF8String:found];
+                NSError *error = nil;
+                loaded = [NSString stringWithContentsOfFile:loaded_path
+                                                   encoding:NSUTF8StringEncoding
+                                                      error:&error];
+                if (!loaded) {
+                    fprintf(stderr,
+                            "ds4: failed to read Metal source %s: %s\n",
+                            [loaded_path UTF8String],
+                            [[error localizedDescription] UTF8String]);
+                    free(found);
+                    return nil;
+                }
+                free(found);
+            }
         }
 
         if (!loaded) {


### PR DESCRIPTION
This PR adds automatic discovery for runtime files to `ds4` and `ds4-agent`, so they can be run from anywhere without fuss.

There is also a new Makefile target `install-user` that installs those runtime files automatically, defensively.

This works for me on macOS, it may need polish for other platforms.

Automatically generated PR message below:

---

## Problem

ds4-agent currently depends on the process CWD to find the model file, Metal kernel sources, and expert routing files. The user must either launch from the ds4 source tree, use --chdir to point to it, or pass -m /full/path/to/model.gguf explicitly every time. This is fragile and confusing — the binary should "just work" from any directory.

## Solution

Add a runtime file discovery chain and a make install-user target so the binaries work from any CWD with zero flags.

### Runtime discovery (ds4.c, ds4_metal.m, ds4.h)

New functions ds4_get_executable_path() and ds4_find_runtime_file() search for runtime files in this order:

1. Absolute path (starts with /) → used as-is
2. $DS4_RUNTIME_DIR env var → checked first
3. Binary-relative (dirname of the running executable) → checked next
4. ~/.ds4/runtime/ → user-level runtime directory
5. CWD-relative → current fallback (preserved for backward compat)

Where the lookup is applied:

| Call site | File | What it resolves |
|---|---|---|
| ds4_engine_open() | ds4.c | model_path, mtp_path |
| ds4_dump_text_tokenization() | ds4.c | model_path for --dump-tokens |
| ds4_gpu_full_source() | ds4_metal.m | metal/*.metal kernel sources |

### User-local install (Makefile)

New make install-user target copies files to user-local paths (no system directories touched):

| File | Destination | Notes |
|---|---|---|
| ds4 | ~/.local/bin/ds4 | Configurable via INSTALL_BIN_DIR |
| ds4-agent | ~/.local/bin/ds4-agent | Same |
| metal/*.metal | ~/.ds4/runtime/metal/ | 19 kernel files |
| Model symlink | Suggested, not auto-created | Prints ln -s command if ds4flash.gguf exists |
| Download instructions | Printed | Points to download_model.sh if no model found |

The model file itself is never copied (multi-GB, fragile). If ds4flash.gguf exists in the build directory the install target prints a one-line ln -s command the user can run explicitly.

--chdir is kept for backward compatibility but is now rarely needed.

Files changed: 4 files, +191/-18 lines