### PR TITLE
cuda: fix uninitialized IQ2 dequant LUTs in batch MoE expert-tile kernels (n_embd > 4096)

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -10816,15 +10816,22 @@ __global__ static void moe_gate_up_mid_expert_tile8_row32_kernel(
         slot[np] = pair[np] - tok[np] * n_expert;
         xqb[np] = xq + (uint64_t)tok[np] * xq_blocks;
     }
+    /* The IQ2 dequant LUTs are consumed unconditionally by the dot calls
+     * below, so they must load for every xq_blocks; only the xq staging is
+     * <=16-blocks specific. Models with n_embd > 4096 (more than 16 q8_K
+     * blocks) used to skip the LUT loads too, leaving s_iq2_grid and
+     * s_iq2_signs uninitialized for the whole gate/up dequant. */
+    for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
+    for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
     if (xq_blocks <= 16u) {
         for (uint32_t i = threadIdx.x; i < np * xq_blocks; i += blockDim.x) {
             uint32_t p = i / xq_blocks;
             uint32_t b = i - p * xq_blocks;
             sxq[p][b] = xqb[p][b];
         }
-        for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
-        for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
-        __syncthreads();
+    }
+    __syncthreads();
+    if (xq_blocks <= 16u) {
         for (uint32_t p = 0; p < np; p++) xqb[p] = sxq[p];
     }
     if (row >= expert_mid_dim) return;
@@ -10906,15 +10913,22 @@ __global__ static void moe_gate_up_mid_expert_tile8_row2048_kernel(
         slot[np] = pair[np] - tok[np] * n_expert;
         xqb[np] = xq + (uint64_t)tok[np] * xq_blocks;
     }
+    /* The IQ2 dequant LUTs are consumed unconditionally by the dot calls
+     * below, so they must load for every xq_blocks; only the xq staging is
+     * <=16-blocks specific. Models with n_embd > 4096 (more than 16 q8_K
+     * blocks) used to skip the LUT loads too, leaving s_iq2_grid and
+     * s_iq2_signs uninitialized for the whole gate/up dequant. */
+    for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
+    for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
     if (xq_blocks <= 16u) {
         for (uint32_t i = threadIdx.x; i < np * xq_blocks; i += blockDim.x) {
             uint32_t p = i / xq_blocks;
             uint32_t b = i - p * xq_blocks;
             sxq[p][b] = xqb[p][b];
         }
-        for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
-        for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
-        __syncthreads();
+    }
+    __syncthreads();
+    if (xq_blocks <= 16u) {
         for (uint32_t p = 0; p < np; p++) xqb[p] = sxq[p];
     }
     for (uint32_t rr = 0; rr < 64u; rr++) {
@@ -11000,15 +11014,22 @@ __global__ static void moe_gate_up_mid_expert_tile8_rowspan_kernel(
         slot[np] = pair[np] - tok[np] * n_expert;
         xqb[np] = xq + (uint64_t)tok[np] * xq_blocks;
     }
+    /* The IQ2 dequant LUTs are consumed unconditionally by the dot calls
+     * below, so they must load for every xq_blocks; only the xq staging is
+     * <=16-blocks specific. Models with n_embd > 4096 (more than 16 q8_K
+     * blocks) used to skip the LUT loads too, leaving s_iq2_grid and
+     * s_iq2_signs uninitialized for the whole gate/up dequant. */
+    for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
+    for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
     if (xq_blocks <= 16u) {
         for (uint32_t i = threadIdx.x; i < np * xq_blocks; i += blockDim.x) {
             uint32_t p = i / xq_blocks;
             uint32_t b = i - p * xq_blocks;
             sxq[p][b] = xqb[p][b];
         }
-        for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) s_iq2_grid[i] = cuda_iq2xxs_grid[i];
-        for (uint32_t i = threadIdx.x; i < 128u; i += blockDim.x) s_iq2_signs[i] = cuda_ksigns_iq2xs[i];
-        __syncthreads();
+    }
+    __syncthreads();
+    if (xq_blocks <= 16u) {
         for (uint32_t p = 0; p < np; p++) xqb[p] = sxq[p];
     }
     for (uint32_t rr = 0; rr < ROW_SPAN / 32u; rr++) {


### PR DESCRIPTION
## Summary

The batch MoE expert-tile kernels (`moe_gate_up_mid_expert_tile8_{row32,row2048,rowspan}`) load the IQ2_XXS dequant tables (`s_iq2_grid`, `s_iq2_signs`) into shared memory inside the `xq_blocks <= 16` activation-staging branch, but the `dev_dot_iq2_xxs_q8_K_block8_deq_lut` calls consume them unconditionally.

Models with `n_embd <= 4096` (16 q8_K blocks, e.g. V4 Flash) always take the branch, so the bug is invisible there. Any model with `n_embd > 4096` skips it and the entire batch gate/up dequant runs against uninitialized shared memory: multi-token batch encodes (prefill, MTP verify) produce fluent garbage at full speed, while single-token decode stays correct because the `n_tokens == 1` path uses different kernels. That combination (fast, plausible-looking token stream, wrong content, decode fine) makes it easy to misattribute to model quality.

## Fix

Hoist the two LUT loads out of the staging conditional in the three kernels and make the `__syncthreads()` barrier unconditional. The `moe_gate_up_mid_decode_lut_qwarp32_kernel` has the same textual pattern but its launcher already guards `use_decode_lut_gate` on `xq_blocks <= 16`, so it is left unchanged.

## How it was found and tested

Found on a GLM-5.2 CUDA port (`n_embd` 7168 = 28 blocks) where long-prompt batch prefill output was corrupt while short prompts (token-major path) were fine. Bisected with per-stage kill switches down to the expert-tile gate/up kernels, then to the conditional LUT load.

Before/after on the same hardware (RTX 4060 Ti 16GB, SSD streaming, 600-token prompt, greedy):

| | prefill | output |
|---|---|---|
| before | 6.5 t/s | fluent garbage |
| after | 6.5 t/s | correct (retrieval question about the prompt answered right) |

Flash-class models are unaffected by the change (they take the same staging branch as before; the LUT loads just move a few lines up).

Context: this came out of the streaming experiments in #495; the same uninitialized LUTs also corrupted 2-token MTP verify logits there.
