### PR TITLE
cuda: enable streaming auto cache (implement recommended_working_set_size)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -90,11 +90,9 @@ static bool ds4_backend_supports_ssd_streaming(ds4_backend backend) {
 
 static bool ds4_backend_supports_streaming_auto_cache(ds4_backend backend) {
     if (backend == DS4_BACKEND_METAL) return true;
-#ifdef DS4_ROCM_BUILD
+    /* CUDA now has a working ds4_gpu_recommended_working_set_size()
+     * implementation, so the auto cache planner can run here too. */
     if (backend == DS4_BACKEND_CUDA) return true;
-#else
-    (void)backend;
-#endif
     return false;
 }
 

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -2781,7 +2781,19 @@ extern "C" void ds4_gpu_set_streaming_expert_cache_expert_bytes(uint64_t bytes) 
 }
 
 extern "C" uint64_t ds4_gpu_recommended_working_set_size(void) {
-    return 0;
+    /* Metal exposes recommendedMaxWorkingSetSize natively; CUDA has no
+     * direct equivalent, so use total device memory as the closest
+     * analogue. The 80% margin applied by callers (see
+     * ds4_ssd_auto_cache_plan) accounts for KV cache, activations and
+     * driver overhead. */
+    size_t free_bytes = 0, total_bytes = 0;
+    cudaError_t err = cudaMemGetInfo(&free_bytes, &total_bytes);
+    (void)free_bytes;
+    if (err != cudaSuccess) {
+        (void)cudaGetLastError();
+        return 0;
+    }
+    return (uint64_t)total_bytes;
 }
 
 extern "C" uint32_t ds4_gpu_stream_expert_cache_configured_count(void) {


### PR DESCRIPTION
`ds4_backend_supports_streaming_auto_cache()` only allowed the SSD
streaming auto cache planner to run under `DS4_BACKEND_METAL`, or
under `DS4_BACKEND_CUDA` when built with `DS4_ROCM_BUILD` — which a
plain `make cuda-generic` (nvcc) build never defines. As a result,
CUDA users always had to pass `--ssd-streaming-cache-experts`
explicitly, and `ds4_gpu_recommended_working_set_size()` in
ds4_cuda.cu was an unimplemented stub returning 0.

This implements the CUDA working set size using `cudaMemGetInfo`'s
total device memory (the closest analogue to Metal's
recommendedMaxWorkingSetSize), and extends the guard so CUDA can use
the same auto cache planner Metal already has.

Tested on a CUDA GPU with 8GB VRAM with DeepSeek V4 Flash (the
project's reference model):

  ds4: SSD streaming auto cache budget
  ds4:   cuda recommends 7.62 GiB working set
  ds4:   using 80% total for model + cached experts: 6.10 GiB
  ds4:   non-routed weights: 8.20 GiB
  ds4:   routed expert size: 6.75 MiB
  ds4:   cached expert count: 1 (0.01 GiB)