### PR TITLE
Bound tokenizer merges count to INT32_MAX like the tokens table

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -22241,7 +22241,8 @@ static void vocab_load(ds4_vocab *vocab, const ds4_model *model) {
         ds4_die("GGUF tokenizer token table is missing or invalid");
     }
     if (!model_get_array(model, "tokenizer.ggml.merges", &merges) ||
-        merges.type != GGUF_VALUE_STRING) {
+        merges.type != GGUF_VALUE_STRING ||
+        merges.len > INT32_MAX) {
         ds4_die("GGUF tokenizer merge table is missing or invalid");
     }
 


### PR DESCRIPTION
### Summary

`vocab_load()` validates the token table with `tokens.len > INT32_MAX`, but the merges table validation omits the same bound. The merge loop then stores each rank with:

```c
table_put(&vocab->merge_rank, merge, (int)i);   // i is uint64_t
```

A GGUF declaring more than `INT32_MAX` merges makes `(int)i` wrap negative and stores corrupt merge ranks (affecting tokenization correctness).

### Fix

Mirror the `tokens` sibling's bound: reject `merges.len > INT32_MAX` in the merges validation.

### Verification

Source-confirmed and compile-checked (the patched translation unit builds cleanly under the ASan/UBSan flags). I did not build a runtime PoC — it would require a crafted GGUF declaring >2³¹ merge entries, which isn't practical to materialize as a file. The `(int)i` narrowing and the missing bound (vs the present one on `tokens.len`) are visible directly in `vocab_load`.

Found during a coordinated security review of ds4.
