### PR TITLE
server: expose only the loaded model in /v1/models

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -898,12 +898,6 @@ static const char *server_model_id_from_engine(ds4_engine *engine) {
            "deepseek-v4-pro" : "deepseek-v4-flash";
 }
 
-static bool server_model_alias_known(const char *id) {
-    return id &&
-           (!strcmp(id, "deepseek-v4-flash") ||
-            !strcmp(id, "deepseek-v4-pro"));
-}
-
 static void stop_list_clear(stop_list *stops) {
     for (int i = 0; i < stops->len; i++) free(stops->v[i]);
     stops->len = 0;
@@ -11213,9 +11207,7 @@ static bool send_model(server *s, int fd, const char *id) {
 static bool send_models(server *s, int fd) {
     buf b = {0};
     buf_puts(&b, "{\"object\":\"list\",\"data\":[");
-    append_model_json(&b, s, "deepseek-v4-flash");
-    buf_putc(&b, ',');
-    append_model_json(&b, s, "deepseek-v4-pro");
+    append_model_json(&b, s, server_model_id_from_engine(s->engine));
     buf_puts(&b, "]}\n");
     bool ok = http_response(fd, s->enable_cors, 200, "application/json", b.ptr);
     buf_free(&b);
@@ -11258,7 +11250,8 @@ static void *client_main(void *arg) {
     const size_t model_path_prefix_len = strlen(model_path_prefix);
     if (!strcmp(hr.method, "GET") &&
         !strncmp(hr.path, model_path_prefix, model_path_prefix_len) &&
-        server_model_alias_known(hr.path + model_path_prefix_len))
+        !strcmp(hr.path + model_path_prefix_len,
+                server_model_id_from_engine(s->engine)))
     {
         send_model(s, fd, hr.path + model_path_prefix_len);
         http_request_free(&hr);


### PR DESCRIPTION
## Problem

`GET /v1/models` always returns both `deepseek-v4-flash` and `deepseek-v4-pro` regardless of which GGUF is actually loaded at startup.  `GET /v1/models/<id>` likewise accepts either alias.

This misleads OpenAI-compatible clients that inspect `/v1/models` to decide which models are available — they see two choices but the server always runs the single GGUF it was started with.

## Fix

- `send_models()`: replace the hardcoded two-entry list with a single call to `server_model_id_from_engine(s->engine)`.
- `/v1/models/<id>` handler: compare the requested ID against `server_model_id_from_engine(s->engine)` directly; return 404 for the non-loaded model.
- Remove `server_model_alias_known()` which is now unused.

## Test plan

- Start server with a Flash GGUF → `GET /v1/models` returns only `deepseek-v4-flash`; `GET /v1/models/deepseek-v4-pro` returns 404.
- Start server with a Pro GGUF → opposite behaviour.

Fixes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)