### PR TITLE
Fix quality-score link after streaming refactor

### DIFF
--- a/gguf-tools/Makefile
+++ b/gguf-tools/Makefile
@@ -4,8 +4,8 @@ UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
 NATIVE_CPU_FLAG ?= -mcpu=native
 QUALITY_LDLIBS := -lm -pthread -framework Foundation -framework Metal
-QUALITY_TARGETS := ds4.o ds4_metal.o
-QUALITY_OBJS := ../ds4.o ../ds4_metal.o
+QUALITY_TARGETS := ds4.o ds4_distributed.o ds4_ssd.o ds4_metal.o
+QUALITY_OBJS := ../ds4.o ../ds4_distributed.o ../ds4_ssd.o ../ds4_metal.o
 QUALITY_LINK := $(CC) $(CFLAGS) -I.. -o
 else
 NATIVE_CPU_FLAG ?= -march=native
@@ -17,8 +17,8 @@ NVCC_ARCH_FLAGS := -arch=$(CUDA_ARCH)
 endif
 NVCCFLAGS ?= -O3 --use_fast_math $(NVCC_ARCH_FLAGS) -Xcompiler $(NATIVE_CPU_FLAG) -Xcompiler -pthread
 QUALITY_LDLIBS ?= -lm -Xcompiler -pthread -L$(CUDA_HOME)/targets/sbsa-linux/lib -L$(CUDA_HOME)/lib64 -lcudart -lcublas
-QUALITY_TARGETS := ds4.o ds4_cuda.o
-QUALITY_OBJS := ../ds4.o ../ds4_cuda.o
+QUALITY_TARGETS := ds4.o ds4_distributed.o ds4_ssd.o ds4_cuda.o
+QUALITY_OBJS := ../ds4.o ../ds4_distributed.o ../ds4_ssd.o ../ds4_cuda.o
 QUALITY_LINK := $(NVCC) $(NVCCFLAGS) -I.. -o
 endif
 


### PR DESCRIPTION
## What

`make -C gguf-tools quality-score` fails to link on current `main` (80ebbc3).

The streaming refactor made `ds4.o` depend on `ds4_distributed.o`
(`ds4_session_*` → `ds4_dist_session_*`) and `ds4_ssd.o`
(`ds4_engine_open`/`close` → `ds4_ssd_*`), but the `quality-score` target still
links only `ds4.o` plus the backend object. The link fails with undefined
`ds4_dist_*` / `ds4_ssd_*` symbols on both the Metal and CUDA branches, and no
`score_official` binary is produced.

## Fix

Add `ds4_distributed.o` and `ds4_ssd.o` to `QUALITY_TARGETS` and `QUALITY_OBJS`
on both branches, matching the `CORE_OBJS` set that `ds4` and `ds4-server`
already link.

## Reproduce / testing (per CONTRIBUTING.md)

Build-only change to a tools target; no inference backend source is touched, so
the correctness (`ds4_test`) and speed (`ds4-bench`) regression tracks are not
affected by this change. The failure mode it addresses is the broken link.

Machine / backend: macOS, Metal, Apple M5 Pro.

Before:

```
$ make -C gguf-tools quality-score
...
ld: Undefined symbols for architecture arm64:
  "_ds4_dist_session_create", referenced from: _ds4_session_create in ds4.o
  "_ds4_ssd_cache_experts_for_byte_budget", referenced from: _ds4_engine_open in ds4.o
  "_ds4_ssd_memory_lock_acquire", referenced from: _ds4_engine_open in ds4.o
  ... (ds4_dist_* and ds4_ssd_*)
clang: error: linker command failed with exit code 1
make: *** [quality-score] Error 1
```

After:

```
$ make -C gguf-tools quality-score
cc -I.. -o quality-testing/score_official quality-testing/score_official.c \
   ../ds4.o ../ds4_distributed.o ../ds4_ssd.o ../ds4_metal.o \
   -lm -pthread -framework Foundation -framework Metal
$ ls gguf-tools/quality-testing/score_official     # built
```

CUDA branch changed symmetrically but **not built here** (no CUDA box). It
mirrors the CUDA `CORE_OBJS` already used to build `ds4-server`, so it should
link there too — worth a confirm on a CUDA machine.

## Scope

Only the two existing Makefile branches (Metal, CUDA). ROCm `quality-score`
wiring is pre-existing / separate and left untouched.
