### PR TITLE
Skip MTP probes while drafts go unused

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -22214,6 +22214,7 @@ struct ds4_session {
     int mtp_draft_token;
     uint64_t mtp_probe_total;
     uint64_t mtp_probe_hit;
+    uint32_t mtp_probe_skip;
     ds4_session_progress_fn progress;
     void *progress_ud;
     ds4_session_progress_fn display_progress;
@@ -25952,6 +25953,13 @@ static int ds4_session_eval_internal(ds4_session *s, int token, bool probe_mtp,
                     s->mtp_draft_token,
                     (unsigned long long)s->mtp_probe_hit,
                     (unsigned long long)s->mtp_probe_total);
+        } else {
+            /* Nothing consumed the pending draft, so the caller is decoding
+             * outside the speculative path (sampled spans do this on every
+             * token) and the drafter eval below is wasted work.  Keep one
+             * probe in sixteen so speculation resumes quickly when the
+             * caller returns to greedy decoding. */
+            s->mtp_probe_skip = 15;
         }
         s->mtp_draft_valid = false;
     }
@@ -25965,7 +25973,9 @@ static int ds4_session_eval_internal(ds4_session *s, int token, bool probe_mtp,
         return 1;
     }
     token_vec_push(&s->checkpoint, token);
-    if (mtp_should_draft) {
+    if (s->mtp_probe_skip > 0) {
+        s->mtp_probe_skip--;
+    } else if (mtp_should_draft) {
         int mtp_top = -1;
         if (metal_graph_eval_mtp_draft(&s->graph,
                                        &e->model,
@@ -26050,6 +26060,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
     int draft_n = 1;
     drafts[0] = s->mtp_draft_token;
     s->mtp_draft_valid = false;
+    s->mtp_probe_skip = 0;
     const bool strict_mtp = e->quality || getenv("DS4_MTP_STRICT") != NULL;
     float mtp_margin_threshold = e->mtp_margin;
     const char *mtp_margin_env = getenv("DS4_MTP_MIN_MARGIN");


### PR DESCRIPTION
Loading `--mtp` makes every plain (non-speculative) eval run the MTP drafter, and when the next call is also a plain eval the draft is invalidated unused. Sampled decoding does this on every token, so any temp>0 span pays a full drafter pass per token with no way to use the result. Measured on an M4 Max (q2-q4-imatrix base, Q4K/Q8 MTP head), paired and interleaved: generating at temp 0.7 with `--mtp` loaded runs 6.5% slower [6.3, 6.7] than without it. The tax is easy to miss because any baseline with `--mtp` loaded pays it too, including `DS4_MTP_SPEC_DISABLE` runs.

The fix is one session counter: when a pending draft is invalidated unused, skip the next 15 probes; a consumed draft resets it. Greedy decoding never arms the skip, since its drafts are always consumed, so the speculative path is untouched: greedy output is byte-identical with and without the patch on copy and prose prompts, and `--mtp-verify-depth` passes.

With the patch, sampled generation with `--mtp` loaded is back to within 0.4% [0.1, 0.8] of not loading it. Under a live pi coding-agent task against ds4-server (mixed greedy tool-call spans and sampled spans, 250k ctx), token-weighted decode improves +2.7% to +7.6% over three paired rounds (mean +5.4%), with the task succeeding in every run.

Not addressed, measured for scope: low-acceptance greedy content (free-flowing prose at temp 0) still pays the probe for drafts that are consumed but rejected; that is the -5.4% draft-2 row in the #369 table, a different effect from this tax. A rate-based gate prototype recovers about half of it; glad to send that separately if you want it, kept out of here so this stays one mechanism.
