### PR TITLE
agent: reject edit calls whose new= text contains [upto]

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -6272,6 +6272,8 @@ static char *agent_tool_edit(agent_worker *w, const agent_tool_call *call) {
     const char *new_text = agent_tool_arg_value(call, "new");
     if (!old || !old[0]) return xstrdup("Tool error: edit requires non-empty old text\n");
     if (!new_text) return xstrdup("Tool error: edit requires new text\n");
+    if (strstr(new_text, "[upto]"))
+        return xstrdup("Tool error: new text must not contain the [upto] anchor marker\n");
 
     char err[256];
     char *data = NULL;


### PR DESCRIPTION
## Problem

`[upto]` is an anchor marker that belongs only in the `old=` parameter of an `edit` tool call, where it acts as a range wildcard between a unique head and tail.

If the model accidentally emits `[upto]` inside the `new=` parameter, `agent_tool_edit()` passes `new_text` straight to `agent_apply_file_splice()`, which splices the literal string — including `[upto]` — into the file.  The resulting file corruption triggers the system to retry the patch, which fails again with the same outcome, looping.

## Fix

Add a guard in `agent_tool_edit()` that returns a `Tool error` immediately when `new_text` contains `"[upto]"`.  This gives the model corrective feedback on the next turn rather than writing the marker to disk.

```c
if (strstr(new_text, "[upto]"))
    return xstrdup("Tool error: new text must not contain the [upto] anchor marker\n");
```

## Test plan

- Craft an edit call where `new=` includes `[upto]`; verify the tool returns the error string and leaves the file unchanged.
- Normal edits with `[upto]` only in `old=` are unaffected.

Fixes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)