### PR TITLE
Add multi-column attn-out low projection kernel for small batches

### DIFF
--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -15711,7 +15711,17 @@ int ds4_gpu_attention_output_q8_batch_tensor(
         (void)group_tmp;
         (void)low_tmp;
 
+        /* Multi-column low projection: one weight read serves every token
+         * column, instead of the per-(group, token) dispatch re-reading the
+         * out_a weights n_tokens times.  This is the dominant cost of this
+         * stage in small-batch verify passes. */
+        const bool use_ext_low =
+            n_tokens >= 2u && n_tokens <= 8u &&
+            (group_dim % 128u) == 0 &&
+            ds4_gpu_mv_ext_r1ptg(n_tokens) != 0 &&
+            getenv("DS4_METAL_DISABLE_ATTN_OUT_LOW_EXT") == NULL;
         const bool use_direct_low =
+            !use_ext_low &&
             n_tokens < 32u && getenv("DS4_METAL_DISABLE_ATTN_OUT_LOW_DIRECT") == NULL;
         /* The exported TensorOps attention-output kernel is a 64-token tile.
          * Keep this on full tiles only; smaller multiples of 32 use the legacy
@@ -15722,7 +15732,7 @@ int ds4_gpu_attention_output_q8_batch_tensor(
             ds4_gpu_use_mpp_attn_out_low_matmul();
         const NSUInteger ids_bytes = (NSUInteger)n_tokens * (NSUInteger)n_groups * sizeof(int32_t);
         id<MTLBuffer> group_ids_buffer = nil;
-        if (!use_direct_low && !use_mpp_low) {
+        if (!use_direct_low && !use_mpp_low && !use_ext_low) {
             if (getenv("DS4_METAL_DISABLE_ATTN_OUT_IDS_CACHE") != NULL) {
                 group_ids_buffer =
                     ds4_gpu_new_transient_buffer(ids_bytes, "attention output group ids");
@@ -15908,6 +15918,59 @@ int ds4_gpu_attention_output_q8_batch_tensor(
                                                 ds4_gpu_tensor_offset(low),
                                                 group_ids_buffer,
                                                 0) != 0;
+            } else if (use_ext_low) {
+                const int16_t ext_nsg = 2;
+                const int16_t ext_nxpsg = ds4_gpu_mv_ext_nxpsg(group_dim, n_tokens);
+                const int16_t ext_r1ptg = ds4_gpu_mv_ext_r1ptg(n_tokens);
+                const char *ext_fn = NULL;
+                switch (ext_r1ptg) {
+                case 2: ext_fn = "kernel_dsv4_attn_out_low_ext_q8_0_r1_2"; break;
+                case 3: ext_fn = "kernel_dsv4_attn_out_low_ext_q8_0_r1_3"; break;
+                case 4: ext_fn = "kernel_dsv4_attn_out_low_ext_q8_0_r1_4"; break;
+                case 5: ext_fn = "kernel_dsv4_attn_out_low_ext_q8_0_r1_5"; break;
+                default: break;
+                }
+                id<MTLComputePipelineState> ext_pipeline =
+                    ext_fn ? ds4_gpu_get_mul_mv_ext_pipeline(ext_fn, ext_nsg, ext_nxpsg) : nil;
+                ok = ext_pipeline != nil;
+                if (ok) {
+                    const int16_t ext_nypsg = 32 / ext_nxpsg;
+                    const NSUInteger ext_r0ptg = (NSUInteger)ext_nypsg * (NSUInteger)ext_nsg;
+                    /* z slice = head group: weights slab g at nb02 strides,
+                     * src1 columns stride by token (nb11) within a group
+                     * (nb12); dst is token-major via the dst_tm=1 kernel. */
+                    ds4_gpu_mul_mv_ext_args ext_args = {
+                        .ne00 = (int32_t)group_dim,
+                        .ne01 = (int32_t)rank,
+                        .ne02 = (int32_t)n_groups,
+                        .nb00 = 34,
+                        .nb01 = row_a_bytes,
+                        .nb02 = (uint64_t)rank * row_a_bytes,
+                        .nb03 = 0,
+                        .ne10 = (int32_t)group_dim,
+                        .ne11 = (int32_t)n_tokens,
+                        .ne12 = (int32_t)n_groups,
+                        .nb10 = sizeof(float),
+                        .nb11 = (uint64_t)n_groups * group_dim * sizeof(float),
+                        .nb12 = (uint64_t)group_dim * sizeof(float),
+                        .nb13 = 0,
+                        .ne0 = (int32_t)rank,
+                        .ne1 = (int32_t)n_tokens,
+                        .r2 = 1,
+                        .r3 = 1,
+                    };
+                    id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
+                    [enc setComputePipelineState:ext_pipeline];
+                    [enc setBytes:&ext_args length:sizeof(ext_args) atIndex:0];
+                    [enc setBuffer:out_a_buf offset:(NSUInteger)out_a_inner atIndex:1];
+                    [enc setBuffer:ds4_gpu_tensor_buffer(heads) offset:ds4_gpu_tensor_offset(heads) atIndex:2];
+                    [enc setBuffer:ds4_gpu_tensor_buffer(low) offset:ds4_gpu_tensor_offset(low) atIndex:3];
+                    [enc dispatchThreadgroups:MTLSizeMake(((NSUInteger)rank + ext_r0ptg - 1u) / ext_r0ptg,
+                                                          ((NSUInteger)n_tokens + (NSUInteger)ext_r1ptg - 1u) / (NSUInteger)ext_r1ptg,
+                                                          (NSUInteger)n_groups)
+                         threadsPerThreadgroup:MTLSizeMake(32, (NSUInteger)ext_nsg, 1)];
+                    ds4_gpu_end_compute_encoder(cb, enc);
+                }
             } else if (use_direct_low) {
                 ds4_gpu_mul_mv_id_args args = {
                     .nei0 = (int32_t)n_groups,

--- a/metal/dense.metal
+++ b/metal/dense.metal
@@ -787,7 +787,11 @@ void dequantize_q8_0_t4(device const block_q8_0 *xb, short il, thread type4 & re
 }
 
 // DS4 small-batch mat-vec kernel used for 2..8 prompt tokens.
-template<short r1ptg, typename q_t, short chpb, void (*deq_t4)(device const q_t *, short, thread float4 &) >
+// dst_tm selects the dst layout: 0 keeps the standard [batch][column][row]
+// order; 1 writes token-major [column][batch][row] (column stride
+// ne0*ne12), which is the low[token][group][rank] layout the attention
+// output projection consumes without a transpose pass.
+template<short r1ptg, typename q_t, short chpb, void (*deq_t4)(device const q_t *, short, thread float4 &), short dst_tm = 0 >
 void kernel_mul_mv_ext_q4_f32_impl(
         constant ds4_metal_args_mul_mv_ext & args,
         device const char * src0,
@@ -877,7 +881,9 @@ void kernel_mul_mv_ext_q4_f32_impl(
 
     if (tx == 0) {
         for (short ir1 = 0; ir1 < r1ptg && i11 + ir1 < args.ne11; ++ir1) {
-            device float * dst_f32 = (device float *) dst + (uint64_t)i1m*args.ne0*args.ne1 + (uint64_t)(i11 + ir1)*args.ne0;
+            device float * dst_f32 = dst_tm == 0
+                ? (device float *) dst + (uint64_t)i1m*args.ne0*args.ne1 + (uint64_t)(i11 + ir1)*args.ne0
+                : (device float *) dst + (uint64_t)(i11 + ir1)*args.ne0*args.ne12 + (uint64_t)i1m*args.ne0;
 
             if (i01 < args.ne01) {
                 dst_f32[i01] = sumf[ir1];
@@ -913,6 +919,29 @@ template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_2")]] kernel mul_mv_ext_q4_f
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_3")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q8_0, 32, dequantize_q8_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_4")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q8_0, 32, dequantize_q8_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_5")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q8_0, 32, dequantize_q8_0_t4>;
+
+// DS4 attention-output low projection, small-batch multi-column variant.
+// One grid z slice per head group; each weight read is shared across all
+// token columns (the per-token re-read in kernel_dsv4_attn_out_low_q8_0_f32
+// is the dominant batch-verify cost of this stage).  src1 columns stride by
+// token (args.nb11 = token stride, args.nb12 = group stride) and dst is
+// written token-major via dst_tm=1 so the out_b matmul reads it directly.
+template<short r1ptg, typename q_t, short epb, void (*deq_t4)(device const q_t *, short, thread float4 &)>
+kernel void kernel_dsv4_attn_out_low_ext_disp(
+        constant ds4_metal_args_mul_mv_ext & args,
+        device const char * src0,
+        device const char * src1,
+        device       char * dst,
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort  tiisg[[thread_index_in_simdgroup]],
+        ushort  sgitg[[simdgroup_index_in_threadgroup]]) {
+    kernel_mul_mv_ext_q4_f32_impl<r1ptg, q_t, epb/4, deq_t4, 1>(args, src0, src1, dst, tgpig, tiisg, sgitg);
+}
+
+template [[host_name("kernel_dsv4_attn_out_low_ext_q8_0_r1_2")]] kernel mul_mv_ext_q4_f32_t kernel_dsv4_attn_out_low_ext_disp<2, block_q8_0, 32, dequantize_q8_0_t4>;
+template [[host_name("kernel_dsv4_attn_out_low_ext_q8_0_r1_3")]] kernel mul_mv_ext_q4_f32_t kernel_dsv4_attn_out_low_ext_disp<3, block_q8_0, 32, dequantize_q8_0_t4>;
+template [[host_name("kernel_dsv4_attn_out_low_ext_q8_0_r1_4")]] kernel mul_mv_ext_q4_f32_t kernel_dsv4_attn_out_low_ext_disp<4, block_q8_0, 32, dequantize_q8_0_t4>;
+template [[host_name("kernel_dsv4_attn_out_low_ext_q8_0_r1_5")]] kernel mul_mv_ext_q4_f32_t kernel_dsv4_attn_out_low_ext_disp<5, block_q8_0, 32, dequantize_q8_0_t4>;
 
 constant bool FC_mul_mm_bc_inp [[function_constant(FC_MUL_MM + 0)]];
 constant bool FC_mul_mm_bc_out [[function_constant(FC_MUL_MM + 1)]];


### PR DESCRIPTION
The batched attention-output low projection dispatched one (group, token) matvec per grid slice, re-reading the out_a weights once per token. The new kernel_dsv4_attn_out_low_ext_q8_0_r1_{2..5} variants reuse the small-batch ext mat-vec body (one weight read serves every token column) with a token-major dst mode so the out_b matmul consumes the result directly. Engaged for 2..8-token batches, which today means the MTP batch-verify suffix passes; DS4_METAL_DISABLE_ATTN_OUT_LOW_EXT restores the per-token path.

Measured on M5 Max: low_proj stage 0.472 -> 0.314 ms/layer in an 8-token verify pass; --mtp --mtp-draft 4 greedy run 27.6 -> 28.4 t/s with output byte-identical to the old path at batch widths 2/4/6/8; --long-context gate OK. Any future consumer of small verify batches gets the same per-pass saving.