### PR TITLE
metal: stop expert-miss readahead racing the pread pool (+13% GLM streaming decode)

### DIFF
--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -14,6 +14,8 @@
 #include <limits.h>
 #include <time.h>
 #include <pthread.h>
+#include <pthread/qos.h>
+#include <sys/resource.h>
 #include <unistd.h>
 #include <sys/mman.h>
 #include <sys/sysctl.h>
@@ -7829,9 +7831,12 @@ static int ds4_gpu_stream_expert_pread_into(
     return 1;
 }
 
+static void ds4_gpu_stream_expert_pread_thread_qos(void);
+
 static void *ds4_gpu_stream_expert_pread_worker(void *arg) {
     ds4_gpu_stream_expert_pread_worker_args *wa =
         (ds4_gpu_stream_expert_pread_worker_args *)arg;
+    ds4_gpu_stream_expert_pread_thread_qos();
     for (uint32_t i = wa->worker_index; i < wa->n_tasks; i += wa->n_workers) {
         ds4_gpu_stream_expert_pread_task *task = &wa->tasks[i];
         task->ok = ds4_gpu_stream_expert_pread_into(task->offset,
@@ -7875,9 +7880,19 @@ static int ds4_gpu_stream_expert_pread_pool_enabled(void) {
     return !(env && strcmp(env, "0") == 0);
 }
 
+/* Expert reads are on the token critical path: exempt reader threads
+ * from the IO throttling / background QoS a demoted parent would hand
+ * them (plain nice does not throttle IO, taskpolicy -b does). */
+static void ds4_gpu_stream_expert_pread_thread_qos(void) {
+    if (getenv("DS4_METAL_DISABLE_STREAMING_EXPERT_PREAD_QOS") != NULL) return;
+    (void)pthread_set_qos_class_self_np(QOS_CLASS_USER_INITIATED, 0);
+    (void)setiopolicy_np(IOPOL_TYPE_DISK, IOPOL_SCOPE_THREAD, IOPOL_IMPORTANT);
+}
+
 static void *ds4_gpu_stream_expert_pread_pool_worker(void *arg) {
     const uint32_t worker_index = (uint32_t)(uintptr_t)arg;
     uint64_t seen_generation = 0;
+    ds4_gpu_stream_expert_pread_thread_qos();
 
     for (;;) {
         pthread_mutex_lock(&g_stream_expert_pread_pool_mutex);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -283,6 +283,7 @@ static void ds4_gpu_stream_expert_cache_clear_all(int reset_stats);
 static void ds4_gpu_stream_expert_pending_load_clear(void);
 static void ds4_gpu_stream_expert_pread_pool_shutdown(void);
 static int ds4_gpu_stream_expert_timing_summary_enabled(void);
+static void ds4_gpu_stream_expert_pread_pool_stats_print(void);
 static int ds4_gpu_stream_expert_cache_entry_protected(
         uint32_t       layer,
         uint32_t       expert,
@@ -2789,6 +2790,7 @@ void ds4_gpu_print_memory_report(const char *label) {
                 ds4_gpu_stream_expert_timing_print("delta", delta);
                 g_stream_expert_timing_last_report = total;
             }
+            ds4_gpu_stream_expert_pread_pool_stats_print();
         }
         if (getenv("DS4_METAL_STREAMING_EXPERT_LAYER_STATS") != NULL) {
             fprintf(stderr, "ds4:   streaming expert cache per-layer stats:\n");
@@ -7855,6 +7857,19 @@ static ds4_gpu_stream_expert_pread_task *g_stream_expert_pread_pool_tasks;
 static int g_stream_expert_pread_pool_initialized;
 static int g_stream_expert_pread_pool_stopping;
 
+/* Dispatch stats for the timing summary: qd_avg = task_ms / wall_ms is
+ * the effective pread concurrency the pool actually sustains. */
+static uint64_t g_stream_expert_pread_pool_stat_dispatches;
+static uint64_t g_stream_expert_pread_pool_stat_tasks;
+static uint64_t g_stream_expert_pread_pool_stat_workers;
+static uint64_t g_stream_expert_pread_pool_stat_bytes;
+static double g_stream_expert_pread_pool_stat_task_ms;
+static double g_stream_expert_pread_pool_stat_wall_ms;
+static double g_stream_expert_pread_pool_stat_t0;
+static const ds4_gpu_stream_expert_pread_task *g_stream_expert_pread_pool_stat_task_ptr;
+static uint32_t g_stream_expert_pread_pool_stat_task_n;
+static int g_stream_expert_pread_pool_stat_pending;
+
 static int ds4_gpu_stream_expert_pread_pool_enabled(void) {
     const char *env = getenv("DS4_METAL_STREAMING_EXPERT_PREAD_POOL");
     return !(env && strcmp(env, "0") == 0);
@@ -7995,6 +8010,11 @@ static int ds4_gpu_stream_expert_pread_pool_begin(
     g_stream_expert_pread_pool_active_workers = n_workers;
     g_stream_expert_pread_pool_remaining_workers = n_workers;
     g_stream_expert_pread_pool_generation++;
+    g_stream_expert_pread_pool_stat_t0 = ds4_gpu_now_ms();
+    g_stream_expert_pread_pool_stat_task_ptr = tasks;
+    g_stream_expert_pread_pool_stat_task_n = n_tasks;
+    g_stream_expert_pread_pool_stat_workers += n_workers;
+    g_stream_expert_pread_pool_stat_pending = 1;
     pthread_cond_broadcast(&g_stream_expert_pread_pool_start_cond);
     pthread_mutex_unlock(&g_stream_expert_pread_pool_mutex);
     return 1;
@@ -8008,8 +8028,49 @@ static int ds4_gpu_stream_expert_pread_pool_wait(void) {
         pthread_cond_wait(&g_stream_expert_pread_pool_done_cond,
                           &g_stream_expert_pread_pool_mutex);
     }
+    if (g_stream_expert_pread_pool_stat_pending) {
+        const ds4_gpu_stream_expert_pread_task *st =
+            g_stream_expert_pread_pool_stat_task_ptr;
+        g_stream_expert_pread_pool_stat_wall_ms +=
+            ds4_gpu_now_ms() - g_stream_expert_pread_pool_stat_t0;
+        g_stream_expert_pread_pool_stat_dispatches++;
+        g_stream_expert_pread_pool_stat_tasks +=
+            g_stream_expert_pread_pool_stat_task_n;
+        for (uint32_t i = 0; i < g_stream_expert_pread_pool_stat_task_n; i++) {
+            g_stream_expert_pread_pool_stat_task_ms += st[i].ms;
+            g_stream_expert_pread_pool_stat_bytes += st[i].read_bytes;
+        }
+        g_stream_expert_pread_pool_stat_task_ptr = NULL;
+        g_stream_expert_pread_pool_stat_task_n = 0;
+        g_stream_expert_pread_pool_stat_pending = 0;
+    }
     pthread_mutex_unlock(&g_stream_expert_pread_pool_mutex);
     return 1;
+}
+
+static void ds4_gpu_stream_expert_pread_pool_stats_print(void) {
+    pthread_mutex_lock(&g_stream_expert_pread_pool_mutex);
+    const uint64_t dispatches = g_stream_expert_pread_pool_stat_dispatches;
+    const uint64_t tasks = g_stream_expert_pread_pool_stat_tasks;
+    const uint64_t workers = g_stream_expert_pread_pool_stat_workers;
+    const uint64_t bytes = g_stream_expert_pread_pool_stat_bytes;
+    const double task_ms = g_stream_expert_pread_pool_stat_task_ms;
+    const double wall_ms = g_stream_expert_pread_pool_stat_wall_ms;
+    pthread_mutex_unlock(&g_stream_expert_pread_pool_mutex);
+    if (dispatches == 0) return;
+    fprintf(stderr,
+            "ds4:   streaming pread pool dispatches=%llu tasks=%llu "
+            "tasks_avg=%.1f workers_avg=%.1f bytes=%.2f GiB wall_avg=%.3f ms "
+            "qd_avg=%.2f pool_gbps=%.2f task_gbps=%.2f\n",
+            (unsigned long long)dispatches,
+            (unsigned long long)tasks,
+            (double)tasks / (double)dispatches,
+            (double)workers / (double)dispatches,
+            ds4_gpu_gib(bytes),
+            wall_ms / (double)dispatches,
+            wall_ms > 0.0 ? task_ms / wall_ms : 0.0,
+            wall_ms > 0.0 ? (double)bytes / 1e6 / wall_ms : 0.0,
+            task_ms > 0.0 ? (double)bytes / 1e6 / task_ms : 0.0);
 }
 
 static int ds4_gpu_stream_expert_pread_pool_dispatch(

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -7658,6 +7658,14 @@ static int ds4_gpu_stream_expert_readahead_enabled(void) {
            getenv("DS4_METAL_DISABLE_STREAMING_EXPERT_READAHEAD") == NULL;
 }
 
+/* Advise for ranges the pread pool reads immediately after: the fcntl
+ * blocks the eval thread while the pool fetches the same bytes anyway.
+ * Off by default; the env restores the old behavior for comparisons. */
+static int ds4_gpu_stream_expert_miss_readahead_enabled(void) {
+    return ds4_gpu_stream_expert_readahead_enabled() &&
+           getenv("DS4_METAL_ENABLE_STREAMING_EXPERT_MISS_READAHEAD") != NULL;
+}
+
 static void ds4_gpu_stream_expert_readahead_range(uint64_t offset, uint64_t len) {
     if (!ds4_gpu_stream_expert_readahead_enabled() || g_model_fd < 0 || len == 0) {
         return;
@@ -10345,9 +10353,11 @@ static ds4_gpu_stream_expert_cache_entry *ds4_gpu_stream_expert_cache_get_protec
         return e;
     }
 
-    ds4_gpu_stream_expert_readahead_range(gate_abs_offset, gate_expert_bytes);
-    ds4_gpu_stream_expert_readahead_range(up_abs_offset, gate_expert_bytes);
-    ds4_gpu_stream_expert_readahead_range(down_abs_offset, down_expert_bytes);
+    if (ds4_gpu_stream_expert_miss_readahead_enabled()) {
+        ds4_gpu_stream_expert_readahead_range(gate_abs_offset, gate_expert_bytes);
+        ds4_gpu_stream_expert_readahead_range(up_abs_offset, gate_expert_bytes);
+        ds4_gpu_stream_expert_readahead_range(down_abs_offset, down_expert_bytes);
+    }
 
     id<MTLBuffer> gate_buf = nil;
     id<MTLBuffer> up_buf = nil;
@@ -10760,12 +10770,14 @@ int ds4_gpu_stream_expert_cache_begin_selected_load(
         const int force_reuse =
             cache_budget != 0 && reserved_entries >= cache_budget;
 
-        ds4_gpu_stream_expert_readahead_range(p->gate_abs_offsets[slot],
-                                              gate_expert_bytes);
-        ds4_gpu_stream_expert_readahead_range(p->up_abs_offsets[slot],
-                                              gate_expert_bytes);
-        ds4_gpu_stream_expert_readahead_range(p->down_abs_offsets[slot],
-                                              down_expert_bytes);
+        if (ds4_gpu_stream_expert_miss_readahead_enabled()) {
+            ds4_gpu_stream_expert_readahead_range(p->gate_abs_offsets[slot],
+                                                  gate_expert_bytes);
+            ds4_gpu_stream_expert_readahead_range(p->up_abs_offsets[slot],
+                                                  gate_expert_bytes);
+            ds4_gpu_stream_expert_readahead_range(p->down_abs_offsets[slot],
+                                                  down_expert_bytes);
+        }
 
         if (!ds4_gpu_stream_expert_cache_prepare_load_buffers(layer,
                                                               expert,
@@ -10982,12 +10994,14 @@ static int ds4_gpu_stream_expert_cache_load_selected_missing(
         const int force_reuse =
             cache_budget != 0 && reserved_entries >= cache_budget;
 
-        ds4_gpu_stream_expert_readahead_range(gate_abs_offsets[slot],
-                                              gate_expert_bytes);
-        ds4_gpu_stream_expert_readahead_range(up_abs_offsets[slot],
-                                              gate_expert_bytes);
-        ds4_gpu_stream_expert_readahead_range(down_abs_offsets[slot],
-                                              down_expert_bytes);
+        if (ds4_gpu_stream_expert_miss_readahead_enabled()) {
+            ds4_gpu_stream_expert_readahead_range(gate_abs_offsets[slot],
+                                                  gate_expert_bytes);
+            ds4_gpu_stream_expert_readahead_range(up_abs_offsets[slot],
+                                                  gate_expert_bytes);
+            ds4_gpu_stream_expert_readahead_range(down_abs_offsets[slot],
+                                                  down_expert_bytes);
+        }
 
         if (!ds4_gpu_stream_expert_cache_prepare_load_buffers(layer,
                                                               expert,


### PR DESCRIPTION
During steady-state SSD-streaming decode the eval thread spends much of its
time in `fcntl(F_RDADVISE)`: every expert-cache miss advises the gate/up/down
ranges and then immediately hands the exact same ranges to the pread pool.
The advise fcntl is synchronous on the eval thread, while the pool reads the
bytes in parallel either way, so the advise only adds stall time. A 5 s
thread `sample` during GLM 5.2 streaming decode (the same three call sites
exist on the `glm5.2` branch):

| eval thread | share |
| --- | ---: |
| `fcntl(F_RDADVISE)` in `readahead_range` (miss paths) | **40%** |
| GPU `waitUntilCompleted` | 44% |
| pread pool wait | 11% |
| CPU | 5% |

## Commits

1. **metal: skip streaming expert miss readahead by default** — gates the
   three miss-path advise sites (single miss, batch load, early load).
   `DS4_METAL_ENABLE_STREAMING_EXPERT_MISS_READAHEAD=1` restores the old
   behavior. The prefill/layer readahead sites are untouched.
2. **metal: report pread pool dispatch stats in the timing summary** — one
   extra line under the existing `DS4_METAL_STREAMING_EXPERT_TIMING_SUMMARY`
   gate: dispatches, tasks, bytes, effective queue depth (sum of per-task
   pread ms / pool wall ms) and delivered bandwidth. This is how the numbers
   below were measured; makes streaming IO regressions visible without
   dtrace.
3. **metal: keep expert pread threads on the important IO tier** — reader
   threads inherit the parent QoS, so under `taskpolicy -b` / background
   launchd jobs every miss pays the throttled IO tier. Pin them to
   user-initiated QoS + `IOPOL_IMPORTANT`
   (`DS4_METAL_DISABLE_STREAMING_EXPERT_PREAD_QOS` opts out).

## Measurements

One machine only: M1 Ultra Mac Studio, 128 GB RAM, 8 TB SSD (~7.2 GB/s
sequential), Metal backend.

**GLM-5.2-UD-IQ2_XXS** (rebased onto `glm5.2`, where the change applies
clean; `--ssd-streaming --ssd-streaming-cache-experts 48GB
--ssd-streaming-full-layers 16`, prefill 2048 + 128 greedy):

| | prefill t/s | steady decode t/s |
| --- | ---: | ---: |
| glm5.2 | 20.9 | 2.34 |
| + this change | **26.7 (+27%)** | **2.74 (+13%)** |

**DeepSeek-V4-Flash Q4KExperts imatrix** streaming on this branch
(`--ssd-streaming-cache-experts 48GB`, prefill 512 + 128 greedy): no
measurable difference (5.01 vs 5.21 gen t/s, inside the run-to-run spread —
two back-to-back pristine runs varied 2.66 vs 3.11 on the shorter form).
Expected: only ~25 GB of this quant misses RAM, so the miss rate — and the
advise tax — is small. The win concentrates on models far bigger than RAM.

**Flash IQ2XXS imatrix resident** (no `--ssd-streaming`): bit-identical
logits and identical speed (25.7 t/s decode) — the changed code never runs
outside streaming mode.

Correctness: every A/B pair above was run with
`--dump-frontier-logits-dir` and the full frontier logits compared
byte-for-byte — identical in all cases (the streaming baseline itself is
deterministic: two pristine runs match bit-for-bit).

Also tried while measuring: splitting each expert read into 2-8 striped
preads to raise queue depth. It lifts large preload dispatches
(5.1 -> 6.8 GB/s) but does not help decode misses, so it is not included.

## Tests run

```
make clean && make            # zero warnings
./ds4_test --server           # OK
./ds4_test --metal-kernels    # OK
./ds4_test --logprob-vectors  # pre-existing ERR (long_code_audit) with the
                              # IQ2XXS imatrix quant; identical on unpatched
                              # main, unrelated to this change
```

Speed/parity A/Bs with `ds4-bench` as above.
