### PR TITLE
ds4-agent: fixes missing --rocm backend argument parsing

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -592,8 +592,13 @@ static agent_config parse_options(int argc, char **argv) {
             c.engine.backend = parse_backend(need_arg(&i, argc, argv, arg));
         } else if (!strcmp(arg, "--metal")) {
             c.engine.backend = DS4_BACKEND_METAL;
+#ifdef DS4_ROCM_BUILD
+        } else if (!strcmp(arg, "--rocm")) {
+            c.engine.backend = DS4_BACKEND_CUDA;
+#else
         } else if (!strcmp(arg, "--cuda")) {
             c.engine.backend = DS4_BACKEND_CUDA;
+#endif
         } else if (!strcmp(arg, "--cpu")) {
             c.engine.backend = DS4_BACKEND_CPU;
         } else if (!strcmp(arg, "-t") || !strcmp(arg, "--threads")) {


### PR DESCRIPTION
Adds missing `--rocm` parsing to ds4-agent; the shared help prints it for all tools and other cli tools have it e.g. see

https://github.com/antirez/ds4/blob/80ebbc396aee40eedc1d829222f3362d10fa4c6c/ds4_cli.c#L1539-L1545

Disclaimer: This was written by the ds4 agent itself running the ds4 flash q2 imatrix quant on a strix halo 128gb.