### PR TITLE
Bound GGUF metadata/tensor counts by file size before allocating (DoS)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -1857,6 +1857,10 @@ static void model_prefetch_cpu_mapping(const ds4_model *m) {
 /* Read the GGUF metadata table.  Values stay in the mmap; we store offsets so
  * later validation can decode only the keys it needs. */
 static void parse_metadata(ds4_model *m, ds4_cursor *c) {
+    /* n_kv comes from the header. Every entry consumes at least one byte in the
+     * file, so a count larger than the bytes remaining cannot be real; reject it
+     * before calloc so a tiny file can't request an enormous allocation. */
+    if (m->n_kv > c->size - c->pos) ds4_die("GGUF metadata count exceeds file size");
     m->kv = calloc((size_t)m->n_kv, sizeof(m->kv[0]));
     if (!m->kv) ds4_die("out of memory while allocating metadata table");
 
@@ -1887,6 +1891,10 @@ static void parse_metadata(ds4_model *m, ds4_cursor *c) {
 /* Read the tensor directory and convert relative GGUF offsets to absolute
  * mmap offsets.  Tensor bytes are still never copied here. */
 static void parse_tensors(ds4_model *m, ds4_cursor *c) {
+    /* As in parse_metadata: each tensor directory entry needs at least one byte
+     * in the file, so reject a count larger than the bytes remaining before the
+     * allocation. */
+    if (m->n_tensors > c->size - c->pos) ds4_die("GGUF tensor count exceeds file size");
     m->tensors = calloc((size_t)m->n_tensors, sizeof(m->tensors[0]));
     if (!m->tensors) ds4_die("out of memory while allocating tensor table");
 


### PR DESCRIPTION
### Summary

`parse_metadata()` and `parse_tensors()` `calloc()` a table sized directly from the header-declared `m->n_kv` / `m->n_tensors`, with no check against the mapped file. A 24-byte file declaring `n_kv = 2^32` makes `parse_metadata()` request **~137 GB** up front — a load-time DoS/OOM from a tiny crafted model file.

### Fix

Each metadata/tensor entry occupies at least one byte in the file, so a count larger than the bytes remaining (`c->size - c->pos`) cannot be real. Reject it before the allocation. Legitimate models are unaffected (their counts are far smaller than the file).

### Verification

Drove the real `parse_metadata()` with a header declaring `n_kv = 2^32` (ASan allocation cap on):

- **before:** `calloc(n_kv, 32)` = ~137 GB request at `parse_metadata`.
- **after:** `ds4: GGUF metadata count exceeds file size`, no large allocation.

Found during a coordinated security review of ds4; a standalone offline PoC is available on request.
