### PR TITLE
cuda: support CUDA toolkits older than 12.2

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -18,6 +18,25 @@
 #include <unordered_map>
 #include <vector>
 
+/* CUDA < 12.2 lacks the cudaMemLocation overloads of cudaMemAdvise() and
+ * cudaMemPrefetchAsync(). Forward to the legacy int-device signatures. */
+#if CUDART_VERSION < 12020
+static inline cudaError_t cudaMemAdvise(const void *ptr, size_t count,
+                                        cudaMemoryAdvise advice,
+                                        cudaMemLocation loc) {
+    int dev = loc.type == cudaMemLocationTypeDevice ? loc.id : cudaCpuDeviceId;
+    return cudaMemAdvise(ptr, count, advice, dev);
+}
+static inline cudaError_t cudaMemPrefetchAsync(const void *ptr, size_t count,
+                                               cudaMemLocation loc,
+                                               unsigned int flags,
+                                               cudaStream_t stream) {
+    (void)flags;
+    int dev = loc.type == cudaMemLocationTypeDevice ? loc.id : cudaCpuDeviceId;
+    return cudaMemPrefetchAsync(ptr, count, dev, stream);
+}
+#endif
+
 #include "ds4_gpu.h"
 
 #ifndef M_PI


### PR DESCRIPTION
The CUDA backend uses the `cudaMemLocation` overloads of `cudaMemAdvise()` and `cudaMemPrefetchAsync()`, introduced in CUDA 12.2. Older toolkits (e.g. Ubuntu 24.04 ships nvcc 12.0) fail to build:

```
ds4_cuda.cu(909): error: no suitable conversion function from "cudaMemLocation" to "int" exists
```

This PR adds two inline overloads guarded by `CUDART_VERSION < 12020` that forward to the legacy int-device signatures (`cudaCpuDeviceId` when the location is host). On 12.2+ the block compiles to nothing.

Tested on Linux / nvcc 12.0 / driver 580.82 / RTX 4060 Ti 16GB (sm_89): builds clean, and `--ssd-streaming` inference on DeepSeek V4 Flash q2 runs correctly (2.2 t/s generation streaming from a PCIe 3 NVMe, 28.7 t/s prefill on a ~1k token prompt - happy to share fuller consumer-hardware benchmark data if useful).
