### PR TITLE
ROCm: run on discrete RDNA4 (gfx1201) — opt-in WMMA fallback + configurable VRAM reserve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,14 @@ CPU_CORE_OBJS = ds4_cpu.o ds4_distributed.o ds4_ssd.o
 CUDA_LDLIBS ?= -lm -Xcompiler -pthread -L$(CUDA_HOME)/targets/sbsa-linux/lib -L$(CUDA_HOME)/lib64 -lcudart -lcublas
 HIPCC ?= $(shell command -v hipcc 2>/dev/null || echo /opt/rocm/bin/hipcc)
 ROCM_ARCH ?= gfx1151
-ROCM_CFLAGS ?= -O3 -ffast-math -g -fno-finite-math-only -pthread -D__HIP_PLATFORM_AMD__ -Wno-unused-command-line-argument --offload-arch=$(ROCM_ARCH)
+ROCM_CFLAGS ?= -O3 -ffast-math -g -fno-finite-math-only -pthread -D__HIP_PLATFORM_AMD__ -Wno-unused-command-line-argument --offload-arch=$(ROCM_ARCH) $(ROCM_EXTRA_CFLAGS)
 ROCM_LDLIBS ?= -lm -pthread -lhipblas -lhipblaslt
 DS4_LINK ?= $(NVCC) $(NVCCFLAGS)
 DS4_LINK_LIBS ?= $(CUDA_LDLIBS)
 METAL_LDLIBS := $(LDLIBS)
 endif
 
-.PHONY: all help clean test cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
+.PHONY: all help clean test cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm rdna4
 
 ifeq ($(UNAME_S),Darwin)
 all: ds4 ds4-server ds4-bench ds4-eval ds4-agent
@@ -86,6 +86,7 @@ help:
 	@echo "  make cuda CUDA_ARCH=sm_N Build CUDA with an explicit nvcc -arch value"
 	@echo "  make strix-halo          Build ROCm for Strix Halo / gfx1151"
 	@echo "  make rocm                Alias for make strix-halo"
+	@echo "  make rdna4               Build ROCm for discrete RDNA4 GPUs / gfx1201"
 	@echo "  make cpu                 Build CPU-only ./ds4, ./ds4-server, ./ds4-bench, ./ds4-eval, and ./ds4-agent"
 	@echo "  make test                Build and run tests"
 	@echo "  make clean               Remove build outputs"
@@ -112,6 +113,9 @@ strix-halo:
 		DS4_LINK_LIBS="$(ROCM_LDLIBS)"
 
 rocm: strix-halo
+
+rdna4:
+	$(MAKE) strix-halo ROCM_ARCH=gfx1201 ROCM_EXTRA_CFLAGS=-DDS4_ROCM_NO_WMMA
 
 ds4: ds4_cli.o ds4_help.o linenoise.o $(CORE_OBJS)
 	$(DS4_LINK) -o $@ $^ $(DS4_LINK_LIBS)

--- a/rocm/ds4_rocm_matmul.cuh
+++ b/rocm/ds4_rocm_matmul.cuh
@@ -274,7 +274,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
         return cuda_ok(cudaGetLastError(), "matmul_q8_0 f32 warp launch");
     }
     if (n_tok > 1) {
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+#if (defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)) && !defined(DS4_ROCM_NO_WMMA)
         if (!g_quality_mode && (in_dim % 32u) == 0u &&
             out_dim >= 1024u &&
             n_tok >= 256u &&

--- a/rocm/ds4_rocm_q8.cuh
+++ b/rocm/ds4_rocm_q8.cuh
@@ -669,7 +669,7 @@ __global__ static void matmul_q8_0_f32_batch_sharedx_warp_rows_w32_toktile_kerne
     }
 }
 
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+#if (defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)) && !defined(DS4_ROCM_NO_WMMA)
 typedef _Float16 __attribute__((ext_vector_type(16))) ds4_q8_half16_t;
 typedef float    __attribute__((ext_vector_type(8)))  ds4_q8_float8_t;
 

--- a/rocm/ds4_rocm_runtime.cuh
+++ b/rocm/ds4_rocm_runtime.cuh
@@ -970,7 +970,22 @@ static int cuda_stream_resident_evict_one(
 }
 
 static uint64_t cuda_stream_resident_free_reserve_bytes(void) {
-    return 16ull * 1024ull * 1024ull * 1024ull;
+    /* Default 16 GiB: tuned for unified-memory APUs (Strix Halo) where the
+     * OS shares the pool. On discrete GPUs (e.g. 32 GiB RDNA4 cards) this
+     * would waste half the VRAM, so allow an override in MiB via
+     * DS4_ROCM_FREE_RESERVE_MB. */
+    static uint64_t cached_reserve = 0;
+    static int reserve_initialized = 0;
+    if (!reserve_initialized) {
+        const char *env = getenv("DS4_ROCM_FREE_RESERVE_MB");
+        if (env && *env) {
+            cached_reserve = strtoull(env, NULL, 10) * 1024ull * 1024ull;
+        } else {
+            cached_reserve = 16ull * 1024ull * 1024ull * 1024ull;
+        }
+        reserve_initialized = 1;
+    }
+    return cached_reserve;
 }
 
 static int cuda_stream_resident_make_room(


### PR DESCRIPTION
First report (as far as I know) of ds4 running on a **discrete RDNA4 GPU**: AMD Radeon AI PRO R9700 32GB, `gfx1201`. Two small opt-in changes were needed; default gfx1151 builds are unchanged. Related discussion: #16.

## Problems

1. **Build fails on gfx1201**: the hand-written Q8 batch GEMM (`rocm/ds4_rocm_q8.cuh`) calls `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32`, a gfx11-style WMMA builtin. RDNA4 changed the WMMA intrinsic signatures, so hipcc dies with `Cannot select: intrinsic %llvm.amdgcn.wmma.f32.16x16x16.f16`. A proper gfx12 WMMA port needs different fragment layouts, so this PR takes the conservative route: an opt-in `DS4_ROCM_NO_WMMA` guard that routes batch prefill to the existing `sharedx` kernel.

2. **SSD streaming unusable above ~12GB expert cache on a 32GB card**: `cuda_stream_resident_free_reserve_bytes()` hardcodes a 16 GiB free-VRAM reserve. That is reasonable on unified-memory APUs (Strix Halo shares the pool with the OS), but on a discrete 32GB card it wastes half the VRAM: decode fails with `streaming expert cache cannot keep 6.75 MiB for layer=N expert=M while preserving 16.00 GiB free`. New env var `DS4_ROCM_FREE_RESERVE_MB` overrides it; default is unchanged.

Plus a `make rdna4` convenience target (= `strix-halo` with `ROCM_ARCH=gfx1201` and the guard).

## Test environment

- Radeon AI PRO R9700 32GB (gfx1201, wave32), monitor on iGPU so full VRAM free
- Ryzen 9 9950X3D, 128GB DDR5, NVMe SSD
- Ubuntu 26.04, ROCm 7.2.2 (hipcc/AMD clang 22), rocWMMA 2.2.0, hipblas/hipblaslt
- Model: `DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix.gguf` (q2-imatrix, ~81GB)

## Commands run

```sh
make rdna4                      # new target, builds clean
make rocm                       # default gfx1151 target still builds clean (compile regression check)
./ds4-eval --self-test-extractors   # passed

DS4_ROCM_FREE_RESERVE_MB=2048 ./ds4 --rocm --ssd-streaming \
  --ssd-streaming-cache-experts 22GB --ctx 8192 --nothink -p "..."
```

`ds4_test` / `ds4_agent_test` link against `$(NVCC)` unconditionally, so I could not run them on a CUDA-less AMD box — that seems to affect every ROCm setup, not just this one.

## Results (one-shot CLI, cold expert cache included)

| Config | prefill t/s | generation t/s |
|---|---|---|
| default reserve (16GiB), 12GB expert cache | 3.67 | 2.30 |
| `DS4_ROCM_FREE_RESERVE_MB=2048`, 22GB cache | 6.24 | 4.43 |
| `DS4_ROCM_FREE_RESERVE_MB=2048`, 26GB cache | 6.33 | 4.70 |

Long-form generations (300+ tokens, Italian and English) are coherent; the server (`/v1/chat/completions` and `/v1/messages`) works, including as a local backend for coding agents. Also hit the mgiustiniani VRAM-reporting caveat from #16 indirectly: with other GPU tenants evicted the allocator behaves as expected at 22–26GB cache.

Happy to run more tests or numeric comparisons against baseline if useful. This PR was developed with an AI coding agent driving the terminal, human-approved throughout — in the spirit of the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSVkwdZNYXKAfgFgdzcPDc