### PR TITLE
glm: fix streaming prefill failures for real-size prompts

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -30722,7 +30722,15 @@ static bool glm_graph_forward_indexed_tokens(
     const uint32_t drain_interval =
         progress_flush_interval != 0 ? glm_graph_indexed_prefill_drain_interval() : 0u;
     const bool progress_requested = display_progress && work_total > 0;
-    ds4_gpu_set_glm_streaming_prefill_full_layer(false);
+    /* Mirror the plain prefill flow: above the full-layer threshold the
+     * selected-expert addr loader is the wrong tool — a chunk of N tokens
+     * selects far more unique experts per layer than the cache can hold, and
+     * its overflow branch needs the full expert tensors mapped.  Hardcoding
+     * false here broke every generation prompt above ~64 tokens ("failed to
+     * map overflow expert views"), while short prompts keep the addr path. */
+    const bool full_layer_prefill =
+        glm_graph_stream_prefill_full_layer_enabled(g, n_tokens);
+    ds4_gpu_set_glm_streaming_prefill_full_layer(full_layer_prefill);
 
     if (trace) {
         glm_graph_indexed_prefill_tracef(
@@ -30818,7 +30826,7 @@ static bool glm_graph_forward_indexed_tokens(
                                                     weights,
                                                     il,
                                                     n_tokens,
-                                                    false);
+                                                    full_layer_prefill);
             if (ok) ok = ds4_gpu_begin_commands() != 0;
         }
         const ds4_layer_weights *l = &weights->layer[il];

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -12859,12 +12859,16 @@ static int ds4_gpu_stream_expert_cache_prepare_selected_batch(
                 continue;
             }
 
-            if (cache_budget != 0 && reserved_entries >= cache_budget) {
-                unique_entries[u] = NULL;
-                continue;
-            }
-
-            const int force_reuse = 0;
+            /* At budget, evict-and-reuse like the decode loader does instead
+             * of spilling to whole-tensor overflow views: the overflow wrap
+             * needs the expert tensors in the mapped view set, which the
+             * decode-expert-cache prefill mapping does not provide, so a
+             * full cache made any checkpoint-extend or small-suffix prefill
+             * fail ("failed to map overflow expert views").  Commands were
+             * just synced by the caller, so reuse cannot race the GPU, and
+             * prepare_load_buffers protects this layer's unique set. */
+            const int force_reuse =
+                cache_budget != 0 && reserved_entries >= cache_budget;
             ds4_gpu_stream_expert_readahead_range(unique_gate_offsets[u],
                                                   gate_expert_bytes);
             ds4_gpu_stream_expert_readahead_range(unique_up_offsets[u],


### PR DESCRIPTION
On the glm5.2 branch, GLM 5.2 SSD-streaming generation fails for any prompt above roughly the full-layer threshold (~64 tokens):

```
ds4: Metal model range 239.43..240.42 GiB is not covered by mapped model views
ds4: Metal streaming prefill batch selected addr failed to map overflow expert views at layer 9
ds4: GLM Metal prefill failed
```

Repro: `./ds4 --metal --ssd-streaming -m GLM-5.2-<routed-Q2K>.gguf --ctx 1024 --nothink --temp 0 -n 8 -p "<any ~300-word prompt>"`. Short benchmark prompts and `--perplexity-file` texts under the overflow point never hit it, which is probably why it survived so far.

Two root causes, one commit each:

1. **The indexed prefill hardcodes `full_layer_prefill=false`** in its per-layer mapping and forces the runtime flag off, so every chunk takes the selected-expert addr path. A chunk above ~64 tokens selects more unique experts per layer than the cache holds; the loader's overflow branch then addresses experts straight out of the mapped model, but the decode-expert-cache spans do not cover the routed expert tensors, and prefill dies. The fix computes the same threshold the plain prefill flow uses (`glm_graph_stream_prefill_full_layer_enabled`) and passes it to both the mapping and the runtime flag. Big chunks now stream full layers with the mm_id kernels; short prompts keep the addr path unchanged.

2. **`prepare_selected_batch` spills to overflow views instead of evicting when the cache is at budget** (`force_reuse` was hardcoded 0). Any small-chunk prefill against a full cache failed the same way — most visibly checkpoint-extend prefills, which broke the disk KV cache flow right after it loaded a matching checkpoint. The fix reuse-evicts at budget exactly like the decode loader does (commands are synced by the caller before prepare, so reuse cannot race the GPU, and `prepare_load_buffers` protects the layer's unique selected set). Overflow views remain as the last resort for allocation failure.

## Testing

Machine: Apple M5 Pro 64 GB, macOS 26 (Darwin 25.5.0), Metal backend, branch = glm5.2 + these two commits, `make clean && make`, `git diff --check` clean.

Correctness track:

- `./ds4_test --server` — OK
- `./ds4_test --metal-kernels` — OK
- `DS4_TEST_SSD_STREAMING=1 DS4_TEST_MODEL=DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix.gguf ./ds4_test --metal-ssd-streaming-cache-pressure` — OK (exercises the modified loader on the DeepSeek family)
- same env, `./ds4_test --logprob-vectors` — OK (official-vector gate; the shared-loader change does not perturb DeepSeek logits)

GLM 5.2 runtime (753B, routed experts Q2_K, attention Q8_0; note: my local artifact uses a ds4-native tensor layout enabled by a separate local patch — the two fixes here are layout-independent and sit in code that never inspects tensor dtypes):

- the repro above completes instead of failing; a 795-token prompt prefills at 9.4 t/s vs 1.5 t/s for the addr path on chunks that did fit before (full-layer streaming reads sequentially);
- `--decode-consistency 8` stays bit-exact vs a fresh prefill (decode untouched);
- disk KV cache now works end to end: 321-token request 181 s cold, 32 s on a same-prefix follow-up (checkpoint hit, 14-token suffix prefill), 33 s across a server restart (checkpoint loaded from disk in ~16 ms).

Speed track: decode is unaffected (same path); prefill only changes for chunk sizes that previously failed outright, where full-layer streaming measures 6x faster than the (broken) addr path would need to be. One observable shift: scoring a text that stays under the overflow point moves +0.7% ppl because those chunks now take the mm_id kernels instead of addr — the same accumulation-order difference already documented in `ds4_gpu_stream_prefill_batch_selected_addr_auto` gating.

Found while enabling the disk KV cache for agentic use; happy to split or adjust if you prefer a different fix shape (e.g. mapping the expert spans in addr mode instead of switching to full-layer above the threshold).

