### PR TITLE
Metal: keep selected-address SSD prefill opt-in by default

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -11575,8 +11575,7 @@ static uint32_t metal_graph_stream_prefill_batch_selected_addr_auto_max(void) {
     if (DS4_MODEL_VARIANT == DS4_VARIANT_PRO ||
         DS4_MODEL_VARIANT == DS4_VARIANT_FLASH) return UINT32_MAX;
 #endif
-    if (DS4_MODEL_VARIANT == DS4_VARIANT_PRO) return 800u;
-    if (DS4_MODEL_VARIANT == DS4_VARIANT_FLASH) return 760u;
+    /* Keep Metal selected-address batch prefill opt-in until it is vector-clean. */
     return 0;
 }
 

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -8831,8 +8831,8 @@ static uint32_t ds4_gpu_stream_prefill_batch_selected_addr_auto_max(
             return (uint32_t)v;
         }
     }
-    if (n_total_expert == 384) return 800u;
-    if (n_total_expert == 256) return 760u;
+    (void)n_total_expert;
+    /* Keep Metal selected-address batch prefill opt-in until it is vector-clean. */
     return 0;
 }
 

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -60,19 +60,15 @@ static void test_restore_env(const char *name, char *saved) {
 
 typedef struct {
     char *cold_decode;
-    char *batch_selected_addr;
 } test_streaming_prefill_env;
 
 static test_streaming_prefill_env test_force_canonical_streaming_prefill(void) {
     test_streaming_prefill_env saved = {
         .cold_decode =
             test_save_env("DS4_METAL_DISABLE_STREAMING_COLD_DECODE_PREFILL"),
-        .batch_selected_addr =
-            test_save_env("DS4_METAL_DISABLE_STREAMING_PREFILL_BATCH_SELECTED_ADDR"),
     };
     if (test_env_bool("DS4_TEST_SSD_STREAMING")) {
         setenv("DS4_METAL_DISABLE_STREAMING_COLD_DECODE_PREFILL", "1", 1);
-        setenv("DS4_METAL_DISABLE_STREAMING_PREFILL_BATCH_SELECTED_ADDR", "1", 1);
     }
     return saved;
 }
@@ -81,8 +77,6 @@ static void test_restore_canonical_streaming_prefill(
         test_streaming_prefill_env saved) {
     test_restore_env("DS4_METAL_DISABLE_STREAMING_COLD_DECODE_PREFILL",
                      saved.cold_decode);
-    test_restore_env("DS4_METAL_DISABLE_STREAMING_PREFILL_BATCH_SELECTED_ADDR",
-                     saved.batch_selected_addr);
 }
 
 static ds4_engine *test_open_engine(bool quality) {
@@ -996,6 +990,14 @@ static void test_metal_ssd_streaming_cache_pressure(void) {
         test_save_env("DS4_METAL_DISABLE_STREAMING_STATIC_DECODE_MAP");
     char *saved_one_stage =
         test_save_env("DS4_METAL_MOE_ONE_STAGE_PROFILE");
+    char *saved_disable_selected_addr =
+        test_save_env("DS4_METAL_DISABLE_STREAMING_PREFILL_BATCH_SELECTED_ADDR");
+    char *saved_enable_selected_addr =
+        test_save_env("DS4_METAL_ENABLE_STREAMING_PREFILL_BATCH_SELECTED_ADDR");
+    char *saved_selected_addr_max =
+        test_save_env("DS4_METAL_STREAMING_PREFILL_BATCH_SELECTED_ADDR_MAX");
+    char *saved_selected_addr_min =
+        test_save_env("DS4_METAL_STREAMING_PREFILL_BATCH_SELECTED_ADDR_MIN");
 
     setenv("DS4_TEST_SSD_STREAMING", "1", 1);
     setenv("DS4_TEST_SSD_STREAMING_CACHE_GB", "16", 1);
@@ -1003,6 +1005,10 @@ static void test_metal_ssd_streaming_cache_pressure(void) {
     unsetenv("DS4_METAL_DISABLE_STREAMING_LAYER_BATCH");
     unsetenv("DS4_METAL_DISABLE_STREAMING_STATIC_DECODE_MAP");
     unsetenv("DS4_METAL_MOE_ONE_STAGE_PROFILE");
+    unsetenv("DS4_METAL_DISABLE_STREAMING_PREFILL_BATCH_SELECTED_ADDR");
+    unsetenv("DS4_METAL_ENABLE_STREAMING_PREFILL_BATCH_SELECTED_ADDR");
+    unsetenv("DS4_METAL_STREAMING_PREFILL_BATCH_SELECTED_ADDR_MAX");
+    unsetenv("DS4_METAL_STREAMING_PREFILL_BATCH_SELECTED_ADDR_MIN");
 
     fprintf(stderr,
             "ds4-test: Metal SSD streaming cache-pressure repro "
@@ -1010,6 +1016,14 @@ static void test_metal_ssd_streaming_cache_pressure(void) {
     test_official_logprob_vectors_run("short_code_completion");
 
     test_restore_env("DS4_METAL_MOE_ONE_STAGE_PROFILE", saved_one_stage);
+    test_restore_env("DS4_METAL_STREAMING_PREFILL_BATCH_SELECTED_ADDR_MIN",
+                     saved_selected_addr_min);
+    test_restore_env("DS4_METAL_STREAMING_PREFILL_BATCH_SELECTED_ADDR_MAX",
+                     saved_selected_addr_max);
+    test_restore_env("DS4_METAL_ENABLE_STREAMING_PREFILL_BATCH_SELECTED_ADDR",
+                     saved_enable_selected_addr);
+    test_restore_env("DS4_METAL_DISABLE_STREAMING_PREFILL_BATCH_SELECTED_ADDR",
+                     saved_disable_selected_addr);
     test_restore_env("DS4_METAL_DISABLE_STREAMING_STATIC_DECODE_MAP",
                      saved_disable_static_decode);
     test_restore_env("DS4_METAL_DISABLE_STREAMING_LAYER_BATCH",


### PR DESCRIPTION
## Summary

- Keep Metal selected-address SSD-streaming batch prefill opt-in instead of auto-enabling it for Flash/Pro.
- Leave the ROCm auto path unchanged.
- Make the Metal SSD-streaming cache-pressure regression exercise the default selected-address behavior instead of inheriting caller env overrides.

Related to #439. This PR narrows one bad default path, but I am not claiming it fully closes #439 across all Apple Metal setups.

## Current understanding

On my M5 Pro, the selected-address batch prefill path and the canonical path produce different logits for the `short_code_completion` repro. With the PR default, Metal no longer auto-enables selected-address prefill and the CLI repro selects the expected lowercase `c`. Explicitly opting selected-address back in still selects uppercase `C`.

A follow-up report in #439 suggests the behavior can also depend on math mode and hardware. I re-ran a wider matrix with the issue command (`DS4_METAL_PREFILL_CHUNK=2048`, `--dump-logprobs`, top-k 10) on both this branch and clean `upstream/main` at `80ebbc3`. On this M5 Pro, `DS4_METAL_MATH_SAFE=1` is not a universal fix: it flips the argmax differently depending on whether selected-address prefill is enabled.

So the conservative change here is only: do not auto-enable the selected-address path on Metal while its numerics are not understood. The path remains available for explicit profiling/debugging.

## Validation

Machine/backend: Apple M5 Pro, 64 GiB RAM, Metal.
Model: DeepSeek-V4-Flash IQ2XXS/Q2_K imatrix GGUF.

Build/test checks run:

- `make clean && make && make ds4_test ds4_agent_test q4k-dot-test`
- `./ds4_test --server`
- `./ds4_test --metal-kernels`
- `./ds4_agent_test`
- `DS4_TEST_MODEL=... ./ds4_test --metal-ssd-streaming-cache-pressure`
- `DS4_TEST_MODEL=... DS4_TEST_SSD_STREAMING=1 DS4_TEST_SSD_STREAMING_CACHE_GB=16 ./ds4_test --logprob-vectors`
- `DS4_TEST_MODEL=... DS4_TEST_SSD_STREAMING=1 DS4_TEST_SSD_STREAMING_CACHE_GB=16 ./ds4_test --long-context`
- `DS4_TEST_MODEL=... DS4_TEST_SSD_STREAMING=1 DS4_TEST_SSD_STREAMING_CACHE_GB=16 ./ds4_test --think-tool-recovery`
- `make cpu`
- `git diff --check`

Additional CLI matrix for #439 repro (`DS4_METAL_PREFILL_CHUNK=2048`, `--logprobs-top-k 10`):

| Tree | Flags | Selected | logit(c) | logit(C) | c-C |
| --- | --- | --- | ---: | ---: | ---: |
| upstream/main | default | `C` | 34.5451698 | 34.7262421 | -0.1810723 |
| upstream/main | `DS4_METAL_DISABLE_STREAMING_PREFILL_BATCH_SELECTED_ADDR=1` | `c` | 35.8293610 | 34.2557144 | 1.5736466 |
| upstream/main | `DS4_METAL_MATH_SAFE=1` | `c` | 35.5860977 | 35.0353928 | 0.5507049 |
| upstream/main | math-safe + selected-address disabled | `C` | 34.0360031 | 34.5594215 | -0.5234184 |
| this PR | default | `c` | 35.8293610 | 34.2557144 | 1.5736466 |
| this PR | `DS4_METAL_ENABLE_STREAMING_PREFILL_BATCH_SELECTED_ADDR=1` | `C` | 34.5451698 | 34.7262421 | -0.1810723 |
| this PR | `DS4_METAL_MATH_SAFE=1` | `C` | 34.0360031 | 34.5594215 | -0.5234184 |
| this PR | math-safe + selected-address enabled | `c` | 35.5860977 | 35.0353928 | 0.5507049 |

Repeated critical cases in a different order reproduced the same logits/token choices.

I am intentionally not making a performance claim in this PR. The latency and prefill-only spot checks are workload-sensitive; correctness should come first here.

## Separate failure

`DS4_TEST_MODEL=... DS4_TEST_SSD_STREAMING=1 DS4_TEST_SSD_STREAMING_CACHE_GB=16 ./ds4_test --tool-call-quality` fails on both this branch and clean `upstream/main` at `80ebbc3` with `Metal model range ... is not covered by mapped model views` in the exact path. I filed that separately as #455.
