### PR TITLE
Unlink bash tool output temp file on job cleanup

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -6690,6 +6690,11 @@ static void agent_bash_job_free(agent_bash_job *job) {
     }
     if (job->pipe_fd >= 0) close(job->pipe_fd);
     if (job->tmp_fd >= 0) close(job->tmp_fd);
+    /* Remove the mkstemp() output file created in agent_bash_start(); only
+     * that function's error paths unlinked it, so a job that started
+     * successfully otherwise leaves /tmp/ds4_agent_output_* behind for the
+     * lifetime of the process (unbounded accumulation across many jobs). */
+    if (job->path[0]) unlink(job->path);
     free(job->cmd);
     free(job);
 }


### PR DESCRIPTION
### Summary

`agent_bash_start()` creates a per-job output file with `mkstemp()` and stores its path in `job->path`. Only that function's own error paths `unlink()` it. The normal cleanup path, `agent_bash_job_free()`, closes the file descriptors and frees memory but never unlinks `job->path`.

A process that runs many bash-tool jobs therefore leaves one `/tmp/ds4_agent_output_*` file behind per job, accumulating without bound for the lifetime of the process (a slow resource leak on long-running agent sessions).

### Fix

`unlink(job->path)` in `agent_bash_job_free()` before freeing the job.

### Verification

Ran the real `agent_bash_start()` + `agent_bash_job_free()` cleanup path for 3 jobs:

- **before:** 3 leftover `/tmp/ds4_agent_output_*` files after cleanup.
- **after:** 0 leftover files.

Found during a coordinated security review of ds4; a standalone offline PoC is available on request.
