### PR TITLE
Fix ROCm Q8->F16 cache reserve starving session tensors on large models (q4q2)

### DIFF
--- a/rocm/ds4_rocm_runtime.cuh
+++ b/rocm/ds4_rocm_runtime.cuh
@@ -3558,15 +3558,20 @@ static uint64_t cuda_q8_f16_cache_reserve_bytes(uint64_t total_bytes) {
     if (g_ssd_streaming_mode) {
         return cuda_stream_resident_free_reserve_bytes();
     }
-    if (total_bytes >= 112ull * 1024ull * 1024ull * 1024ull) {
-        return 512ull * 1048576ull;
-    }
 
     /* The expanded Q8->F16 cache is only an acceleration path.  Keep enough
-     * device memory free for cuBLAS workspaces, transient graph buffers, and
-     * driver bookkeeping instead of letting optional cached weights consume the
-     * last few GiB on 96 GiB cards. */
-    const uint64_t min_reserve = 4096ull * 1048576ull;
+     * device memory free for the session/context tensors, cuBLAS workspaces,
+     * and transient graph buffers allocated after model load, instead of
+     * letting optional cached weights consume the last few GiB.
+     *
+     * 100K ctx session needs ~7 GiB.
+     *
+     * Do not shrink this to a sub-GiB reserve on large unified-memory machines -
+     * a tiny reserve lets the eager preload fill device memory down to a few
+     * hundred MiB and OOM at session creation.
+     * Loading an MTP model disables this cache and hides the issue. */
+
+    const uint64_t min_reserve = 8192ull * 1048576ull; /* 8 GiB */
     const uint64_t pct_reserve = total_bytes / 20u; /* 5% */
     return pct_reserve > min_reserve ? pct_reserve : min_reserve;
 }


### PR DESCRIPTION
Loading q4q2 model on rocm without MTP (which disables the q8f16 cache)or without ssd-streaming causes OOM issue
This change is to fix that

before

```
$ ./ds4 -m gguf/DeepSeek-V4-Flash-Layers37-42Q4KExperts-OtherExpertLayersIQ2XXSGateUp-Q2KDown-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix-fixed.gguf -p "where can I buy fresh meat?"
ds4: Linux rocm backend set oom_score_adj=1000
ds4: ROCm backend initialized on AMD Radeon 8060S Graphics (sm_115)
ds4: ROCm preparing model tensor mappings: 90.36 GiB
ds4: ROCm startup model preparation covered 90.88 GiB of tensor spans in 20.217s
ds4: rocm backend initialized for graph diagnostics
ds4: context buffers 1053.75 MiB (ctx=32768, backend=rocm, prefill_chunk=4096, raw_kv_rows=4352, compressed_kv_rows=8194)
ds4: ROCm tensor alloc failed: out of memory
ds4: ROCm tensor fill f32 launch failed: out of memory
ds4: ROCm tensor alloc failed: out of memory
<skipped>
ds4: sampled CLI generation requires a session backend
```

after
```
$ ./ds4 -m gguf/DeepSeek-V4-Flash-Layers37-42Q4KExperts-OtherExpertLayersIQ2XXSGateUp-Q2KDown-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix-fixed.gguf -p "where can I buy fresh meat?"
ds4: Linux rocm backend set oom_score_adj=1000
ds4: ROCm backend initialized on AMD Radeon 8060S Graphics (sm_115)
ds4: ROCm preparing model tensor mappings: 90.36 GiB
ds4: ROCm q8 fp16 cache budget exhausted; using q8 kernels (request=16.00 MiB cached=5.14 GiB free=6.00 GiB reserve=6.00 GiB total=120.00 GiB)
ds4: ROCm startup model preparation covered 90.88 GiB of tensor spans in 19.873s
ds4: rocm backend initialized for graph diagnostics
ds4: context buffers 1053.75 MiB (ctx=32768, backend=rocm, prefill_chunk=4096, raw_kv_rows=4352, compressed_kv_rows=8194)
processing 16 input tokens: 16/16 (100.0%)
We need to answer where to buy fresh meat. The user is likely asking for general places or specific to their location? Since no location given, I'll give common options: supermarkets, butcher shops, f
armers markets, online delivery services. Also consider local context. Provide a helpful, general answer.
You can buy fresh meat from a variety of places, depending on your location and preferences:

- **Local butcher shops** – Often offer high-quality, freshly cut meat and can provide custom cuts.
- **Supermarkets** – Most grocery stores have a meat section with fresh options (e.g., packaged or from the butcher counter).
- **Farmers' markets** – Great for locally sourced, often grass-fed or pasture-raised meat.
- **Specialty food stores** – Butcheries or delis that focus on premium meats.
- **Online meat delivery services** – Companies like Crowd Cow, ButcherBox, or local farm-to-door services ship fresh, frozen, or chilled meat.

For the best freshness, consider visiting a local butcher or farmers' market, and always check the sell-by date and appearance. If you need a specific location or type of meat, let me know!
```