### PR TITLE
ROCm: add optimized gfx906 wave64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ CPU_CORE_OBJS = ds4_cpu.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
 CUDA_LDLIBS ?= -lm -Xcompiler -pthread -L$(CUDA_HOME)/targets/sbsa-linux/lib -L$(CUDA_HOME)/lib64 -lcudart -lcublas
 HIPCC ?= $(shell command -v hipcc 2>/dev/null || echo /opt/rocm/bin/hipcc)
 ROCM_ARCH ?= gfx1151
+ROCM_CPPFLAGS :=
+ifeq ($(ROCM_ARCH),gfx906)
+ROCM_CPPFLAGS += -DDS4_GFX906
+endif
 ROCM_CFLAGS ?= -O3 -ffast-math -g -fno-finite-math-only -pthread -D__HIP_PLATFORM_AMD__ -Wno-unused-command-line-argument --offload-arch=$(ROCM_ARCH)
 ROCM_LDLIBS ?= -lm -pthread -lhipblas -lhipblaslt
 DS4_LINK ?= $(NVCC) $(NVCCFLAGS)
@@ -47,7 +51,7 @@ DS4_LINK_LIBS ?= $(CUDA_LDLIBS)
 METAL_LDLIBS := $(LDLIBS)
 endif
 
-.PHONY: all help clean test test-metal-session-batch test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
+.PHONY: all help clean test test-metal-session-batch test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm gfx906 rocm-regression
 
 ifeq ($(UNAME_S),Darwin)
 all: ds4 ds4-server ds4-bench ds4-eval ds4-agent
@@ -106,7 +110,9 @@ help:
 	@echo "  make cuda-generic        Build CUDA for a generic local CUDA GPU"
 	@echo "  make cuda CUDA_ARCH=sm_N Build CUDA with an explicit nvcc -arch value"
 	@echo "  make strix-halo          Build ROCm for Strix Halo / gfx1151"
-	@echo "  make rocm                Alias for make strix-halo"
+	@echo "  make rocm ROCM_ARCH=gfxN Build ROCm for an explicit AMD GPU architecture"
+	@echo "  make gfx906              Build ROCm for Vega 20 / gfx906"
+	@echo "  make rocm-regression ROCM_ARCH=gfxN  Build and run ROCm GPU regressions"
 	@echo "  make cpu                 Build CPU-only ./ds4, ./ds4-server, ./ds4-bench, ./ds4-eval, and ./ds4-agent"
 	@echo "  make test                Build and run tests"
 	@echo "  make dspark-verify-depth Run DSpark speculative verification smoke if support GGUF is present"
@@ -127,14 +133,17 @@ cuda:
 	fi
 	$(MAKE) -B ds4 ds4-server ds4-bench ds4-eval ds4-agent CUDA_ARCH="$(CUDA_ARCH)"
 
-strix-halo:
+rocm:
 	$(MAKE) -B ds4 ds4-server ds4-bench ds4-eval ds4-agent \
 		CORE_OBJS="ds4.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o" \
 		CFLAGS="$(CFLAGS) -DDS4_ROCM_BUILD" \
-		DS4_LINK="$(HIPCC) $(ROCM_CFLAGS)" \
+		DS4_LINK="$(HIPCC) $(ROCM_CFLAGS) $(ROCM_CPPFLAGS)" \
 		DS4_LINK_LIBS="$(ROCM_LDLIBS)"
+strix-halo:
+	$(MAKE) rocm ROCM_ARCH=gfx1151
 
-rocm: strix-halo
+gfx906:
+	$(MAKE) rocm ROCM_ARCH=gfx906
 
 ds4: ds4_cli.o ds4_help.o linenoise.o ds4_gpu_args.o $(CORE_OBJS)
 	$(DS4_LINK) -o $@ $^ $(DS4_LINK_LIBS)
@@ -163,6 +172,13 @@ cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_eval_cpu.o ds4_agent_cpu
 
 cuda-regression: tests/cuda_long_context_smoke
 	./tests/cuda_long_context_smoke
+
+rocm-regression: tests/rocm_long_context_smoke
+	./tests/rocm_long_context_smoke
+ifeq ($(ROCM_ARCH),gfx906)
+	$(MAKE) tests/gfx906_wmma_test ROCM_ARCH=gfx906
+	./tests/gfx906_wmma_test
+endif
 endif
 
 ds4.o: ds4.c ds4.h ds4_ssd.h ds4_distributed.h ds4_gpu.h
@@ -247,7 +263,7 @@ ds4_cuda.o: ds4_cuda.cu ds4_gpu.h ds4_gpu_mgpu.h ds4_iq2_tables_cuda.inc
 	$(NVCC) $(NVCCFLAGS) -c -o $@ ds4_cuda.cu
 
 ds4_rocm.o: ds4_rocm.cu ds4_gpu.h ds4_iq2_tables_cuda.inc $(ROCM_SRCS)
-	$(HIPCC) $(ROCM_CFLAGS) -c -o $@ ds4_rocm.cu
+	$(HIPCC) $(ROCM_CFLAGS) $(ROCM_CPPFLAGS) -c -o $@ ds4_rocm.cu
 
 ds4_rocm_compat.o: ds4_rocm_compat.cu ds4_gpu.h ds4_gpu_mgpu.h ds4_gpu_args.h
 	$(HIPCC) $(ROCM_CFLAGS) -c -o $@ ds4_rocm_compat.cu
@@ -344,6 +360,12 @@ test-cuda-mixed-batch: tests/test_cuda_mixed_batch
 	DS4_TEST_MODEL="$(DS4_TEST_MODEL)" ./tests/test_cuda_mixed_batch
 endif
 
+tests/rocm_long_context_smoke: tests/cuda_long_context_smoke.o ds4_rocm.o
+	$(HIPCC) $(ROCM_CFLAGS) $(ROCM_CPPFLAGS) -o $@ $^ $(ROCM_LDLIBS)
+
+tests/gfx906_wmma_test: tests/shim_test.cu rocm/ds4_rocm_wmma_gfx906.cuh rocm/ds4_rocm_q8.cuh rocm/ds4_rocm_router.cuh
+	$(HIPCC) $(ROCM_CFLAGS) $(ROCM_CPPFLAGS) -I. -o $@ tests/shim_test.cu
+
 ds4_test: ds4_test.o ds4_help.o ds4_kvstore.o rax.o $(CORE_OBJS)
 ifeq ($(UNAME_S),Darwin)
 	$(CC) $(CFLAGS) -o $@ ds4_test.o ds4_help.o ds4_kvstore.o rax.o $(CORE_OBJS) $(METAL_LDLIBS)
@@ -402,4 +424,4 @@ q4k-dot-test: tests/test_q4k_dot.c
 	./tests/test_q4k_dot
 
 clean:
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official tests/test_q4k_dot tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official tests/test_q4k_dot tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/rocm_long_context_smoke tests/gfx906_wmma_test tests/cuda_long_context_smoke.o

--- a/ds4_rocm.h
+++ b/ds4_rocm.h
@@ -4,8 +4,15 @@
 #include <hipblas/hipblas.h>
 #include <hip/hip_fp16.h>
 #include <hipcub/hipcub.hpp>
+#if defined(DS4_GFX906)
+// gfx906 (Vega 20) lacks MFMA matrix cores and rocWMMA refuses to compile for
+// it (static_assert "Unsupported architecture"). Use our device-side shim that
+// emulates the small rocWMMA subset ds4 uses via __shfl width=32 wave32 lanes.
+#include "rocm/ds4_rocm_wmma_gfx906.cuh"
+#else
 #include <rocwmma/rocwmma-version.hpp>
 #include <rocwmma/rocwmma.hpp>
+#endif
 
 #define cudaError_t hipError_t
 #define cudaStream_t hipStream_t

--- a/rocm/ds4_rocm_attention.cuh
+++ b/rocm/ds4_rocm_attention.cuh
@@ -445,6 +445,28 @@ __device__ __forceinline__ static float attention_dot_f32_vec4_oldhip(const floa
     return s;
 }
 
+__device__ __forceinline__ static float attention_dot_f32_vec4_coop_oldhip_w32(
+        const float *a, const float *b, uint32_t n, uint32_t lane) {
+    float s0 = 0.0f, s1 = 0.0f, s2 = 0.0f, s3 = 0.0f;
+    const uint32_t n4 = n >> 2u;
+    const float4 *a4 = (const float4 *)a;
+    const float4 *b4 = (const float4 *)b;
+    for (uint32_t i = lane; i < n4; i += 32u) {
+        const float4 av = a4[i];
+        const float4 bv = b4[i];
+        s0 += av.x * bv.x;
+        s1 += av.y * bv.y;
+        s2 += av.z * bv.z;
+        s3 += av.w * bv.w;
+    }
+    s0 = attention_warp_sum_oldhip_w32(s0);
+    s1 = attention_warp_sum_oldhip_w32(s1);
+    s2 = attention_warp_sum_oldhip_w32(s2);
+    s3 = attention_warp_sum_oldhip_w32(s3);
+    return (s0 + s1) + (s2 + s3);
+}
+
+template <bool COOPERATIVE_DOT = false>
 __global__ static void attention_decode_mixed_one_fast_oldhip_kernel(
         float *heads,
         const float *q,
@@ -469,30 +491,63 @@ __global__ static void attention_decode_mixed_one_fast_oldhip_kernel(
     const float scale = rsqrtf((float)head_dim);
 
     float local_max = sinks[h];
-    for (uint32_t r = tid; r < n_raw; r += blockDim.x) {
-        const uint32_t row = raw_cap ? ((raw_start + r) % raw_cap) : r;
-        const float *kv = raw_kv + (uint64_t)row * head_dim;
-        float s = use_vec4 ? attention_dot_f32_vec4_oldhip(qh, kv, head_dim) : 0.0f;
-        if (!use_vec4) {
-            for (uint32_t i = 0; i < head_dim; i++) s += qh[i] * kv[i];
-        }
-        s *= scale;
-        scores[r] = s;
-        local_max = fmaxf(local_max, s);
-    }
-    for (uint32_t c = tid; c < n_comp; c += blockDim.x) {
-        float s = -3.4e38f;
-        if (!(use_mask && comp_mask && comp_mask[c] <= -5.0e29f)) {
-            const float *kv = comp_kv + (uint64_t)c * head_dim;
-            float dot = use_vec4 ? attention_dot_f32_vec4_oldhip(qh, kv, head_dim) : 0.0f;
-            if (!use_vec4) {
-                for (uint32_t i = 0; i < head_dim; i++) dot += qh[i] * kv[i];
+    if (COOPERATIVE_DOT) {
+        const uint32_t lane = tid & 31u;
+        const uint32_t group = tid >> 5u;
+        const uint32_t groups = blockDim.x >> 5u;
+        for (uint32_t rr = group; rr < n_rows; rr += groups) {
+            const bool raw = rr < n_raw;
+            const uint32_t logical_row = raw ? rr : rr - n_raw;
+            const bool valid = raw || !(use_mask && comp_mask &&
+                                        comp_mask[logical_row] <= -5.0e29f);
+            float s = -3.4e38f;
+            if (valid) {
+                const uint32_t row = raw && raw_cap
+                    ? ((raw_start + logical_row) % raw_cap) : logical_row;
+                const float *kv = (raw ? raw_kv : comp_kv) +
+                                  (uint64_t)row * head_dim;
+                float dot = use_vec4
+                    ? attention_dot_f32_vec4_coop_oldhip_w32(qh, kv, head_dim, lane)
+                    : 0.0f;
+                if (!use_vec4) {
+                    for (uint32_t i = lane; i < head_dim; i += 32u)
+                        dot += qh[i] * kv[i];
+                    dot = attention_warp_sum_oldhip_w32(dot);
+                }
+                s = dot * scale;
+                if (!raw && use_mask && comp_mask) s += comp_mask[logical_row];
             }
-            s = dot * scale;
-            if (use_mask && comp_mask) s += comp_mask[c];
+            if (lane == 0u) {
+                scores[rr] = s;
+                local_max = fmaxf(local_max, s);
+            }
         }
-        scores[n_raw + c] = s;
-        local_max = fmaxf(local_max, s);
+    } else {
+        for (uint32_t r = tid; r < n_raw; r += blockDim.x) {
+            const uint32_t row = raw_cap ? ((raw_start + r) % raw_cap) : r;
+            const float *kv = raw_kv + (uint64_t)row * head_dim;
+            float s = use_vec4 ? attention_dot_f32_vec4_oldhip(qh, kv, head_dim) : 0.0f;
+            if (!use_vec4) {
+                for (uint32_t i = 0; i < head_dim; i++) s += qh[i] * kv[i];
+            }
+            s *= scale;
+            scores[r] = s;
+            local_max = fmaxf(local_max, s);
+        }
+        for (uint32_t c = tid; c < n_comp; c += blockDim.x) {
+            float s = -3.4e38f;
+            if (!(use_mask && comp_mask && comp_mask[c] <= -5.0e29f)) {
+                const float *kv = comp_kv + (uint64_t)c * head_dim;
+                float dot = use_vec4 ? attention_dot_f32_vec4_oldhip(qh, kv, head_dim) : 0.0f;
+                if (!use_vec4) {
+                    for (uint32_t i = 0; i < head_dim; i++) dot += qh[i] * kv[i];
+                }
+                s = dot * scale;
+                if (use_mask && comp_mask) s += comp_mask[c];
+            }
+            scores[n_raw + c] = s;
+            local_max = fmaxf(local_max, s);
+        }
     }
     const float max_score = attention_block_max_oldhip_w32(local_max);
 
@@ -717,7 +772,7 @@ __global__ static void attention_decode_mixed_kernel(
                 if (kvrow) {
                     float dot = 0.0f;
                     for (uint32_t d = qlane; d < head_dim; d += 8u) dot += qh[d] * kvrow[d];
-                    const uint32_t mask = 0xffu << (threadIdx.x & 24u);
+                    const MASK_T mask = ds4_subgroup_mask(threadIdx.x, 8u);
                     for (uint32_t off = 4u; off > 0u; off >>= 1u) {
                         dot += __shfl_down_sync(static_cast<MASK_T>(mask), dot, off, 8);
                     }
@@ -962,7 +1017,7 @@ __global__ static void attention_indexed_mixed_kernel(
                     : comp_kv + (uint64_t)comp_rows[row - raw_count] * head_dim;
                 float dot = 0.0f;
                 for (uint32_t d = qlane; d < head_dim; d += 8u) dot += qh[d] * kvrow[d];
-                const uint32_t mask = 0xffu << (threadIdx.x & 24u);
+                const MASK_T mask = ds4_subgroup_mask(threadIdx.x, 8u);
                 for (uint32_t off = 4u; off > 0u; off >>= 1u) {
                     dot += __shfl_down_sync(static_cast<MASK_T>(mask), dot, off, 8);
                 }
@@ -1146,7 +1201,7 @@ __global__ static void attention_indexed_mixed_heads8_online_kernel(
                               dot4_f32(q2, k2) +
                               dot4_f32(q3, k3);
                 score = warp_sum_f32(score) * scale;
-                score = __shfl_sync(FULL_WARP_MASK, score, 0);
+                score = __shfl_sync(FULL_WARP_MASK, score, 0, 32);
 
                 const float new_m = fmaxf(max_s, score);
                 const float old_scale = expf(max_s - new_m);
@@ -1257,7 +1312,7 @@ __global__ static void attention_static_mixed_heads8_online_kernel(
         const float *score_row = scores + warp * 768u;
         for (uint32_t i = lane; i < n_score; i += 32u) max_s = fmaxf(max_s, score_row[i]);
         max_s = warp_max_f32(max_s);
-        max_s = __shfl_sync(FULL_WARP_MASK, max_s, 0);
+        max_s = __shfl_sync(FULL_WARP_MASK, max_s, 0, 32);
     }
     float den = 0.0f;
     if (valid_head) {
@@ -1269,7 +1324,7 @@ __global__ static void attention_static_mixed_heads8_online_kernel(
         }
         den = warp_sum_f32(den);
         den += expf(sinks[head] - max_s);
-        den = __shfl_sync(FULL_WARP_MASK, den, 0);
+        den = __shfl_sync(FULL_WARP_MASK, den, 0, 32);
     }
 
     float4 o0 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -1422,7 +1477,7 @@ __global__ static void attention_decode_mixed_heads8_online_kernel(
                               dot4_f32(q2, k2) +
                               dot4_f32(q3, k3);
                 score = warp_sum_f32(score) * scale;
-                score = __shfl_sync(FULL_WARP_MASK, score, 0);
+                score = __shfl_sync(FULL_WARP_MASK, score, 0, 32);
 
                 max_s = fmaxf(max_s, score);
             }
@@ -1458,7 +1513,7 @@ __global__ static void attention_decode_mixed_heads8_online_kernel(
                               dot4_f32(q2, k2) +
                               dot4_f32(q3, k3);
                 score = warp_sum_f32(score) * scale;
-                score = __shfl_sync(FULL_WARP_MASK, score, 0);
+                score = __shfl_sync(FULL_WARP_MASK, score, 0, 32);
 
                 const float row_scale = expf(score - max_s);
                 sum_s += row_scale;

--- a/rocm/ds4_rocm_attention_launch.cuh
+++ b/rocm/ds4_rocm_attention_launch.cuh
@@ -60,7 +60,25 @@ extern "C" int ds4_gpu_attention_decode_heads_tensor(
     if (cfg->oldhip_attention_decode) {
         const uint32_t rows = n_raw + n_comp;
         const size_t shmem = (size_t)(rows ? rows : 1u) * sizeof(float);
-        attention_decode_mixed_one_fast_oldhip_kernel<<<(unsigned)n_head, 256, shmem>>>(
+#if defined(DS4_GFX906)
+        /* Cooperative rows coalesce the score-dot loads and win for the
+         * short decode shapes.  Once the cache grows, shuffle overhead
+         * outweighs that benefit; keep the scalar-per-row path for long
+         * contexts (8,228 rows measured 7.7% faster on Vega 20). */
+        if (cfg->attention_cooperative_dot && rows <= 1024u)
+            attention_decode_mixed_one_fast_oldhip_kernel<true><<<
+                    (unsigned)n_head, 256, shmem>>>(
+                (float *)heads->ptr,
+                (const float *)q->ptr,
+                (const float *)raw_kv->ptr,
+                n_comp ? (const float *)comp_kv->ptr : NULL,
+                use_mask ? (const float *)comp_mask->ptr : NULL,
+                sinks, n_raw, raw_cap, raw_start, n_comp, use_mask,
+                n_head, head_dim, (uint32_t)((head_dim & 3u) == 0u));
+        else
+#endif
+        attention_decode_mixed_one_fast_oldhip_kernel<false><<<
+                (unsigned)n_head, 256, shmem>>>(
                 (float *)heads->ptr,
                 (const float *)q->ptr,
                 (const float *)raw_kv->ptr,
@@ -1303,28 +1321,62 @@ extern "C" int ds4_gpu_attention_output_low_q8_tensor(
                 (uint32_t)low_dim);
         return cuda_ok(cudaGetLastError(), "attention_output_low_q8 splitk sum launch");
     }
-    if ((group_dim & 31u) == 0u && group_dim <= 4096u && (rank % 64u) == 0u) {
-        const unsigned rows_per_block = 64u;
-        grouped_q8_0_a_f32_sharedx_rows_w32_2row_kernel<<<
-                (unsigned)((low_dim + rows_per_block - 1u) / rows_per_block),
-                1024u,
-                (size_t)group_dim * sizeof(float)>>>(
+    if (!cuda_runtime_config()->q8_prequant_decode) {
+        if ((group_dim & 31u) == 0u && group_dim <= 4096u && (rank % 64u) == 0u) {
+            const unsigned rows_per_block = 64u;
+            grouped_q8_0_a_f32_sharedx_rows_w32_2row_kernel<<<
+                    (unsigned)((low_dim + rows_per_block - 1u) / rows_per_block),
+                    1024u,
+                    (size_t)group_dim * sizeof(float)>>>(
+                    (float *)low->ptr,
+                    out_a,
+                    (const float *)heads->ptr,
+                    n_groups,
+                    (uint32_t)blocks_a,
+                    rank,
+                    blocks_a * 34u);
+            return cuda_ok(cudaGetLastError(), "attention_output_low_q8 f32 sharedx launch");
+        }
+        grouped_q8_0_a_f32_warp8_kernel<<<((unsigned)low_dim + 7u) / 8u, 256>>>(
                 (float *)low->ptr,
                 out_a,
                 (const float *)heads->ptr,
-                n_groups,
-                (uint32_t)blocks_a,
+                group_dim,
                 rank,
-                blocks_a * 34u);
-        return cuda_ok(cudaGetLastError(), "attention_output_low_q8 f32 sharedx launch");
+                n_groups,
+                blocks_a);
+        return cuda_ok(cudaGetLastError(), "attention_output_low_q8 f32 launch");
     }
-    grouped_q8_0_a_f32_warp8_kernel<<<((unsigned)low_dim + 7u) / 8u, 256>>>(
+
+    const uint64_t x_rows = (uint64_t)n_groups;
+    const uint64_t xq_bytes = x_rows * blocks_a * 32u;
+    const uint64_t scale_offset = (xq_bytes + 15u) & ~15ull;
+    const uint64_t tmp_bytes = scale_offset + x_rows * blocks_a * sizeof(float);
+    void *tmp = cuda_tmp_alloc(tmp_bytes, "attention output low q8 prequant");
+    if (!tmp) return 0;
+    int8_t *xq = (int8_t *)tmp;
+    float *xscale = (float *)((char *)tmp + scale_offset);
+    const ds4_rocm_runtime_config *cfg = cuda_runtime_config();
+    const int use_dp4a = 1;
+    dim3 qgrid((unsigned)blocks_a, (unsigned)x_rows, 1);
+    quantize_q8_0_f32_kernel<<<qgrid, 32>>>(xq,
+                                            xscale,
+                                            (const float *)heads->ptr,
+                                            group_dim,
+                                            blocks_a);
+    if (!cuda_ok(cudaGetLastError(), "attention_output_low_q8 prequant launch")) return 0;
+    const uint32_t rows_per_block = cfg->attn_out_low_decode_rpb;
+    dim3 grid_a(((unsigned)low_dim + rows_per_block - 1u) / rows_per_block, 1, 1);
+    grouped_q8_0_a_preq_warp8_kernel<<<grid_a, rows_per_block * 32u>>>(
             (float *)low->ptr,
             out_a,
-            (const float *)heads->ptr,
+            xq,
+            xscale,
             group_dim,
             rank,
             n_groups,
-            blocks_a);
-    return cuda_ok(cudaGetLastError(), "attention_output_low_q8 f32 launch");
+            1,
+            blocks_a,
+            use_dp4a);
+    return cuda_ok(cudaGetLastError(), "attention_output_low_q8 launch");
 }

--- a/rocm/ds4_rocm_common.cuh
+++ b/rocm/ds4_rocm_common.cuh
@@ -3,6 +3,25 @@
 // Included from ds4_cuda.cu before more specialized modules; these helpers are
 // intentionally kept static in the single translation unit.
 
+/*
+ * Return the mask for the power-of-two logical subgroup containing
+ * linear_lane. CUDA hardware uses 32-lane warps, while gfx9 uses 64-lane
+ * wavefronts and packs two logical DS4 wave32 groups into one wavefront.
+ * Keeping this calculation in one helper avoids accidentally addressing the
+ * wrong half of a wave64 in shuffle reductions.
+ */
+__device__ static MASK_T ds4_subgroup_mask(uint32_t linear_lane, uint32_t width) {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+    const uint32_t wave_width = (uint32_t)__builtin_amdgcn_wavefrontsize();
+#else
+    const uint32_t wave_width = (uint32_t)warpSize;
+#endif
+    if (width >= wave_width) return (MASK_T)FULL_WARP_MASK;
+    const MASK_T low = ((MASK_T)1u << width) - (MASK_T)1u;
+    const uint32_t wave_lane = linear_lane & (wave_width - 1u);
+    return low << (wave_lane & ~(width - 1u));
+}
+
 __global__ static void fill_f32_kernel(float *x, uint64_t n, float v) {
     uint64_t i = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
     if (i < n) x[i] = v;

--- a/rocm/ds4_rocm_matmul.cuh
+++ b/rocm/ds4_rocm_matmul.cuh
@@ -329,7 +329,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
     }
     const char *wptr = cuda_model_range_ptr(model_map, weight_offset, weight_bytes, "q8_0");
     if (!wptr) return 0;
-    if (n_tok == 1) {
+    if (n_tok == 1 && !cuda_runtime_config()->q8_prequant_decode) {
         const bool extended_sharedx =
             in_dim > 8192u &&
             in_dim <= 16384u &&
@@ -388,6 +388,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
     }
     if (n_tok > 1) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+#if !defined(DS4_GFX906)
         if (!g_quality_mode && (in_dim % 32u) == 0u &&
             out_dim >= 1024u &&
             n_tok >= 256u &&
@@ -405,6 +406,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
                     blocks * 34u);
             return cuda_ok(cudaGetLastError(), "matmul_q8_0 f32 batch wmma 4w launch");
         }
+#endif
 #endif
         if ((in_dim & 31u) == 0u && out_dim <= UINT32_MAX && n_tok <= UINT32_MAX) {
             const uint32_t rows_per_block = 32u;
@@ -478,10 +480,26 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
     if (!tmp) return 0;
     int8_t *xq = (int8_t *)tmp;
     float *xscale = (float *)((char *)tmp + scale_offset);
+    const ds4_rocm_runtime_config *cfg = cuda_runtime_config();
     const int use_dp4a = 1;
     dim3 qgrid((unsigned)blocks, (unsigned)n_tok, 1);
     quantize_q8_0_f32_kernel<<<qgrid, 32>>>(xq, xscale, (const float *)x->ptr, in_dim, blocks);
     if (!cuda_ok(cudaGetLastError(), "matmul_q8_0 quantize launch")) return 0;
+    if (n_tok == 1) {
+        const uint32_t rows_per_block = cfg->q8_decode_rpb;
+        matmul_q8_0_preq_rows_w32_kernel<<<((unsigned)out_dim + rows_per_block - 1u) / rows_per_block,
+                                            rows_per_block * 32u>>>(
+                (float *)out->ptr,
+                reinterpret_cast<const unsigned char *>(wptr),
+                xq,
+                xscale,
+                in_dim,
+                out_dim,
+                blocks,
+                rows_per_block,
+                use_dp4a);
+        return cuda_ok(cudaGetLastError(), "matmul_q8_0 rows launch");
+    }
     if (blocks <= 32u) {
         dim3 bgrid(((unsigned)out_dim + 7u) / 8u, (unsigned)n_tok, 1);
         matmul_q8_0_preq_batch_warp8_kernel<<<bgrid, 256>>>(
@@ -606,36 +624,77 @@ extern "C" int ds4_gpu_matmul_q8_0_pair_tensor(
     const char *w0 = cuda_model_range_ptr(model_map, weight0_offset, weight0_bytes, "q8_0_pair0");
     const char *w1 = cuda_model_range_ptr(model_map, weight1_offset, weight1_bytes, "q8_0_pair1");
     if (!w0 || !w1) return 0;
-    const uint64_t max_out = out0_dim > out1_dim ? out0_dim : out1_dim;
-    if ((in_dim & 31u) == 0u && in_dim <= 8192u) {
-        const unsigned rows_per_block = 32u;
-        const unsigned threads = rows_per_block * 32u;
-        matmul_q8_0_pair_f32_sharedx_warp_rows_w32_kernel<<<
-                (unsigned)((max_out + rows_per_block - 1u) / rows_per_block),
-                threads,
-                (size_t)in_dim * sizeof(float)>>>(
+    if (!cuda_runtime_config()->q8_prequant_decode) {
+        const uint64_t max_out = out0_dim > out1_dim ? out0_dim : out1_dim;
+        if ((in_dim & 31u) == 0u && in_dim <= 8192u) {
+            const unsigned rows_per_block = 32u;
+            const unsigned threads = rows_per_block * 32u;
+            matmul_q8_0_pair_f32_sharedx_warp_rows_w32_kernel<<<
+                    (unsigned)((max_out + rows_per_block - 1u) / rows_per_block),
+                    threads,
+                    (size_t)in_dim * sizeof(float)>>>(
+                    (float *)out0->ptr,
+                    (float *)out1->ptr,
+                    reinterpret_cast<const unsigned char *>(w0),
+                    reinterpret_cast<const unsigned char *>(w1),
+                    (const float *)x->ptr,
+                    (uint32_t)blocks,
+                    out0_dim,
+                    out1_dim,
+                    blocks * 34u);
+            return cuda_ok(cudaGetLastError(), "matmul_q8_0 pair f32 sharedx launch");
+        }
+        matmul_q8_0_pair_f32_warp8_kernel<<<((unsigned)max_out + 7u) / 8u, 256>>>(
                 (float *)out0->ptr,
                 (float *)out1->ptr,
                 reinterpret_cast<const unsigned char *>(w0),
                 reinterpret_cast<const unsigned char *>(w1),
                 (const float *)x->ptr,
-                (uint32_t)blocks,
+                in_dim,
                 out0_dim,
                 out1_dim,
-                blocks * 34u);
-        return cuda_ok(cudaGetLastError(), "matmul_q8_0 pair f32 sharedx launch");
+                blocks);
+        return cuda_ok(cudaGetLastError(), "matmul_q8_0 pair f32 warp launch");
     }
-    matmul_q8_0_pair_f32_warp8_kernel<<<((unsigned)max_out + 7u) / 8u, 256>>>(
+
+    const uint64_t xq_bytes = blocks * 32u;
+    const uint64_t scale_offset = (xq_bytes + 15u) & ~15ull;
+    const uint64_t tmp_bytes = scale_offset + blocks * sizeof(float);
+    void *tmp = cuda_tmp_alloc(tmp_bytes, "q8_0 pair prequant");
+    if (!tmp) return 0;
+    int8_t *xq = (int8_t *)tmp;
+    float *xscale = (float *)((char *)tmp + scale_offset);
+    const int use_dp4a = 1;
+    dim3 qgrid((unsigned)blocks, 1, 1);
+    quantize_q8_0_f32_kernel<<<qgrid, 32>>>(xq, xscale, (const float *)x->ptr, in_dim, blocks);
+    if (!cuda_ok(cudaGetLastError(), "matmul_q8_0 pair quantize launch")) return 0;
+    const uint32_t rows_per_block = cuda_runtime_config()->q8_decode_rpb;
+    matmul_q8_0_preq_rows_w32_kernel<<<
+            ((unsigned)out0_dim + rows_per_block - 1u) / rows_per_block,
+            rows_per_block * 32u>>>(
             (float *)out0->ptr,
-            (float *)out1->ptr,
             reinterpret_cast<const unsigned char *>(w0),
-            reinterpret_cast<const unsigned char *>(w1),
-            (const float *)x->ptr,
+            xq,
+            xscale,
             in_dim,
             out0_dim,
+            blocks,
+            rows_per_block,
+            use_dp4a);
+    if (!cuda_ok(cudaGetLastError(), "matmul_q8_0 pair rows0 launch")) return 0;
+    matmul_q8_0_preq_rows_w32_kernel<<<
+            ((unsigned)out1_dim + rows_per_block - 1u) / rows_per_block,
+            rows_per_block * 32u>>>(
+            (float *)out1->ptr,
+            reinterpret_cast<const unsigned char *>(w1),
+            xq,
+            xscale,
+            in_dim,
             out1_dim,
-            blocks);
-    return cuda_ok(cudaGetLastError(), "matmul_q8_0 pair f32 warp launch");
+            blocks,
+            rows_per_block,
+            use_dp4a);
+    return cuda_ok(cudaGetLastError(), "matmul_q8_0 pair rows1 launch");
 }
 
 static int cuda_matmul_q8_0_hc_expand_tensor_labeled(
@@ -674,13 +733,30 @@ static int cuda_matmul_q8_0_hc_expand_tensor_labeled(
     }
     const char *wptr = cuda_model_range_ptr(model_map, weight_offset, weight_bytes, label ? label : "q8_0_hc_expand");
     if (!wptr) return 0;
-    if ((in_dim & 31u) == 0u && in_dim <= 8192u) {
-        const unsigned rows_per_block = 32u;
-        const unsigned threads = rows_per_block * 32u;
-        matmul_q8_0_hc_expand_f32_sharedx_warp_rows_w32_kernel<<<
-                (unsigned)((out_dim + rows_per_block - 1u) / rows_per_block),
-                threads,
-                (size_t)in_dim * sizeof(float)>>>(
+    if (!cuda_runtime_config()->q8_prequant_decode) {
+        if ((in_dim & 31u) == 0u && in_dim <= 8192u) {
+            const unsigned rows_per_block = 32u;
+            const unsigned threads = rows_per_block * 32u;
+            matmul_q8_0_hc_expand_f32_sharedx_warp_rows_w32_kernel<<<
+                    (unsigned)((out_dim + rows_per_block - 1u) / rows_per_block),
+                    threads,
+                    (size_t)in_dim * sizeof(float)>>>(
+                    (float *)out_hc->ptr,
+                    (float *)block_out->ptr,
+                    block_add ? (const float *)block_add->ptr : (const float *)block_out->ptr,
+                    (const float *)residual_hc->ptr,
+                    (const float *)split->ptr,
+                    reinterpret_cast<const unsigned char *>(wptr),
+                    (const float *)x->ptr,
+                    (uint32_t)blocks,
+                    out_dim,
+                    blocks * 34u,
+                    n_embd,
+                    n_hc,
+                    block_add ? 1 : 0);
+            return cuda_ok(cudaGetLastError(), "matmul_q8_0_hc_expand f32 sharedx launch");
+        }
+        matmul_q8_0_hc_expand_f32_warp8_kernel<<<((unsigned)out_dim + 7u) / 8u, 256>>>(
                 (float *)out_hc->ptr,
                 (float *)block_out->ptr,
                 block_add ? (const float *)block_add->ptr : (const float *)block_out->ptr,
@@ -688,29 +764,46 @@ static int cuda_matmul_q8_0_hc_expand_tensor_labeled(
                 (const float *)split->ptr,
                 reinterpret_cast<const unsigned char *>(wptr),
                 (const float *)x->ptr,
-                (uint32_t)blocks,
+                in_dim,
                 out_dim,
-                blocks * 34u,
                 n_embd,
                 n_hc,
+                blocks,
                 block_add ? 1 : 0);
-        return cuda_ok(cudaGetLastError(), "matmul_q8_0_hc_expand f32 sharedx launch");
+        return cuda_ok(cudaGetLastError(), "matmul_q8_0_hc_expand f32 launch");
     }
-    matmul_q8_0_hc_expand_f32_warp8_kernel<<<((unsigned)out_dim + 7u) / 8u, 256>>>(
+
+    const uint64_t xq_bytes = blocks * 32u;
+    const uint64_t scale_offset = (xq_bytes + 15u) & ~15ull;
+    const uint64_t tmp_bytes = scale_offset + blocks * sizeof(float);
+    void *tmp = cuda_tmp_alloc(tmp_bytes, "q8_0 hc expand prequant");
+    if (!tmp) return 0;
+    int8_t *xq = (int8_t *)tmp;
+    float *xscale = (float *)((char *)tmp + scale_offset);
+    const ds4_rocm_runtime_config *cfg = cuda_runtime_config();
+    const int use_dp4a = 1;
+    quantize_q8_0_f32_kernel<<<(unsigned)blocks, 32>>>(xq, xscale, (const float *)x->ptr, in_dim, blocks);
+    if (!cuda_ok(cudaGetLastError(), "matmul_q8_0_hc_expand quantize launch")) return 0;
+    const uint32_t rows_per_block = cfg->q8_hc_decode_rpb;
+    matmul_q8_0_hc_expand_preq_rows_w32_kernel<<<((unsigned)out_dim + rows_per_block - 1u) / rows_per_block,
+                                                  rows_per_block * 32u>>>(
             (float *)out_hc->ptr,
             (float *)block_out->ptr,
             block_add ? (const float *)block_add->ptr : (const float *)block_out->ptr,
             (const float *)residual_hc->ptr,
             (const float *)split->ptr,
             reinterpret_cast<const unsigned char *>(wptr),
-            (const float *)x->ptr,
+            xq,
+            xscale,
             in_dim,
             out_dim,
             n_embd,
             n_hc,
             blocks,
-            block_add ? 1 : 0);
-    return cuda_ok(cudaGetLastError(), "matmul_q8_0_hc_expand f32 launch");
+            rows_per_block,
+            block_add ? 1 : 0,
+            use_dp4a);
+    return cuda_ok(cudaGetLastError(), "matmul_q8_0_hc_expand rows launch");
 }
 
 extern "C" int ds4_gpu_matmul_f16_tensor(ds4_gpu_tensor *out, const void *model_map, uint64_t model_size, uint64_t weight_offset, uint64_t in_dim, uint64_t out_dim, const ds4_gpu_tensor *x, uint64_t n_tok) {
@@ -820,7 +913,7 @@ extern "C" int ds4_gpu_matmul_f16_pair_tensor(
     if (!w0 || !w1) return 0;
     if (!g_quality_mode && !cuda_runtime_config()->graph_dump) {
         if (in_dim <= 8192u && in_dim * sizeof(float) <= 65536u) {
-            const uint32_t rows_per_block = 32u;
+            const uint32_t rows_per_block = cuda_runtime_config()->f16_pair_decode_rpb;
             matmul_f16_pair_f32_sharedx_warp_rows_w32_kernel<<<
                     ((unsigned)out_dim + rows_per_block - 1u) / rows_per_block,
                     rows_per_block * 32u,

--- a/rocm/ds4_rocm_moe.cuh
+++ b/rocm/ds4_rocm_moe.cuh
@@ -4,7 +4,11 @@
 // ds4_rocm_moe_launch.cuh so host policy/glue can keep using these static kernels directly.
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+#if defined(DS4_GFX906)
+#include "ds4_rocm_wmma_gfx906.cuh"
+#else
 #include <rocwmma/rocwmma.hpp>
+#endif
 #endif
 
 __device__ static float dev_f16_to_f32(uint16_t v) {
@@ -463,7 +467,7 @@ __device__ static void dev_dot_q2_K_q8_K_block8(
 }
 
 __device__ static float half_warp_sum_f32(float v, uint32_t lane16) {
-    uint32_t mask = 0xffffu << (threadIdx.x & 16u);
+    const MASK_T mask = ds4_subgroup_mask(threadIdx.x, 16u);
     for (int offset = 8; offset > 0; offset >>= 1) {
         v += __shfl_down_sync(static_cast<MASK_T>(mask), v, offset, 16);
     }
@@ -472,7 +476,7 @@ __device__ static float half_warp_sum_f32(float v, uint32_t lane16) {
 }
 
 __device__ static float quarter_warp_sum_f32(float v, uint32_t lane8) {
-    uint32_t mask = 0xffu << (threadIdx.x & 24u);
+    const MASK_T mask = ds4_subgroup_mask(threadIdx.x, 8u);
     for (int offset = 4; offset > 0; offset >>= 1) {
         v += __shfl_down_sync(static_cast<MASK_T>(mask), v, offset, 8);
     }

--- a/rocm/ds4_rocm_q8.cuh
+++ b/rocm/ds4_rocm_q8.cuh
@@ -4,7 +4,11 @@
 // private/static while we gradually split the custom ROCm backend into modules.
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+#if defined(DS4_GFX906)
+#include "ds4_rocm_wmma_gfx906.cuh"
+#else
 #include <rocwmma/rocwmma.hpp>
+#endif
 #endif
 
 __device__ __forceinline__ static int32_t load_i8x4_i32_aligned(const int8_t *p) {
@@ -679,6 +683,7 @@ typedef float    __attribute__((ext_vector_type(8)))  ds4_q8_float8_t;
  * into LDS as f16, while each wave owns 16 output rows and computes four
  * 16-token WMMA columns.  It is opt-in from host code because it only wins once
  * the token batch is large enough to amortize the bigger tile. */
+#if !defined(DS4_GFX906)
 __launch_bounds__(128, 2)
 __global__ static void matmul_q8_0_f32_batch_wmma_4w_kernel(
         float *out,
@@ -780,6 +785,7 @@ __global__ static void matmul_q8_0_f32_batch_wmma_4w_kernel(
         }
     }
 }
+#endif
 
 template <int TILES_N=8, int BM=16, int BN=16, int BK=16>
 __global__ static void matmul_q8_0_f32_batch_wmma_onthefly_kernel(

--- a/rocm/ds4_rocm_router.cuh
+++ b/rocm/ds4_rocm_router.cuh
@@ -8,7 +8,7 @@ __device__ __forceinline__ static bool router_score_better(float av, uint32_t ai
     return av > bv || (av == bv && ai < bi);
 }
 
-template <uint32_t N_EXPERT>
+template <uint32_t N_EXPERT, uint32_t LOGICAL_WIDTH = 32u>
 __global__ static void router_select_warp_topk_kernel(
         int32_t *selected,
         float *weights,
@@ -24,22 +24,24 @@ __global__ static void router_select_warp_topk_kernel(
         float expert_weight_scale,
         int has_bias,
         int hash_mode) {
+    static_assert(N_EXPERT % LOGICAL_WIDTH == 0u,
+                  "router expert count must be divisible by the logical wave width");
     const uint32_t lane = threadIdx.x;
     const uint32_t row_in_block = threadIdx.y;
     const uint32_t t = blockIdx.x * blockDim.y + row_in_block;
-    if (t >= n_tokens || lane >= 32u) return;
+    if (t >= n_tokens || lane >= LOGICAL_WIDTH) return;
 
     const float *log = logits + (uint64_t)t * N_EXPERT;
     float *prob = probs + (uint64_t)t * N_EXPERT;
     int32_t *sel = selected + (uint64_t)t * n_expert_used;
     float *w = weights + (uint64_t)t * n_expert_used;
     __shared__ float sprob[4][N_EXPERT];
-    float local_prob[N_EXPERT / 32u];
-    float local_score[N_EXPERT / 32u];
+    float local_prob[N_EXPERT / LOGICAL_WIDTH];
+    float local_score[N_EXPERT / LOGICAL_WIDTH];
 
     #pragma unroll
-    for (uint32_t j = 0; j < N_EXPERT / 32u; j++) {
-        const uint32_t e = lane + j * 32u;
+    for (uint32_t j = 0; j < N_EXPERT / LOGICAL_WIDTH; j++) {
+        const uint32_t e = lane + j * LOGICAL_WIDTH;
         const float p = ds4_precise_sqrtf(softplus_dev(log[e]));
         local_prob[j] = p;
         local_score[j] = p + (has_bias ? bias[e] : 0.0f);
@@ -74,8 +76,8 @@ __global__ static void router_select_warp_topk_kernel(
         float best_prob = 0.0f;
         uint32_t best_idx = UINT32_MAX;
         #pragma unroll
-        for (uint32_t j = 0; j < N_EXPERT / 32u; j++) {
-            const uint32_t e = lane + j * 32u;
+        for (uint32_t j = 0; j < N_EXPERT / LOGICAL_WIDTH; j++) {
+            const uint32_t e = lane + j * LOGICAL_WIDTH;
             const float s = local_score[j];
             if (router_score_better(s, e, best_score, best_idx)) {
                 best_score = s;
@@ -84,10 +86,12 @@ __global__ static void router_select_warp_topk_kernel(
             }
         }
         #pragma unroll
-        for (uint32_t mask = 16u; mask > 0u; mask >>= 1u) {
-            const float other_score = __shfl_xor_sync(FULL_WARP_MASK, best_score, mask);
-            const float other_prob = __shfl_xor_sync(FULL_WARP_MASK, best_prob, mask);
-            const uint32_t other_idx = __shfl_xor_sync(FULL_WARP_MASK, best_idx, mask);
+        for (uint32_t mask = LOGICAL_WIDTH >> 1u; mask > 0u; mask >>= 1u) {
+            const uint32_t lane_abs = threadIdx.y * blockDim.x + threadIdx.x;
+            const MASK_T row_mask = ds4_subgroup_mask(lane_abs, LOGICAL_WIDTH);
+            const float other_score = __shfl_xor_sync(row_mask, best_score, mask);
+            const float other_prob = __shfl_xor_sync(row_mask, best_prob, mask);
+            const uint32_t other_idx = __shfl_xor_sync(row_mask, best_idx, mask);
             if (router_score_better(other_score, other_idx, best_score, best_idx)) {
                 best_score = other_score;
                 best_prob = other_prob;
@@ -95,8 +99,8 @@ __global__ static void router_select_warp_topk_kernel(
             }
         }
         #pragma unroll
-        for (uint32_t j = 0; j < N_EXPERT / 32u; j++) {
-            const uint32_t e = lane + j * 32u;
+        for (uint32_t j = 0; j < N_EXPERT / LOGICAL_WIDTH; j++) {
+            const uint32_t e = lane + j * LOGICAL_WIDTH;
             if (e == best_idx) local_score[j] = -INFINITY;
         }
         if (lane == 0) {
@@ -118,6 +122,7 @@ __global__ static void router_select_warp_topk_kernel(
     }
 }
 
+#ifndef DS4_ROCM_ROUTER_KERNEL_ONLY
 extern "C" int ds4_gpu_router_select_tensor(ds4_gpu_tensor *selected, ds4_gpu_tensor *weights, ds4_gpu_tensor *probs, const void *model_map, uint64_t model_size, uint64_t bias_offset, uint64_t hash_offset, uint32_t hash_rows, uint32_t token, uint32_t n_expert, uint32_t n_expert_used, float expert_weight_scale, uint32_t n_expert_groups, uint32_t n_group_used, bool has_bias, bool hash_mode, const ds4_gpu_tensor *logits) {
     const uint32_t active_n_expert = n_expert != 0u ? n_expert : DS4_ROCM_N_EXPERT;
     const uint32_t active_n_expert_used = n_expert_used != 0u ? n_expert_used : DS4_ROCM_N_EXPERT_USED;
@@ -149,19 +154,38 @@ extern "C" int ds4_gpu_router_select_tensor(ds4_gpu_tensor *selected, ds4_gpu_te
         }
     }
     if (ok) {
-        dim3 block(32, 4, 1);
-        if (active_n_expert == DS4_ROCM_MAX_N_EXPERT) {
-            router_select_warp_topk_kernel<DS4_ROCM_MAX_N_EXPERT><<<1, block>>>(
-                    (int32_t *)selected->ptr, (float *)weights->ptr, (float *)probs->ptr,
-                    bias, hash, (const float *)logits->ptr, NULL, tok, hash_rows, 1,
-                    active_n_expert_used, active_scale, has_bias && !hash_mode, hash_mode);
-        } else {
-            router_select_warp_topk_kernel<DS4_ROCM_N_EXPERT><<<1, block>>>(
-                    (int32_t *)selected->ptr, (float *)weights->ptr, (float *)probs->ptr,
-                    bias, hash, (const float *)logits->ptr, NULL, tok, hash_rows, 1,
-                    active_n_expert_used, active_scale, has_bias && !hash_mode, hash_mode);
+#if defined(DS4_GFX906)
+        if (cuda_runtime_config()->router_wave64) {
+            dim3 block(64, 1, 1);
+            if (active_n_expert == DS4_ROCM_MAX_N_EXPERT) {
+                router_select_warp_topk_kernel<DS4_ROCM_MAX_N_EXPERT, 64u><<<1, block>>>(
+                        (int32_t *)selected->ptr, (float *)weights->ptr, (float *)probs->ptr,
+                        bias, hash, (const float *)logits->ptr, NULL, tok, hash_rows, 1,
+                        active_n_expert_used, active_scale, has_bias && !hash_mode, hash_mode);
+            } else {
+                router_select_warp_topk_kernel<DS4_ROCM_N_EXPERT, 64u><<<1, block>>>(
+                        (int32_t *)selected->ptr, (float *)weights->ptr, (float *)probs->ptr,
+                        bias, hash, (const float *)logits->ptr, NULL, tok, hash_rows, 1,
+                        active_n_expert_used, active_scale, has_bias && !hash_mode, hash_mode);
+            }
+            ok = cuda_ok(cudaGetLastError(), "router_select wave64 launch");
+        } else
+#endif
+        {
+            dim3 block(32, 4, 1);
+            if (active_n_expert == DS4_ROCM_MAX_N_EXPERT) {
+                router_select_warp_topk_kernel<DS4_ROCM_MAX_N_EXPERT><<<1, block>>>(
+                        (int32_t *)selected->ptr, (float *)weights->ptr, (float *)probs->ptr,
+                        bias, hash, (const float *)logits->ptr, NULL, tok, hash_rows, 1,
+                        active_n_expert_used, active_scale, has_bias && !hash_mode, hash_mode);
+            } else {
+                router_select_warp_topk_kernel<DS4_ROCM_N_EXPERT><<<1, block>>>(
+                        (int32_t *)selected->ptr, (float *)weights->ptr, (float *)probs->ptr,
+                        bias, hash, (const float *)logits->ptr, NULL, tok, hash_rows, 1,
+                        active_n_expert_used, active_scale, has_bias && !hash_mode, hash_mode);
+            }
+            ok = cuda_ok(cudaGetLastError(), "router_select launch");
         }
-        ok = cuda_ok(cudaGetLastError(), "router_select launch");
     }
     return ok;
 }
@@ -196,6 +220,27 @@ extern "C" int ds4_gpu_router_select_batch_tensor(ds4_gpu_tensor *selected, ds4_
         if (!hash) return 0;
     }
     dim3 block(32, 4, 1);
+#if defined(DS4_GFX906)
+    if (cuda_runtime_config()->router_wave64) {
+        block = dim3(64, 4, 1);
+        if (active_n_expert == DS4_ROCM_MAX_N_EXPERT) {
+            router_select_warp_topk_kernel<DS4_ROCM_MAX_N_EXPERT, 64u><<<(n_tokens + 3u) / 4u, block>>>(
+                    (int32_t *)selected->ptr, (float *)weights->ptr, (float *)probs->ptr,
+                    bias, hash, (const float *)logits->ptr,
+                    tokens ? (const int32_t *)tokens->ptr : NULL,
+                    0, hash_rows, n_tokens, active_n_expert_used, active_scale,
+                    has_bias && !hash_mode, hash_mode);
+        } else {
+            router_select_warp_topk_kernel<DS4_ROCM_N_EXPERT, 64u><<<(n_tokens + 3u) / 4u, block>>>(
+                    (int32_t *)selected->ptr, (float *)weights->ptr, (float *)probs->ptr,
+                    bias, hash, (const float *)logits->ptr,
+                    tokens ? (const int32_t *)tokens->ptr : NULL,
+                    0, hash_rows, n_tokens, active_n_expert_used, active_scale,
+                    has_bias && !hash_mode, hash_mode);
+        }
+        return cuda_ok(cudaGetLastError(), "router_select batch wave64 launch");
+    }
+#endif
     if (active_n_expert == DS4_ROCM_MAX_N_EXPERT) {
         router_select_warp_topk_kernel<DS4_ROCM_MAX_N_EXPERT><<<(n_tokens + 3u) / 4u, block>>>(
                 (int32_t *)selected->ptr,
@@ -231,3 +276,4 @@ extern "C" int ds4_gpu_router_select_batch_tensor(ds4_gpu_tensor *selected, ds4_
     }
     return cuda_ok(cudaGetLastError(), "router_select launch");
 }
+#endif

--- a/rocm/ds4_rocm_runtime.cuh
+++ b/rocm/ds4_rocm_runtime.cuh
@@ -1550,9 +1550,9 @@ static int cuda_stream_resident_make_room(
 
     size_t free_b = 0;
     size_t total_b = 0;
-    const uint64_t reserve = cuda_stream_resident_free_reserve_bytes();
     while (cudaMemGetInfo(&free_b, &total_b) == cudaSuccess) {
         (void)total_b;
+        const uint64_t reserve = cuda_stream_resident_free_reserve_bytes();
         if ((uint64_t)free_b >= reserve &&
             bytes <= (uint64_t)free_b - reserve) {
             return 1;
@@ -4742,12 +4742,13 @@ static uint32_t cuda_rows_per_block_env_or_default(const char *name, uint32_t de
     char *end = NULL;
     errno = 0;
     unsigned long v = strtoul(env, &end, 10);
-    if (end == env || errno != 0) return def;
+    if (end == env || *end != '\0' || errno != 0 || v > UINT32_MAX) return def;
     return cuda_rows_per_block_or_default((uint32_t)v, def);
 }
 
 struct ds4_rocm_runtime_config {
     int initialized;
+    int q8_prequant_decode;
     int disable_splitk_attn_out_low;
     int disable_shared_gate_up_fused_w32;
     int attention_output_cublas_all;
@@ -4756,6 +4757,12 @@ struct ds4_rocm_runtime_config {
     int glm_grouped_qk_low;
     int q8_decode_sharedx_64k;
     int graph_dump;
+    int router_wave64;
+    int attention_cooperative_dot;
+    uint32_t q8_decode_rpb;
+    uint32_t f16_pair_decode_rpb;
+    uint32_t q8_hc_decode_rpb;
+    uint32_t attn_out_low_decode_rpb;
     uint32_t moe_decode_rpb;
     uint32_t moe_decode_gate_rpb;
     uint32_t moe_decode_down_rpb;
@@ -4766,6 +4773,18 @@ static ds4_rocm_runtime_config g_rocm_cfg;
 
 static const ds4_rocm_runtime_config *cuda_runtime_config(void) {
     if (!g_rocm_cfg.initialized) {
+#if defined(DS4_GFX906)
+        /* Vega 20 has substantially higher one-token Q8 throughput when the
+         * activation is quantized once and reused by all output rows.  The
+         * F32-input path can also expose asynchronous wave64 corruption, so
+         * keep this enabled in quality mode; the environment switch remains
+         * available for controlled diagnostics.  Other architectures retain
+         * the upstream dispatch. */
+        g_rocm_cfg.q8_prequant_decode =
+            !cuda_env_present(getenv("DS4_ROCM_DISABLE_Q8_PREQUANT_DECODE"));
+#else
+        g_rocm_cfg.q8_prequant_decode = 0;
+#endif
         g_rocm_cfg.disable_splitk_attn_out_low = !g_quality_mode;
         g_rocm_cfg.disable_shared_gate_up_fused_w32 = !g_quality_mode;
         g_rocm_cfg.attention_output_cublas_all = !g_quality_mode;
@@ -4805,6 +4824,35 @@ static const ds4_rocm_runtime_config *cuda_runtime_config(void) {
             cuda_env_present(getenv("DS4_ROCM_GRAPH_DUMP_NONINVASIVE"));
         g_rocm_cfg.graph_dump =
             graph_dump_requested && !graph_dump_noninvasive;
+#if defined(DS4_GFX906)
+        g_rocm_cfg.router_wave64 =
+            !cuda_env_present(getenv("DS4_ROCM_DISABLE_ROUTER_WAVE64"));
+        g_rocm_cfg.attention_cooperative_dot =
+            !cuda_env_present(getenv("DS4_ROCM_DISABLE_ATTENTION_COOP_DOT"));
+#else
+        g_rocm_cfg.router_wave64 = 0;
+        g_rocm_cfg.attention_cooperative_dot = 0;
+#endif
+        uint32_t q8_decode_default = g_quality_mode ? 8u : 1u;
+#if defined(DS4_GFX906)
+        /* Pack two independent software-wave32 rows into each hardware wave64.
+         * Row arithmetic and reduction order remain unchanged. */
+        if (!g_quality_mode) q8_decode_default = 2u;
+#endif
+        g_rocm_cfg.q8_decode_rpb =
+            cuda_rows_per_block_env_or_default("DS4_ROCM_Q8_DECODE_RPB",
+                                               q8_decode_default);
+        uint32_t f16_pair_default = 32u;
+#if defined(DS4_GFX906)
+        /* A 1024-thread block exposes too few workgroups for the 60 CUs in
+         * Vega 20 at the 256/512/1024-row decode shapes. */
+        f16_pair_default = 8u;
+#endif
+        g_rocm_cfg.f16_pair_decode_rpb =
+            cuda_rows_per_block_env_or_default("DS4_ROCM_F16_PAIR_DECODE_RPB",
+                                               f16_pair_default);
+        g_rocm_cfg.q8_hc_decode_rpb = g_quality_mode ? 8u : 16u;
+        g_rocm_cfg.attn_out_low_decode_rpb = g_quality_mode ? 8u : 32u;
         const char *moe_decode_rpb_env = getenv("DS4_ROCM_MOE_DECODE_RPB");
         const int moe_decode_rpb_env_present =
             moe_decode_rpb_env != NULL && moe_decode_rpb_env[0] != '\0';
@@ -5506,7 +5554,21 @@ static int cuda_stream_model_cache_prepare_memory(
 }
 
 static uint64_t cuda_model_arena_chunk_bytes(uint64_t need) {
-    uint64_t bytes = 1792ull * 1048576ull;
+    uint64_t mb = 1792;
+    const char *env = getenv("DS4_ROCM_WEIGHT_ARENA_CHUNK_MB");
+    if (!env || !env[0]) env = getenv("DS4_CUDA_WEIGHT_ARENA_CHUNK_MB");
+    if (env && env[0]) {
+        char *end = NULL;
+        unsigned long long v = strtoull(env, &end, 10);
+        if (end != env && v > 0) mb = (uint64_t)v;
+    }
+    if (mb < 256) mb = 256;
+    if (mb > 8192) mb = 8192;
+    uint64_t bytes = mb * 1048576ull;
+    if (need > bytes / 2u) {
+        const uint64_t align = 64ull * 1048576ull;
+        return (need + align - 1u) & ~(align - 1u);
+    }
     if (bytes < need) {
         const uint64_t align = 256ull * 1048576ull;
         bytes = (need + align - 1u) & ~(align - 1u);
@@ -5662,6 +5724,15 @@ static const char *cuda_model_range_ptr_from_fd(
     g_model_ranges.push_back({model_map, offset, bytes, dev, NULL, NULL, 0, 0, 1});
     g_model_range_by_offset[offset] = g_model_ranges.size() - 1u;
     g_model_range_bytes += bytes;
+    if (cuda_stream_cache_stats_on()) {
+        fprintf(stderr,
+                DS4_GPU_LOG_PREFIX "model arena map %-18s off=%.3f GiB bytes=%.2f MiB total=%.2f GiB ranges=%zu\n",
+                what ? what : "weights",
+                (double)offset / 1073741824.0,
+                (double)bytes / 1048576.0,
+                (double)g_model_range_bytes / 1073741824.0,
+                g_model_ranges.size());
+    }
     cuda_model_load_progress_note(g_model_range_bytes);
     return (const char *)dev;
 }

--- a/rocm/ds4_rocm_wmma_gfx906.cuh
+++ b/rocm/ds4_rocm_wmma_gfx906.cuh
@@ -1,0 +1,196 @@
+// Device-side compatibility implementation for the rocWMMA subset used by ds4
+// on AMD gfx906 GPUs (Vega 20: Radeon VII / Pro VII / MI50). These devices do
+// not have the MFMA matrix instructions introduced with gfx908, and the
+// official rocWMMA headers reject the architecture.
+//
+// The ROCm backend uses software-wave32 kernel layouts. This header follows the
+// same convention on wave64 hardware: lane = tid & 31 and shuffles use an
+// explicit width of 32.
+//
+// Implemented API subset:
+//   - fragment<matrix_a|matrix_b|accumulator, M, N, K, half|float, row_major|col_major>
+//   - load_matrix_sync(frag, ptr, ldm)            // default row_major
+//   - load_matrix_sync(frag, ptr, ldm, layout)    // explicit layout
+//   - fill_fragment(frag, val)
+//   - mma_sync(d, a, b, c)                        // d = a*b + c  (in-place ok)
+//   - store_matrix_sync(ptr, frag, ldm, layout)
+//
+// The only supported tile is M=N=K=16, half x half -> float. The internal
+// fragment layout does not need to match rocWMMA: 256 row-major elements are
+// distributed over 32 logical lanes, eight elements per lane.
+//   lane l owns tile[l/2][(l%2)*8 .. (l%2)*8+7]
+//
+// mma_sync su 32 lane via __shfl width=32:
+//   - A[lane/2][k] k=0..15: 8 owned + 8 shfl da lane^1  (8 shfl half)
+//   - B[k][(l%2)*8+c] k=0..15,c=0..7: shfl da lane 2*k+(l%2) (128 shfl half)
+//   - 8 FMA per (c,k) → 128 FMA/lane per mma_sync
+// This prioritizes compatibility over performance. Packed shuffles or a native
+// wave64 kernel can replace it later without changing call sites.
+#pragma once
+
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+namespace rocwmma {
+
+// Matrix-kind tags.
+struct matrix_a {};
+struct matrix_b {};
+struct accumulator {};
+
+// Fragment-layout tags.
+struct row_major {};
+struct col_major {};
+
+// Store layout, matching the names used by rocWMMA call sites.
+enum layout_t { mem_row_major, mem_col_major, mem_stride };
+
+namespace detail {
+
+__device__ __forceinline__ int wmma_lane() { return static_cast<int>(threadIdx.x) & 31; }
+
+} // namespace detail
+
+// Eight elements per lane (256 tile elements / 32 logical lanes). Layout
+// defaults to row_major, as it does for ds4's rocWMMA accumulator fragments.
+template <typename MatKind, int M, int N, int K, typename T, typename Layout = row_major>
+struct fragment {
+    static_assert(M == 16 && N == 16 && K == 16,
+                  "ds4 gfx906 shim supports only 16x16x16 tiles");
+    T x[8];
+};
+
+// ===================== load_matrix_sync =====================
+// matrix_a, row_major: A[i][j] is ptr + i*ldm + j.
+template <int M, int N, int K>
+__device__ __forceinline__ void
+load_matrix_sync(fragment<matrix_a, M, N, K, half, row_major> &frag,
+                 const half *ptr, uint32_t ldm) {
+    const int l = detail::wmma_lane();
+    const int i = l >> 1;
+    const int j0 = (l & 1) * 8;
+    const half *p = ptr + (uint64_t)i * ldm + j0;
+    #pragma unroll
+    for (int c = 0; c < 8; ++c) frag.x[c] = p[c];
+}
+
+// matrix_a, col_major: A[i][j] is ptr + j*ldm + i.
+template <int M, int N, int K>
+__device__ __forceinline__ void
+load_matrix_sync(fragment<matrix_a, M, N, K, half, col_major> &frag,
+                 const half *ptr, uint32_t ldm) {
+    const int l = detail::wmma_lane();
+    const int i = l >> 1;
+    const int j0 = (l & 1) * 8;
+    #pragma unroll
+    for (int c = 0; c < 8; ++c) frag.x[c] = ptr[(uint64_t)(j0 + c) * ldm + i];
+}
+
+// matrix_b, row_major: B[k][j] is ptr + k*ldm + j.
+template <int M, int N, int K>
+__device__ __forceinline__ void
+load_matrix_sync(fragment<matrix_b, M, N, K, half, row_major> &frag,
+                 const half *ptr, uint32_t ldm) {
+    const int l = detail::wmma_lane();
+    const int k = l >> 1;
+    const int j0 = (l & 1) * 8;
+    const half *p = ptr + (uint64_t)k * ldm + j0;
+    #pragma unroll
+    for (int c = 0; c < 8; ++c) frag.x[c] = p[c];
+}
+
+// matrix_b, col_major: B[k][j] is ptr + j*ldm + k.
+template <int M, int N, int K>
+__device__ __forceinline__ void
+load_matrix_sync(fragment<matrix_b, M, N, K, half, col_major> &frag,
+                 const half *ptr, uint32_t ldm) {
+    const int l = detail::wmma_lane();
+    const int k = l >> 1;
+    const int j0 = (l & 1) * 8;
+    #pragma unroll
+    for (int c = 0; c < 8; ++c) frag.x[c] = ptr[(uint64_t)(j0 + c) * ldm + k];
+}
+
+// ===================== fill_fragment =====================
+template <int M, int N, int K>
+__device__ __forceinline__ void
+fill_fragment(fragment<accumulator, M, N, K, float, row_major> &frag, float v) {
+    #pragma unroll
+    for (int c = 0; c < 8; ++c) frag.x[c] = v;
+}
+template <int M, int N, int K>
+__device__ __forceinline__ void
+fill_fragment(fragment<accumulator, M, N, K, float, col_major> &frag, float v) {
+    #pragma unroll
+    for (int c = 0; c < 8; ++c) frag.x[c] = v;
+}
+
+// ===================== mma_sync =====================
+// d = a * b + c   (tile 16x16: d[i][j] = sum_k a[i][k]*b[k][j])
+// d/c are float accumulators; a/b are half fragments. In-place d == c is safe
+// because c is copied to lane-local accumulators before d is written.
+template <int M, int N, int K, typename LA, typename LB>
+__device__ __forceinline__ void
+mma_sync(fragment<accumulator, M, N, K, float, row_major> &d,
+         const fragment<matrix_a, M, N, K, half, LA> &a,
+         const fragment<matrix_b, M, N, K, half, LB> &b,
+         const fragment<accumulator, M, N, K, float, row_major> &cfrag) {
+    const int l = detail::wmma_lane();
+    const int j0 = (l & 1) * 8;
+
+    // Lane-local accumulator, allowing d to alias cfrag.
+    float acc[8];
+    #pragma unroll
+    for (int c = 0; c < 8; ++c) acc[c] = cfrag.x[c];
+
+    // Gather a full A row: eight owned values plus eight from the peer lane.
+    half a_row[16];
+    #pragma unroll
+    for (int c = 0; c < 8; ++c) a_row[j0 + c] = a.x[c];
+    const int peer = l ^ 1;
+    #pragma unroll
+    for (int c = 0; c < 8; ++c)
+        a_row[(1 - (l & 1)) * 8 + c] = __shfl(a.x[c], peer, 32);
+
+    // Gather B[k][j0..j0+7] from lane 2*k+(l&1), then accumulate.
+    #pragma unroll
+    for (int k = 0; k < 16; ++k) {
+        const int src = (k << 1) + (l & 1);
+        const float af = __half2float(a_row[k]);
+        #pragma unroll
+        for (int c = 0; c < 8; ++c) {
+            const half bh = __shfl(b.x[c], src, 32);
+            acc[c] = fmaf(af, __half2float(bh), acc[c]);
+        }
+    }
+
+    // Write the destination fragment.
+    #pragma unroll
+    for (int c = 0; c < 8; ++c) d.x[c] = acc[c];
+}
+
+// ===================== store_matrix_sync =====================
+template <int M, int N, int K>
+__device__ __forceinline__ void
+store_matrix_sync(float *ptr,
+                  const fragment<accumulator, M, N, K, float, row_major> &frag,
+                  uint32_t ldm, layout_t layout) {
+    const int l = detail::wmma_lane();
+    const int i = l >> 1;
+    const int j0 = (l & 1) * 8;
+    if (layout == mem_col_major) {
+        // C[i][j] is ptr + j*ldm + i.
+        #pragma unroll
+        for (int c = 0; c < 8; ++c)
+            ptr[(uint64_t)(j0 + c) * ldm + i] = frag.x[c];
+    } else { // Treat mem_stride as row-major for this restricted API.
+        float *p = ptr + (uint64_t)i * ldm + j0;
+        #pragma unroll
+        for (int c = 0; c < 8; ++c) p[c] = frag.x[c];
+    }
+}
+
+} // namespace rocwmma
+
+#endif // __HIP_PLATFORM_AMD__ || __HIPCC__

--- a/tests/cuda_long_context_smoke.c
+++ b/tests/cuda_long_context_smoke.c
@@ -1,6 +1,7 @@
 #include "ds4_gpu.h"
 
 #include <stdint.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -40,7 +41,7 @@ static int check_large_topk(void) {
     double elapsed = 0.0;
     if (scores && selected &&
         ds4_gpu_tensor_write(scores, 0, scores_host, score_count * sizeof(float))) {
-        /* Exclude one-time CUDA module/kernel setup from the throughput guard. */
+        /* Exclude one-time GPU module/kernel setup from the throughput guard. */
         if (!ds4_gpu_indexer_topk_tensor(selected, scores, n_comp, n_tokens, top_k) ||
             !ds4_gpu_synchronize()) {
             rc = 1;
@@ -69,8 +70,9 @@ static int check_large_topk(void) {
         }
     }
     if (rc == 0) {
-        const double max_seconds = getenv_seconds("DS4_CUDA_TOPK_REGRESSION_SEC", 2.0);
-        fprintf(stderr, "cuda-regression: top-k n_comp=%u n_tokens=%u elapsed=%.3fs\n",
+        const double max_seconds = getenv_seconds("DS4_GPU_TOPK_REGRESSION_SEC",
+                getenv_seconds("DS4_CUDA_TOPK_REGRESSION_SEC", 2.0));
+        fprintf(stderr, "gpu-regression: top-k n_comp=%u n_tokens=%u elapsed=%.3fs\n",
                 n_comp, n_tokens, elapsed);
         if (elapsed > max_seconds) {
             fprintf(stderr, "top-k regression: %.3fs exceeds %.3fs\n", elapsed, max_seconds);
@@ -156,11 +158,123 @@ static int check_decode_attention_overflow_path(void) {
     return rc;
 }
 
+static int check_decode_attention_ring_reference(void) {
+    const uint32_t n_head = 8;
+    const uint32_t head_dim = 512;
+    const uint32_t n_raw = 257;
+    const uint32_t raw_cap = 300;
+    const uint32_t raw_start = 270;
+    const uint32_t n_comp = 511;
+    const uint64_t q_count = (uint64_t)n_head * head_dim;
+    const uint64_t raw_count = (uint64_t)raw_cap * head_dim;
+    const uint64_t comp_count = (uint64_t)n_comp * head_dim;
+    float *sinks = (float *)malloc(n_head * sizeof(float));
+    float *q_host = (float *)malloc((size_t)q_count * sizeof(float));
+    float *raw_host = (float *)malloc((size_t)raw_count * sizeof(float));
+    float *comp_host = (float *)malloc((size_t)comp_count * sizeof(float));
+    float *mask_host = (float *)malloc(n_comp * sizeof(float));
+    float *heads_host = (float *)malloc((size_t)q_count * sizeof(float));
+    float *reference = (float *)malloc((size_t)q_count * sizeof(float));
+    float *scores = (float *)malloc((n_raw + n_comp) * sizeof(float));
+    if (!sinks || !q_host || !raw_host || !comp_host || !mask_host ||
+        !heads_host || !reference || !scores) return 1;
+
+    for (uint32_t h = 0; h < n_head; h++) sinks[h] = -0.25f + (float)h * 0.01f;
+    for (uint64_t i = 0; i < q_count; i++)
+        q_host[i] = (float)((int)((i * 13u + 5u) % 101u) - 50) / 700.0f;
+    for (uint64_t i = 0; i < raw_count; i++)
+        raw_host[i] = (float)((int)((i * 17u + 3u) % 127u) - 63) / 500.0f;
+    for (uint64_t i = 0; i < comp_count; i++)
+        comp_host[i] = (float)((int)((i * 19u + 7u) % 131u) - 65) / 550.0f;
+    for (uint32_t c = 0; c < n_comp; c++)
+        mask_host[c] = (c % 17u == 0u) ? -1.0e30f : -(float)(c % 7u) * 0.015f;
+
+    const float scale = 1.0f / sqrtf((float)head_dim);
+    for (uint32_t h = 0; h < n_head; h++) {
+        const float *qh = q_host + (uint64_t)h * head_dim;
+        float max_score = sinks[h];
+        for (uint32_t r = 0; r < n_raw; r++) {
+            const uint32_t row = (raw_start + r) % raw_cap;
+            const float *kv = raw_host + (uint64_t)row * head_dim;
+            float dot = 0.0f;
+            for (uint32_t d = 0; d < head_dim; d++) dot += qh[d] * kv[d];
+            scores[r] = dot * scale;
+            if (scores[r] > max_score) max_score = scores[r];
+        }
+        for (uint32_t c = 0; c < n_comp; c++) {
+            float s = -3.4e38f;
+            if (mask_host[c] > -5.0e29f) {
+                const float *kv = comp_host + (uint64_t)c * head_dim;
+                float dot = 0.0f;
+                for (uint32_t d = 0; d < head_dim; d++) dot += qh[d] * kv[d];
+                s = dot * scale + mask_host[c];
+            }
+            scores[n_raw + c] = s;
+            if (s > max_score) max_score = s;
+        }
+        float denom = expf(sinks[h] - max_score);
+        for (uint32_t r = 0; r < n_raw + n_comp; r++) {
+            scores[r] = expf(scores[r] - max_score);
+            denom += scores[r];
+        }
+        for (uint32_t d = 0; d < head_dim; d++) {
+            float acc = 0.0f;
+            for (uint32_t r = 0; r < n_raw; r++) {
+                const uint32_t row = (raw_start + r) % raw_cap;
+                acc += scores[r] * raw_host[(uint64_t)row * head_dim + d];
+            }
+            for (uint32_t c = 0; c < n_comp; c++)
+                acc += scores[n_raw + c] * comp_host[(uint64_t)c * head_dim + d];
+            reference[(uint64_t)h * head_dim + d] = acc / denom;
+        }
+    }
+
+    ds4_gpu_tensor *heads = ds4_gpu_tensor_alloc(q_count * sizeof(float));
+    ds4_gpu_tensor *q = ds4_gpu_tensor_alloc(q_count * sizeof(float));
+    ds4_gpu_tensor *raw = ds4_gpu_tensor_alloc(raw_count * sizeof(float));
+    ds4_gpu_tensor *comp = ds4_gpu_tensor_alloc(comp_count * sizeof(float));
+    ds4_gpu_tensor *mask = ds4_gpu_tensor_alloc((uint64_t)n_comp * sizeof(float));
+    int rc = 1;
+    if (heads && q && raw && comp && mask &&
+        ds4_gpu_tensor_write(q, 0, q_host, q_count * sizeof(float)) &&
+        ds4_gpu_tensor_write(raw, 0, raw_host, raw_count * sizeof(float)) &&
+        ds4_gpu_tensor_write(comp, 0, comp_host, comp_count * sizeof(float)) &&
+        ds4_gpu_tensor_write(mask, 0, mask_host, (uint64_t)n_comp * sizeof(float)) &&
+        ds4_gpu_attention_decode_heads_tensor(heads, sinks, n_head * sizeof(float), 0,
+                                              q, raw, n_raw, raw_cap, raw_start,
+                                              comp, 0, n_comp, mask, 1,
+                                              n_head, head_dim) &&
+        ds4_gpu_synchronize() &&
+        ds4_gpu_tensor_read(heads, 0, heads_host, q_count * sizeof(float))) {
+        float max_abs = 0.0f;
+        float max_rel = 0.0f;
+        for (uint64_t i = 0; i < q_count; i++) {
+            const float abs_err = fabsf(heads_host[i] - reference[i]);
+            const float rel_err = abs_err / fmaxf(1.0e-4f, fabsf(reference[i]));
+            if (abs_err > max_abs) max_abs = abs_err;
+            if (rel_err > max_rel) max_rel = rel_err;
+        }
+        fprintf(stderr, "gpu-regression: attention ring reference max_abs=%g max_rel=%g\n",
+                (double)max_abs, (double)max_rel);
+        rc = (max_abs <= 2.0e-5f && max_rel <= 2.0e-3f) ? 0 : 1;
+    }
+
+    ds4_gpu_tensor_free(mask);
+    ds4_gpu_tensor_free(comp);
+    ds4_gpu_tensor_free(raw);
+    ds4_gpu_tensor_free(q);
+    ds4_gpu_tensor_free(heads);
+    free(scores); free(reference); free(heads_host); free(mask_host);
+    free(comp_host); free(raw_host); free(q_host); free(sinks);
+    return rc;
+}
+
 int main(void) {
     if (!ds4_gpu_init()) return 1;
     int rc = check_large_topk();
     if (check_decode_attention_overflow_path() != 0) rc = 1;
+    if (check_decode_attention_ring_reference() != 0) rc = 1;
     ds4_gpu_cleanup();
-    if (rc == 0) puts("cuda long-context regression: OK");
+    if (rc == 0) puts("GPU long-context regression: OK");
     return rc;
 }

--- a/tests/shim_test.cu
+++ b/tests/shim_test.cu
@@ -1,0 +1,340 @@
+// Validates ds4_rocm_wmma_gfx906.cuh on real gfx906 hardware.
+// Mimics the ds4 MoE tile kernel pattern: blockDim=256, wave=tid>>5 (8 software
+// wave32 groups on wave64 hardware), rocwmma fragment load/mma/store.
+// Verifies: launch safety (no HSA exception) + numerics vs CPU reference.
+#include "ds4_rocm.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+#define FULL_WARP_MASK 0xFFFFFFFFFFFFFFFFULL
+#define MASK_T uint64_t
+#define DS4_ROCM_UNUSED __attribute__((unused))
+#include "rocm/ds4_rocm_common.cuh"
+#include "rocm/ds4_rocm_q8.cuh"
+
+enum {
+    DS4_ROCM_N_EXPERT = 256u,
+    DS4_ROCM_MAX_N_EXPERT = 384u,
+    DS4_ROCM_N_EXPERT_USED = 6u
+};
+#define DS4_ROCM_ROUTER_KERNEL_ONLY
+#include "rocm/ds4_rocm_router.cuh"
+
+#define MTILES 8
+#define NB 4  // 4 B fragments per wave like the MoE gate_up_mid kernel (bg0,bu0,bg1,bu1)
+
+static bool hip_ok(hipError_t err, const char *what) {
+    if (err == hipSuccess) return true;
+    std::fprintf(stderr, "%s failed: %s\n", what, hipGetErrorString(err));
+    return false;
+}
+
+__global__ void shim_mma_kernel(const half *A, const half *B, float *C, int n_waves) {
+    const uint32_t tid = threadIdx.x;
+    const uint32_t wave = tid >> 5u;
+    if (wave >= (uint32_t)n_waves) return;
+
+    rocwmma::fragment<rocwmma::matrix_a, 16, 16, 16, half, rocwmma::row_major> a;
+    rocwmma::fragment<rocwmma::matrix_b, 16, 16, 16, half, rocwmma::row_major> b0, b1, b2, b3;
+    rocwmma::fragment<rocwmma::accumulator, 16, 16, 16, float, rocwmma::row_major> c0, c1, c2, c3;
+
+    rocwmma::fill_fragment(c0, 0.0f);
+    rocwmma::fill_fragment(c1, 0.0f);
+    rocwmma::fill_fragment(c2, 0.0f);
+    rocwmma::fill_fragment(c3, 0.0f);
+
+    // 2 K-step iterations to exercise accumulation (like k0 loop in ds4).
+    for (uint32_t k0 = 0; k0 < 2u; k0++) {
+        rocwmma::load_matrix_sync(a, A + (size_t)wave * 512 + k0 * 256, 16);
+        rocwmma::load_matrix_sync(b0, B + ((size_t)wave * NB + 0) * 512 + k0 * 256, 16);
+        rocwmma::load_matrix_sync(b1, B + ((size_t)wave * NB + 1) * 512 + k0 * 256, 16);
+        rocwmma::load_matrix_sync(b2, B + ((size_t)wave * NB + 2) * 512 + k0 * 256, 16);
+        rocwmma::load_matrix_sync(b3, B + ((size_t)wave * NB + 3) * 512 + k0 * 256, 16);
+        rocwmma::mma_sync(c0, a, b0, c0);
+        rocwmma::mma_sync(c1, a, b1, c1);
+        rocwmma::mma_sync(c2, a, b2, c2);
+        rocwmma::mma_sync(c3, a, b3, c3);
+    }
+
+    rocwmma::store_matrix_sync(C + ((size_t)wave * NB + 0) * 256, c0, 16, rocwmma::mem_row_major);
+    rocwmma::store_matrix_sync(C + ((size_t)wave * NB + 1) * 256, c1, 16, rocwmma::mem_row_major);
+    rocwmma::store_matrix_sync(C + ((size_t)wave * NB + 2) * 256, c2, 16, rocwmma::mem_row_major);
+    rocwmma::store_matrix_sync(C + ((size_t)wave * NB + 3) * 256, c3, 16, rocwmma::mem_row_major);
+}
+
+// CPU reference: C[i][j] = sum over 2 K-tiles of sum_k A[i][k]*B[k][j]
+static void ref_gemm(const std::vector<float> &A, const std::vector<float> &B,
+                     std::vector<float> &C, int wave, int nb) {
+    for (int i = 0; i < 16; i++)
+        for (int j = 0; j < 16; j++) {
+            float acc = 0.0f;
+            for (int kt = 0; kt < 2; kt++)
+                for (int k = 0; k < 16; k++)
+                    acc += A[(size_t)wave * 512 + kt * 256 + i * 16 + k] *
+                           B[((size_t)wave * NB + nb) * 512 + kt * 256 + k * 16 + j];
+            C[((size_t)wave * NB + nb) * 256 + i * 16 + j] = acc;
+        }
+}
+
+static bool test_q8_wave64_row_packing() {
+    const uint64_t in_dim = 4096;
+    const uint64_t out_dim = 4097;
+    const uint64_t blocks = in_dim / 32;
+    const size_t weight_bytes = (size_t)out_dim * blocks * 34u;
+
+    std::vector<unsigned char> hw(weight_bytes);
+    std::vector<int8_t> hxq(blocks * 32u);
+    std::vector<float> hxscale(blocks);
+    std::vector<float> h1(out_dim), h2(out_dim);
+    for (uint64_t row = 0; row < out_dim; row++) {
+        for (uint64_t block = 0; block < blocks; block++) {
+            const half scale = __float2half(0.0025f * (float)(1u + ((row + block) % 13u)));
+            unsigned char *dst = hw.data() + ((size_t)row * blocks + block) * 34u;
+            std::memcpy(dst, &scale, sizeof(scale));
+            for (uint32_t i = 0; i < 32u; i++)
+                dst[2u + i] = (unsigned char)(int8_t)(((row * 3u + block * 5u + i * 7u) % 255u) - 127);
+        }
+    }
+    for (size_t i = 0; i < hxq.size(); i++) hxq[i] = (int8_t)(((i * 11u) % 255u) - 127);
+    for (size_t i = 0; i < hxscale.size(); i++) hxscale[i] = 0.001f * (float)(1u + (i % 17u));
+
+    unsigned char *dw = nullptr;
+    int8_t *dxq = nullptr;
+    float *dxscale = nullptr, *d1 = nullptr, *d2 = nullptr;
+    const bool allocated =
+        hip_ok(hipMalloc(&dw, hw.size()), "q8 malloc weights") &&
+        hip_ok(hipMalloc(&dxq, hxq.size()), "q8 malloc activation") &&
+        hip_ok(hipMalloc(&dxscale, hxscale.size() * sizeof(float)), "q8 malloc scales") &&
+        hip_ok(hipMalloc(&d1, h1.size() * sizeof(float)), "q8 malloc rpb1") &&
+        hip_ok(hipMalloc(&d2, h2.size() * sizeof(float)), "q8 malloc rpb2");
+    if (!allocated) {
+        (void)hipFree(d2); (void)hipFree(d1); (void)hipFree(dxscale);
+        (void)hipFree(dxq); (void)hipFree(dw);
+        return false;
+    }
+    bool ok =
+        hip_ok(hipMemcpy(dw, hw.data(), hw.size(), hipMemcpyHostToDevice), "q8 copy weights") &&
+        hip_ok(hipMemcpy(dxq, hxq.data(), hxq.size(), hipMemcpyHostToDevice), "q8 copy activation") &&
+        hip_ok(hipMemcpy(dxscale, hxscale.data(), hxscale.size() * sizeof(float), hipMemcpyHostToDevice),
+               "q8 copy scales");
+    if (ok) {
+        matmul_q8_0_preq_rows_w32_kernel<<<(unsigned)out_dim, 32>>>(
+            d1, dw, dxq, dxscale, in_dim, out_dim, blocks, 1u, 1);
+        matmul_q8_0_preq_rows_w32_kernel<<<((unsigned)out_dim + 1u) / 2u, 64>>>(
+            d2, dw, dxq, dxscale, in_dim, out_dim, blocks, 2u, 1);
+        ok = hip_ok(hipDeviceSynchronize(), "q8 packed rows launch") &&
+             hip_ok(hipMemcpy(h1.data(), d1, h1.size() * sizeof(float), hipMemcpyDeviceToHost),
+                    "q8 copy rpb1") &&
+             hip_ok(hipMemcpy(h2.data(), d2, h2.size() * sizeof(float), hipMemcpyDeviceToHost),
+                    "q8 copy rpb2");
+    }
+    size_t mismatches = 0;
+    if (ok) {
+        for (size_t i = 0; i < h1.size(); i++)
+            if (std::memcmp(&h1[i], &h2[i], sizeof(float)) != 0) mismatches++;
+    }
+    std::printf("Q8 WAVE64 ROW PACKING %s (%zu rows, %zu bit mismatches)\n",
+                ok && mismatches == 0 ? "PASS" : "FAIL", h1.size(), mismatches);
+    (void)hipFree(d2); (void)hipFree(d1); (void)hipFree(dxscale);
+    (void)hipFree(dxq); (void)hipFree(dw);
+    return ok && mismatches == 0;
+}
+
+static bool test_f16_pair_workgroup_sizing() {
+    const uint32_t in_dim = 1024;
+    const uint32_t out_dim = 513;
+    std::vector<half> hw0((size_t)in_dim * out_dim), hw1(hw0.size());
+    std::vector<float> hx(in_dim), href0(out_dim), href1(out_dim), h0(out_dim), h1(out_dim);
+    for (size_t i = 0; i < hw0.size(); i++) {
+        hw0[i] = __float2half((float)((int)(i % 31u) - 15) / 32.0f);
+        hw1[i] = __float2half((float)((int)(i % 29u) - 14) / 32.0f);
+    }
+    for (uint32_t i = 0; i < in_dim; i++) hx[i] = (float)((int)(i % 23u) - 11) / 16.0f;
+
+    half *dw0 = nullptr, *dw1 = nullptr;
+    float *dx = nullptr, *do0 = nullptr, *do1 = nullptr;
+    const bool allocated =
+        hip_ok(hipMalloc(&dw0, hw0.size() * sizeof(half)), "f16 pair malloc w0") &&
+        hip_ok(hipMalloc(&dw1, hw1.size() * sizeof(half)), "f16 pair malloc w1") &&
+        hip_ok(hipMalloc(&dx, hx.size() * sizeof(float)), "f16 pair malloc x") &&
+        hip_ok(hipMalloc(&do0, href0.size() * sizeof(float)), "f16 pair malloc out0") &&
+        hip_ok(hipMalloc(&do1, href1.size() * sizeof(float)), "f16 pair malloc out1");
+    if (!allocated) {
+        (void)hipFree(do1); (void)hipFree(do0); (void)hipFree(dx);
+        (void)hipFree(dw1); (void)hipFree(dw0);
+        return false;
+    }
+    bool ok =
+        hip_ok(hipMemcpy(dw0, hw0.data(), hw0.size() * sizeof(half), hipMemcpyHostToDevice),
+               "f16 pair copy w0") &&
+        hip_ok(hipMemcpy(dw1, hw1.data(), hw1.size() * sizeof(half), hipMemcpyHostToDevice),
+               "f16 pair copy w1") &&
+        hip_ok(hipMemcpy(dx, hx.data(), hx.size() * sizeof(float), hipMemcpyHostToDevice),
+               "f16 pair copy x");
+    if (ok) {
+        matmul_f16_pair_f32_sharedx_warp_rows_w32_kernel<<<(out_dim + 31u) / 32u,
+            1024u, (size_t)in_dim * sizeof(float)>>>(do0, do1, dw0, dw1, dx, in_dim, out_dim);
+        ok = hip_ok(hipDeviceSynchronize(), "f16 pair rpb32 launch") &&
+             hip_ok(hipMemcpy(href0.data(), do0, href0.size() * sizeof(float), hipMemcpyDeviceToHost),
+                    "f16 pair copy reference 0") &&
+             hip_ok(hipMemcpy(href1.data(), do1, href1.size() * sizeof(float), hipMemcpyDeviceToHost),
+                    "f16 pair copy reference 1");
+    }
+    if (ok) {
+        matmul_f16_pair_f32_sharedx_warp_rows_w32_kernel<<<(out_dim + 7u) / 8u,
+            256u, (size_t)in_dim * sizeof(float)>>>(do0, do1, dw0, dw1, dx, in_dim, out_dim);
+        ok = hip_ok(hipDeviceSynchronize(), "f16 pair rpb8 launch") &&
+             hip_ok(hipMemcpy(h0.data(), do0, h0.size() * sizeof(float), hipMemcpyDeviceToHost),
+                    "f16 pair copy rpb8 0") &&
+             hip_ok(hipMemcpy(h1.data(), do1, h1.size() * sizeof(float), hipMemcpyDeviceToHost),
+                    "f16 pair copy rpb8 1");
+    }
+    size_t mismatches = 0;
+    if (ok) {
+        for (size_t i = 0; i < h0.size(); i++)
+            if (std::memcmp(&h0[i], &href0[i], sizeof(float)) != 0 ||
+                std::memcmp(&h1[i], &href1[i], sizeof(float)) != 0) mismatches++;
+    }
+    std::printf("F16 PAIR WORKGROUP SIZING %s (%zu rows, %zu bit mismatches)\n",
+                ok && mismatches == 0 ? "PASS" : "FAIL", h0.size(), mismatches);
+    (void)hipFree(do1); (void)hipFree(do0); (void)hipFree(dx);
+    (void)hipFree(dw1); (void)hipFree(dw0);
+    return ok && mismatches == 0;
+}
+
+template <uint32_t N_EXPERT>
+static bool test_router_wave64() {
+    std::vector<float> hlogits(N_EXPERT), hbias(N_EXPERT);
+    std::vector<int32_t> href_sel(DS4_ROCM_N_EXPERT_USED), h_sel(DS4_ROCM_N_EXPERT_USED);
+    std::vector<float> href_weights(DS4_ROCM_N_EXPERT_USED), h_weights(DS4_ROCM_N_EXPERT_USED);
+    std::vector<float> href_probs(N_EXPERT), h_probs(N_EXPERT);
+    for (uint32_t i = 0; i < N_EXPERT; i++) {
+        hlogits[i] = (float)((int)((i * 17u) % 101u) - 50) / 9.0f;
+        hbias[i] = (float)((int)((i * 7u) % 31u) - 15) / 100.0f;
+    }
+    /* Deliberate equal scores exercise the expert-index tie break. */
+    hlogits[3] = hlogits[131] = 4.0f;
+    hbias[3] = hbias[131] = 0.25f;
+
+    float *dlogits = nullptr, *dbias = nullptr, *dweights = nullptr, *dprobs = nullptr;
+    int32_t *dselected = nullptr;
+    const bool allocated =
+        hip_ok(hipMalloc(&dlogits, hlogits.size() * sizeof(float)), "router malloc logits") &&
+        hip_ok(hipMalloc(&dbias, hbias.size() * sizeof(float)), "router malloc bias") &&
+        hip_ok(hipMalloc(&dselected, h_sel.size() * sizeof(int32_t)), "router malloc selected") &&
+        hip_ok(hipMalloc(&dweights, h_weights.size() * sizeof(float)), "router malloc weights") &&
+        hip_ok(hipMalloc(&dprobs, h_probs.size() * sizeof(float)), "router malloc probs");
+    if (!allocated) {
+        (void)hipFree(dprobs); (void)hipFree(dweights); (void)hipFree(dselected);
+        (void)hipFree(dbias); (void)hipFree(dlogits);
+        return false;
+    }
+    bool ok =
+        hip_ok(hipMemcpy(dlogits, hlogits.data(), hlogits.size() * sizeof(float), hipMemcpyHostToDevice),
+               "router copy logits") &&
+        hip_ok(hipMemcpy(dbias, hbias.data(), hbias.size() * sizeof(float), hipMemcpyHostToDevice),
+               "router copy bias");
+    if (ok) {
+        router_select_warp_topk_kernel<N_EXPERT, 32u><<<1, dim3(32, 4, 1)>>>(
+            dselected, dweights, dprobs, dbias, nullptr, dlogits, nullptr, 0,
+            0, 1, DS4_ROCM_N_EXPERT_USED, 1.5f, 1, 0);
+        ok = hip_ok(hipDeviceSynchronize(), "router wave32 launch") &&
+             hip_ok(hipMemcpy(href_sel.data(), dselected, href_sel.size() * sizeof(int32_t),
+                              hipMemcpyDeviceToHost), "router copy selected reference") &&
+             hip_ok(hipMemcpy(href_weights.data(), dweights, href_weights.size() * sizeof(float),
+                              hipMemcpyDeviceToHost), "router copy weights reference") &&
+             hip_ok(hipMemcpy(href_probs.data(), dprobs, href_probs.size() * sizeof(float),
+                              hipMemcpyDeviceToHost), "router copy probs reference");
+    }
+    if (ok) {
+        router_select_warp_topk_kernel<N_EXPERT, 64u><<<1, dim3(64, 1, 1)>>>(
+            dselected, dweights, dprobs, dbias, nullptr, dlogits, nullptr, 0,
+            0, 1, DS4_ROCM_N_EXPERT_USED, 1.5f, 1, 0);
+        ok = hip_ok(hipDeviceSynchronize(), "router wave64 launch") &&
+             hip_ok(hipMemcpy(h_sel.data(), dselected, h_sel.size() * sizeof(int32_t),
+                              hipMemcpyDeviceToHost), "router copy selected wave64") &&
+             hip_ok(hipMemcpy(h_weights.data(), dweights, h_weights.size() * sizeof(float),
+                              hipMemcpyDeviceToHost), "router copy weights wave64") &&
+             hip_ok(hipMemcpy(h_probs.data(), dprobs, h_probs.size() * sizeof(float),
+                              hipMemcpyDeviceToHost), "router copy probs wave64");
+    }
+    size_t mismatches = 0;
+    if (ok) {
+        for (size_t i = 0; i < h_sel.size(); i++) {
+            mismatches += h_sel[i] != href_sel[i];
+            mismatches += std::memcmp(&h_weights[i], &href_weights[i], sizeof(float)) != 0;
+        }
+        for (size_t i = 0; i < h_probs.size(); i++)
+            mismatches += std::memcmp(&h_probs[i], &href_probs[i], sizeof(float)) != 0;
+    }
+    std::printf("ROUTER WAVE64 %s (%u experts, %zu bit mismatches)\n",
+                ok && mismatches == 0 ? "PASS" : "FAIL", N_EXPERT, mismatches);
+    (void)hipFree(dprobs); (void)hipFree(dweights); (void)hipFree(dselected);
+    (void)hipFree(dbias); (void)hipFree(dlogits);
+    return ok && mismatches == 0;
+}
+
+int main() {
+    const int waves = MTILES;
+    std::vector<float> hA(waves * 512), hB(waves * NB * 512);
+    std::vector<float> hC_ref(waves * NB * 256, 0.0f);
+    std::vector<float> hC(waves * NB * 256, -1.0f);
+
+    srand(42);
+    for (auto &v : hA) v = ((rand() % 17) - 8) / 8.0f;
+    for (auto &v : hB) v = ((rand() % 13) - 6) / 8.0f;
+
+    for (int w = 0; w < waves; w++)
+        for (int nb = 0; nb < NB; nb++) ref_gemm(hA, hB, hC_ref, w, nb);
+
+    half *dA = nullptr, *dB = nullptr;
+    float *dC = nullptr;
+    std::vector<half> hAh(hA.size()), hBh(hB.size());
+    for (size_t i = 0; i < hA.size(); i++) hAh[i] = __float2half(hA[i]);
+    for (size_t i = 0; i < hB.size(); i++) hBh[i] = __float2half(hB[i]);
+
+    if (!hip_ok(hipMalloc(&dA, hAh.size() * sizeof(half)), "malloc A") ||
+        !hip_ok(hipMalloc(&dB, hBh.size() * sizeof(half)), "malloc B") ||
+        !hip_ok(hipMalloc(&dC, hC.size() * sizeof(float)), "malloc C") ||
+        !hip_ok(hipMemcpy(dA, hAh.data(), hAh.size() * sizeof(half), hipMemcpyHostToDevice), "copy A") ||
+        !hip_ok(hipMemcpy(dB, hBh.data(), hBh.size() * sizeof(half), hipMemcpyHostToDevice), "copy B") ||
+        !hip_ok(hipMemset(dC, 0, hC.size() * sizeof(float)), "clear C")) {
+        (void)hipFree(dC);
+        (void)hipFree(dB);
+        (void)hipFree(dA);
+        return 2;
+    }
+
+    shim_mma_kernel<<<1, 256>>>(dA, dB, dC, waves);
+    hipError_t err = hipDeviceSynchronize();
+    if (err != hipSuccess) {
+        printf("SHIM TEST LAUNCH FAILURE: %s\n", hipGetErrorString(err));
+        return 3;
+    }
+    if (!hip_ok(hipMemcpy(hC.data(), dC, hC.size() * sizeof(float), hipMemcpyDeviceToHost), "copy C")) {
+        (void)hipFree(dC);
+        (void)hipFree(dB);
+        (void)hipFree(dA);
+        return 3;
+    }
+
+    double max_err = 0.0;
+    for (size_t i = 0; i < hC.size(); i++) {
+        double e = fabs((double)hC[i] - (double)hC_ref[i]);
+        if (e > max_err) max_err = e;
+    }
+    printf("max_err=%g (256 tiles checked, %zu values)\n", max_err, hC.size());
+    (void)hipFree(dC);
+    (void)hipFree(dB);
+    (void)hipFree(dA);
+    if (max_err > 1e-3) { printf("SHIM TEST NUMERIC MISMATCH\n"); return 4; }
+    if (!test_q8_wave64_row_packing()) return 5;
+    if (!test_f16_pair_workgroup_sizing()) return 6;
+    if (!test_router_wave64<DS4_ROCM_N_EXPERT>()) return 7;
+    if (!test_router_wave64<DS4_ROCM_MAX_N_EXPERT>()) return 8;
+    printf("SHIM TEST PASS\n");
+    return 0;
+}


### PR DESCRIPTION
> **AI implementation disclosure:** this gfx906 port, its tests, profiling,
> and pull-request preparation were implemented with OpenAI Codex under human
> direction and validated on the hardware described below.

## Summary

Add an optimized ROCm backend path for `gfx906` GPUs (Vega 20: Radeon VII,
Radeon Pro VII, Instinct MI50, and MI60).

These GPUs use fixed 64-lane wavefronts and cannot compile the gfx11 rocWMMA
path used by the existing `gfx1151` target. This change adds a wave64-safe
compatibility implementation for the exact 16x16 F16 x F16 -> F32 fragment
subset used by ds4, then selects native gfx906 paths for the decode kernels
that benefit from wave64 execution.

This revision deliberately limits the PR to the gfx906 backend core. Earlier
server/live-KV, distributed memory policy, long-context launcher, profiling,
and speculative-decoding changes were removed from the branch and can be
reviewed independently.

## Changes

- Add `make gfx906` and architecture-selectable ROCm build/regression targets.
- Add `rocm/ds4_rocm_wmma_gfx906.cuh`, selected only with `DS4_GFX906`.
- Make subgroup masks and broadcasts safe for logical wave32 groups inside a
  hardware wave64.
- Exclude the gfx11-only raw WMMA builtin and rocWMMA headers from gfx906.
- Pack two Q8 logical rows per wave64 and use pre-quantized decode activation.
- Tune F16-pair workgroups for Vega 20's 60 CUs.
- Add a native wave64 router path and cooperative short-cache attention dots.
- Keep non-gfx906 ROCm builds on their existing defaults and dispatch paths.
- Add real-device regressions for WMMA, Q8 packing, F16 sizing, router output,
  top-k, attention overflow, and ring-buffer attention numerics.

## Validation hardware

| Component | Configuration |
|---|---|
| CPU | AMD Ryzen Threadripper PRO 3955WX |
| GPUs | 6 x gfx906 / 60 CU: five 16 GiB plus one 32 GiB Vega 20 |
| GPU models | Radeon VII and Radeon Pro VII variants |
| Software | ROCm 7.2.4, `--offload-arch=gfx906` |

## Validation

```text
make -j6 gfx906                                      PASS
ROCR_VISIBLE_DEVICES=2 make rocm-regression \
    ROCM_ARCH=gfx906                                 PASS
  top-k n_comp=32768, n_tokens=32                   PASS
  attention ring max_abs=2.59664e-07                PASS
  gfx906 WMMA: 256 tiles / 8192 values, max_err=0   PASS
  Q8 wave64 packing: 4097 rows, 0 mismatches        PASS
  F16-pair sizing: 513 rows, 0 mismatches           PASS
  router wave64: 256 and 384 experts, 0 mismatches  PASS
make -j6 cpu                                         PASS
make -j6 rocm ROCM_ARCH=gfx1151                     PASS (compile-only)
```

The controlled legacy-versus-gfx906 workgroup A/B improved end-to-end decode
by 5.0%. The isolated Q8 decode path improved by 18.5%; F16-pair and router
regressions are bit-identical to their reference paths.

CUDA hardware and `nvcc` are not available on this validation host. Production
changes are confined to ROCm headers/build selection; the shared GPU regression
source was exercised through HIP, and a CUDA run remains desirable.

## Reproduction

```sh
make -j6 gfx906
ROCR_VISIBLE_DEVICES=<gfx906-index> \
    make rocm-regression ROCM_ARCH=gfx906
```

## Known limitation

gfx906 has no native MFMA support for the fragment API used here. The WMMA
compatibility path prioritizes correctness; the dedicated decode kernels avoid
that emulation where a faster wave64 implementation is available.
