### PR TITLE
Fix pre-auth double-free in JSON request parser

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -219,6 +219,13 @@ static bool json_u16(const char **p, uint32_t *out) {
 }
 
 static bool json_string(const char **p, char **out) {
+    /* Always define *out. Every failure path below returns false without
+     * producing a string, and several callers reparse in place with
+     * `free(x); json_string(&p, &x)` (e.g. duplicate JSON keys, the "model"
+     * field). Without this, a non-string or malformed value leaves *out
+     * holding the just-freed pointer, which a later cleanup frees again --
+     * a double-free. Nulling on entry closes that whole class at the root. */
+    *out = NULL;
     json_ws(p);
     if (**p != '"') return false;
     (*p)++;


### PR DESCRIPTION
### Summary

`json_string()` returns `false` on a non-string or malformed value **without writing `*out`**. Several callers reparse in place with `free(x); json_string(&p, &x)`:

- the `"model"` field in `parse_chat_request`, `parse_completion_request`, and `parse_anthropic_request`;
- duplicate JSON keys for `type` / `name` / `description` / `order.name` across the tool-schema and message parsers (~12 sites in total).

On a failed reparse, `*out` keeps the **just-freed** pointer (dangling, not `NULL`). The request's cleanup path (`request_free`) then `free()`s it a second time — a double-free of a small heap allocation, reachable **pre-auth with a single request**:

```
POST /v1/chat/completions
{"messages":[{"role":"user","content":"hi"}],"model":0}
```

(also via `/v1/messages`, `/v1/responses`, `/v1/completions`; and a duplicate-key variant `{"content":"ok","content":0}`).

### Fix

Initialize `*out = NULL` at the top of `json_string`, so every failure path leaves the caller's pointer **defined**. This closes all the `free(x); json_string(&p, &x)` sites at the root instead of patching each call site, and matches the pattern the parser already uses where it nulls after freeing. Behavior on the success path is unchanged (`*out` is still overwritten by `buf_take`), so valid requests parse exactly as before.

### Verification

Built the parser under AddressSanitizer/UBSan (driving the real `parse_chat_request`, unmodified):

- **before:** `AddressSanitizer: attempting double-free` — alloc in `xstrdup`, first free at the `"model"` handler, second free in `request_free` via the `bad:` label.
- **after:** the malformed request is cleanly rejected (`invalid JSON request`), no sanitizer error.

Found during a coordinated security review of ds4; a standalone offline PoC is available on request. Happy to adjust the approach (e.g. per-call-site nulling) if you prefer.
