### PR TITLE
Fix bug with impact on DeepSeek V4 Pro MTP Drafter usage

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -14016,9 +14016,14 @@ static bool metal_graph_encode_decode_layer(
     const uint64_t expert_mid_dim = layer->ffn_gate_exps->dim[1];
     const uint64_t down_in_dim = layer->ffn_down_exps->dim[0];
     const uint64_t routed_out_dim = layer->ffn_down_exps->dim[1];
-    const bool compressed = ds4_layer_compress_ratio(il) != 0;
-    const float freq_base = layer_rope_freq_base(il);
-    const float freq_scale = layer_rope_freq_scale(il);
+    /* The MTP draft block is dense (no KV compressor) but borrows il=1, whose ratio
+     * is non-zero on Pro (all Pro main layers are compressed). Detect the dense block
+     * by its absent compressor and force dense compression + RoPE, so Pro MTP works
+     * (matches Flash, where layer 1 is naturally dense). Also covers ratio-0 layers. */
+    const bool dense_layer = (layer->attn_compressor_kv == NULL);
+    const bool compressed = !dense_layer && ds4_layer_compress_ratio(il) != 0;
+    const float freq_base = dense_layer ? DS4_ROPE_FREQ_BASE : layer_rope_freq_base(il);
+    const float freq_scale = dense_layer ? 1.0f : layer_rope_freq_scale(il);
     const float ext_factor = compressed && DS4_ROPE_SCALE_FACTOR > 1.0f ? 1.0f : 0.0f;
     float attn_factor = 1.0f;
     if (ext_factor != 0.0f && freq_scale > 0.0f) {
@@ -19071,7 +19076,7 @@ static bool metal_graph_eval_mtp_draft_from_hc(
         ok = metal_graph_encode_decode_layer(g,
                                              mtp_model,
                                              &mtp->block,
-                                             1,
+                                             1, /* in-bounds; MTP forced dense in encode_decode_layer (absent compressor) */
                                              pos,
                                              g->mtp_raw_cache,
                                              g->raw_cap,


### PR DESCRIPTION
# Bug: MTP speculative decoding broken for DeepSeek V4 **Pro** (works on Flash)

## Summary

The MTP draft path hardcodes layer index `il = 1` when invoking
`metal_graph_encode_decode_layer()` for the MTP block. `il` is then used to derive
the layer's compression *and* RoPE behavior via `ds4_layer_compress_ratio(il)`.
This is correct only when layer 1 is dense. On **Flash** layer 1 is dense
(`compress_ratios[1] == 0`), so MTP works. On **Pro** every main layer is
compressed (`compress_ratios = [128,128,4,128,4,…,4,0]`; only the MTP's own index
`n_layer` is 0), so `il = 1` makes the engine treat the dense MTP block as
compressed.

## Symptom (Pro + `--mtp`)

Per generated token:

```
ds4: Metal graph compressor expects paired F16 compressor projections
```

Output is still correct (verifier falls back), but speculation is effectively
disabled and stderr is flooded.

## Root cause

`ds4.c`, MTP draft call (~line 19071):

```c
ok = metal_graph_encode_decode_layer(g, mtp_model, &mtp->block,
                                     1,            // <-- borrowed dense layer index; Flash-only
                                     pos, g->mtp_raw_cache, ...);
```

Inside the callee:

- `const bool compressed = ds4_layer_compress_ratio(il) != 0;`  → true on Pro for il=1
  → requires `attn_compressor_kv/gate/ape/norm`, which the (dense) MTP block lacks
  → "expects paired F16 compressor projections", `ok=false`.
- `layer_rope_freq_base(il)` / `layer_rope_freq_scale(il)` also key off
  `ds4_layer_compress_ratio(il)`, so the MTP would additionally get compressed-layer
  RoPE on Pro even if the compressor check were bypassed.

## Fix

NOTE: passing `DS4_N_LAYER` as `il` does NOT work — `ds4_layer_compress_ratio()`
(and the per-layer arrays) bounds-check `il < DS4_N_LAYER`, so the MTP's own index
trips "DeepSeek4 layer index is outside the loaded model layout".

Instead keep `il = 1` (in-bounds) and force the dense MTP block to behave densely in
`metal_graph_encode_decode_layer()`. The dense block is identifiable by its absent KV
compressor (it's never loaded for the MTP, nor for any ratio-0 layer):

```c
    const uint64_t routed_out_dim = layer->ffn_down_exps->dim[1];
-   const bool compressed = ds4_layer_compress_ratio(il) != 0;
-   const float freq_base = layer_rope_freq_base(il);
-   const float freq_scale = layer_rope_freq_scale(il);
+   const bool dense_layer = (layer->attn_compressor_kv == NULL);
+   const bool compressed = !dense_layer && ds4_layer_compress_ratio(il) != 0;
+   const float freq_base = dense_layer ? DS4_ROPE_FREQ_BASE : layer_rope_freq_base(il);
+   const float freq_scale = dense_layer ? 1.0f : layer_rope_freq_scale(il);
```

This forces `compressed=false` and dense RoPE for the MTP block, fixing both the
compressor check and the RoPE base/scale. It's a no-op for normal layers: compressed
layers always have the compressor (`dense_layer=false`); ratio-0 layers are already
dense, and their `layer_rope_freq_base/scale` already return the dense values. The MTP
keeps using its own `g->mtp_raw_cache`. A cleaner alternative would be an explicit
`is_mtp`/`force_dense` parameter threaded from the MTP call site.

## Notes

- Speculation is lossless regardless (the main model verifies every draft token), so
  this only affected acceptance/speed and the error spam, not output correctness.
- A Pro MTP support GGUF can be produced from the original DeepSeek V4 Pro safetensors
  (the checkpoint ships the module as `mtp.0.*`; routed experts are MXFP4(e2m1)+ue8m0,
  the rest F8_E4M3+ue8m0 / BF16; hyper-connection params verbatim F32).

```

```