### PR TITLE
cuda: run streaming selected load for single-token ffn batch encodes

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -14342,10 +14342,15 @@ static bool metal_graph_cuda_stream_prefill_batch_selected_load(
         uint64_t                  gate_expert_bytes,
         uint64_t                  down_expert_bytes) {
 #if !defined(DS4_ROCM_BUILD) && !defined(DS4_NO_GPU) && !defined(__APPLE__)
+    /* n_tokens == 1 must also take the selected load. The MTP verifier can
+     * issue single-position ffn batch encodes; skipping the selected load
+     * there falls through to resident full-expert ranges, which cannot fit
+     * in device memory under SSD streaming (observed as ~1.8 GiB arena
+     * allocation failures followed by "MTP verifier failed"). */
     if (!metal_graph_decode_cuda_selected_slots_expected(g, layer) ||
         !model ||
         !g->batch_router_selected ||
-        n_tokens <= 1 ||
+        n_tokens == 0 ||
         DS4_N_EXPERT == 0 ||
         DS4_N_EXPERT_USED == 0 ||
         getenv("DS4_CUDA_DISABLE_STREAMING_PREFILL_BATCH_SELECTED_LOAD") != NULL) {


### PR DESCRIPTION
Fixes the concrete failure behind the `--mtp` + `--ssd-streaming` guard on CUDA (context: #495).

`metal_graph_cuda_stream_prefill_batch_selected_load()` skips when `n_tokens <= 1`, assuming batch encodes only come from multi-token prefill chunks. The MTP verifier can issue single-position ffn batch encodes; with the selected load skipped, the routed MoE falls through to allocating full resident expert ranges, which by definition cannot fit under SSD streaming:

```
ds4: CUDA model arena alloc failed for moe_gate (1792.00 MiB chunk): out of memory
ds4: gpu layer 2 ffn batch encode failed
ds4: decode failed: MTP verifier failed
```

The one-line fix lets `n_tokens == 1` take the selected load; the batch machinery already handles a one-token union.

Tested on RTX 4060 Ti 16GB / Linux, Flash q2 streaming from NVMe, with the engine guard bypassed locally for testing:

| config | before | after |
|---|---|---|
| margin `--mtp-draft 2` | hard crash (above) | runs, 1.32 t/s |
| margin `--mtp-draft 4` | OOM + fallback loops, 0.85 t/s | clean, 0.84 t/s |
| strict `--mtp-draft 2` | 1.25 t/s, token-identical to greedy | 1.18 t/s, still token-identical |
| non-MTP baseline | 2.65 t/s | 2.55 t/s (noise) |

This does not touch the engine guard itself; whether to relax it (e.g. allow with strict verify) seems like your call. Happy to follow up with that change plus docs if you want it.