### PR TITLE
Handle NaN in json_int() (undefined double->int cast)

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -281,7 +281,11 @@ static bool json_number(const char **p, double *out) {
 static bool json_int(const char **p, int *out) {
     double v = 0.0;
     if (!json_number(p, &v)) return false;
-    if (v < 0) v = 0;
+    /* json_number() uses strtod(), which accepts "NaN"/"Infinity". NaN fails
+     * every comparison, so a plain `v < 0` clamp would let it through to the
+     * (int) cast, which is undefined for NaN; `!(v >= 0)` folds NaN (and
+     * negatives) to 0. +/-Infinity are handled by the two clamps. */
+    if (!(v >= 0)) v = 0;
     if (v > INT_MAX) v = INT_MAX;
     *out = (int)v;
     return true;


### PR DESCRIPTION
### Summary

`json_number()` is a thin `strtod()` wrapper, which per C99 accepts `"NaN"` and `"Infinity"`. In `json_int()` the two clamps `v < 0` and `v > INT_MAX` are **both false for NaN** (every comparison against NaN is false), so a NaN value reaches the `(int)v` cast, which is undefined behavior for NaN (on x86-64 it yields `INT_MIN`).

So a request field like `{"max_tokens": NaN}` produces an out-of-range integer conversion rather than being rejected/clamped.

### Fix

Replace `if (v < 0) v = 0;` with `if (!(v >= 0)) v = 0;`, which folds NaN (and negatives) to 0. `+Infinity` / `-Infinity` remain handled by the existing clamps. One-line change, no new dependency.

### Verification

Built under UBSan with `-fsanitize=float-cast-overflow`, driving the real `json_int("NaN")`:

- **before:** `runtime error: nan is outside the range of representable values of type 'int'`.
- **after:** returns `0`, no trap.

Low severity (no memory corruption), found during a coordinated security review of ds4; a standalone offline PoC is available on request.
