### PR TITLE
Fix CPU backend abort on DeepSeek V4 PRO: use DS4_N_OUT_GROUP for attention-output grouping

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -7098,7 +7098,7 @@ static void layer_grouped_out_one(
         const ds4_model   * model,
         const ds4_layer_weights * layer,
         const float       * heads) {
-    const uint32_t n_groups = 8;
+    const uint32_t n_groups = DS4_N_OUT_GROUP;
     const uint32_t group_heads = DS4_N_HEAD / n_groups;
     const uint32_t group_dim = DS4_N_HEAD_DIM * group_heads;
     const uint32_t rank = 1024;
@@ -7117,7 +7117,7 @@ static void layer_grouped_out_one_decode_scratch(
         const ds4_layer_weights * layer,
         const float            * heads,
         ds4_cpu_decode_scratch * scratch) {
-    const uint32_t n_groups = 8;
+    const uint32_t n_groups = DS4_N_OUT_GROUP;
     const uint32_t group_heads = DS4_N_HEAD / n_groups;
     const uint32_t group_dim = DS4_N_HEAD_DIM * group_heads;
     const uint32_t rank = 1024;
@@ -7134,7 +7134,7 @@ static void layer_grouped_out_batch(
         const ds4_layer_weights * layer,
         const float       * heads,
         uint32_t            n_tok) {
-    const uint32_t n_groups = 8;
+    const uint32_t n_groups = DS4_N_OUT_GROUP;
     const uint32_t group_heads = DS4_N_HEAD / n_groups;
     const uint32_t group_dim = DS4_N_HEAD_DIM * group_heads;
     const uint32_t rank = 1024;


### PR DESCRIPTION
## Fix CPU backend abort on DeepSeek V4 PRO

The CPU reference path aborts at prefill layer 1 on any DeepSeek V4 **PRO** model with
`grouped Q8_0 tensor has an unexpected layout`. **Flash is unaffected.**

### Root cause
`layer_grouped_out_one()`, `layer_grouped_out_one_decode_scratch()`, and
`layer_grouped_out_batch()` hardcode the attention-output group count to `8` (the Flash value).
PRO's shape profile sets `n_out_group = 16`, so with the literal `8` the code computes
`group_dim = n_head_dim * (n_head / 8) = 512 * (128 / 8) = 8192`, while PRO's `attn_output_a`
tensor has `dim[0] = 512 * (128 / 16) = 4096` → the layout check in the grouped-Q8_0 matmul fails
and `ds4_die()` fires.

### Fix
Use the existing `DS4_N_OUT_GROUP` macro (`= g_ds4_shape.n_out_group`) instead of the literal `8`
at the three call sites. `rank = 1024` is shared across profiles, so no other change is needed.
Flash takes the identical path (macro == 8); PRO now prefills all 61 layers.

```diff
-    const uint32_t n_groups = 8;
+    const uint32_t n_groups = DS4_N_OUT_GROUP;
```

### Testing (per CONTRIBUTING.md)
Backend: **CPU** (`make cpu`), x86-64 Linux (Ubuntu 24.04, Xeon w9-3595X).

| Model (Q2 imatrix) | Before | After |
|---|---|---|
| Flash (`DeepSeek-V4-Flash-IQ2XXS…imatrix`) | coherent, ~3 t/s | **unchanged**, coherent, ~3 t/s |
| PRO (`DeepSeek-V4-Pro-IQ2XXS…Instruct-imatrix`) | **abort** at prefill layer 1 | coherent, all 61 layers, ~0.95 t/s |

Command:
```sh
./ds4 -m <model>.gguf --cpu -t 60 -c 2048 -n 48 --nothink -p "In one short paragraph, explain how vaccines work."
```

Note: I validated on the **CPU** backend via manual smoke tests (Flash output byte-path is
unchanged since the macro resolves to 8 for Flash; PRO output is coherent). I did **not** run the
full `ds4_test` regression suite, which builds the default GPU backend (`nvcc`) unavailable on this
CPU-only host — happy to run any specific check you suggest.

Fixes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
