### PR TITLE
rocm: use numerically stable SiLU to avoid NaN on large-magnitude gate

### DIFF
--- a/rocm/ds4_rocm_common.cuh
+++ b/rocm/ds4_rocm_common.cuh
@@ -8,6 +8,19 @@ __global__ static void fill_f32_kernel(float *x, uint64_t n, float v) {
     if (i < n) x[i] = v;
 }
 
+/* Numerically stable sigmoid/SiLU matching the CPU reference (ds4.c
+ * sigmoid_stable/silu). The naive gate/(1+expf(-gate)) overflows for large
+ * negative gate: expf(-gate) -> +inf makes it -inf/inf = NaN, which the CPU
+ * path avoids. Use these everywhere the ROCm MoE/FFN applies SiLU. */
+__device__ __forceinline__ static float dev_sigmoid_stable(float x) {
+    if (x >= 0.0f) return 1.0f / (1.0f + expf(-x));
+    const float e = expf(x);
+    return e / (1.0f + e);
+}
+__device__ __forceinline__ static float dev_silu_stable(float x) {
+    return x * dev_sigmoid_stable(x);
+}
+
 __global__ static void embed_token_hc_kernel(float *out, const unsigned short *w, uint32_t token, uint32_t n_embd, uint32_t n_hc) {
     uint32_t i = blockIdx.x * blockDim.x + threadIdx.x;
     uint32_t n = n_embd * n_hc;

--- a/rocm/ds4_rocm_moe.cuh
+++ b/rocm/ds4_rocm_moe.cuh
@@ -584,7 +584,7 @@ __global__ static DS4_ROCM_UNUSED void moe_gate_up_mid_kernel(
         const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
         gate_out[off] = gate;
         up_out[off] = up;
-        mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+        mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
     }
 }
 
@@ -633,7 +633,7 @@ __global__ static DS4_ROCM_UNUSED void moe_gate_up_mid_warp8_kernel(
         const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
         gate_out[off] = gate;
         up_out[off] = up;
-        mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+        mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
     }
 }
 
@@ -681,7 +681,7 @@ __global__ static DS4_ROCM_UNUSED void moe_gate_up_mid_hwarp16_kernel(
         const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
         gate_out[off] = gate;
         up_out[off] = up;
-        mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+        mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
     }
 }
 
@@ -733,7 +733,7 @@ __global__ static void moe_gate_up_mid_qwarp32_kernel(
             const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
             gate_out[off] = gate;
             up_out[off] = up;
-            mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+            mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
         }
     }
 }
@@ -788,7 +788,7 @@ __global__ static void moe_gate_up_mid_qwarp32_ptrs_kernel(
             const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
             gate_out[off] = gate;
             up_out[off] = up;
-            mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+            mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
         }
     }
 }
@@ -846,7 +846,7 @@ __global__ static void moe_gate_up_mid_qwarp32_ptrs_split_kernel(
             const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
             gate_out[off] = gate;
             up_out[off] = up;
-            mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+            mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
         }
     }
 }
@@ -912,7 +912,7 @@ __global__ static void moe_gate_up_mid_decode_lut_qwarp32_kernel(
                 gate_out[off] = gate;
                 up_out[off] = up;
             }
-            mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+            mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
         }
     }
 }
@@ -980,7 +980,7 @@ __global__ static void moe_gate_up_mid_decode_lut_qwarp32_ptrs_kernel(
                 gate_out[off] = gate;
                 up_out[off] = up;
             }
-            mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+            mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
         }
     }
 }
@@ -1126,7 +1126,7 @@ __global__ static void moe_gate_up_mid_sorted_qwarp32_kernel(
         const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
         gate_out[off] = gate;
         up_out[off] = up;
-        mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+        mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
     }
 }
 
@@ -1187,7 +1187,7 @@ __global__ static DS4_ROCM_UNUSED void moe_gate_up_mid_expert_tile8_kernel(
             const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
             gate_out[off] = gate;
             up_out[off] = up;
-            mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+            mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
         }
     }
 }
@@ -1270,7 +1270,7 @@ __global__ static void moe_gate_up_mid_expert_tile4_row32_kernel(
                 gate_out[off] = gate[p];
                 up_out[off] = up[p];
             }
-            mid_out[off] = (gate[p] / (1.0f + expf(-gate[p]))) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
+            mid_out[off] = (dev_silu_stable(gate[p])) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
         }
     }
 }
@@ -1363,7 +1363,7 @@ __global__ static void moe_gate_up_mid_expert_tile8_row32_kernel(
                 gate_out[off] = gate[p];
                 up_out[off] = up[p];
             }
-            mid_out[off] = (gate[p] / (1.0f + expf(-gate[p]))) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
+            mid_out[off] = (dev_silu_stable(gate[p])) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
         }
     }
 }
@@ -1458,7 +1458,7 @@ __global__ static void moe_gate_up_mid_expert_tile8_row2048_kernel(
                     gate_out[off] = gate[p];
                     up_out[off] = up[p];
                 }
-                mid_out[off] = (gate[p] / (1.0f + expf(-gate[p]))) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
+                mid_out[off] = (dev_silu_stable(gate[p])) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
             }
         }
     }
@@ -1555,7 +1555,7 @@ __global__ static void moe_gate_up_mid_expert_tile8_rowspan_kernel(
                     gate_out[off] = gate[p];
                     up_out[off] = up[p];
                 }
-                mid_out[off] = (gate[p] / (1.0f + expf(-gate[p]))) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
+                mid_out[off] = (dev_silu_stable(gate[p])) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
             }
         }
     }
@@ -1609,7 +1609,7 @@ __global__ static void moe_gate_up_mid_sorted_p2_qwarp32_kernel(
         const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
         gate_out[off] = gate;
         up_out[off] = up;
-        mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+        mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
     }
 }
 
@@ -1658,7 +1658,7 @@ __global__ static void moe_gate_up_mid_q4K_sorted_qwarp32_kernel(
         const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
         gate_out[off] = gate;
         up_out[off] = up;
-        mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+        mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
     }
 }
 
@@ -1740,7 +1740,7 @@ __global__ static void moe_gate_up_mid_q4K_expert_tile4_row32_kernel(
                 gate_out[off] = gate[p];
                 up_out[off] = up[p];
             }
-            mid_out[off] = (gate[p] / (1.0f + expf(-gate[p]))) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
+            mid_out[off] = (dev_silu_stable(gate[p])) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
         }
     }
 }
@@ -1827,7 +1827,7 @@ __global__ static void moe_gate_up_mid_q4K_expert_tile8_row32_kernel(
                 gate_out[off] = gate[p];
                 up_out[off] = up[p];
             }
-            mid_out[off] = (gate[p] / (1.0f + expf(-gate[p]))) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
+            mid_out[off] = (dev_silu_stable(gate[p])) * up[p] * weights[(uint64_t)tok[p] * n_expert + slot[p]];
         }
     }
 }
@@ -1991,7 +1991,7 @@ __global__ static void moe_gate_up_mid_decode_q4K_qwarp32_kernel(
                 gate_out[off] = gate;
                 up_out[off] = up;
             }
-            mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+            mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
         }
     }
 }
@@ -2051,7 +2051,7 @@ __global__ static void moe_gate_up_mid_q2K_decode_q8_qwarp32_kernel(
                 gate_out[off] = gate;
                 up_out[off] = up;
             }
-            mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+            mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
         }
     }
 }
@@ -3089,7 +3089,7 @@ __device__ __forceinline__ static void q2_K_dequant_dual_pair_tile_half_rowwise(
 }
 
 __device__ __forceinline__ static float moe_silu_oldhip(float x) {
-    return x * (1.0f / (1.0f + expf(-x)));
+    return dev_silu_stable(x);
 }
 
 __global__ __launch_bounds__(32) static void moe_gate_up_mid_q2K_rows_rpb1_w32_kernel(
@@ -4168,7 +4168,7 @@ __global__ static void moe_gate_up_mid_f32_kernel(
         const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
         gate_out[off] = gate;
         up_out[off] = up;
-        mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+        mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
     }
 }
 
@@ -4228,7 +4228,7 @@ __global__ static void moe_gate_up_mid_q2K_f32_kernel(
         const uint64_t off = (uint64_t)pair * expert_mid_dim + row;
         gate_out[off] = gate;
         up_out[off] = up;
-        mid_out[off] = (gate / (1.0f + expf(-gate))) * up * weights[(uint64_t)tok * n_expert + slot];
+        mid_out[off] = (dev_silu_stable(gate)) * up * weights[(uint64_t)tok * n_expert + slot];
     }
 }
 

--- a/rocm/ds4_rocm_output.cuh
+++ b/rocm/ds4_rocm_output.cuh
@@ -29,7 +29,7 @@ __global__ static void swiglu_kernel(float *out, const float *gate, const float 
         g = fminf(g, clamp);
         u = fminf(fmaxf(u, -clamp), clamp);
     }
-    float s = g / (1.0f + expf(-g));
+    float s = dev_silu_stable(g);
     out[i] = s * u * weight;
 }
 

--- a/rocm/ds4_rocm_q8.cuh
+++ b/rocm/ds4_rocm_q8.cuh
@@ -295,7 +295,7 @@ __global__ static void shared_gate_up_swiglu_q8_0_pair_preq_warp8_kernel(
             sg = fminf(sg, clamp);
             su = fminf(fmaxf(su, -clamp), clamp);
         }
-        mid[row] = (sg / (1.0f + expf(-sg))) * su;
+        mid[row] = (dev_silu_stable(sg)) * su;
     }
 }
 
@@ -602,7 +602,7 @@ __global__ static void shared_gate_up_swiglu_q8_0_batch_sharedx_w32_kernel(
                     gate[off] = g;
                     up[off] = uv;
                 }
-                mid[off] = (g / (1.0f + expf(-g))) * uv;
+                mid[off] = (dev_silu_stable(g)) * uv;
             }
         }
     }
@@ -991,7 +991,7 @@ __global__ static void shared_gate_up_swiglu_q8_0_rows_w32_kernel(
             sg = fminf(sg, clamp);
             su = fminf(fmaxf(su, -clamp), clamp);
         }
-        mid[row] = (sg / (1.0f + expf(-sg))) * su;
+        mid[row] = (dev_silu_stable(sg)) * su;
     }
 }
 


### PR DESCRIPTION
The ROCm MoE/FFN kernels computed SiLU as the naive `gate / (1.0f + expf(-gate))`. For a large negative gate, `expf(-gate)` overflows to +inf, so the expression becomes `-inf / inf = NaN`. The CPU reference (`ds4.c` `silu`/`sigmoid_stable`) deliberately avoids this by branching on the sign, so the two backends disagreed on extreme inputs and only ROCm produced NaN — which then propagates through the rest of the network (e.g. a later router selecting expert id -1).

Add `dev_sigmoid_stable`/`dev_silu_stable` in `ds4_rocm_common.cuh` (matching the CPU sign-branched form) and replace the 27 naive SiLU sites across `ds4_rocm_moe.cuh`, `ds4_rocm_q8.cuh`, and `ds4_rocm_output.cuh`. No behavior change for well-conditioned inputs; only removes the overflow path on extreme gate values.