### PR TITLE
Add rocm-test target and fix test builds for ROCm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,13 @@ strix-halo:
 
 rocm: strix-halo
 
+rocm-test:
+	$(MAKE) test \
+		CORE_OBJS="ds4.o ds4_distributed.o ds4_ssd.o ds4_rocm.o" \
+		CFLAGS="$(CFLAGS) -DDS4_ROCM_BUILD" \
+		DS4_LINK="$(HIPCC) $(ROCM_CFLAGS)" \
+		DS4_LINK_LIBS="$(ROCM_LDLIBS)"
+
 ds4: ds4_cli.o ds4_help.o linenoise.o $(CORE_OBJS)
 	$(DS4_LINK) -o $@ $^ $(DS4_LINK_LIBS)
 
@@ -221,14 +228,14 @@ ds4_test: ds4_test.o ds4_help.o ds4_kvstore.o rax.o $(CORE_OBJS)
 ifeq ($(UNAME_S),Darwin)
 	$(CC) $(CFLAGS) -o $@ ds4_test.o ds4_help.o ds4_kvstore.o rax.o $(CORE_OBJS) $(METAL_LDLIBS)
 else
-	$(NVCC) $(NVCCFLAGS) -o $@ ds4_test.o ds4_help.o ds4_kvstore.o rax.o $(CORE_OBJS) $(CUDA_LDLIBS)
+	$(DS4_LINK) -o $@ ds4_test.o ds4_help.o ds4_kvstore.o rax.o $(CORE_OBJS) $(DS4_LINK_LIBS)
 endif
 
 ds4_agent_test: ds4_agent_test.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o $(CORE_OBJS)
 ifeq ($(UNAME_S),Darwin)
 	$(CC) $(CFLAGS) -o $@ ds4_agent_test.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o $(CORE_OBJS) $(METAL_LDLIBS)
 else
-	$(NVCC) $(NVCCFLAGS) -o $@ ds4_agent_test.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o $(CORE_OBJS) $(CUDA_LDLIBS)
+	$(DS4_LINK) -o $@ ds4_agent_test.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o $(CORE_OBJS) $(DS4_LINK_LIBS)
 endif
 
 test: ds4_test ds4_agent_test ds4-eval q4k-dot-test


### PR DESCRIPTION
## Problem

On systems with ROCm but without CUDA (no nvcc), `make test` fails:
```
make: /usr/local/cuda/bin/nvcc: No such file or directory
make: *** [Makefile:219: ds4_cuda.o] Error 127
```

The Makefile hardcodes NVCC for non-Darwin test binaries (ds4_test and ds4_agent_test), making it impossible to run tests on ROCm-only systems.

## Solution

1. Change test binary linking to use `DS4_LINK` and `DS4_LINK_LIBS` instead of hardcoded NVCC/CUDA_LDLIBS. This respects the backend selected by the user (CUDA or ROCm).

2. Add `rocm-test` target that runs `make test` with ROCm variables set, providing a convenient way to build and run tests with ROCm backend.

## Testing

**Machine:** ROCm on Radeon 8060S Graphics (gfx1151)  
**Model:** ds4flash.gguf

### Before (main branch):
```bash
$ make test
make: /usr/local/cuda/bin/nvcc: No such file or directory
make: *** [Makefile:219: ds4_cuda.o] Error 127
```

### After (this branch):
```bash
$ make rocm-test
[builds successfully]

$ ./ds4_test --server
server: OK

$ ./ds4_test --metal-kernels
metal-kernels: OK
```

## Impact

The change allows ROCm users to run the full test suite without requiring CUDA installation, while maintaining backward compatibility for CUDA users.