### PR TITLE
fix(kv-cache): refresh cold anchor after partial prefix hits

### DIFF
--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -753,6 +753,24 @@ void ds4_kvstore_note_store(ds4_kvstore *kc, int tokens) {
     }
 }
 
+int ds4_kvstore_cold_store_target(const ds4_kvstore *kc, int cached,
+                                  int anchor, int prompt_tokens) {
+    if (!kc->enabled || kc->opt.cold_max_tokens <= 0) return 0;
+    if (prompt_tokens < kc->opt.min_tokens) return 0;
+    if (prompt_tokens > kc->opt.cold_max_tokens) return 0;
+    if (cached == 0) {
+        return anchor >= kc->opt.min_tokens ?
+               anchor : ds4_kvstore_store_len(kc, prompt_tokens);
+    }
+    /* The prompt resumed from a checkpoint shorter than the stable chat
+     * prefix.  The anchor stored on disk no longer matches this prompt,
+     * otherwise the lookup would have returned it instead of the shorter
+     * entry.  Refresh the anchor so the next fresh session reuses the full
+     * stable prefix instead of repaying anchor-minus-cached tokens on every
+     * new conversation. */
+    return anchor > cached ? anchor : 0;
+}
+
 int ds4_kvstore_suppress_continued_store(ds4_kvstore *kc, int tokens) {
     if (ds4_kvstore_continued_store_target(kc, tokens) != tokens) return -1;
     int old = kc->continued_last_store_tokens;

--- a/ds4_kvstore.h
+++ b/ds4_kvstore.h
@@ -138,6 +138,8 @@ int ds4_kvstore_chat_anchor_pos(const ds4_kvstore *kc,
                                 int user_token_id,
                                 int assistant_token_id);
 int ds4_kvstore_continued_store_target(const ds4_kvstore *kc, int live_tokens);
+int ds4_kvstore_cold_store_target(const ds4_kvstore *kc, int cached,
+                                  int anchor, int prompt_tokens);
 void ds4_kvstore_note_store(ds4_kvstore *kc, int tokens);
 int ds4_kvstore_suppress_continued_store(ds4_kvstore *kc, int tokens);
 void ds4_kvstore_restore_suppressed_continued(ds4_kvstore *kc,

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -8642,6 +8642,11 @@ static int kv_cache_continued_store_target(const kv_disk_cache *kc, int live_tok
     return ds4_kvstore_continued_store_target(kc, live_tokens);
 }
 
+static int kv_cache_cold_store_target(const kv_disk_cache *kc, int cached,
+                                      int anchor, int prompt_tokens) {
+    return ds4_kvstore_cold_store_target(kc, cached, anchor, prompt_tokens);
+}
+
 /* A same-text-prefix file can be reused by a larger context, but not by a
  * smaller one: the payload was validated against the context capacity recorded
  * in the file.  If the existing file cannot be used by this server, replace it
@@ -10181,17 +10186,28 @@ static void generate_job(server *s, job *j) {
     ds4_session_set_display_progress(s->session, server_progress_cb, &progress);
 
     int cold_store_len = 0;
-    if (cached == 0 &&
-        s->kv.enabled &&
-        prompt_for_sync->len >= s->kv.opt.min_tokens &&
-        s->kv.opt.cold_max_tokens > 0 &&
-        prompt_for_sync->len <= s->kv.opt.cold_max_tokens)
-    {
-        const int anchor = kv_cache_chat_anchor_pos(&s->kv, prompt_for_sync,
-                                                    ds4_token_user(s->engine),
-                                                    ds4_token_assistant(s->engine));
-        cold_store_len = anchor >= s->kv.opt.min_tokens ?
-                         anchor : kv_cache_store_len(&s->kv, prompt_for_sync->len);
+    if (s->kv.enabled && prompt_for_sync->len >= s->kv.opt.min_tokens) {
+        if (s->kv.opt.cold_max_tokens > 0 &&
+            prompt_for_sync->len > s->kv.opt.cold_max_tokens)
+        {
+            /* Without this hint the skip is invisible: agent clients whose
+             * first prompt grows past the limit (tool schemas, MCP servers)
+             * silently lose cold checkpoints and repay the full stable
+             * prefix on every fresh session. */
+            if (cached == 0) {
+                server_log(DS4_LOG_WARNING,
+                           "ds4-server: cold checkpoint skipped: prompt %d "
+                           "tokens exceeds --kv-cache-cold-max-tokens %d",
+                           prompt_for_sync->len, s->kv.opt.cold_max_tokens);
+            }
+        } else {
+            const int anchor =
+                kv_cache_chat_anchor_pos(&s->kv, prompt_for_sync,
+                                         ds4_token_user(s->engine),
+                                         ds4_token_assistant(s->engine));
+            cold_store_len = kv_cache_cold_store_target(&s->kv, cached, anchor,
+                                                        prompt_for_sync->len);
+        }
     }
     int suppressed_continued_last = -1;
     if (cold_store_len >= s->kv.opt.min_tokens) {
@@ -14686,6 +14702,47 @@ static void test_kv_cache_continued_uses_aligned_frontiers(void) {
     TEST_ASSERT(kv_cache_continued_store_target(&kc, 30000) == 30000);
 }
 
+static void test_kv_cache_cold_store_target_cold_start(void) {
+    kv_disk_cache kc = {0};
+    kc.enabled = true;
+    kc.opt = kv_cache_default_options();
+
+    /* Cold start with a usable anchor stores at the anchor. */
+    TEST_ASSERT(kv_cache_cold_store_target(&kc, 0, 27005, 30000) == 27005);
+    /* Cold start without an anchor falls back to the aligned boundary. */
+    TEST_ASSERT(kv_cache_cold_store_target(&kc, 0, -1, 11011) == 10240);
+    /* Prompts past cold_max never store cold. */
+    TEST_ASSERT(kv_cache_cold_store_target(&kc, 0, 27005, 30001) == 0);
+    /* Short prompts never store cold. */
+    TEST_ASSERT(kv_cache_cold_store_target(&kc, 0, -1, 100) == 0);
+
+    kc.opt.cold_max_tokens = 0;
+    TEST_ASSERT(kv_cache_cold_store_target(&kc, 0, 27005, 30000) == 0);
+
+    kc.opt = kv_cache_default_options();
+    kc.enabled = false;
+    TEST_ASSERT(kv_cache_cold_store_target(&kc, 0, 27005, 30000) == 0);
+}
+
+static void test_kv_cache_cold_store_target_refreshes_anchor_after_partial_hit(void) {
+    kv_disk_cache kc = {0};
+    kc.enabled = true;
+    kc.opt = kv_cache_default_options();
+
+    /* A partial hit below the anchor proves the stored anchor no longer
+     * matches this prompt: refresh it. */
+    TEST_ASSERT(kv_cache_cold_store_target(&kc, 20480, 27005, 30000) == 27005);
+    /* A hit at or past the anchor means the stable prefix is already
+     * covered: nothing to refresh. */
+    TEST_ASSERT(kv_cache_cold_store_target(&kc, 27005, 27005, 30000) == 0);
+    TEST_ASSERT(kv_cache_cold_store_target(&kc, 29000, 27005, 30000) == 0);
+    /* No anchor: partial hits have nothing to refresh (no full-prompt
+     * fallback, that would duplicate the evict/continued schedule). */
+    TEST_ASSERT(kv_cache_cold_store_target(&kc, 20480, -1, 30000) == 0);
+    /* Oversize prompts stay excluded on partial hits too. */
+    TEST_ASSERT(kv_cache_cold_store_target(&kc, 20480, 27005, 30001) == 0);
+}
+
 static void test_kv_cache_cold_store_suppresses_duplicate_continued_boundary(void) {
     kv_disk_cache kc = {0};
     kc.enabled = true;
@@ -15700,6 +15757,8 @@ static void ds4_server_unit_tests_run(void) {
     test_kv_cache_chat_anchor_uses_last_user_before_assistant();
     test_kv_cache_chat_anchor_ignores_multiturn_tail();
     test_kv_cache_continued_uses_aligned_frontiers();
+    test_kv_cache_cold_store_target_cold_start();
+    test_kv_cache_cold_store_target_refreshes_anchor_after_partial_hit();
     test_kv_cache_cold_store_suppresses_duplicate_continued_boundary();
     test_kv_cache_file_size_must_fit_budget();
     test_sha1_bytes_hex_matches_known_vector();


### PR DESCRIPTION
Fixes #393. Also adds the skip hint proposed in #392 (the default-value question is left to that issue).

Cold checkpoints were only written on fully cold prefills (`cached == 0`). When the stable chat prefix changes between sessions (agent clients rewrite an early prompt block — Claude Code does this on every git commit), fresh sessions partially hit a shorter `continued` waypoint, `cached != 0` blocks the cold path, and the stale anchor is never replaced. Every subsequent fresh session repays `anchor - waypoint` tokens forever; we measured the cache permanently running at half its designed benefit (13.8s prefill with a fresh anchor vs ~30s steady state, logs in #393).

## Change

- Extract the cold-store decision into `ds4_kvstore_cold_store_target()` next to the existing `ds4_kvstore_continued_store_target()`. Cold starts keep the original behavior (anchor, else aligned boundary of the full prompt).
- New case: a partial hit **below** the anchor (`0 < cached < anchor`) now stores the anchor during the same prefill. The lookup returning a shorter entry proves no matching anchor exists on disk, so this never rewrites a matching checkpoint; hits at or past the anchor store nothing. Cost: one extra checkpoint write (~70 ms for a 27K-token anchor on our setup) on the first session after the prefix changed.
- Log a one-line hint when a fully cold prompt skips the cold store because it exceeds `--kv-cache-cold-max-tokens` (#392); previously the skip was invisible.

## Test plan

- [x] `make` clean build, Apple Silicon / Metal (M4)
- [x] `./ds4_test --server` passes, including two new unit tests:
  - `test_kv_cache_cold_store_target_cold_start` — original behavior preserved (anchor, boundary fallback, cold_max/min/enabled gates)
  - `test_kv_cache_cold_store_target_refreshes_anchor_after_partial_hit` — refresh below anchor; no store at/past anchor, without anchor, or past cold_max
- [x] Production verification done on M2 Ultra (192 GiB, DeepSeek V4 Flash q2-q4-imatrix, Claude Code workload): after a git commit invalidated the anchor, the first fresh session logged `reason=cold tokens=27009` mid-prefill and the second fresh session returned to 13.8s prefill (vs ~30s steady state unpatched). Logs in the comment below.

Co-authored with Claude (analysis from sse-tee request-body diffs + L3 logs of a production deployment; details in #392/#393).
