### PR TITLE
Resolve Metal shader sources relative to the executable

### DIFF
--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
+#include <mach-o/dyld.h>
 
 #include <stdint.h>
 #include <inttypes.h>
@@ -3066,6 +3067,20 @@ static NSString *ds4_gpu_full_source(void) {
         @[@"DS4_METAL_SET_ROWS_SOURCE",   @"metal/set_rows.metal"],
     ];
 
+    /* Shader sources resolve against the current directory first, then against
+     * the directory containing the executable, so the binary can be launched
+     * from any working directory (e.g. inside another project). */
+    NSString *exe_dir = nil;
+    {
+        char exe_path[4096];
+        uint32_t exe_len = sizeof(exe_path);
+        if (_NSGetExecutablePath(exe_path, &exe_len) == 0) {
+            NSString *resolved = [[NSString stringWithUTF8String:exe_path]
+                                     stringByResolvingSymlinksInPath];
+            exe_dir = [resolved stringByDeletingLastPathComponent];
+        }
+    }
+
     NSMutableString *source = [NSMutableString stringWithString:base];
     for (NSArray<NSString *> *spec in required_sources) {
         const char *override_path = getenv([spec[0] UTF8String]);
@@ -3075,6 +3090,8 @@ static NSString *ds4_gpu_full_source(void) {
         }
         [paths addObject:spec[1]];
         [paths addObject:[@"./" stringByAppendingString:spec[1]]];
+        if (exe_dir)
+            [paths addObject:[exe_dir stringByAppendingPathComponent:spec[1]]];
 
         NSString *loaded = nil;
         NSString *loaded_path = nil;


### PR DESCRIPTION
Launching any ds4 binary from outside the repo silently falls back to the CPU backend: the Metal kernel sources only resolve as `metal/*.metal` against the current directory, so from another working directory the library build fails and the engine starts with `backend=cpu` and CPU-speed prefill, with no error pointing at the cause. The README's `--chdir` note covers it, but that requires knowing the trap exists.

The fix adds one more candidate path per kernel source: the directory containing the executable, obtained via `_NSGetExecutablePath` with symlinks resolved (so a symlink from `~/bin` or `/usr/local/bin` also works). Lookup order is unchanged otherwise: per-file env override first, then the two cwd-relative forms, then the executable-relative path. In-repo launches behave exactly as before; the file is Darwin-only so CUDA/ROCm paths are untouched.

Validation: `make` on top of current main, zero warnings (`-Wall -Wextra`). On an M5 Max with the patch applied, launching `ds4-agent` from an unrelated directory now starts with `backend=metal` in the context-buffers banner (previously `backend=cpu`), and the same holds when launched through a PATH symlink. Not run here: CUDA/ROCm builds (no change to those paths).

*Implemented with the help of a coding agent (Claude Code) and reviewed locally by the author.*
