### PR TITLE
Handle modified Enter as newline in multiline linenoise

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -2240,10 +2240,20 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
         linenoiseEditHistoryNext(l, LINENOISE_HISTORY_NEXT);
         break;
     case ESC:    /* escape sequence */
-        /* Read the next two bytes representing the escape sequence.
-         * Use two calls to handle slow terminals returning the two
-         * chars at different times. */
+        /* Read first byte after ESC. */
         if (linenoiseReadByte(l, seq) != 1) break;
+
+        /* Option+Enter / Meta+Enter on macOS and many terminals
+         * sends ESC followed by CR (or LF).  In multiline mode,
+         * insert a literal newline; otherwise ignore. */
+        if (seq[0] == '\r' || seq[0] == '\n') {
+            if (mlmode) {
+                linenoiseEditInsert(l, "\n", 1);
+            }
+            break;
+        }
+
+        /* Read second byte of escape sequence. */
         if (linenoiseReadByte(l, seq + 1) != 1) break;
 
         /* ESC [ sequences. */
@@ -2270,6 +2280,12 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
                     } else if (plen == 3 && memcmp(param,"200",3) == 0) {
                         linenoiseEditPaste(l);
                     }
+                } else if (final == 'u') {
+                    /* Kitty keyboard protocol: ESC [ keycode ; modifier u
+                     * Insert newline for Enter (13) with any modifier. */
+                    long keycode = strtol(param, NULL, 10);
+                    if (keycode == 13 && mlmode)
+                        linenoiseEditInsert(l, "\n", 1);
                 }
             } else {
                 switch(seq[1]) {


### PR DESCRIPTION
## Summary

This teaches the linenoise multiline editor to insert a literal newline when the terminal reports modified Enter.

Handled cases:
- Meta/Option+Enter as ESC followed by CR or LF, used by macOS terminals and other terminal configurations.
- Kitty keyboard protocol Enter reports such as ESC [ 13 ; modifier u.

The behavior is gated on `mlmode`, so normal single-line linenoise use continues to ignore those modified Enter sequences.

## Validation

- `git diff --check upstream/main...HEAD`
- `make -j8 ds4-agent ds4_agent_test`
- `./ds4_agent_test`