### PR TITLE
CUDA: batch gate/up/down uploads for selected expert cache misses

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -1744,6 +1744,87 @@ static int cuda_model_copy_to_device_streamed(
     return 1;
 }
 
+/* Return -1 when this expert needs the general streamed-copy path. */
+static int cuda_model_copy_expert_to_device_streamed(
+        char *const dst[3],
+        const void *model_map,
+        uint64_t model_size,
+        const uint64_t offset[3],
+        const uint64_t bytes[3],
+        const char *const what[3]) {
+    if (g_model_fd < 0 ||
+        (g_model_fd_host_base != NULL && model_map != g_model_fd_host_base)) {
+        return -1;
+    }
+
+    const uint64_t chunk = cuda_model_copy_chunk_bytes();
+    for (uint32_t i = 0; i < 3; i++) {
+        if (!dst[i] || offset[i] > model_size ||
+            bytes[i] == 0 || bytes[i] > model_size - offset[i] ||
+            bytes[i] > chunk) {
+            return -1;
+        }
+    }
+
+    const uint64_t stage_bytes =
+        chunk + (g_model_direct_align > 1 ? g_model_direct_align : 1);
+    if (!cuda_stream_selected_stage_pool_alloc(stage_bytes)) return 0;
+
+    int enqueued = 0;
+    for (uint32_t i = 0; i < 3; i++) {
+        const char *payload = NULL;
+        if (!cuda_model_stage_read(g_stream_selected_stage[i],
+                                   g_stream_selected_stage_bytes,
+                                   offset[i], bytes[i], &payload)) {
+            fprintf(stderr,
+                    "ds4: CUDA streaming selected read failed for %s: %s\n",
+                    what[i], strerror(errno));
+            if (enqueued) {
+                (void)cudaStreamSynchronize(g_stream_selected_upload_stream);
+            }
+            return 0;
+        }
+        cudaError_t err = cudaMemcpyAsync(dst[i], payload, (size_t)bytes[i],
+                                          cudaMemcpyHostToDevice,
+                                          g_stream_selected_upload_stream);
+        if (err != cudaSuccess) {
+            fprintf(stderr,
+                    "ds4: CUDA streaming selected copy failed for %s: %s\n",
+                    what[i], cudaGetErrorString(err));
+            (void)cudaGetLastError();
+            if (enqueued) {
+                (void)cudaStreamSynchronize(g_stream_selected_upload_stream);
+            }
+            return 0;
+        }
+        enqueued = 1;
+        err = cudaEventRecord(g_stream_selected_stage_event[i],
+                              g_stream_selected_upload_stream);
+        if (err != cudaSuccess) {
+            fprintf(stderr,
+                    "ds4: CUDA streaming selected staging record failed for %s: %s\n",
+                    what[i], cudaGetErrorString(err));
+            (void)cudaGetLastError();
+            (void)cudaStreamSynchronize(g_stream_selected_upload_stream);
+            return 0;
+        }
+        cuda_model_drop_file_pages(offset[i], bytes[i]);
+        cuda_model_discard_source_pages(model_map, model_size,
+                                        offset[i], bytes[i]);
+    }
+
+    const cudaError_t err =
+        cudaStreamSynchronize(g_stream_selected_upload_stream);
+    if (err != cudaSuccess) {
+        fprintf(stderr,
+                "ds4: CUDA streaming selected expert upload sync failed: %s\n",
+                cudaGetErrorString(err));
+        (void)cudaGetLastError();
+        return 0;
+    }
+    return 1;
+}
+
 static uint64_t cuda_model_cache_limit_bytes(void) {
     uint64_t gb = 0;
     const char *env = getenv("DS4_CUDA_WEIGHT_CACHE_LIMIT_GB");
@@ -23037,21 +23118,36 @@ static int cuda_stream_selected_cache_begin_load(
             table->down_offset + expert * table->down_expert_bytes;
         const uint64_t gate_dst = (uint64_t)i * table->gate_expert_bytes;
         const uint64_t down_dst = (uint64_t)i * table->down_expert_bytes;
-        if (!cuda_model_copy_to_device_streamed(
-                    g_stream_selected_cache.gate_ptr + gate_dst,
-                    table->model_map, table->model_size,
-                    gate_src, table->gate_expert_bytes,
-                    "stream gate expert copy") ||
-            !cuda_model_copy_to_device_streamed(
-                    g_stream_selected_cache.up_ptr + gate_dst,
-                    table->model_map, table->model_size,
-                    up_src, table->gate_expert_bytes,
-                    "stream up expert copy") ||
-            !cuda_model_copy_to_device_streamed(
-                    g_stream_selected_cache.down_ptr + down_dst,
-                    table->model_map, table->model_size,
-                    down_src, table->down_expert_bytes,
-                    "stream down expert copy")) {
+        char *dst[3] = {
+            g_stream_selected_cache.gate_ptr + gate_dst,
+            g_stream_selected_cache.up_ptr + gate_dst,
+            g_stream_selected_cache.down_ptr + down_dst
+        };
+        const uint64_t src[3] = { gate_src, up_src, down_src };
+        const uint64_t bytes[3] = {
+            table->gate_expert_bytes,
+            table->gate_expert_bytes,
+            table->down_expert_bytes
+        };
+        const char *what[3] = {
+            "stream gate expert copy",
+            "stream up expert copy",
+            "stream down expert copy"
+        };
+        const int batched = cuda_model_copy_expert_to_device_streamed(
+                dst, table->model_map, table->model_size,
+                src, bytes, what);
+        if (batched == 0 ||
+            (batched < 0 &&
+             (!cuda_model_copy_to_device_streamed(
+                      dst[0], table->model_map, table->model_size,
+                      src[0], bytes[0], what[0]) ||
+              !cuda_model_copy_to_device_streamed(
+                      dst[1], table->model_map, table->model_size,
+                      src[1], bytes[1], what[1]) ||
+              !cuda_model_copy_to_device_streamed(
+                      dst[2], table->model_map, table->model_size,
+                      src[2], bytes[2], what[2])))) {
             cuda_stream_selected_cache_invalidate();
             return 0;
         }


### PR DESCRIPTION
### Motivation

In the CUDA direct-I/O path, a selected expert cache miss uploads the gate/up/down tensors independently, synchronizing the selected upload stream after each tensor.

This patch batches the three uploads belonging to the same expert and synchronizes the selected upload stream once after all three have been enqueued.

### Properties

- no API changes
- no kernel changes
- no cache policy changes
- resident and compact cache layouts are unchanged
- unsupported cases fall back to the existing path

### Validation

Tested after rebasing onto `efdadd4`, which was the current `main` at the time, on an NVIDIA A100 80GB PCIe with CUDA 12.4 (`sm_80`).

* Baseline commit: `efdadd4`
* PR commit: `6ece876`
* Clean CUDA builds: passed
* Deterministic output: identical
* Normalized output SHA-256: identical
* No CUDA staging, upload, or synchronization errors

#### Targeted miss-heavy Nsight Systems validation

| Expert cache |                           Metric | Baseline |      PR | Difference |
| ------------ | -------------------------------: | -------: | ------: | ---------: |
| 8GB          |    `cudaStreamSynchronize` calls |  108,276 |  36,092 |    −66.67% |
| 8GB          | `cudaStreamSynchronize` API time |  1.649 s | 0.587 s |    −64.42% |
| 16GB         |    `cudaStreamSynchronize` calls |  108,276 |  36,092 |    −66.67% |
| 16GB         | `cudaStreamSynchronize` API time |  1.742 s | 0.584 s |    −66.49% |

The number of `cudaMemcpyAsync` calls remained unchanged at 108,276.

This confirms that the patch preserves the same gate/up/down uploads while reducing synchronization from once per tensor upload to once per three-upload group.

End-to-end throughput differences were within normal run-to-run noise:

| Expert cache |     Metric | Baseline median | PR median |
| ------------ | ---------: | --------------: | --------: |
| 8GB          |    Prefill |        2.45 t/s |  2.41 t/s |
| 8GB          | Generation |        0.65 t/s |  0.65 t/s |
| 8GB          |  Wall time |        220.53 s |  221.08 s |
| 16GB         |    Prefill |        2.40 t/s |  2.42 t/s |
| 16GB         | Generation |        0.64 t/s |  0.64 t/s |
| 16GB         |  Wall time |        221.89 s |  222.31 s |

This change should therefore be considered a synchronization-granularity improvement, not a demonstrated overall throughput improvement on the current upstream code.
