### PR TITLE
Reject oversized snapshot token_count before allocating (distributed DoS)

### DIFF
--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -7000,6 +7000,17 @@ static int dist_worker_handle_snapshot_load(
         snprintf(err, sizeof(err), "invalid distributed snapshot load header");
     }
 
+    /* Reject a token_count larger than the worker context up front, before the
+     * allocation and the read loop below. token_count is only bounded to
+     * ~UINT32_MAX/4 by the header check above, so without this a peer could
+     * drive a multi-GB malloc and a full-length socket read before the
+     * matching-state check further down (which also tests token_count > ctx_size)
+     * finally rejects the request. */
+    if (!err[0] && begin.token_count > (uint32_t)state->ctx_size) {
+        dist_discard_bytes(upstream->fd, body_bytes);
+        snprintf(err, sizeof(err), "snapshot token count exceeds worker context size");
+    }
+
     int *tokens = NULL;
     if (!err[0]) {
         tokens = malloc((size_t)begin.token_count * sizeof(tokens[0]));


### PR DESCRIPTION
### Summary

In the `SNAPSHOT_LOAD_BEGIN` worker path, `begin.token_count` is only bounded to `~UINT32_MAX/4` by the header check (`expected_token_bytes <= UINT32_MAX`). The code then `malloc()`s `token_count * 4` bytes and runs the full token read loop, and **only afterwards** does the matching-state check reject `token_count > ctx_size`.

Because the distributed protocol is unauthenticated (any peer reaching the port is treated as a cluster member), an untrusted peer can drive a multi-GB allocation and a full-length socket read before the request is rejected.

### Fix

Move the `token_count > ctx_size` test ahead of the allocation and the read loop (discarding the body bytes, consistent with the header-validation path), so an over-large count is rejected up front. The existing later check is left in place for the other state fields.

### Verification

Source-confirmed and compile-checked (verified the patched translation unit builds cleanly under the ASan/UBSan flags). I did not build a runtime PoC for this one — triggering it needs a fully loaded worker plus a socket peer, which I couldn't stand up cheaply. The exact pre-existing line ordering (`malloc` + read loop before the `token_count > ctx_size` check) is straightforward to confirm by eye.

Found during a coordinated security review of ds4.
