### PR TITLE
CPU backend: SSD streaming for routed experts (safe CPU inference on macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1212,8 +1212,8 @@ make cpu
 Do not treat the CPU path as the production target. The CLI and `ds4-server`
 support the CPU backend for reference/debug use and share the same KV session
 and snapshot format as Metal and CUDA, but normal inference should use Metal or
-CUDA. On macOS, the CPU backend requires `--ssd-streaming` to avoid the kernel
-VM issue described above.
+CUDA. On macOS, use `--ssd-streaming` with the CPU backend: the plain mmap CPU
+path can panic current macOS kernels.
 
 ## Steering
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ That said, a few important things about this project:
 * This software is developed with **strong assistance from GPT 5.5** and with humans leading the ideas, testing, and debugging. We say this openly because it shaped how the project was built. If you are not happy with AI-developed code, this software is not for you. The acknowledgement below is equally important: this would not exist without `llama.cpp` and GGML, largely written by hand.
 * This implementation is based on the idea that compressed KV caches like the one of DeepSeek v4 and the fast SSD disks of modern MacBooks should change our idea that KV cache belongs to RAM. **The KV cache is actually a first-class disk citizen**. Fast SSD disks also changed the inference game from the point of view of "model needs to fit RAM": while having more RAM the the model size is still preferred, SSD streaming allows to turn the available amount of RAM from a hard cutoff (can I run this model or not?) to continuous spectrum of speed levels.
 * Our vision is that local inference should be a set of three things working well together, out of the box: A) inference engine with HTTP API + B) GGUF specially crafted to run well under a given engine and given assumptions + C) testing and validation with coding agents implementations. D) Purpose built agents for specific models and execution environments. DwarfStar only runs with the GGUF files provided. It gets tested against officially obtained logits at different context sizes. This project exists because we wanted to make one local model feel finished end to end, not just runnable. However this is beta quality code, so probably we are not still there, especially since recently we introduced large new features: distributed inference, SSD streaming, and other minor improvements.
-* The optimized graph path targets **Metal on macOS** and **CUDA on Linux**. The CPU path is only for correctness checks and model/tokenizer diagnostics. For CPU-only Linux builds, use `make cpu`; it builds the normal `./ds4` and `./ds4-server` binaries without CUDA or Metal. On macOS, **warning: current macOS versions have a bug in the virtual memory implementation that will crash the kernel** if you try to run the CPU code. Remember? Software sucks. It was not possible to fix the CPU inference to avoid crashing, since each time you have to restart the computer, which is not funny. Help us, if you have the guts.
+* The optimized graph path targets **Metal on macOS** and **CUDA on Linux**. The CPU path is only for correctness checks and model/tokenizer diagnostics. For CPU-only Linux builds, use `make cpu`; it builds the normal `./ds4` and `./ds4-server` binaries without CUDA or Metal. On macOS, **warning: current macOS versions have a bug in the virtual memory implementation that will crash the kernel** if you try to run the CPU code. Remember? Software sucks. It was not possible to fix the CPU inference to avoid crashing, since each time you have to restart the computer, which is not funny. Help us, if you have the guts. Update: the CPU backend can now run safely on macOS with `--ssd-streaming`: routed experts are pread() into a bounded cache instead of being faulted through the huge mmap, which keeps the kernel out of the pathological VM regime. This does not make the CPU path fast, it makes it safe to use for correctness checks and diagnostics. Example: `./ds4 --cpu --ssd-streaming -m ds4flash.gguf`.
 
 ## Acknowledgements to llama.cpp and GGML
 
@@ -214,6 +214,15 @@ it takes 80% of the Metal recommended working set, subtracts non-routed weights,
 then uses the rest for routed experts. Leave the hot expert preload enabled for
 normal use; use `--ssd-streaming-cold` and `--ssd-streaming-preload-experts N`
 only for measurements.
+
+`--ssd-streaming` also works with `--cpu`. It is the supported way to run the
+CPU backend on macOS (see the warning above): routed experts are pread() from
+the GGUF into a bounded cache instead of being faulted through the mmap.
+`--ssd-streaming-cache-experts N|NGB` applies as above; with no explicit cache
+size, the CPU backend defaults to 25% of physical RAM, floored so a full layer
+of experts always fits. `--ssd-streaming-preload-experts` is ignored on the
+CPU backend (a warning is printed) since the cache is filled on demand rather
+than pre-seeded.
 
 ### Practical SSD streaming examples
 
@@ -1203,7 +1212,8 @@ make cpu
 Do not treat the CPU path as the production target. The CLI and `ds4-server`
 support the CPU backend for reference/debug use and share the same KV session
 and snapshot format as Metal and CUDA, but normal inference should use Metal or
-CUDA.
+CUDA. On macOS, the CPU backend requires `--ssd-streaming` to avoid the kernel
+VM issue described above.
 
 ## Steering
 

--- a/ds4.c
+++ b/ds4.c
@@ -5565,16 +5565,16 @@ typedef struct {
     uint64_t hits, misses, evictions, pread_bytes;  /* stats for the summary log */
 } cpu_stream_state;
 
-cpu_stream_state g_cpu_stream;
+static cpu_stream_state g_cpu_stream;
 
-uint64_t cpu_stream_triple_bytes(uint32_t il) {
+static uint64_t cpu_stream_triple_bytes(uint32_t il) {
     return g_cpu_stream.expert_bytes[CPU_STREAM_GATE][il] +
            g_cpu_stream.expert_bytes[CPU_STREAM_UP][il] +
            g_cpu_stream.expert_bytes[CPU_STREAM_DOWN][il];
 }
 
 /* Victim: lowest use_count, oldest last_used as tie-break; skip pinned. */
-uint32_t cpu_stream_pick_victim(void) {
+static uint32_t cpu_stream_pick_victim(void) {
     const uint64_t total = (uint64_t)DS4_MAX_LAYER * g_cpu_stream.n_experts;
     uint32_t victim = UINT32_MAX;
     for (uint64_t i = 0; i < total; i++) {
@@ -5591,7 +5591,7 @@ uint32_t cpu_stream_pick_victim(void) {
     return victim;
 }
 
-bool cpu_stream_evict_one(void) {
+static bool cpu_stream_evict_one(void) {
     const uint32_t victim = cpu_stream_pick_victim();
     if (victim == UINT32_MAX) return false;
     cpu_stream_entry *en = &g_cpu_stream.entries[victim];
@@ -5603,8 +5603,71 @@ bool cpu_stream_evict_one(void) {
     return true;
 }
 
-void cpu_stream_layer_begin(void) {
+static void cpu_stream_layer_begin(void) {
     if (g_cpu_stream.enabled) g_cpu_stream.seq++;
+}
+
+/* Self-test hook for the cache policy, callable from ds4_test (which links
+ * against ds4.o and cannot see the statics above). Returns 1 on pass. */
+int ds4_cpu_stream_policy_self_test(void) {
+#define CPU_STREAM_CHECK(x) \
+    do { if (!(x)) { fprintf(stderr, "cpu-stream self-test failed: %s\n", #x); return 0; } } while (0)
+
+    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+    g_cpu_stream.enabled = true;
+    g_cpu_stream.n_experts = 4;
+    g_cpu_stream.entries = calloc((size_t)DS4_MAX_LAYER * 4, sizeof(cpu_stream_entry));
+    CPU_STREAM_CHECK(g_cpu_stream.entries != NULL);
+    for (uint32_t il = 0; il < 2; il++) {
+        g_cpu_stream.expert_bytes[CPU_STREAM_GATE][il] = 64;
+        g_cpu_stream.expert_bytes[CPU_STREAM_UP][il] = 64;
+        g_cpu_stream.expert_bytes[CPU_STREAM_DOWN][il] = 64;
+    }
+    /* Install 3 synthetic entries in layer 0: experts 0,1,2. */
+    for (uint32_t e = 0; e < 3; e++) {
+        cpu_stream_entry *en = &g_cpu_stream.entries[0 * 4 + e];
+        for (int k = 0; k < 3; k++) {
+            en->buf[k] = aligned_alloc(64, 64);
+            CPU_STREAM_CHECK(en->buf[k] != NULL);
+        }
+        en->valid = true;
+        en->last_used = 10 + e;   /* 10, 11, 12 */
+        en->use_count = 5;
+        g_cpu_stream.used_bytes += cpu_stream_triple_bytes(0);
+    }
+    /* Expert 1 is hotter; expert 0 and 2 tie on use_count, 0 is older. */
+    g_cpu_stream.entries[1].use_count = 9;
+
+    uint32_t v = cpu_stream_pick_victim();
+    CPU_STREAM_CHECK(v == 0);                       /* lowest count, oldest */
+
+    /* Pin expert 0: victim must move to expert 2 (same count, newer but unpinned). */
+    g_cpu_stream.seq = 7;
+    g_cpu_stream.entries[0].pin_seq = 7;
+    v = cpu_stream_pick_victim();
+    CPU_STREAM_CHECK(v == 2);
+
+    /* Evict: frees buffers, drops used_bytes, marks invalid. */
+    uint64_t before = g_cpu_stream.used_bytes;
+    CPU_STREAM_CHECK(cpu_stream_evict_one());
+    CPU_STREAM_CHECK(g_cpu_stream.used_bytes == before - cpu_stream_triple_bytes(0));
+    CPU_STREAM_CHECK(!g_cpu_stream.entries[2].valid);
+    CPU_STREAM_CHECK(g_cpu_stream.evictions == 1);
+
+    /* Pin everything remaining: no victim available. */
+    g_cpu_stream.entries[1].pin_seq = 7;
+    CPU_STREAM_CHECK(cpu_stream_pick_victim() == UINT32_MAX);
+    CPU_STREAM_CHECK(!cpu_stream_evict_one());
+
+    for (uint32_t e = 0; e < 3; e++) {
+        cpu_stream_entry *en = &g_cpu_stream.entries[e];
+        if (en->valid) for (int k = 0; k < 3; k++) free(en->buf[k]);
+    }
+    free(g_cpu_stream.entries);
+    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+
+    return 1;
+#undef CPU_STREAM_CHECK
 }
 
 /* Locate one expert's 2D matrix inside a 3D GGUF expert tensor. */

--- a/ds4.c
+++ b/ds4.c
@@ -5525,6 +5525,88 @@ static float tensor_2d_value(const ds4_model *m, const ds4_tensor *t, uint64_t x
     return tensor_1d_value(m, t, y * t->dim[0] + x);
 }
 
+/* ---------------- CPU backend SSD streaming of routed experts ----------------
+ *
+ * On macOS, faulting the whole multi-GB GGUF through the CPU mmap can panic
+ * the kernel (see README and the mmap_flags comment in model_open). When
+ * --ssd-streaming is used with the CPU backend, routed expert weights are
+ * pread() into a bounded LRU cache of heap slabs instead, and the huge mmap
+ * is only touched for the (small) non-routed weights.
+ *
+ * Invariant: all lookups happen on the orchestrating thread. Worker threads
+ * only consume base pointers computed before dispatch, so no locking is
+ * needed. Entries touched during the current layer call carry
+ * pin_seq == g_cpu_stream.seq and are never evicted within that call. */
+
+/* Kinds of per-expert weight slabs (order matches Metal's gate/up/down naming). */
+typedef enum { CPU_STREAM_GATE = 0, CPU_STREAM_UP = 1, CPU_STREAM_DOWN = 2 } cpu_stream_kind;
+
+typedef struct {
+    uint8_t *buf[3];        /* gate/up/down slabs, aligned_alloc(64), NULL when !valid */
+    uint64_t last_used;     /* LRU clock stamp */
+    uint64_t use_count;     /* hotness (halved periodically) */
+    uint64_t pin_seq;       /* == g_cpu_stream.seq -> cannot be evicted this layer call */
+    bool valid;
+} cpu_stream_entry;
+
+typedef struct {
+    bool enabled;
+    int fd;                       /* model file descriptor (m->fd) */
+    uint32_t n_layers;            /* layers that HAVE expert tensors (moe layers) */
+    uint32_t n_experts;           /* experts per layer, from gate tensor dim[2] */
+    /* Per-moe-layer geometry, indexed by GGUF "blk.N" layer id (il). Layers
+     * without expert tensors keep off[il]==0 and are never resolved. */
+    uint64_t off[3][DS4_MAX_LAYER];          /* file abs_offset of gate/up/down tensor */
+    uint64_t expert_bytes[3][DS4_MAX_LAYER]; /* one expert's slab bytes per kind */
+    cpu_stream_entry *entries;    /* DS4_MAX_LAYER * n_experts, calloc'd */
+    uint64_t clock;               /* lookup counter, drives LRU + decay */
+    uint64_t seq;                 /* layer-call sequence, drives pinning */
+    uint64_t budget_bytes, used_bytes;
+    uint64_t hits, misses, evictions, pread_bytes;  /* stats for the summary log */
+} cpu_stream_state;
+
+cpu_stream_state g_cpu_stream;
+
+uint64_t cpu_stream_triple_bytes(uint32_t il) {
+    return g_cpu_stream.expert_bytes[CPU_STREAM_GATE][il] +
+           g_cpu_stream.expert_bytes[CPU_STREAM_UP][il] +
+           g_cpu_stream.expert_bytes[CPU_STREAM_DOWN][il];
+}
+
+/* Victim: lowest use_count, oldest last_used as tie-break; skip pinned. */
+uint32_t cpu_stream_pick_victim(void) {
+    const uint64_t total = (uint64_t)DS4_MAX_LAYER * g_cpu_stream.n_experts;
+    uint32_t victim = UINT32_MAX;
+    for (uint64_t i = 0; i < total; i++) {
+        cpu_stream_entry *en = &g_cpu_stream.entries[i];
+        if (!en->valid || (en->pin_seq != 0 && en->pin_seq == g_cpu_stream.seq)) continue;
+        if (victim == UINT32_MAX) { victim = (uint32_t)i; continue; }
+        cpu_stream_entry *v = &g_cpu_stream.entries[victim];
+        if (en->use_count < v->use_count ||
+            (en->use_count == v->use_count && en->last_used < v->last_used))
+        {
+            victim = (uint32_t)i;
+        }
+    }
+    return victim;
+}
+
+bool cpu_stream_evict_one(void) {
+    const uint32_t victim = cpu_stream_pick_victim();
+    if (victim == UINT32_MAX) return false;
+    cpu_stream_entry *en = &g_cpu_stream.entries[victim];
+    const uint32_t il = victim / g_cpu_stream.n_experts;
+    for (int k = 0; k < 3; k++) { free(en->buf[k]); en->buf[k] = NULL; }
+    en->valid = false;
+    g_cpu_stream.used_bytes -= cpu_stream_triple_bytes(il);
+    g_cpu_stream.evictions++;
+    return true;
+}
+
+void cpu_stream_layer_begin(void) {
+    if (g_cpu_stream.enabled) g_cpu_stream.seq++;
+}
+
 /* Locate one expert's 2D matrix inside a 3D GGUF expert tensor. */
 static const uint8_t *tensor_expert_bytes(
         const ds4_model  *m,

--- a/ds4.c
+++ b/ds4.c
@@ -32,6 +32,9 @@
 #include <sys/file.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
 #include <stdarg.h>
 #include <time.h>
 #include <unistd.h>
@@ -5980,6 +5983,112 @@ static const uint8_t *cpu_stream_expert_bytes(
 static void cpu_stream_ensure_experts(uint32_t il, const uint32_t *experts, uint32_t n) {
     if (!g_cpu_stream.enabled) return;
     for (uint32_t i = 0; i < n; i++) (void)cpu_stream_fetch(il, experts[i]);
+}
+
+/* Physical RAM size, used to size the default streaming cache budget when the
+ * caller does not pass an explicit --ssd-streaming-cache-experts/bytes. */
+static uint64_t cpu_stream_phys_ram(void) {
+#ifdef __APPLE__
+    uint64_t mem = 0; size_t len = sizeof(mem);
+    if (sysctlbyname("hw.memsize", &mem, &len, NULL, 0) == 0 && mem) return mem;
+#else
+    long pages = sysconf(_SC_PHYS_PAGES), psize = sysconf(_SC_PAGE_SIZE);
+    if (pages > 0 && psize > 0) return (uint64_t)pages * (uint64_t)psize;
+#endif
+    return 8ull * 1024 * 1024 * 1024;  /* conservative fallback */
+}
+
+/* Explicit flags win; otherwise default to 25% of physical RAM, floored so a
+ * full prefill layer (every expert selected once) always fits. */
+static uint64_t cpu_stream_resolve_budget(const ds4_engine_options *opt) {
+    uint64_t max_triple = 0;
+    for (uint32_t il = 0; il < DS4_MAX_LAYER; il++) {
+        const uint64_t t = cpu_stream_triple_bytes(il);
+        if (t > max_triple) max_triple = t;
+    }
+    const uint64_t floor_bytes = max_triple * g_cpu_stream.n_experts;
+    uint64_t budget = 0;
+    if (opt->ssd_streaming_cache_bytes) {
+        budget = opt->ssd_streaming_cache_bytes;
+    } else if (opt->ssd_streaming_cache_experts) {
+        budget = (uint64_t)opt->ssd_streaming_cache_experts * max_triple;
+    } else {
+        budget = cpu_stream_phys_ram() / 4;
+    }
+    return budget < floor_bytes ? floor_bytes : budget;
+}
+
+/* Build the (layer, kind) -> file range tables from the GGUF tensor directory
+ * alone (names like "blk.N.ffn_gate_exps.weight"), so init only needs the
+ * model, not the resolved weights table. */
+static bool cpu_stream_init(const ds4_model *m, const ds4_engine_options *opt) {
+    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+    uint32_t n_experts = 0, n_moe_layers = 0;
+    static const char *suffix[3] = {
+        ".ffn_gate_exps.weight", ".ffn_up_exps.weight", ".ffn_down_exps.weight",
+    };
+    for (uint64_t i = 0; i < m->n_tensors; i++) {
+        const ds4_tensor *t = &m->tensors[i];
+        if (t->ndim != 3 || t->name.len >= 64) continue;
+        char name[64];
+        memcpy(name, t->name.ptr, t->name.len);
+        name[t->name.len] = '\0';
+        unsigned il = 0; int k = -1; char rest[48] = "";
+        if (sscanf(name, "blk.%u%47s", &il, rest) != 2 || il >= DS4_MAX_LAYER) continue;
+        for (int s = 0; s < 3; s++) if (!strcmp(rest, suffix[s])) { k = s; break; }
+        if (k < 0) continue;
+        const gguf_type_info *info = tensor_type(t->type);
+        if (!info || info->block_elems == 0) return false;
+        const uint64_t blocks = (t->dim[0] + info->block_elems - 1) / info->block_elems;
+        g_cpu_stream.off[k][il] = t->abs_offset;
+        g_cpu_stream.expert_bytes[k][il] = t->dim[1] * (blocks * info->block_bytes);
+        if (n_experts == 0) n_experts = (uint32_t)t->dim[2];
+        if (t->dim[2] != n_experts) return false;
+        if (k == 0) n_moe_layers++;
+    }
+    if (!n_experts || !n_moe_layers) return false;
+    g_cpu_stream.n_experts = n_experts;
+    g_cpu_stream.n_layers = n_moe_layers;
+    g_cpu_stream.fd = m->fd;
+    g_cpu_stream.entries = calloc((size_t)DS4_MAX_LAYER * n_experts, sizeof(cpu_stream_entry));
+    if (!g_cpu_stream.entries) return false;
+    g_cpu_stream.budget_bytes = cpu_stream_resolve_budget(opt);
+    g_cpu_stream.enabled = true;
+    ds4_log(stderr, DS4_LOG_WARNING,
+            "ds4: CPU SSD streaming: %u moe layers, %u experts/layer, cache budget %.2f GiB\n",
+            n_moe_layers, n_experts,
+            (double)g_cpu_stream.budget_bytes / (1024.0 * 1024.0 * 1024.0));
+    return true;
+}
+
+static void cpu_stream_close(void) {
+    if (!g_cpu_stream.entries) return;
+    const uint64_t total = (uint64_t)DS4_MAX_LAYER * g_cpu_stream.n_experts;
+    for (uint64_t i = 0; i < total; i++) {
+        cpu_stream_entry *en = &g_cpu_stream.entries[i];
+        if (en->valid) for (int k = 0; k < 3; k++) free(en->buf[k]);
+    }
+    free(g_cpu_stream.entries);
+    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+}
+
+/* WILLNEED only the non-routed weights: they are the small resident part.
+ * Never hint the routed expert ranges -- those go through pread. */
+static void cpu_stream_prefetch_nonrouted(const ds4_model *m) {
+#if defined(POSIX_MADV_WILLNEED)
+    for (uint64_t i = 0; i < m->n_tensors; i++) {
+        const ds4_tensor *t = &m->tensors[i];
+        if (t->ndim == 3) {
+            uint32_t il; cpu_stream_kind kind;
+            if (cpu_stream_resolve(t, &il, &kind)) continue;  /* routed: skip */
+        }
+        if (t->bytes == 0) continue;
+        posix_madvise((void *)(m->map + t->abs_offset), (size_t)t->bytes,
+                      POSIX_MADV_WILLNEED);
+    }
+#else
+    (void)m;
+#endif
 }
 
 /* Locate one expert's 2D matrix inside a 3D GGUF expert tensor. */
@@ -26077,15 +26186,35 @@ int ds4_engine_open(ds4_engine **out, const ds4_engine_options *opt) {
 
     const bool graph_backend = ds4_backend_uses_graph(opt->backend);
     if (graph_backend) ds4_linux_graph_backend_set_oom_score(opt->backend);
-    model_open(&e->model, opt->model_path, graph_backend, !opt->inspect_only);
+    const bool cpu_streaming = opt->ssd_streaming && opt->backend == DS4_BACKEND_CPU;
+    /* CPU streaming replaces the whole-file WILLNEED prefetch with per-tensor
+     * hints on the non-routed weights only (see cpu_stream_prefetch_nonrouted). */
+    model_open(&e->model, opt->model_path, graph_backend,
+               !opt->inspect_only && !cpu_streaming);
     if (opt->warm_weights) model_warm_weights(&e->model);
     if (!opt->inspect_only) vocab_load(&e->vocab, &e->model);
     config_validate_model(&e->model);
     if (e->ssd_streaming && !ds4_backend_supports_ssd_streaming(e->backend)) {
-        fprintf(stderr, "ds4: --ssd-streaming is currently supported only with --metal/--cuda/--rocm\n");
-        ds4_engine_close(e);
-        *out = NULL;
-        return 1;
+        if (e->backend == DS4_BACKEND_CPU) {
+            /* CPU streaming: bounded pread cache for routed experts. This is
+             * the supported way to run the CPU backend on macOS, where
+             * faulting the whole GGUF through the mmap can panic the kernel. */
+            if (!cpu_stream_init(&e->model, opt)) {
+                fprintf(stderr, "ds4: --ssd-streaming: model has no routed expert tensors\n");
+                ds4_engine_close(e);
+                *out = NULL;
+                return 1;
+            }
+            if (opt->ssd_streaming_preload_experts != 0) {
+                fprintf(stderr, "ds4: --ssd-streaming-preload-experts is ignored on the CPU backend\n");
+            }
+            if (!opt->inspect_only) cpu_stream_prefetch_nonrouted(&e->model);
+        } else {
+            fprintf(stderr, "ds4: --ssd-streaming is currently supported only with --metal/--cuda/--rocm (or --cpu)\n");
+            ds4_engine_close(e);
+            *out = NULL;
+            return 1;
+        }
     }
     const char *expert_profile_path = opt->expert_profile_path;
     if (!expert_profile_path || !expert_profile_path[0]) {
@@ -26499,6 +26628,7 @@ void ds4_engine_close(ds4_engine *e) {
     vocab_free(&e->vocab);
     ds4_threads_shutdown();
     if (e->mtp_ready) model_close(&e->mtp_model);
+    cpu_stream_close();
     model_close(&e->model);
 #ifndef DS4_NO_GPU
     ds4_gpu_cleanup();

--- a/ds4.c
+++ b/ds4.c
@@ -5533,10 +5533,17 @@ static float tensor_2d_value(const ds4_model *m, const ds4_tensor *t, uint64_t x
  * pread() into a bounded LRU cache of heap slabs instead, and the huge mmap
  * is only touched for the (small) non-routed weights.
  *
- * Invariant: all lookups happen on the orchestrating thread. Worker threads
- * only consume base pointers computed before dispatch, so no locking is
- * needed. Entries touched during the current layer call carry
- * pin_seq == g_cpu_stream.seq and are never evicted within that call. */
+ * Invariant: cache lookups can happen concurrently from pool worker threads
+ * (layer_routed_moe_tokens_parallel() dispatches routed_moe_tokens_worker()
+ * across the pool, each reaching cpu_stream_fetch() through
+ * tensor_expert_bytes()), so cpu_stream_fetch() serializes its body under
+ * g_cpu_stream_lock. Entries touched during the current layer call carry
+ * pin_seq == g_cpu_stream.seq and are never evicted within that call, which
+ * keeps pointers already handed to workers valid while others still run.
+ * The pin sequence itself is only advanced by the orchestrating thread
+ * between parallel sections (cpu_stream_layer_begin() never runs on a
+ * worker thread), and cpu_stream_resolve() needs no lock since it only
+ * reads tables that are immutable once streaming is enabled. */
 
 /* Kinds of per-expert weight slabs (order matches Metal's gate/up/down naming). */
 typedef enum { CPU_STREAM_GATE = 0, CPU_STREAM_UP = 1, CPU_STREAM_DOWN = 2 } cpu_stream_kind;
@@ -5566,6 +5573,18 @@ typedef struct {
 } cpu_stream_state;
 
 static cpu_stream_state g_cpu_stream;
+
+/* layer_routed_moe_tokens_parallel() dispatches routed_moe_tokens_worker()
+ * across pool worker threads, each of which reaches cpu_stream_fetch() via
+ * tensor_expert_bytes() concurrently for disjoint token ranges of the same
+ * layer. This mutex serializes the cache's shared state (entries table,
+ * used_bytes, LRU/hotness bookkeeping) across those threads. It is safe and
+ * cheap: entries pinned in the current seq are never evicted, so a pointer
+ * handed back to one worker stays valid while other workers run; seq itself
+ * is only advanced by the orchestrating thread between parallel sections
+ * (cpu_stream_layer_begin() never runs on a worker thread), so no worker can
+ * unpin another worker's in-flight entry mid-layer. */
+static pthread_mutex_t g_cpu_stream_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static uint64_t cpu_stream_triple_bytes(uint32_t il) {
     return g_cpu_stream.expert_bytes[CPU_STREAM_GATE][il] +
@@ -5625,8 +5644,9 @@ static void cpu_stream_pread_range(int fd, void *dst, uint64_t len, uint64_t off
 }
 
 /* Make (il, e) resident and return its entry. Evicts until the triple fits;
- * dies if the budget cannot hold the working set (all candidates pinned). */
-static cpu_stream_entry *cpu_stream_fetch(uint32_t il, uint32_t e) {
+ * dies if the budget cannot hold the working set (all candidates pinned).
+ * Must be called with g_cpu_stream_lock held; see cpu_stream_fetch(). */
+static cpu_stream_entry *cpu_stream_fetch_locked(uint32_t il, uint32_t e) {
     cpu_stream_entry *en = &g_cpu_stream.entries[(uint64_t)il * g_cpu_stream.n_experts + e];
     g_cpu_stream.clock++;
     /* Periodic hotness decay so old bursts don't pin the cache forever. */
@@ -5660,6 +5680,19 @@ static cpu_stream_entry *cpu_stream_fetch(uint32_t il, uint32_t e) {
     en->use_count = 1;
     g_cpu_stream.used_bytes += need;
     g_cpu_stream.misses++;
+    return en;
+}
+
+/* Worker threads in layer_routed_moe_tokens_parallel() call this concurrently
+ * (one thread per disjoint token range, same layer) via tensor_expert_bytes().
+ * The whole cache lookup/install/eviction body runs under g_cpu_stream_lock;
+ * see the comment above g_cpu_stream_lock for why this is safe to serialize
+ * without stalling correctness (pinned entries keep returned pointers alive
+ * across the critical section). */
+static cpu_stream_entry *cpu_stream_fetch(uint32_t il, uint32_t e) {
+    pthread_mutex_lock(&g_cpu_stream_lock);
+    cpu_stream_entry *en = cpu_stream_fetch_locked(il, e);
+    pthread_mutex_unlock(&g_cpu_stream_lock);
     return en;
 }
 
@@ -5788,6 +5821,167 @@ int ds4_cpu_stream_fetch_self_test(void) {
 #undef CPU_STREAM_CHECK
 }
 
+/* Shared context for ds4_cpu_stream_parallel_self_test()'s worker threads. */
+typedef struct {
+    uint32_t experts[2];      /* the two experts this thread alternates between */
+    volatile int *failed;     /* shared failure flag, set (never cleared) on mismatch */
+} cpu_stream_parallel_worker_ctx;
+
+/* Worker body for the concurrent fetch stress test: repeatedly fetches its
+ * two assigned experts in layer 0 and verifies every byte of all three
+ * returned slabs against the deterministic file pattern. Runs concurrently
+ * with sibling threads the way routed_moe_tokens_worker() calls
+ * cpu_stream_fetch() (via tensor_expert_bytes()) from multiple pool threads
+ * for the same layer. */
+static void *cpu_stream_parallel_self_test_worker(void *arg) {
+    cpu_stream_parallel_worker_ctx *ctx = arg;
+    for (int iter = 0; iter < 100; iter++) {
+        const uint32_t e = ctx->experts[iter & 1];
+        cpu_stream_entry *en = cpu_stream_fetch(0, e);
+        if (!en || !en->valid) { *ctx->failed = 1; continue; }
+        for (int k = 0; k < 3; k++) {
+            uint8_t expected[256];
+            for (int i = 0; i < 256; i++) {
+                expected[i] = (uint8_t)(k * 31 + (int)e * 7 + (i & 0xFF));
+            }
+            if (memcmp(en->buf[k], expected, sizeof(expected)) != 0) {
+                *ctx->failed = 1;
+            }
+        }
+    }
+    return NULL;
+}
+
+/* Self-test hook for concurrent cpu_stream_fetch() calls, callable from
+ * ds4_test (which links against ds4.o and cannot see the statics above).
+ * Reproduces the concurrency shape of layer_routed_moe_tokens_parallel():
+ * the orchestrator advances the pin sequence once per round, then several
+ * threads call cpu_stream_fetch() concurrently for the same layer. A tight
+ * 5-triple budget forces cross-round eviction so the mutex + pinning
+ * invariants are actually exercised, not just the uncontended fast path.
+ * Returns 1 on pass. */
+int ds4_cpu_stream_parallel_self_test(void) {
+#define CPU_STREAM_CHECK(x) \
+    do { if (!(x)) { fprintf(stderr, "cpu-stream parallel self-test failed: %s\n", #x); return 0; } } while (0)
+
+    enum { N_EXPERTS = 8, SLAB = 256, N_THREADS = 4, N_ROUNDS = 50 };
+
+    char path[] = "/tmp/ds4_cpu_stream_parallel_test_XXXXXX";
+    int fd = mkstemp(path);
+    CPU_STREAM_CHECK(fd >= 0);
+
+    /* Layout: 1 layer, 8 experts, 3 kinds, 256-byte slabs per expert.
+     * gate at file offset 0, up at 2048, down at 4096. Byte i of expert e's
+     * kind-k slab holds (uint8_t)(k*31 + e*7 + (i & 0xFF)). */
+    uint8_t *filedata = xmalloc((size_t)N_EXPERTS * SLAB * 3);
+    for (int k = 0; k < 3; k++) {
+        for (int e = 0; e < N_EXPERTS; e++) {
+            uint8_t *slab = filedata + (size_t)k * N_EXPERTS * SLAB + (size_t)e * SLAB;
+            for (int i = 0; i < SLAB; i++) slab[i] = (uint8_t)(k * 31 + e * 7 + (i & 0xFF));
+        }
+    }
+    CPU_STREAM_CHECK(write(fd, filedata, (size_t)N_EXPERTS * SLAB * 3) ==
+                     (ssize_t)((size_t)N_EXPERTS * SLAB * 3));
+    free(filedata);
+
+    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+    g_cpu_stream.enabled = true;
+    g_cpu_stream.fd = fd;
+    g_cpu_stream.n_experts = N_EXPERTS;
+    g_cpu_stream.off[CPU_STREAM_GATE][0] = 0;
+    g_cpu_stream.off[CPU_STREAM_UP][0] = (uint64_t)N_EXPERTS * SLAB;
+    g_cpu_stream.off[CPU_STREAM_DOWN][0] = (uint64_t)N_EXPERTS * SLAB * 2;
+    for (int k = 0; k < 3; k++) g_cpu_stream.expert_bytes[k][0] = SLAB;
+    g_cpu_stream.entries = calloc((size_t)DS4_MAX_LAYER * N_EXPERTS, sizeof(cpu_stream_entry));
+    CPU_STREAM_CHECK(g_cpu_stream.entries != NULL);
+    /* Budget = 5 triples: each round's union of touched experts is 4 triples
+     * ({0,1,2,3} or {4,5,6,7}), so a round never exceeds the budget on its
+     * own, but alternating rounds guarantee eviction across rounds. */
+    g_cpu_stream.budget_bytes = 5 * (uint64_t)(SLAB * 3);
+
+    volatile int failed = 0;
+
+    for (int round = 0; round < N_ROUNDS; round++) {
+        cpu_stream_layer_begin();
+        const uint32_t base = (round & 1) ? 4 : 0;
+        pthread_t threads[N_THREADS];
+        cpu_stream_parallel_worker_ctx ctxs[N_THREADS];
+        for (int t = 0; t < N_THREADS; t++) {
+            ctxs[t].experts[0] = base + (uint32_t)t;
+            ctxs[t].experts[1] = base + (((uint32_t)t + 1) & 3);
+            ctxs[t].failed = &failed;
+            CPU_STREAM_CHECK(pthread_create(&threads[t], NULL,
+                                             cpu_stream_parallel_self_test_worker,
+                                             &ctxs[t]) == 0);
+        }
+        for (int t = 0; t < N_THREADS; t++) pthread_join(threads[t], NULL);
+    }
+
+    CPU_STREAM_CHECK(!failed);
+    CPU_STREAM_CHECK(g_cpu_stream.evictions > 0);
+
+    const uint64_t total = (uint64_t)DS4_MAX_LAYER * N_EXPERTS;
+    for (uint64_t i = 0; i < total; i++) {
+        cpu_stream_entry *en = &g_cpu_stream.entries[i];
+        if (en->valid) for (int k = 0; k < 3; k++) free(en->buf[k]);
+    }
+    free(g_cpu_stream.entries);
+    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+    close(fd); unlink(path);
+
+    return 1;
+#undef CPU_STREAM_CHECK
+}
+
+/* Map a routed expert tensor back to (layer, kind) by its file offset. Linear
+ * scan over <= 61*3 entries; negligible next to the matvec work per call. */
+static bool cpu_stream_resolve(const ds4_tensor *w, uint32_t *il, cpu_stream_kind *kind) {
+    for (uint32_t l = 0; l < DS4_MAX_LAYER; l++) {
+        for (int k = 0; k < 3; k++) {
+            if (g_cpu_stream.expert_bytes[k][l] != 0 &&
+                g_cpu_stream.off[k][l] == w->abs_offset)
+            {
+                *il = l; *kind = (cpu_stream_kind)k;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/* Streaming twin of tensor_expert_bytes(): same out-params, but the returned
+ * pointer refers to a resident cache slab instead of the mmap. */
+static const uint8_t *cpu_stream_expert_bytes(
+        const ds4_model  *m,
+        const ds4_tensor *w,
+        uint32_t          expert,
+        uint64_t         *in_dim,
+        uint64_t         *out_dim,
+        uint64_t         *row_bytes) {
+    uint32_t il; cpu_stream_kind kind;
+    if (!cpu_stream_resolve(w, &il, &kind)) {
+        /* Not a routed expert tensor we track (should not happen: only 3D
+         * expert tensors reach this path). Fall back to the mmap. */
+        (void)m;
+        return NULL;
+    }
+    *in_dim = w->dim[0];
+    *out_dim = w->dim[1];
+    const gguf_type_info *info = tensor_type(w->type);
+    if (!info || info->block_elems == 0) ds4_die("unsupported expert tensor type");
+    const uint64_t blocks = (*in_dim + info->block_elems - 1) / info->block_elems;
+    *row_bytes = blocks * info->block_bytes;
+    cpu_stream_entry *en = cpu_stream_fetch(il, expert);
+    return en->buf[kind];
+}
+
+/* Pin + prefetch every unique expert a batch will touch in this layer, in
+ * ascending expert id (== ascending file offset, so reads are near-sequential). */
+static void cpu_stream_ensure_experts(uint32_t il, const uint32_t *experts, uint32_t n) {
+    if (!g_cpu_stream.enabled) return;
+    for (uint32_t i = 0; i < n; i++) (void)cpu_stream_fetch(il, experts[i]);
+}
+
 /* Locate one expert's 2D matrix inside a 3D GGUF expert tensor. */
 static const uint8_t *tensor_expert_bytes(
         const ds4_model  *m,
@@ -5798,6 +5992,11 @@ static const uint8_t *tensor_expert_bytes(
         uint64_t         *row_bytes) {
     if (w->ndim != 3) ds4_die("expected a 3D expert tensor");
     if (expert >= w->dim[2]) ds4_die("expert id is outside expert tensor");
+
+    if (g_cpu_stream.enabled) {
+        const uint8_t *p = cpu_stream_expert_bytes(m, w, expert, in_dim, out_dim, row_bytes);
+        if (p) return p;
+    }
 
     *in_dim = w->dim[0];
     *out_dim = w->dim[1];
@@ -7706,6 +7905,7 @@ static void layer_routed_moe_one(
         int                 token,
         float               clamp,
         bool                trace) {
+    cpu_stream_layer_begin();
     int selected[DS4_MAX_EXPERT_USED];
     float expert_weight[DS4_MAX_EXPERT_USED];
     float *gate = trace ? xmalloc((size_t)DS4_N_FF_EXP * sizeof(gate[0])) : NULL;
@@ -7854,6 +8054,7 @@ static void layer_routed_moe_batch(
         uint32_t            n_tok,
         uint32_t            il,
         float               clamp) {
+    cpu_stream_layer_begin();
     const uint64_t expert_in_dim = layer->ffn_gate_exps->dim[0];
     const uint64_t expert_out_dim = layer->ffn_gate_exps->dim[1];
     const uint64_t down_in_dim = layer->ffn_down_exps->dim[0];
@@ -7905,6 +8106,8 @@ static void layer_routed_moe_batch(
         cursor[e] = counts[e];
         if (counts[e + 1] != counts[e]) active_expert[n_active++] = e;
     }
+
+    cpu_stream_ensure_experts(il, active_expert, n_active);
 
     uint32_t *pair_ids = xmalloc((size_t)total_pairs * sizeof(pair_ids[0]));
     for (uint32_t p = 0; p < total_pairs; p++) {
@@ -8207,6 +8410,7 @@ static void layer_ffn_one_decode_scratch(
     if (profile) t_norm = now_sec() - t0;
 
     t0 = profile ? now_sec() : 0.0;
+    cpu_stream_layer_begin();
     layer_routed_moe_one_prealloc(scratch->ffn_moe,
                                   model,
                                   layer,
@@ -8372,6 +8576,10 @@ static void layer_routed_moe_tokens_parallel(
         .down_in_dim = layer->ffn_down_exps->dim[0],
         .il = il,
     };
+    /* Bump the pin sequence once here, on the orchestrating thread, before
+     * dispatching worker threads that will call cpu_stream_fetch() (via
+     * tensor_expert_bytes()) concurrently for this layer. */
+    cpu_stream_layer_begin();
     ds4_parallel_for_min_rows(n_tok, routed_moe_tokens_worker, &ctx, 1);
 }
 
@@ -8428,6 +8636,7 @@ static void layer_ffn_shared_batch(
     if (routed_token_parallel) {
         layer_routed_moe_tokens_parallel(moe, model, layer, norm, token_ids, n_tok, il);
     } else {
+        cpu_stream_layer_begin();
         for (uint32_t t = 0; t < n_tok; t++) {
             layer_routed_moe_one_prealloc(moe + (uint64_t)t * DS4_N_EMBD,
                                           model,
@@ -16661,6 +16870,7 @@ static void metal_graph_trace_layer_stages(
                               shared_xscale);
     swiglu(cpu_shared_mid, cpu_shared_gate, cpu_shared_up, shared_dim, DS4_SWIGLU_CLAMP_EXP);
     matvec_q8_0(cpu_shared, model, layer->ffn_down_shexp, cpu_shared_mid);
+    cpu_stream_layer_begin();
     layer_routed_moe_one_prealloc(cpu_routed,
                                   model,
                                   layer,
@@ -16886,6 +17096,7 @@ static int metal_graph_decode_test(
                           cpu_after_attn_hc, cpu_ffn_cur, cpu_ffn_post, cpu_ffn_comb);
     rms_norm_weight(cpu_ffn_norm, cpu_ffn_cur, tensor_data(model, layer->ffn_norm), DS4_N_EMBD, DS4_RMS_EPS);
     layer_shared_ffn_one(cpu_shared, model, layer, cpu_ffn_norm);
+    cpu_stream_layer_begin();
     layer_routed_moe_one_prealloc(cpu_routed,
                                   model,
                                   layer,

--- a/ds4.c
+++ b/ds4.c
@@ -5902,6 +5902,9 @@ int ds4_cpu_stream_parallel_self_test(void) {
      * own, but alternating rounds guarantee eviction across rounds. */
     g_cpu_stream.budget_bytes = 5 * (uint64_t)(SLAB * 3);
 
+    /* pthread_join() below is the real synchronization barrier that makes
+     * each round's writes to failed visible to this thread; volatile is
+     * belt-and-braces, not load-bearing. */
     volatile int failed = 0;
 
     for (int round = 0; round < N_ROUNDS; round++) {
@@ -5953,7 +5956,11 @@ static bool cpu_stream_resolve(const ds4_tensor *w, uint32_t *il, cpu_stream_kin
 }
 
 /* Streaming twin of tensor_expert_bytes(): same out-params, but the returned
- * pointer refers to a resident cache slab instead of the mmap. */
+ * pointer refers to a resident cache slab instead of the mmap. Never returns
+ * NULL: a routed expert tensor that fails to resolve means the streaming
+ * cache's tables disagree with the model it was built from, which is a bug,
+ * not a condition to silently fall back on (that fallback is exactly the
+ * huge-mmap-fault regime --ssd-streaming exists to avoid). */
 static const uint8_t *cpu_stream_expert_bytes(
         const ds4_model  *m,
         const ds4_tensor *w,
@@ -5961,12 +5968,10 @@ static const uint8_t *cpu_stream_expert_bytes(
         uint64_t         *in_dim,
         uint64_t         *out_dim,
         uint64_t         *row_bytes) {
+    (void)m;
     uint32_t il; cpu_stream_kind kind;
     if (!cpu_stream_resolve(w, &il, &kind)) {
-        /* Not a routed expert tensor we track (should not happen: only 3D
-         * expert tensors reach this path). Fall back to the mmap. */
-        (void)m;
-        return NULL;
+        ds4_die("cpu-stream: routed expert tensor is not registered in the streaming cache");
     }
     *in_dim = w->dim[0];
     *out_dim = w->dim[1];
@@ -5981,6 +5986,7 @@ static const uint8_t *cpu_stream_expert_bytes(
 /* Pin + prefetch every unique expert a batch will touch in this layer, in
  * ascending expert id (== ascending file offset, so reads are near-sequential). */
 static void cpu_stream_ensure_experts(uint32_t il, const uint32_t *experts, uint32_t n) {
+    /* enabled is set once at init, before any worker thread exists. */
     if (!g_cpu_stream.enabled) return;
     for (uint32_t i = 0; i < n; i++) (void)cpu_stream_fetch(il, experts[i]);
 }
@@ -6008,12 +6014,20 @@ static uint64_t cpu_stream_resolve_budget(const ds4_engine_options *opt) {
     }
     const uint64_t floor_bytes = max_triple * g_cpu_stream.n_experts;
     uint64_t budget = 0;
+    const bool explicit_budget =
+        opt->ssd_streaming_cache_bytes != 0 || opt->ssd_streaming_cache_experts != 0;
     if (opt->ssd_streaming_cache_bytes) {
         budget = opt->ssd_streaming_cache_bytes;
     } else if (opt->ssd_streaming_cache_experts) {
         budget = (uint64_t)opt->ssd_streaming_cache_experts * max_triple;
     } else {
         budget = cpu_stream_phys_ram() / 4;
+    }
+    if (explicit_budget && budget < floor_bytes) {
+        fprintf(stderr,
+                "ds4: cpu-stream: requested expert cache below the one-layer minimum; "
+                "raised to %.2f GiB\n",
+                (double)floor_bytes / (1024.0 * 1024.0 * 1024.0));
     }
     return budget < floor_bytes ? floor_bytes : budget;
 }
@@ -6063,6 +6077,16 @@ static bool cpu_stream_init(const ds4_model *m, const ds4_engine_options *opt) {
 
 static void cpu_stream_close(void) {
     if (!g_cpu_stream.entries) return;
+    if (g_cpu_stream.enabled) {
+        ds4_log(stderr, DS4_LOG_WARNING,
+                "ds4: CPU stream: %u layers, %llu hits, %llu misses, %llu evictions, "
+                "%.2f GiB read\n",
+                g_cpu_stream.n_layers,
+                (unsigned long long)g_cpu_stream.hits,
+                (unsigned long long)g_cpu_stream.misses,
+                (unsigned long long)g_cpu_stream.evictions,
+                (double)g_cpu_stream.pread_bytes / (1024.0 * 1024.0 * 1024.0));
+    }
     const uint64_t total = (uint64_t)DS4_MAX_LAYER * g_cpu_stream.n_experts;
     for (uint64_t i = 0; i < total; i++) {
         cpu_stream_entry *en = &g_cpu_stream.entries[i];
@@ -6103,8 +6127,7 @@ static const uint8_t *tensor_expert_bytes(
     if (expert >= w->dim[2]) ds4_die("expert id is outside expert tensor");
 
     if (g_cpu_stream.enabled) {
-        const uint8_t *p = cpu_stream_expert_bytes(m, w, expert, in_dim, out_dim, row_bytes);
-        if (p) return p;
+        return cpu_stream_expert_bytes(m, w, expert, in_dim, out_dim, row_bytes);
     }
 
     *in_dim = w->dim[0];
@@ -26187,6 +26210,16 @@ int ds4_engine_open(ds4_engine **out, const ds4_engine_options *opt) {
     const bool graph_backend = ds4_backend_uses_graph(opt->backend);
     if (graph_backend) ds4_linux_graph_backend_set_oom_score(opt->backend);
     const bool cpu_streaming = opt->ssd_streaming && opt->backend == DS4_BACKEND_CPU;
+#ifdef __APPLE__
+    /* Advisory only: we do not refuse to run, we just warn. Tokenizer-only
+     * (--inspect-only) runs never touch the tensor payload, so they cannot
+     * trigger the mmap fault storm this warns about. */
+    if (opt->backend == DS4_BACKEND_CPU && !opt->ssd_streaming && !opt->inspect_only) {
+        fprintf(stderr,
+                "ds4: warning: the plain CPU path can crash current macOS kernels with "
+                "large models; use --ssd-streaming (see README)\n");
+    }
+#endif
     /* CPU streaming replaces the whole-file WILLNEED prefetch with per-tensor
      * hints on the non-routed weights only (see cpu_stream_prefetch_nonrouted). */
     model_open(&e->model, opt->model_path, graph_backend,

--- a/ds4.c
+++ b/ds4.c
@@ -5607,6 +5607,62 @@ static void cpu_stream_layer_begin(void) {
     if (g_cpu_stream.enabled) g_cpu_stream.seq++;
 }
 
+/* Robust positional read: loops on EINTR/short reads; model file truncation
+ * is fatal, matching ds4_die_errno style elsewhere. */
+static void cpu_stream_pread_range(int fd, void *dst, uint64_t len, uint64_t off) {
+    uint8_t *p = dst;
+    uint64_t pos = 0;
+    while (pos < len) {
+        ssize_t n = pread(fd, p + pos, (size_t)(len - pos), (off_t)(off + pos));
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            ds4_die_errno("cpu-stream: pread of expert slab failed", "expert slab");
+        }
+        if (n == 0) ds4_die("cpu-stream: model file truncated while reading expert slab");
+        pos += (uint64_t)n;
+    }
+    g_cpu_stream.pread_bytes += len;
+}
+
+/* Make (il, e) resident and return its entry. Evicts until the triple fits;
+ * dies if the budget cannot hold the working set (all candidates pinned). */
+static cpu_stream_entry *cpu_stream_fetch(uint32_t il, uint32_t e) {
+    cpu_stream_entry *en = &g_cpu_stream.entries[(uint64_t)il * g_cpu_stream.n_experts + e];
+    g_cpu_stream.clock++;
+    /* Periodic hotness decay so old bursts don't pin the cache forever. */
+    if ((g_cpu_stream.clock & 0xFFF) == 0) {
+        const uint64_t total = (uint64_t)DS4_MAX_LAYER * g_cpu_stream.n_experts;
+        for (uint64_t i = 0; i < total; i++) g_cpu_stream.entries[i].use_count >>= 1;
+    }
+    en->pin_seq = g_cpu_stream.seq;
+    if (en->valid) {
+        en->last_used = g_cpu_stream.clock;
+        en->use_count++;
+        g_cpu_stream.hits++;
+        return en;
+    }
+    const uint64_t need = cpu_stream_triple_bytes(il);
+    while (g_cpu_stream.used_bytes + need > g_cpu_stream.budget_bytes) {
+        if (!cpu_stream_evict_one()) {
+            ds4_die("cpu-stream: expert cache budget too small for the working set; "
+                    "raise --ssd-streaming-cache-experts");
+        }
+    }
+    for (int k = 0; k < 3; k++) {
+        const uint64_t bytes = g_cpu_stream.expert_bytes[k][il];
+        en->buf[k] = aligned_alloc(64, (size_t)((bytes + 63) & ~63ull));
+        if (!en->buf[k]) ds4_die("cpu-stream: out of memory allocating expert slab");
+        cpu_stream_pread_range(g_cpu_stream.fd, en->buf[k], bytes,
+                               g_cpu_stream.off[k][il] + (uint64_t)e * bytes);
+    }
+    en->valid = true;
+    en->last_used = g_cpu_stream.clock;
+    en->use_count = 1;
+    g_cpu_stream.used_bytes += need;
+    g_cpu_stream.misses++;
+    return en;
+}
+
 /* Self-test hook for the cache policy, callable from ds4_test (which links
  * against ds4.o and cannot see the statics above). Returns 1 on pass. */
 int ds4_cpu_stream_policy_self_test(void) {
@@ -5665,6 +5721,68 @@ int ds4_cpu_stream_policy_self_test(void) {
     }
     free(g_cpu_stream.entries);
     memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+
+    return 1;
+#undef CPU_STREAM_CHECK
+}
+
+/* Self-test hook for the pread loader and fetch/install path, callable from
+ * ds4_test (which links against ds4.o and cannot see the statics above).
+ * Exercises a real temp file so byte round-tripping and eviction-triggered
+ * re-reads are verified against actual pread() behavior. Returns 1 on pass. */
+int ds4_cpu_stream_fetch_self_test(void) {
+#define CPU_STREAM_CHECK(x) \
+    do { if (!(x)) { fprintf(stderr, "cpu-stream fetch self-test failed: %s\n", #x); return 0; } } while (0)
+
+    char path[] = "/tmp/ds4_cpu_stream_test_XXXXXX";
+    int fd = mkstemp(path);
+    CPU_STREAM_CHECK(fd >= 0);
+    /* Layout: layer 0 has 2 experts, slabs of 64 bytes per kind.
+     * gate tensor at off 0 (2*64), up at 128 (2*64), down at 256 (2*64). */
+    uint8_t filedata[384];
+    for (int i = 0; i < 384; i++) filedata[i] = (uint8_t)(i * 7 + 3);
+    CPU_STREAM_CHECK(write(fd, filedata, sizeof(filedata)) == (ssize_t)sizeof(filedata));
+
+    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+    g_cpu_stream.enabled = true;
+    g_cpu_stream.fd = fd;
+    g_cpu_stream.n_experts = 2;
+    g_cpu_stream.off[CPU_STREAM_GATE][0] = 0;
+    g_cpu_stream.off[CPU_STREAM_UP][0] = 128;
+    g_cpu_stream.off[CPU_STREAM_DOWN][0] = 256;
+    for (int k = 0; k < 3; k++) g_cpu_stream.expert_bytes[k][0] = 64;
+    g_cpu_stream.entries = calloc((size_t)DS4_MAX_LAYER * 2, sizeof(cpu_stream_entry));
+    CPU_STREAM_CHECK(g_cpu_stream.entries != NULL);
+    g_cpu_stream.budget_bytes = 2 * 192;   /* room for both experts */
+
+    cpu_stream_entry *e1 = cpu_stream_fetch(0, 1);
+    CPU_STREAM_CHECK(e1 && e1->valid);
+    /* Expert 1's gate slab lives at file offset 0 + 1*64. */
+    CPU_STREAM_CHECK(memcmp(e1->buf[CPU_STREAM_GATE], filedata + 64, 64) == 0);
+    CPU_STREAM_CHECK(memcmp(e1->buf[CPU_STREAM_UP], filedata + 128 + 64, 64) == 0);
+    CPU_STREAM_CHECK(memcmp(e1->buf[CPU_STREAM_DOWN], filedata + 256 + 64, 64) == 0);
+    CPU_STREAM_CHECK(g_cpu_stream.misses == 1);
+
+    cpu_stream_entry *again = cpu_stream_fetch(0, 1);
+    CPU_STREAM_CHECK(again == e1 && g_cpu_stream.hits == 1 && g_cpu_stream.misses == 1);
+
+    /* Budget for one expert only: fetching 0 evicts 1 (unpinned in new seq). */
+    g_cpu_stream.budget_bytes = 192;
+    g_cpu_stream.seq++;
+    cpu_stream_entry *e0 = cpu_stream_fetch(0, 0);
+    CPU_STREAM_CHECK(e0 && e0->valid);
+    CPU_STREAM_CHECK(!g_cpu_stream.entries[1].valid);   /* evicted */
+    CPU_STREAM_CHECK(g_cpu_stream.evictions == 1);
+    CPU_STREAM_CHECK(memcmp(e0->buf[CPU_STREAM_GATE], filedata + 0, 64) == 0);
+    CPU_STREAM_CHECK(g_cpu_stream.used_bytes == 192);
+
+    for (uint32_t e = 0; e < 2; e++) {
+        cpu_stream_entry *en = &g_cpu_stream.entries[e];
+        if (en->valid) for (int k = 0; k < 3; k++) free(en->buf[k]);
+    }
+    free(g_cpu_stream.entries);
+    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+    close(fd); unlink(path);
 
     return 1;
 #undef CPU_STREAM_CHECK

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -162,10 +162,10 @@ static void print_model_runtime(FILE *fp, const help_colors *c,
     }
     opt(fp, c, "-t, --threads N", "CPU helper threads for host-side/reference work.");
     opt(fp, c, "--power N", "GPU duty-cycle target, 1..100. Default: 100");
-    opt(fp, c, "--ssd-streaming", "Metal/CUDA/ROCm: opt in to SSD-backed model streaming instead of full residency.");
+    opt(fp, c, "--ssd-streaming", "Metal/CUDA/ROCm/CPU: opt in to SSD-backed model streaming instead of full residency. On macOS, use --cpu only with --ssd-streaming: the plain mmap CPU path can panic current macOS kernels.");
     opt(fp, c, "--ssd-streaming-cold", "SSD streaming: skip default popularity-based expert-cache preload.");
-    opt(fp, c, "--ssd-streaming-cache-experts N|NGB", "SSD streaming: routed expert cache as expert count or GiB, e.g. 32GB. Metal/ROCm default: 80% working set minus non-routed weights; CUDA default: backend fixed cache.");
-    opt(fp, c, "--ssd-streaming-preload-experts N", "SSD streaming: upfront popularity preload count. Default: auto hot seed capped at 4096; use --ssd-streaming-cold to skip.");
+    opt(fp, c, "--ssd-streaming-cache-experts N|NGB", "SSD streaming: routed expert cache as expert count or GiB, e.g. 32GB. Metal/ROCm default: 80% working set minus non-routed weights; CUDA default: backend fixed cache; CPU default: 25% of physical RAM.");
+    opt(fp, c, "--ssd-streaming-preload-experts N", "SSD streaming: upfront popularity preload count. Default: auto hot seed capped at 4096; use --ssd-streaming-cold to skip. Ignored on the CPU backend.");
     opt(fp, c, "--simulate-used-memory NGB", "Diagnostic: lock N GiB before model load to simulate a smaller-memory machine.");
     opt(fp, c, "--prefill-chunk N", "Metal graph prefill chunk size. Default: auto (PRO long prompts use 8192; others use 4096).");
     if (full) {

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -5,38 +5,6 @@
 #include "../ds4_gpu.h"
 #include <math.h>
 
-/* Forward declarations for CPU SSD streaming expert cache (defined in ds4.c) */
-#define CPU_STREAM_MAX_LAYER 61
-typedef enum { CPU_STREAM_GATE = 0, CPU_STREAM_UP = 1, CPU_STREAM_DOWN = 2 } cpu_stream_kind;
-
-typedef struct {
-    uint8_t *buf[3];
-    uint64_t last_used;
-    uint64_t use_count;
-    uint64_t pin_seq;
-    bool valid;
-} cpu_stream_entry;
-
-typedef struct {
-    bool enabled;
-    int fd;
-    uint32_t n_layers;
-    uint32_t n_experts;
-    uint64_t off[3][CPU_STREAM_MAX_LAYER];
-    uint64_t expert_bytes[3][CPU_STREAM_MAX_LAYER];
-    cpu_stream_entry *entries;
-    uint64_t clock;
-    uint64_t seq;
-    uint64_t budget_bytes, used_bytes;
-    uint64_t hits, misses, evictions, pread_bytes;
-} cpu_stream_state;
-
-extern cpu_stream_state g_cpu_stream;
-extern uint64_t cpu_stream_triple_bytes(uint32_t il);
-extern uint32_t cpu_stream_pick_victim(void);
-extern bool cpu_stream_evict_one(void);
-extern void cpu_stream_layer_begin(void);
-
 static ds4_engine *test_engine_fast;
 static ds4_engine *test_engine_quality;
 
@@ -170,62 +138,13 @@ static uint64_t test_round_up_u64(uint64_t n, uint64_t align) {
     return (n + align - 1) & ~(align - 1);
 }
 
-/* Unit test for the CPU streaming expert cache eviction policy. Builds a tiny
- * synthetic cache (no model file needed) and checks victim selection: lowest
- * use_count first, oldest last_used as tie-break, pinned entries skipped. */
+/* Unit test for the CPU streaming expert cache eviction policy. The policy
+ * internals (g_cpu_stream and friends) are static in ds4.c, which this test
+ * binary links as a separately compiled object, so the actual test body
+ * lives in ds4.c behind the ds4_cpu_stream_policy_self_test() hook. */
 static void test_cpu_stream_cache_policy(void) {
-    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
-    g_cpu_stream.enabled = true;
-    g_cpu_stream.n_experts = 4;
-    g_cpu_stream.entries = calloc((size_t)CPU_STREAM_MAX_LAYER * 4, sizeof(cpu_stream_entry));
-    TEST_ASSERT(g_cpu_stream.entries != NULL);
-    for (uint32_t il = 0; il < 2; il++) {
-        g_cpu_stream.expert_bytes[CPU_STREAM_GATE][il] = 64;
-        g_cpu_stream.expert_bytes[CPU_STREAM_UP][il] = 64;
-        g_cpu_stream.expert_bytes[CPU_STREAM_DOWN][il] = 64;
-    }
-    /* Install 3 synthetic entries in layer 0: experts 0,1,2. */
-    for (uint32_t e = 0; e < 3; e++) {
-        cpu_stream_entry *en = &g_cpu_stream.entries[0 * 4 + e];
-        for (int k = 0; k < 3; k++) {
-            en->buf[k] = aligned_alloc(64, 64);
-            TEST_ASSERT(en->buf[k] != NULL);
-        }
-        en->valid = true;
-        en->last_used = 10 + e;   /* 10, 11, 12 */
-        en->use_count = 5;
-        g_cpu_stream.used_bytes += cpu_stream_triple_bytes(0);
-    }
-    /* Expert 1 is hotter; expert 0 and 2 tie on use_count, 0 is older. */
-    g_cpu_stream.entries[1].use_count = 9;
-
-    uint32_t v = cpu_stream_pick_victim();
-    TEST_ASSERT(v == 0);                       /* lowest count, oldest */
-
-    /* Pin expert 0: victim must move to expert 2 (same count, newer but unpinned). */
-    g_cpu_stream.seq = 7;
-    g_cpu_stream.entries[0].pin_seq = 7;
-    v = cpu_stream_pick_victim();
-    TEST_ASSERT(v == 2);
-
-    /* Evict: frees buffers, drops used_bytes, marks invalid. */
-    uint64_t before = g_cpu_stream.used_bytes;
-    TEST_ASSERT(cpu_stream_evict_one());
-    TEST_ASSERT(g_cpu_stream.used_bytes == before - cpu_stream_triple_bytes(0));
-    TEST_ASSERT(!g_cpu_stream.entries[2].valid);
-    TEST_ASSERT(g_cpu_stream.evictions == 1);
-
-    /* Pin everything remaining: no victim available. */
-    g_cpu_stream.entries[1].pin_seq = 7;
-    TEST_ASSERT(cpu_stream_pick_victim() == UINT32_MAX);
-    TEST_ASSERT(!cpu_stream_evict_one());
-
-    for (uint32_t e = 0; e < 3; e++) {
-        cpu_stream_entry *en = &g_cpu_stream.entries[e];
-        if (en->valid) for (int k = 0; k < 3; k++) free(en->buf[k]);
-    }
-    free(g_cpu_stream.entries);
-    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+    extern int ds4_cpu_stream_policy_self_test(void);
+    TEST_ASSERT(ds4_cpu_stream_policy_self_test() == 1);
     printf("cpu-stream cache policy: OK\n");
 }
 

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -5,6 +5,38 @@
 #include "../ds4_gpu.h"
 #include <math.h>
 
+/* Forward declarations for CPU SSD streaming expert cache (defined in ds4.c) */
+#define CPU_STREAM_MAX_LAYER 61
+typedef enum { CPU_STREAM_GATE = 0, CPU_STREAM_UP = 1, CPU_STREAM_DOWN = 2 } cpu_stream_kind;
+
+typedef struct {
+    uint8_t *buf[3];
+    uint64_t last_used;
+    uint64_t use_count;
+    uint64_t pin_seq;
+    bool valid;
+} cpu_stream_entry;
+
+typedef struct {
+    bool enabled;
+    int fd;
+    uint32_t n_layers;
+    uint32_t n_experts;
+    uint64_t off[3][CPU_STREAM_MAX_LAYER];
+    uint64_t expert_bytes[3][CPU_STREAM_MAX_LAYER];
+    cpu_stream_entry *entries;
+    uint64_t clock;
+    uint64_t seq;
+    uint64_t budget_bytes, used_bytes;
+    uint64_t hits, misses, evictions, pread_bytes;
+} cpu_stream_state;
+
+extern cpu_stream_state g_cpu_stream;
+extern uint64_t cpu_stream_triple_bytes(uint32_t il);
+extern uint32_t cpu_stream_pick_victim(void);
+extern bool cpu_stream_evict_one(void);
+extern void cpu_stream_layer_begin(void);
+
 static ds4_engine *test_engine_fast;
 static ds4_engine *test_engine_quality;
 
@@ -136,6 +168,65 @@ static void test_close_engine(bool quality) {
 
 static uint64_t test_round_up_u64(uint64_t n, uint64_t align) {
     return (n + align - 1) & ~(align - 1);
+}
+
+/* Unit test for the CPU streaming expert cache eviction policy. Builds a tiny
+ * synthetic cache (no model file needed) and checks victim selection: lowest
+ * use_count first, oldest last_used as tie-break, pinned entries skipped. */
+static void test_cpu_stream_cache_policy(void) {
+    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+    g_cpu_stream.enabled = true;
+    g_cpu_stream.n_experts = 4;
+    g_cpu_stream.entries = calloc((size_t)CPU_STREAM_MAX_LAYER * 4, sizeof(cpu_stream_entry));
+    TEST_ASSERT(g_cpu_stream.entries != NULL);
+    for (uint32_t il = 0; il < 2; il++) {
+        g_cpu_stream.expert_bytes[CPU_STREAM_GATE][il] = 64;
+        g_cpu_stream.expert_bytes[CPU_STREAM_UP][il] = 64;
+        g_cpu_stream.expert_bytes[CPU_STREAM_DOWN][il] = 64;
+    }
+    /* Install 3 synthetic entries in layer 0: experts 0,1,2. */
+    for (uint32_t e = 0; e < 3; e++) {
+        cpu_stream_entry *en = &g_cpu_stream.entries[0 * 4 + e];
+        for (int k = 0; k < 3; k++) {
+            en->buf[k] = aligned_alloc(64, 64);
+            TEST_ASSERT(en->buf[k] != NULL);
+        }
+        en->valid = true;
+        en->last_used = 10 + e;   /* 10, 11, 12 */
+        en->use_count = 5;
+        g_cpu_stream.used_bytes += cpu_stream_triple_bytes(0);
+    }
+    /* Expert 1 is hotter; expert 0 and 2 tie on use_count, 0 is older. */
+    g_cpu_stream.entries[1].use_count = 9;
+
+    uint32_t v = cpu_stream_pick_victim();
+    TEST_ASSERT(v == 0);                       /* lowest count, oldest */
+
+    /* Pin expert 0: victim must move to expert 2 (same count, newer but unpinned). */
+    g_cpu_stream.seq = 7;
+    g_cpu_stream.entries[0].pin_seq = 7;
+    v = cpu_stream_pick_victim();
+    TEST_ASSERT(v == 2);
+
+    /* Evict: frees buffers, drops used_bytes, marks invalid. */
+    uint64_t before = g_cpu_stream.used_bytes;
+    TEST_ASSERT(cpu_stream_evict_one());
+    TEST_ASSERT(g_cpu_stream.used_bytes == before - cpu_stream_triple_bytes(0));
+    TEST_ASSERT(!g_cpu_stream.entries[2].valid);
+    TEST_ASSERT(g_cpu_stream.evictions == 1);
+
+    /* Pin everything remaining: no victim available. */
+    g_cpu_stream.entries[1].pin_seq = 7;
+    TEST_ASSERT(cpu_stream_pick_victim() == UINT32_MAX);
+    TEST_ASSERT(!cpu_stream_evict_one());
+
+    for (uint32_t e = 0; e < 3; e++) {
+        cpu_stream_entry *en = &g_cpu_stream.entries[e];
+        if (en->valid) for (int k = 0; k < 3; k++) free(en->buf[k]);
+    }
+    free(g_cpu_stream.entries);
+    memset(&g_cpu_stream, 0, sizeof(g_cpu_stream));
+    printf("cpu-stream cache policy: OK\n");
 }
 
 static uint16_t test_float_to_f16(float f) {
@@ -2204,6 +2295,7 @@ static const ds4_test_entry test_entries[] = {
     {"--mtp-verify-depth", "mtp-verify-depth", "MTP speculative verify commits autoregressive-identical tokens at draft depth > 2", test_mtp_verify_depth},
 #endif
     {"--server", "server", "server parser/rendering/cache unit tests", test_server_unit_group},
+    {"--cpu-stream-cache", "cpu-stream-cache", "CPU streaming expert cache policy unit test", test_cpu_stream_cache_policy},
 };
 
 static void test_print_help(const char *prog) {

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -148,6 +148,15 @@ static void test_cpu_stream_cache_policy(void) {
     printf("cpu-stream cache policy: OK\n");
 }
 
+/* Unit test for the CPU streaming expert cache pread loader and fetch/install
+ * path. Same reasoning as above: the scenario lives in ds4.c behind the
+ * ds4_cpu_stream_fetch_self_test() hook since g_cpu_stream is static there. */
+static void test_cpu_stream_fetch(void) {
+    extern int ds4_cpu_stream_fetch_self_test(void);
+    TEST_ASSERT(ds4_cpu_stream_fetch_self_test() == 1);
+    printf("cpu-stream fetch/install: OK\n");
+}
+
 static uint16_t test_float_to_f16(float f) {
     union {
         float f;
@@ -2215,6 +2224,7 @@ static const ds4_test_entry test_entries[] = {
 #endif
     {"--server", "server", "server parser/rendering/cache unit tests", test_server_unit_group},
     {"--cpu-stream-cache", "cpu-stream-cache", "CPU streaming expert cache policy unit test", test_cpu_stream_cache_policy},
+    {"--cpu-stream-fetch", "cpu-stream-fetch", "CPU streaming pread/install unit test", test_cpu_stream_fetch},
 };
 
 static void test_print_help(const char *prog) {

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -92,11 +92,7 @@ static ds4_engine *test_open_engine(bool quality) {
     const char *mtp = getenv("DS4_TEST_MTP");
     ds4_engine_options opt = {
         .model_path = test_model_path(),
-#ifdef __APPLE__
-        .backend = DS4_BACKEND_METAL,
-#else
-        .backend = DS4_BACKEND_CUDA,
-#endif
+        .backend = DS4_BACKEND_METAL, /* overridden below */
         .quality = quality,
         .ssd_streaming = test_env_bool("DS4_TEST_SSD_STREAMING"),
         .ssd_streaming_cold = test_env_bool("DS4_TEST_SSD_STREAMING_COLD"),
@@ -109,6 +105,14 @@ static ds4_engine *test_open_engine(bool quality) {
         .mtp_path = (mtp && mtp[0] && !quality) ? mtp : NULL,
         .mtp_draft_tokens = (mtp && mtp[0] && !quality) ? 4 : 0,
     };
+    const char *backend_env = getenv("DS4_TEST_BACKEND");
+    if (backend_env && !strcmp(backend_env, "cpu")) {
+        opt.backend = DS4_BACKEND_CPU;
+    } else {
+#ifndef __APPLE__
+        opt.backend = DS4_BACKEND_CUDA;
+#endif
+    }
     TEST_ASSERT(ds4_engine_open(&engine, &opt) == 0);
     return engine;
 }

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -157,6 +157,17 @@ static void test_cpu_stream_fetch(void) {
     printf("cpu-stream fetch/install: OK\n");
 }
 
+/* Concurrency stress test for cpu_stream_fetch(): spawns worker threads that
+ * fetch experts under the same layer sequence, the way routed_moe_tokens_worker
+ * does on the token-parallel decode path. Same reasoning as above: the scenario
+ * lives in ds4.c behind the ds4_cpu_stream_parallel_self_test() hook since
+ * g_cpu_stream and the mutex guarding it are static there. */
+static void test_cpu_stream_parallel(void) {
+    extern int ds4_cpu_stream_parallel_self_test(void);
+    TEST_ASSERT(ds4_cpu_stream_parallel_self_test() == 1);
+    printf("cpu-stream concurrent fetch stress: OK\n");
+}
+
 static uint16_t test_float_to_f16(float f) {
     union {
         float f;
@@ -2225,6 +2236,7 @@ static const ds4_test_entry test_entries[] = {
     {"--server", "server", "server parser/rendering/cache unit tests", test_server_unit_group},
     {"--cpu-stream-cache", "cpu-stream-cache", "CPU streaming expert cache policy unit test", test_cpu_stream_cache_policy},
     {"--cpu-stream-fetch", "cpu-stream-fetch", "CPU streaming pread/install unit test", test_cpu_stream_fetch},
+    {"--cpu-stream-parallel", "cpu-stream-parallel", "CPU streaming concurrent fetch stress test", test_cpu_stream_parallel},
 };
 
 static void test_print_help(const char *prog) {


### PR DESCRIPTION

The README says the macOS CPU path "will crash the kernel … Help us, if you have the guts." This PR is an attempt at that, from someone whose M4 Max hit the watchdog panic in #483.

**This does not fix Apple's kernel bug — it keeps ds4 out of the regime that triggers it.** With `--cpu --ssd-streaming`, routed expert weights are `pread()` into a bounded LRU cache of heap slabs instead of being faulted through the 81–98 GB whole-file mmap. Non-routed weights (attention, shared expert, embeddings, output) stay on the existing `MAP_PRIVATE` mmap — they are small and stay hot. The kernel never has to stream tens of GB of file-backed pages under concurrent fault pressure, which is what both observed panic signatures grow out of:

1. **watchdog starvation** (#483 and my own machine): 12 CPU threads faulting through the huge mapping saturate `kernel_task`'s pageout/compressor path until `watchdogd` misses its 90 s check-in;
2. the **VM accounting panic** mentioned in the `model_open` comment — consistent with VM map entry / zone exhaustion under the same load (XNU has no `vm.max_map_count`-style errno path; exhaustion ends in jetsam-then-panic).

For what it's worth: llama.cpp maps models the same way ds4's Metal path does (`MAP_SHARED` + `WILLNEED`) and its users report the same whole-machine crashes in the same model≫RAM MoE regime (ggml-org/llama.cpp#19825, #3029). The trigger is the access pattern, not any specific mmap flag — which is why this PR bounds residency instead of tweaking flags.

### Design

- **One seam.** All CPU routed-expert access already flows through `tensor_expert_bytes()`; when streaming is enabled it returns a pointer into the cache slab instead of `map + offset`. The matvec code is untouched and unaware.
- **Per-backend implementation, zero GPU changes.** No edits to `ds4_metal.m`, `ds4_cuda.cu`, `ds4_rocm.cu`, or `ds4_ssd.c/h` (CUDA already has its own streaming implementation; this follows that pattern — `make cpu` builds don't compile the Metal file, so sharing its code isn't possible). `ds4_backend_supports_ssd_streaming()` is untouched; the CPU allowance is a sibling branch at the gate.
- **Thread safety.** The token-parallel decode path fetches from pool workers, so fetch runs under a single mutex; entry lifetime is guaranteed by pinning (entries touched in the current layer call can't be evicted), with the sequence only advanced by the orchestrator. A 4-thread eviction-stress self-test runs clean under ThreadSanitizer.
- **Bounded by construction.** Cache budget = explicit flag or 25% of physical RAM, floored so one full layer of experts always fits (which also makes the "budget too small" abort unreachable in normal decode/prefill). If a routed tensor ever reached the seam unregistered, ds4 dies loudly rather than silently falling back to the mmap.
- **No more whole-file `WILLNEED`.** With streaming on, only non-routed tensor ranges get the prefetch hint.
- `--ssd-streaming-preload-experts` is ignored on CPU (warned); on macOS, `--cpu` without `--ssd-streaming` now prints an advisory warning (kept advisory on purpose — easy to drop or harden, your call).

### Testing (M4 Max 128 GB, macOS 26.5.1, DeepSeek-V4 Flash IQ2XXS 81 GiB — 43 MoE layers × 256 experts)

- `make` (Metal), `make cpu`, `make test` (Metal): clean; the branch adds three self-tests (`--cpu-stream-cache/-fetch/-parallel`, no model needed).
- **Official logprob vectors on `--cpu --ssd-streaming`**: 3 of 4 executable cases pass exactly (16 GiB cache, 8m19s; identical results at a 3 GiB cache forcing ~24× eviction pressure). The one failing case (`short_code_completion`) fails **byte-for-byte identically on unmodified Metal with the same file** — my test model is a community-modified ("abliterated") quant, and the divergence tracks the weights, not the backend (inferred from the cross-backend isolation; `--metal-tensor-equivalence` passes strictly). Happy to rerun against a pristine quant if you want that in the record.
- **The point of the exercise:** 500-token generation, physical footprint flat at 16.6 GiB against the 81 GiB model, swapfiles 32→32, 6.57 t/s decode, clean exit — on the same machine and model file that previously died with the #483 watchdog panic on the plain CPU path. Peak footprint with an 8 GiB cache: 9.18 GiB.
- Floor-budget torture: explicit cache of 1 expert gets raised to the 1.69 GiB floor (with a notice); 2-token run does 1,842 misses / 1,586 evictions / 12.14 GiB of preads and still decodes correctly.

CPU stays a reference/debug path — this makes it safe, not fast.

<details>
<summary>Full evidence bundle (commands, per-case tables, memory samples)</summary>

## 3. Correctness evidence

### 3.1 Self-tests (unit level, no model required)

From Tasks 1-3, re-confirmed in this task's build-matrix run (§6):

```
$ ./ds4_test --cpu-stream-cache
cpu-stream cache policy: OK
$ ./ds4_test --cpu-stream-fetch
cpu-stream fetch/install: OK
$ ./ds4_test --cpu-stream-parallel
cpu-stream concurrent fetch stress: OK
```

- `--cpu-stream-cache`: victim selection (lowest use_count, LRU tie-break), pinning semantics, eviction bookkeeping, and the all-pinned/no-victim case.
- `--cpu-stream-fetch`: pread-based fetch/install against a synthetic temp file with a byte-patterned fixture, including hit/evict/refetch.
- `--cpu-stream-parallel`: 4-thread, 50-round, 100-iterations-per-thread concurrent fetch stress against a 5-triple budget forcing repeated cross-round eviction; asserts zero data corruption and that eviction was actually exercised (`evictions > 0`). Additionally run under ThreadSanitizer (`-fsanitize=thread`, separate throwaway build) with **zero TSan diagnostics** — confirms the `g_cpu_stream_lock` mutex added in `5610610` fully serializes the shared cache state with no unprotected access path. Also run 20x back-to-back with no flakiness (Task 3).

### 3.2 Official logprob-vector fixture (`tests/test-vectors/official.vec`, 5 cases)

**Run A** — CPU + SSD-streaming, 16 GiB expert cache (2,427 experts cached of 11,008 total):

```
DS4_TEST_MODEL="$MODEL" DS4_TEST_BACKEND=cpu DS4_TEST_SSD_STREAMING=1 \
DS4_TEST_SSD_STREAMING_CACHE_GB=16 caffeinate -i ./ds4_test --logprob-vectors
```

| Case | ctx | steps | Result |
|---|---|---|---|
| `short_italian_fact` | 16384 | 4 | PASS |
| `short_code_completion` | 4096 | 4 | **FAIL** (token mismatch every step) |
| `short_reasoning_plain` | 4096 | 1 | PASS |
| `long_memory_archive` | 16384 | 4 | SKIPPED (pre-existing `API/official graph mismatch`, unrelated to backend) |
| `long_code_audit` | 16384 | 4 | PASS |

3 of 4 executable cases pass exactly. Wall clock 8m19s.

**Disambiguation** (run immediately per the controller's anti-tampering protocol, since the failure was a hard token-bytes mismatch, not a logprob-delta-over-tolerance): the same 5-vector fixture run on **Metal**, no CPU/streaming env, same model file:

```
DS4_TEST_MODEL="$MODEL" ./ds4_test --logprob-vectors
```

An unrelated pre-existing `ds4-server --metal` process (PID 5634, not started by this work) was holding the GPU during this run and caused spurious `kIOGPUCommandBufferCallbackErrorOutOfMemory` failures on 2 of 5 cases (`short_italian_fact`, `long_code_audit` — both already passing on CPU, so this is not a concern). Crucially, **`short_code_completion` — the one case that failed on CPU — ran on Metal with zero interleaved OOM errors**, and its failure signature on Metal is **byte-for-byte identical** to the CPU failure:

```
ds4-test: vector short_code_completion step 0 selected token mismatch
ds4-test: vector short_code_completion step 1 selected token mismatch
ds4-test: vector short_code_completion step 1 official top token missing locally
ds4-test: vector short_code_completion step 2 selected token mismatch
ds4-test: vector short_code_completion step 2 official top token missing locally
ds4-test: vector short_code_completion step 3 selected token mismatch
ds4-test: vector short_code_completion step 3 official top token missing locally
```

**Verdict: Metal (unmodified by this branch) fails identically to CPU+streaming on this one case → the divergence is caused by the abliterated model's weights differing from the official DeepSeek API's weights (inferred from cross-backend isolation; official non-abliterated weights were not available to test directly), not by the CPU/SSD-streaming code.** This is corroborated independently by Run C's `metal-tensor-equivalence` subtest (§3.4), a strict *local* logits comparison (not against the official API) that passes cleanly on `short_code_completion` — Metal's own numerics are self-consistent; only the comparison against the official (non-abliterated) API vector diverges.

### 3.3 Eviction-stress rerun (Run B — cache_gb=3)

Amended pass criterion (set by the controller after the disambiguation cleared the code): identical failure signature to Run A, no new failures, no crashes, no cache death.

```
DS4_TEST_MODEL="$MODEL" DS4_TEST_BACKEND=cpu DS4_TEST_SSD_STREAMING=1 \
DS4_TEST_SSD_STREAMING_CACHE_GB=3 caffeinate -i ./ds4_test --logprob-vectors
```

- Cache budget resolves to 3.00 GiB / 6.75 MiB per expert = **455 experts cached against 11,008 total routed experts** (43 layers x 256 experts) — heavy forced eviction, vs. Run A's 2,427-expert budget.
- **Result: PASS.** Failure signature extracted from the log is byte-for-byte identical to Run A: same 3 cases pass (`short_italian_fact`, `short_reasoning_plain`, `long_code_audit`), only `short_code_completion` fails with the exact same 7 assertions, `long_memory_archive` skips the same way. Grep for `budget too small|abort|crash|signal|panic|Insufficient` over the whole log: zero hits.
- Wall clock 8m01s (not measurably slower than Run A's 8m19s despite 5x smaller cache — OS page cache was warm from prior runs on the same model file).

**Conclusion: the CPU SSD-streaming cache survives heavy eviction (455 of 11,008 experts resident) with bit-identical decode behavior to a roomy 2,427-expert budget.** The eviction path does not perturb correctness.

### 3.4 Full Metal regression (Run C)

`DS4_TEST_MODEL="$MODEL" caffeinate -i make test` — 18 subtests, 15 executed (3 skipped by design: no MTP head, no `DS4_TEST_SSD_STREAMING` for one CPU-only subtest). Only 2 of 15 fail, and both are the same `short_code_completion` root cause described above:

| Subtest | Result |
|---|---|
| long-context | OK |
| tool-call-quality | OK |
| think-tool-recovery | OK |
| logprob-vectors | ERR (model-caused, see §3.2) |
| metal-ssd-streaming-cache-pressure | ERR (same root cause, restricted to `short_code_completion`) |
| local-golden-vectors | OK |
| metal-short-prefill | OK |
| metal-kernels | OK |
| metal-tensor-equivalence | **OK** (strict local logits check, all 5 cases incl. `short_code_completion`: `top1_mismatch=0 min_top5_overlap=5/5 min_overlap=20/20 worst_rank_delta=0 worst_rms=0`) |
| streaming-decode-prefill-correctness | OK (skipped, no `DS4_TEST_SSD_STREAMING`) |
| mtp-verify-depth | OK (skipped, no MTP head) |
| server | OK |
| cpu-stream-cache | OK |
| cpu-stream-fetch | OK |
| cpu-stream-parallel | OK |

Wall clock 5m36s. `make test` exits nonzero (`Error 1`) purely because of the model-caused divergence — not touched/worked around, per the controller's explicit anti-tampering instruction.

## 4. Safety / mechanism evidence

### 4.1 The problem this branch makes safe (the kernel bug itself is Apple's to fix)

Before this branch, running the CPU backend on macOS with a model too large to fully fit resident (e.g. this 81 GiB model on a machine with 128 GB RAM, but with other memory pressure — including the concurrent unrelated `ds4-server` process observed on this very machine, which alone holds the full model Metal-resident plus a 60 GB on-disk KV cache) could fault the entire GGUF through a plain `mmap`. On current macOS/XNU kernels this has been observed to panic the kernel outright — this exact failure mode is documented in the repo's own README ("current macOS versions have a bug in the virtual memory implementation that will crash the kernel if you try to run the CPU code... each time you have to restart the computer") and corresponds to upstream issue **#483**, tracked with two independently-identified panic mechanisms against this project's own panic logs and the XNU source (`xnu-12377.121.6`): (1) **watchdog starvation** — 12 CPU threads all faulting pages from the same huge mmap saturate the kernel's page-fault path badly enough that `watchdogd` cannot check in within its timeout and the kernel panics; (2) **VM map entry / zone exhaustion** — the huge single mmap fragments into enough VM map entries under heavy concurrent fault pressure to exhaust a kernel zone. Both mechanisms are avoided by never mmap-faulting the routed-expert region at all.

### 4.2 The fix's mechanism

`--cpu --ssd-streaming` on this branch never faults routed-expert weight ranges through mmap. Instead: `cpu_stream_init` reads expert geometry (offsets, sizes, counts) straight from the GGUF tensor directory (no page faults — this is metadata only); non-routed weights are still selectively `WILLNEED`-hinted (small, safe); routed-expert weight slabs are `pread()` directly into a bounded LRU+hotness cache of heap-allocated buffers, sized by an explicit flag or a default of 25% of physical RAM (always floored so one full layer's worth of experts fits). The cache is bounded by construction — its heap footprint cannot exceed the configured budget regardless of model size or generation length, because every fetch either hits an existing entry or evicts before installing a new one.

### 4.3 Smoke test (Task 4, prior work — cited here for continuity)

8-token generation, 8 GiB cache, same 81 GB model:

```
caffeinate -i ./ds4 --cpu --ssd-streaming --ssd-streaming-cache-experts 8GB -m "$MODEL" -p "The capital of France is" -n 8
```

Peak RSS **17.77 GiB**, peak footprint **9.18 GiB** — both far below the 81 GB model file. (RSS includes resident non-routed mmap pages and page-cache attribution; **peak physical footprint is the bounded metric** to compare against the cache budget.) Exit code 0, no crash, no panic. First-ever safe CPU run of this specific model on this machine (the old unprotected CPU mmap path is documented in-code as having triggered the kernel-level VM panic previously).

### 4.4 New centerpiece evidence: 500-token bounded-footprint run (this task)

```
caffeinate -i ./ds4 --cpu --ssd-streaming --ssd-streaming-cache-experts 16GB \
  -m "$MODEL" -p "Write a long story about a lighthouse keeper." -n 500
```

Run concurrently with an independent memory-monitor loop sampling `vmmap --summary <pid> | grep -i "physical footprint"` and `sysctl vm.swapusage` every ~30s.

**Result: completed in full, exit clean, ~505 tokens generated (word-count-estimated; the run hit the requested `-n 500` cap mid-sentence, which is the expected/correct behavior for a token-budget cutoff, not a crash).** Total wall clock was under 2 minutes — much faster than the tens-of-minutes estimate in the task brief, because the OS page cache for this model's non-routed weights and popular experts was already warm from the Task 4/5 runs earlier in this same session on the same machine/model.

Reported throughput (from ds4's own output):
```
ds4: prefill: 2.74 t/s, generation: 6.57 t/s
```

Physical-footprint samples (only 3 fell within the run's short duration before the monitor's own exit-detection stopped it — the plateau is nonetheless clear and consistent with the 16 GiB cache budget plus fixed overhead):

| Timestamp | Physical footprint | Physical footprint (peak) |
|---|---|---|
| 22:52:59 | 16.6 GiB | 16.6 GiB |
| 22:53:31 | 16.6 GiB | 16.6 GiB |
| 22:54:04 | 16.6 GiB | 16.6 GiB |
| 22:54:36 | (process exited; monitor self-terminated) | — |

**Footprint is flat/bounded across the entire run — no monotonic growth, no drift** — consistent with the streaming cache never exceeding its configured 16 GiB budget regardless of how many of the 11,008 routed experts get touched over the course of 500 generated tokens.

Swapfile count (`ls /System/Volumes/VM/ | grep -c swapfile`): **32 before, 32 after — zero new swapfiles.**

`vm.swapusage` was already near-saturated throughout (`total = 32768.00M used = 32154.88M free = 613.12M`) — this is a **pre-existing condition from the unrelated, still-running `ds4-server --metal` process (PID 5634)** on this shared machine (that process alone holds the 81 GB model Metal-resident plus a 60 GB on-disk KV cache directory), not something this run caused: swap usage was static across all samples during our run (`32154.88M` in every single sample, byte-for-byte), meaning our streaming run made zero net contribution to swap pressure.

**Exit status: 0** (process ran to completion and exited on its own; confirmed via `pgrep` returning no match for the ds4 PID immediately after the log's final `generation:` stats line appeared, with no error/panic/signal text anywhere in the log).

**Win condition met**: footprint bounded/plateaued (not monotonic growth), no swapfile explosion, clean exit, throughput numbers printed by ds4 itself.

### 4.5 Speed numbers (transparency only — CPU is a reference path, not the production target)

| Run | Cache | Tokens/steps | Duration | Throughput |
|---|---|---|---|---|
| Task 4 smoke | 8 GiB | 8 tokens | 5.96s (real) | prefill 4.52 t/s, generation 3.79 t/s |
| Task 5 Run A (vectors) | 16 GiB | 5 short/medium cases, 1-4 steps each | 8m19s | n/a (correctness run, not throughput-focused) |
| Task 5 Run B (vectors, stress) | 3 GiB | same as Run A | 8m01s | n/a |
| **This task: 500-token generation** | **16 GiB** | **~500 tokens** | **< 2 min wall clock** | **prefill 2.74 t/s, generation 6.57 t/s** |

No separate `ds4-bench` CPU run was performed — the CLI's own printed throughput from the generation run above is the reported number, per the task's "no separate bench needed for CPU" instruction.

## 5. Metal non-regression

**Metal before/after `ds4-bench` sweep: SKIPPED.** An unrelated user process `ds4-server --metal` (PID 5634) was confirmed running and holding the GPU on this machine throughout this task (`pgrep -fl ds4-server` returns it; started well before this task, serving on port 8081 with a 100k-token context and a 60 GB on-disk KV cache directory). Running a Metal bench sweep concurrently would produce contaminated, non-comparable numbers (this exact contamination was observed and documented in Task 5's disambiguation run — spurious `kIOGPUCommandBufferCallbackErrorOutOfMemory` errors). The unrelated server was **not** killed (out of scope; it is another user's/process's workload on a shared machine).

Metal non-regression is instead evidenced by:

**(a) Zero Metal source files touched.**
```
$ git diff --stat main...HEAD
 README.md        |  14 +-
 ds4.c            | 614 +++...
 ds4_help.c       |   6 +-
 tests/ds4_test.c |  47 ++++-
 4 files changed, 666 insertions(+), 15 deletions(-)

$ git diff --name-only main...HEAD | grep -iE "metal|cuda|rocm"
(no output — zero matches)
```
`ds4_metal.m`, `ds4_cuda.cu`, `ds4_rocm.cu`, and `ds4_ssd.c/h` are all untouched by this branch, confirmed both by the diffstat (they don't appear at all) and by an explicit grep for their names/extensions across the changed-file list. The one shared-code touchpoint, `ds4_backend_supports_ssd_streaming`, was read but not modified — the CPU allowance was added as a sibling branch in the calling gate, not a change to that predicate function, so GPU-backend auto-cache logic is provably unreachable from this diff.

**(b) Full `make test` pass (Task 5 Run C, §3.4 above).** 15 of 15 executed subtests pass except the two instances of the single model-caused `short_code_completion` divergence, which is independently confirmed to reproduce identically on Metal with zero CPU/streaming code involved. Every Metal-specific subtest (`metal-short-prefill`, `metal-kernels`, `metal-tensor-equivalence`, `local-golden-vectors`, `tool-call-quality`, `think-tool-recovery`, `long-context`, `server`) passes cleanly. `metal-tensor-equivalence` in particular is a strict local-reference logits comparison (not an official-API comparison) and is clean across all 5 test-vector cases, positively confirming Metal's numerics are unperturbed.

Between (a) and (b), Metal non-regression is established without needing a live bench run on a GPU that is not actually free on this machine right now.

## 6. Build matrix

All three builds re-run clean from scratch in this task, on HEAD `340a7aa`:

```
$ make clean && make            # Metal (default) build
... (0 warnings, 0 errors)
cc ... -o ds4 ds4_cli.o ds4_help.o linenoise.o ds4.o ds4_distributed.o ds4_ssd.o ds4_metal.o -lm -pthread -framework Foundation -framework Metal
cc ... -o ds4-server ...
cc ... -o ds4-bench ...
cc ... -o ds4-eval ...
cc ... -o ds4-agent ...

$ make clean && make cpu        # CPU-only (DS4_NO_GPU) build
8 warnings generated.           # pre-existing, identical count/content to the pre-branch baseline
                                 # (unused-function warnings on GPU-only helpers compiled out
                                 #  under -DDS4_NO_GPU, e.g. ds4_engine_configure_streaming_auto_cache,
                                 #  ds4_engine_preload_pro_q4_expert_tables — none relate to cpu_stream code)
cc ... -o ds4 ds4_cli_cpu.o ds4_help.o linenoise.o ds4_cpu.o ds4_distributed.o ds4_ssd.o -lm -pthread
cc ... -o ds4-server ...
cc ... -o ds4-bench ...
cc ... -o ds4-eval ...
cc ... -o ds4-agent ...

$ make clean && make && make ds4_test   # test binary, built against the Metal object set
cc ... -c -o ds4_test.o tests/ds4_test.c
cc ... -o ds4_test ds4_test.o ds4_help.o ds4_kvstore.o rax.o ds4.o ds4_distributed.o ds4_ssd.o ds4_metal.o -lm -pthread -framework Foundation -framework Metal
```

Self-tests re-confirmed against this exact fresh build:
```
$ ./ds4_test --cpu-stream-cache && ./ds4_test --cpu-stream-fetch && ./ds4_test --cpu-stream-parallel
cpu-stream cache policy: OK
cpu-stream fetch/install: OK
cpu-stream concurrent fetch stress: OK
```

The 8 `make cpu` warnings were separately verified in Task 4 (via `git stash` + rebuild) to be present identically on pre-branch HEAD — not introduced by this branch.

## 7. Concerns / caveats carried into this evidence bundle

1. **Model is a community "abliterated" variant.** Its greedy-decode outputs diverge from the official DeepSeek API on one of five official test-vector cases (`short_code_completion`). This is fully isolated to the model weights via the Metal disambiguation (§3.2) and is not attributable to this branch.
2. **`long_memory_archive` is skipped by the test harness itself** (`API/official graph mismatch`) in every run, pre-existing and unrelated to this branch — reduces effective official-vector coverage to 4 of 5 cases per run.
3. **Metal bench sweep was not run** due to a genuinely occupied GPU on this shared machine (unrelated `ds4-server --metal`, PID 5634, left running). Non-regression is argued from the diffstat + `make test`, not a live A/B bench; a maintainer with a free GPU can run the `ds4-bench` sweep from the commands appendix below to get an additional numeric comparison if desired.
4. **The 500-token run finished much faster than estimated** (under 2 minutes vs. an estimated 30-90 minutes) because the OS page cache was warm from earlier same-session runs on the same model file. This means the footprint monitor only captured 3 samples 30s apart rather than the dozens originally anticipated — however, all 3 samples plus the smoke test's independent RSS/footprint numbers (§4.3) are mutually consistent with a flat, bounded cache, and no sign of growth appeared at any point.
5. **`--ssd-streaming-cache-bytes` (raw byte budget) and the preload-warning path were not exercised end-to-end** in any task (only `--ssd-streaming-cache-experts` was used); the preload-ignored-on-CPU `fprintf` was verified by code inspection only. Considered low-risk (single unconditional print, no control-flow effect).
6. **This machine runs a long-lived, unrelated `ds4-server --metal` process** that holds significant GPU/unified-memory/swap pressure throughout this entire evidence-gathering session; it was never started or stopped by this work, and its presence is called out wherever it could plausibly have contaminated a result (Metal disambiguation OOMs in Task 5, and the pre-saturated `vm.swapusage` baseline in §4.4).

## 8. Commands appendix (verbatim, for reproduction)

Self-tests:
```bash
./ds4_test --cpu-stream-cache
./ds4_test --cpu-stream-fetch
./ds4_test --cpu-stream-parallel
```

Task 4 smoke test:
```bash
caffeinate -i ./ds4 --cpu --ssd-streaming --ssd-streaming-cache-experts 8GB \
  -m "$MODEL" -p "The capital of France is" -n 8
```
(wrapped in `/usr/bin/time -l` for RSS/footprint capture)

Task 5 Run A (official logprob vectors, CPU+streaming, 16 GiB cache):
```bash
DS4_TEST_MODEL="$MODEL" DS4_TEST_BACKEND=cpu DS4_TEST_SSD_STREAMING=1 \
DS4_TEST_SSD_STREAMING_CACHE_GB=16 caffeinate -i ./ds4_test --logprob-vectors
```

Task 5 disambiguation (same vectors, Metal, no streaming env):
```bash
DS4_TEST_MODEL="$MODEL" ./ds4_test --logprob-vectors
```

Task 5 Run B (eviction stress, 3 GiB cache):
```bash
DS4_TEST_MODEL="$MODEL" DS4_TEST_BACKEND=cpu DS4_TEST_SSD_STREAMING=1 \
DS4_TEST_SSD_STREAMING_CACHE_GB=3 caffeinate -i ./ds4_test --logprob-vectors
```

Task 5 Run C (full Metal regression):
```bash
DS4_TEST_MODEL="$MODEL" caffeinate -i make test
```

This task's centerpiece 500-token bounded-footprint run:
```bash
MODEL=/Users/tatlatat/.claude/codex-fleet-local-model/scratchpad/ds4-build/gguf/cyberneurova-DeepSeek-V4-Flash-abliterated-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix-aligned.gguf

caffeinate -i ./ds4 --cpu --ssd-streaming --ssd-streaming-cache-experts 16GB \
  -m "$MODEL" -p "Write a long story about a lighthouse keeper." -n 500 \
  > /tmp/task7-gen.log 2>&1 &

# concurrently, sampled every ~30s:
PID=<ds4 pid>
vmmap --summary $PID | grep -i "physical footprint"
sysctl vm.swapusage

# swapfile count before/after:
ls /System/Volumes/VM/ | grep -c swapfile
```

Environment check (run before any GPU-affecting step):
```bash
pgrep -fl ds4-server
```

Build matrix:
```bash
make clean && make            # Metal (default)
make clean && make cpu        # CPU-only (DS4_NO_GPU)
make clean && make && make ds4_test
```

Git evidence:
```bash
git log --oneline main..HEAD
git diff --stat main...HEAD
git diff --name-only main...HEAD | grep -iE "metal|cuda|rocm"   # expect: no output
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4PSPFYh6oBLsLWZsu3jB2
