### PR TITLE
Canonicalize blank reasoning blocks

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -2269,6 +2269,19 @@ static bool role_is_user_like(const char *role) {
     return !strcmp(role, "user") || !strcmp(role, "tool") || !strcmp(role, "function");
 }
 
+static bool text_is_ascii_ws_only(const char *s) {
+    if (!s) return true;
+    for (; *s; s++) {
+        if (!isspace((unsigned char)*s)) return false;
+    }
+    return true;
+}
+
+static const char *canonical_reasoning_text(const chat_msg *m) {
+    if (!m || text_is_ascii_ws_only(m->reasoning)) return "";
+    return m->reasoning;
+}
+
 static bool chat_history_uses_tool_context(const chat_msgs *msgs,
                                            const char *tool_schemas) {
     if (tool_schemas && tool_schemas[0]) return true;
@@ -2337,7 +2350,7 @@ static char *render_chat_prompt_text(const chat_msgs *msgs, const char *tool_sch
                 if (think) {
                     if (tool_context || i > last_user_idx) {
                         buf_puts(&out, "<think>");
-                        buf_puts(&out, m->reasoning ? m->reasoning : "");
+                        buf_puts(&out, canonical_reasoning_text(m));
                         buf_puts(&out, "</think>");
                     } else {
                         buf_puts(&out, "</think>");
@@ -2408,7 +2421,7 @@ static char *render_live_tool_tail(const chat_msgs *msgs, int start,
                 buf_puts(&out, "<｜Assistant｜>");
                 if (think) {
                     buf_puts(&out, "<think>");
-                    buf_puts(&out, m->reasoning ? m->reasoning : "");
+                    buf_puts(&out, canonical_reasoning_text(m));
                     buf_puts(&out, "</think>");
                 } else {
                     buf_puts(&out, "</think>");
@@ -13133,6 +13146,31 @@ static void test_render_preserves_reasoning_with_tools(void) {
     chat_msgs_free(&msgs);
 }
 
+static void test_render_canonicalizes_blank_reasoning_with_tools(void) {
+    chat_msgs msgs = {0};
+    chat_msg user = {0};
+    user.role = xstrdup("user");
+    user.content = xstrdup("hello");
+    chat_msgs_push(&msgs, user);
+    chat_msg assistant = {0};
+    assistant.role = xstrdup("assistant");
+    assistant.reasoning = xstrdup(" \t\n");
+    assistant.content = xstrdup("answer");
+    chat_msgs_push(&msgs, assistant);
+    chat_msg tool = {0};
+    tool.role = xstrdup("tool");
+    tool.content = xstrdup("result");
+    chat_msgs_push(&msgs, tool);
+
+    char *prompt = render_chat_prompt_text(&msgs, "{}", NULL, DS4_THINK_HIGH);
+    TEST_ASSERT(prompt != NULL);
+    TEST_ASSERT(strstr(prompt, "<｜Assistant｜><think></think>answer") != NULL);
+    TEST_ASSERT(strstr(prompt, "<think> \t\n</think>") == NULL);
+
+    free(prompt);
+    chat_msgs_free(&msgs);
+}
+
 static void test_render_chat_prompt_text_renders_tools_before_system(void) {
     /* The tool-schema block must sit at the head of the system region so the
      * client's system content stays at the tail, right before <｜User｜>.
@@ -15765,6 +15803,7 @@ static void ds4_server_unit_tests_run(void) {
     test_render_non_thinking_prompt_closes_think();
     test_render_drops_old_reasoning_without_tools();
     test_render_preserves_reasoning_with_tools();
+    test_render_canonicalizes_blank_reasoning_with_tools();
     test_render_chat_prompt_text_renders_tools_before_system();
     test_tool_schema_order_from_anthropic_schema();
     test_tool_schema_order_from_openai_tools();


### PR DESCRIPTION
## Summary
- render whitespace-only assistant reasoning as an empty reasoning block
- keep non-empty reasoning content unchanged
- add a server unit test covering blank reasoning in tool-context prompt replay

## Why
A replayed assistant turn can carry an empty reasoning block as whitespace, for example `<think> </think>`, while the live KV prefix may contain `<think></think>`. That difference is semantically empty but changes the rendered prompt bytes/tokens and can cause a live KV cache token mismatch.

## Tests
- `make ds4_test && ./ds4_test --server && make ds4-server`