### PR TITLE
Fixes thinking levels for pi.dev setup in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,12 +896,11 @@ For **Pi**, add a provider to `~/.pi/agent/models.json`:
           "name": "DeepSeek V4 Flash (ds4.c local)",
           "reasoning": true,
           "thinkingLevelMap": {
-            "off": null,
-            "minimal": "low",
-            "low": "low",
-            "medium": "medium",
+            "minimal": null,
+            "low": null,
+            "medium": null,
             "high": "high",
-            "xhigh": "xhigh"
+            "max": "max"
           },
           "input": ["text"],
           "contextWindow": 100000,
@@ -924,7 +923,8 @@ Optionally make it the default Pi model in `~/.pi/agent/settings.json`:
 ```json
 {
   "defaultProvider": "ds4",
-  "defaultModel": "deepseek-v4-flash"
+  "defaultModel": "deepseek-v4-flash",
+  "defaultThinkingLevel": "high"
 }
 ```
 


### PR DESCRIPTION
This changeset fixes the pi.dev setup in the readme; deepseek-v4 only has three modes: nothinking, thinking/high, and thinking/max. Also note that switching from/to thinking/max will invalidate the cache because:

> Furthermore, for the "Think Max" mode, we prepend a specific instruction to the beginning of the system prompt to guide the model’s reasoning process, as shown in Table 3.

https://arxiv.org/abs/2606.19348