### PR TITLE
Add guarded long-context benchmark tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 /tests/test_layer_pack
 /tests/test_metal_session_batch
 /tests/test_q4k_dot
+/tests/test_bench_metrics
 /tests/test_sampling
 *.o
 *.dSYM/

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ DS4_LINK_LIBS ?= $(CUDA_LDLIBS)
 METAL_LDLIBS := $(LDLIBS)
 endif
 
-.PHONY: all help clean test test-metal-session-batch test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
+.PHONY: all help clean test test-bench-metrics test-memory-guard test-metal-session-batch test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
 
 ifeq ($(UNAME_S),Darwin)
 all: ds4 ds4-server ds4-bench ds4-eval ds4-agent
@@ -67,8 +67,8 @@ ds4: ds4_cli.o ds4_help.o linenoise.o ds4_gpu_args.o $(CORE_OBJS)
 ds4-server: ds4_server.o ds4_help.o ds4_kvstore.o rax.o ds4_gpu_args.o $(CORE_OBJS)
 	$(CC) $(CFLAGS) -o $@ ds4_server.o ds4_help.o ds4_kvstore.o rax.o ds4_gpu_args.o $(CORE_OBJS) $(METAL_LDLIBS)
 
-ds4-bench: ds4_bench.o ds4_help.o ds4_gpu_args.o $(CORE_OBJS)
-	$(CC) $(CFLAGS) -o $@ ds4_bench.o ds4_help.o ds4_gpu_args.o $(CORE_OBJS) $(METAL_LDLIBS)
+ds4-bench: ds4_bench.o ds4_bench_metrics.o ds4_help.o ds4_gpu_args.o $(CORE_OBJS)
+	$(CC) $(CFLAGS) -o $@ ds4_bench.o ds4_bench_metrics.o ds4_help.o ds4_gpu_args.o $(CORE_OBJS) $(METAL_LDLIBS)
 
 ds4-eval: ds4_eval.o ds4_help.o $(CORE_OBJS)
 	$(CC) $(CFLAGS) -o $@ ds4_eval.o ds4_help.o $(CORE_OBJS) $(METAL_LDLIBS)
@@ -88,10 +88,10 @@ tests/test_metal_session_batch: tests/test_metal_session_batch.o $(CORE_OBJS)
 test-metal-session-batch: tests/test_metal_session_batch
 	DS4_TEST_MODEL="$(DS4_TEST_MODEL)" ./tests/test_metal_session_batch
 
-cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_eval_cpu.o ds4_agent_cpu.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS)
+cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_bench_metrics.o ds4_eval_cpu.o ds4_agent_cpu.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS)
 	$(CC) $(CFLAGS) -o ds4 ds4_cli_cpu.o ds4_help.o linenoise.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-server ds4_server_cpu.o ds4_help.o ds4_kvstore.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
-	$(CC) $(CFLAGS) -o ds4-bench ds4_bench_cpu.o ds4_help.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
+	$(CC) $(CFLAGS) -o ds4-bench ds4_bench_cpu.o ds4_bench_metrics.o ds4_help.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-eval ds4_eval_cpu.o ds4_help.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-agent ds4_agent_cpu.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 
@@ -142,7 +142,7 @@ ds4: ds4_cli.o ds4_help.o linenoise.o ds4_gpu_args.o $(CORE_OBJS)
 ds4-server: ds4_server.o ds4_help.o ds4_kvstore.o rax.o ds4_gpu_args.o $(CORE_OBJS)
 	$(DS4_LINK) -o $@ $^ $(DS4_LINK_LIBS)
 
-ds4-bench: ds4_bench.o ds4_help.o ds4_gpu_args.o $(CORE_OBJS)
+ds4-bench: ds4_bench.o ds4_bench_metrics.o ds4_help.o ds4_gpu_args.o $(CORE_OBJS)
 	$(DS4_LINK) -o $@ $^ $(DS4_LINK_LIBS)
 
 ds4-eval: ds4_eval.o ds4_help.o $(CORE_OBJS)
@@ -154,10 +154,10 @@ ds4-agent: ds4_agent.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o ds4_gpu_ar
 gguf-tools/quality-testing/score_official: gguf-tools/quality-testing/score_official.c ds4.h $(CORE_OBJS) rax.o
 	$(DS4_LINK) $(filter-out -ffast-math,$(QUALITY_CFLAGS)) -I. -o $@ gguf-tools/quality-testing/score_official.c $(CORE_OBJS) rax.o $(DS4_LINK_LIBS)
 
-cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_eval_cpu.o ds4_agent_cpu.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS)
+cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_bench_metrics.o ds4_eval_cpu.o ds4_agent_cpu.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS)
 	$(CC) $(CFLAGS) -o ds4 ds4_cli_cpu.o ds4_help.o linenoise.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-server ds4_server_cpu.o ds4_help.o ds4_kvstore.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
-	$(CC) $(CFLAGS) -o ds4-bench ds4_bench_cpu.o ds4_help.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
+	$(CC) $(CFLAGS) -o ds4-bench ds4_bench_cpu.o ds4_bench_metrics.o ds4_help.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-eval ds4_eval_cpu.o ds4_help.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-agent ds4_agent_cpu.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 
@@ -189,8 +189,11 @@ ds4_gpu_args.o: ds4_gpu_args.c ds4_gpu_args.h ds4_gpu_mgpu.h
 ds4_server.o: ds4_server.c ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h ds4_kvstore.h rax.h
 	$(CC) $(CFLAGS) -c -o $@ ds4_server.c
 
-ds4_bench.o: ds4_bench.c ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h
+ds4_bench.o: ds4_bench.c ds4_bench_metrics.h ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h
 	$(CC) $(CFLAGS) -c -o $@ ds4_bench.c
+
+ds4_bench_metrics.o: ds4_bench_metrics.c ds4_bench_metrics.h
+	$(CC) $(CFLAGS) -c -o $@ ds4_bench_metrics.c
 
 ds4_eval.o: ds4_eval.c ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h
 	$(CC) $(CFLAGS) -c -o $@ ds4_eval.c
@@ -231,7 +234,7 @@ ds4_gpu_args_cpu.o: ds4_gpu_args.c ds4_gpu_args.h ds4_gpu_mgpu.h
 ds4_server_cpu.o: ds4_server.c ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h ds4_kvstore.h rax.h
 	$(CC) $(CFLAGS) -DDS4_NO_GPU -c -o $@ ds4_server.c
 
-ds4_bench_cpu.o: ds4_bench.c ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h
+ds4_bench_cpu.o: ds4_bench.c ds4_bench_metrics.h ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h
 	$(CC) $(CFLAGS) -DDS4_NO_GPU -c -o $@ ds4_bench.c
 
 ds4_eval_cpu.o: ds4_eval.c ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h
@@ -372,6 +375,16 @@ ifneq ($(UNAME_S),Darwin)
 	./tests/test_sampling
 endif
 
+test-memory-guard:
+	python3 tests/test_memory_guard.py
+
+tests/test_bench_metrics: tests/test_bench_metrics.c ds4_bench_metrics.o
+	$(CC) $(CFLAGS) -I. -o $@ tests/test_bench_metrics.c ds4_bench_metrics.o $(LDLIBS)
+
+test-bench-metrics: tests/test_bench_metrics ds4-bench
+	./tests/test_bench_metrics
+	./tests/test_bench_metrics_cli.sh
+
 dspark-acceptance: ds4
 	DS4_DSPARK_MODEL="$(DS4_DSPARK_MODEL)" \
 	DS4_DSPARK_SUPPORT="$(DS4_DSPARK_SUPPORT)" \
@@ -402,4 +415,4 @@ q4k-dot-test: tests/test_q4k_dot.c
 	./tests/test_q4k_dot
 
 clean:
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official tests/test_q4k_dot tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official tests/test_q4k_dot tests/test_bench_metrics tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o

--- a/README.md
+++ b/README.md
@@ -834,6 +834,20 @@ exponential sweeps. Output is CSV with one row per frontier: latest prefill
 interval tokens/sec, generation tokens/sec at that frontier, and
 `kvcache_bytes`.
 
+Use `--gen-warmup-tokens N` to keep generating the requested `--gen-tokens`
+while excluding the first N tokens only from the appended `gen_measured_*`
+columns. The original `gen_tokens`, `gen_tps`, `gen_first_ms`, and
+`gen_steady_*` columns retain their existing meaning. For example,
+`--gen-tokens 512 --gen-warmup-tokens 32` reports a 32-token diagnostic warmup
+and a 480-token primary measurement window. The default warmup is 0 for
+backward-compatible runs.
+
+`tests/long_context_story_prompt_gb10.txt` is the deterministic extended
+fact-recall fixture for 65K–100K sweeps. Regenerate it with
+`python3 tests/generate_gb10_long_context_fixture.py`; the canonical source
+prompt remains unchanged and the extended file contains exactly one final
+query.
+
 Sessions prefill long prompts in 4096-token chunks by default. Use
 `--prefill-chunk 2048`, for example, to match the strict official-vector
 checkpoint path. Changing the chunk changes the KV checkpoint/logit path, so

--- a/ds4_bench.c
+++ b/ds4_bench.c
@@ -1,4 +1,5 @@
 #include "ds4.h"
+#include "ds4_bench_metrics.h"
 #include "ds4_distributed.h"
 #include "ds4_gpu_args.h"
 #include "ds4_help.h"
@@ -41,6 +42,7 @@ typedef struct {
     int ctx_alloc;
     int step_incr;
     int gen_tokens;
+    int gen_warmup_tokens;
     int power_percent;
     uint32_t prefill_chunk;
     uint32_t ssd_streaming_cache_experts;
@@ -254,6 +256,9 @@ static bench_config parse_options(int argc, char **argv) {
             c.step_mul = parse_double_arg(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--gen-tokens") || !strcmp(arg, "--tokens") || !strcmp(arg, "-n")) {
             c.gen_tokens = parse_nonnegative_int(need_arg(&i, argc, argv, arg), arg);
+        } else if (!strcmp(arg, "--gen-warmup-tokens")) {
+            c.gen_warmup_tokens =
+                parse_nonnegative_int(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--csv")) {
             c.csv_path = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--dump-frontier-logits-dir")) {
@@ -353,6 +358,11 @@ static bench_config parse_options(int argc, char **argv) {
     }
     if (c.ctx_max > INT_MAX - c.gen_tokens - 1) {
         fprintf(stderr, "ds4-bench: requested context is too large\n");
+        exit(2);
+    }
+    if (c.gen_warmup_tokens > c.gen_tokens) {
+        fprintf(stderr,
+                "ds4-bench: --gen-warmup-tokens must be <= --gen-tokens\n");
         exit(2);
     }
     if (c.ctx_alloc == 0) c.ctx_alloc = c.ctx_max + c.gen_tokens + 1;
@@ -668,7 +678,7 @@ int main(int argc, char **argv) {
             return 1;
         }
     }
-    fprintf(out, "ctx_tokens,prefill_tokens,prefill_tps,gen_tokens,gen_tps,gen_first_ms,gen_steady_tokens,gen_steady_tps,kvcache_bytes\n");
+    fprintf(out, "ctx_tokens,prefill_tokens,prefill_tps,gen_tokens,gen_tps,gen_first_ms,gen_steady_tokens,gen_steady_tps,kvcache_bytes,gen_warmup_tokens,gen_warmup_ms,gen_warmup_tps,gen_measured_tokens,gen_measured_ms,gen_measured_tps\n");
     fflush(out);
 
     const int eos = ds4_token_eos(engine);
@@ -730,6 +740,7 @@ int main(int argc, char **argv) {
         }
 
         const double gen_t0 = bench_now_sec();
+        double gen_measured_t0 = gen_t0;
         double gen_first_sec = 0.0;
         double gen_steady_sec = 0.0;
         int gen_done = 0;
@@ -760,6 +771,8 @@ int main(int argc, char **argv) {
             else gen_steady_sec += token_t1 - token_t0;
             if (gen_token_buf) gen_token_buf[gen_token_count++] = token;
             gen_done++;
+            if (gen_done == cfg.gen_warmup_tokens)
+                gen_measured_t0 = token_t1;
         }
         const double gen_t1 = bench_now_sec();
         if (cfg.show_output && gen_token_buf && gen_token_count > 0) {
@@ -796,8 +809,14 @@ int main(int argc, char **argv) {
 
         const double gen_sec = gen_t1 - gen_t0;
         const int gen_steady_tokens = gen_done > 1 ? gen_done - 1 : 0;
+        const ds4_bench_decode_metrics decode_metrics =
+            ds4_bench_decode_metrics_make(gen_done,
+                                          cfg.gen_warmup_tokens,
+                                          gen_t0,
+                                          gen_measured_t0,
+                                          gen_t1);
         fprintf(out,
-                "%d,%d,%.2f,%d,%.2f,%.3f,%d,%.2f,%llu\n",
+                "%d,%d,%.2f,%d,%.2f,%.3f,%d,%.2f,%llu,%d,%.3f,%.2f,%d,%.3f,%.2f\n",
                 frontier,
                 prefill_tokens,
                 prefill_sec > 0.0 ? (double)prefill_tokens / prefill_sec : 0.0,
@@ -806,7 +825,13 @@ int main(int argc, char **argv) {
                 gen_first_sec * 1000.0,
                 gen_steady_tokens,
                 gen_steady_sec > 0.0 ? (double)gen_steady_tokens / gen_steady_sec : 0.0,
-                (unsigned long long)(have_snapshot ? snap.len : 0));
+                (unsigned long long)(have_snapshot ? snap.len : 0),
+                decode_metrics.warmup_tokens,
+                decode_metrics.warmup_sec * 1000.0,
+                decode_metrics.warmup_tps,
+                decode_metrics.measured_tokens,
+                decode_metrics.measured_sec * 1000.0,
+                decode_metrics.measured_tps);
         fflush(out);
 
         previous = frontier;

--- a/ds4_bench_metrics.c
+++ b/ds4_bench_metrics.c
@@ -1,0 +1,30 @@
+#include "ds4_bench_metrics.h"
+
+ds4_bench_decode_metrics ds4_bench_decode_metrics_make(
+        int gen_tokens,
+        int requested_warmup_tokens,
+        double total_start_sec,
+        double measured_start_sec,
+        double total_end_sec) {
+    ds4_bench_decode_metrics m = {0};
+    if (gen_tokens < 0) gen_tokens = 0;
+    if (requested_warmup_tokens < 0) requested_warmup_tokens = 0;
+
+    m.warmup_tokens = requested_warmup_tokens < gen_tokens
+        ? requested_warmup_tokens : gen_tokens;
+    m.measured_tokens = gen_tokens - m.warmup_tokens;
+
+    double boundary = measured_start_sec;
+    if (m.warmup_tokens == 0) boundary = total_start_sec;
+    else if (m.measured_tokens == 0) boundary = total_end_sec;
+    if (boundary < total_start_sec) boundary = total_start_sec;
+    if (boundary > total_end_sec) boundary = total_end_sec;
+
+    if (m.warmup_tokens > 0) m.warmup_sec = boundary - total_start_sec;
+    if (m.measured_tokens > 0) m.measured_sec = total_end_sec - boundary;
+    if (m.warmup_sec > 0.0)
+        m.warmup_tps = (double)m.warmup_tokens / m.warmup_sec;
+    if (m.measured_sec > 0.0)
+        m.measured_tps = (double)m.measured_tokens / m.measured_sec;
+    return m;
+}

--- a/ds4_bench_metrics.h
+++ b/ds4_bench_metrics.h
@@ -1,0 +1,20 @@
+#ifndef DS4_BENCH_METRICS_H
+#define DS4_BENCH_METRICS_H
+
+typedef struct {
+    int warmup_tokens;
+    double warmup_sec;
+    double warmup_tps;
+    int measured_tokens;
+    double measured_sec;
+    double measured_tps;
+} ds4_bench_decode_metrics;
+
+ds4_bench_decode_metrics ds4_bench_decode_metrics_make(
+    int gen_tokens,
+    int requested_warmup_tokens,
+    double total_start_sec,
+    double measured_start_sec,
+    double total_end_sec);
+
+#endif

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -375,6 +375,7 @@ static void print_bench_specific(FILE *fp, const help_colors *c) {
     opt(fp, c, "--step-mul F", "Multiplicative step. Default: 1");
     opt(fp, c, "--step-incr N", "Linear step when --step-mul is 1. Default: 2048");
     opt(fp, c, "--gen-tokens N", "Greedy decode tokens per frontier. 0 for pure prefill. Default: 128");
+    opt(fp, c, "--gen-warmup-tokens N", "Exclude the first N decode tokens only from gen_measured_tps. Default: 0");
     opt(fp, c, "--csv FILE", "Write CSV there instead of stdout.");
     opt(fp, c, "--dump-frontier-logits-dir DIR", "Write one full-logit JSON file per frontier.");
     fputc('\n', fp);

--- a/speed-bench/README.md
+++ b/speed-bench/README.md
@@ -11,8 +11,19 @@ Run `ds4-bench` as:
   --ctx-start 2048 \
   --ctx-max 65536 \
   --step-incr 2048 \
-  --gen-tokens 128
+  --gen-tokens 512 \
+  --gen-warmup-tokens 32
 ```
+
+`--gen-warmup-tokens` does not generate extra tokens. It appends warmup and
+post-warmup fields to the CSV while preserving the meaning and order of the
+existing columns. With the values above, `gen_measured_tps` covers the final
+480 tokens. The option defaults to 0.
+
+For the GB10 65K/100K campaign, use
+`tests/long_context_story_prompt_gb10.txt`. It is generated deterministically
+from the canonical fact-recall story by
+`tests/generate_gb10_long_context_fixture.py` and retains one final query.
 
 Provide PR including your numbers if your hardware was not already tested.
 Call the benchmark csv file something like `m3_max.csv` or alike, so that
@@ -26,3 +37,34 @@ python3 speed-bench/plot_speed.py speed-bench/m3_max.csv --title "M3 Max t/s"
 
 The script uses only the Python standard library. By default it writes a file
 next to the CSV using the `_ts.svg` suffix, such as `speed-bench/m3_max_ts.svg`.
+
+### Memory guard
+
+On Linux, run model-backed benchmarks through `memory_guard.py`. It samples the
+whole child process group every 250 ms, records RSS, periodically records PSS,
+queries NVIDIA per-process accounting every second, tracks host `MemAvailable`,
+and writes both a CSV trace and a JSON summary. NVIDIA memory may be reported as
+unavailable on unified-memory systems; the host and process limits remain
+active. The defaults stop the run at 108 GB decimal group RSS/PSS, leaving a
+2 GB margin below the campaign's 110 GB hard cap, or when host available memory
+falls to 12 GiB:
+
+```
+python3 speed-bench/memory_guard.py \
+  --csv speed-bench/local-runs/q2-65k.memory.csv \
+  --summary-json speed-bench/local-runs/q2-65k.memory.json \
+  -- \
+  ./ds4-bench \
+    -m gguf/DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix.gguf \
+    --prompt-file speed-bench/promessi_sposi.txt \
+    --ctx-start 65536 --ctx-max 65536 \
+    --gen-tokens 512 --gen-warmup-tokens 32
+```
+
+At a limit, the guard sends `SIGTERM` to the process group, waits 10 seconds,
+then uses `SIGKILL` if needed. A guarded run returns exit status 75 and records
+the triggering metric in JSON. Set thresholds explicitly for diagnostic runs;
+do not disable the host-availability floor on unified-memory systems. Existing
+artifacts are not overwritten unless `--overwrite` is passed explicitly. Run
+the synthetic guard tests with `make test-memory-guard`; they do not open a
+model.

--- a/speed-bench/memory_guard.py
+++ b/speed-bench/memory_guard.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""Run a command with Linux process-group memory sampling and safety limits.
+
+The guard is designed for unified-memory systems such as NVIDIA DGX Spark,
+where host memory pressure is a useful last-resort signal even when per-process
+GPU accounting is unavailable. It never starts a model by itself; the command
+to supervise must follow ``--`` on the command line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+MIB = 1024 * 1024
+DEFAULT_INTERVAL_MS = 250
+DEFAULT_PSS_INTERVAL_MS = 1000
+DEFAULT_NVIDIA_INTERVAL_MS = 1000
+# Soft stop below the campaign's 110 GB decimal hard cap.
+DEFAULT_MAX_GROUP_MIB = 108_000_000_000 // MIB
+DEFAULT_MIN_AVAILABLE_MIB = 12 * 1024
+WATCHDOG_EXIT = 75
+
+
+@dataclass
+class ProcessMemory:
+    process_count: int = 0
+    rss_bytes: int = 0
+    pss_bytes: int | None = None
+    vm_hwm_bytes: int = 0
+
+
+@dataclass
+class HostMemory:
+    mem_total_bytes: int
+    mem_available_bytes: int
+    swap_free_bytes: int
+
+
+def parse_kib_lines(text: str) -> dict[str, int]:
+    """Parse ``Key: N kB`` records and return byte values."""
+    values: dict[str, int] = {}
+    for line in text.splitlines():
+        key, separator, rest = line.partition(":")
+        if not separator:
+            continue
+        fields = rest.split()
+        if not fields:
+            continue
+        try:
+            value = int(fields[0])
+        except ValueError:
+            continue
+        multiplier = 1024 if len(fields) < 2 or fields[1] == "kB" else 1
+        values[key] = value * multiplier
+    return values
+
+
+def read_host_memory(path: Path = Path("/proc/meminfo")) -> HostMemory:
+    values = parse_kib_lines(path.read_text(encoding="ascii"))
+    return HostMemory(
+        mem_total_bytes=values["MemTotal"],
+        mem_available_bytes=values["MemAvailable"],
+        swap_free_bytes=values.get("SwapFree", 0),
+    )
+
+
+def process_group_id(pid: int, proc_root: Path = Path("/proc")) -> int | None:
+    try:
+        stat = (proc_root / str(pid) / "stat").read_text(encoding="ascii")
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
+        return None
+    closing = stat.rfind(")")
+    if closing < 0:
+        return None
+    fields = stat[closing + 2 :].split()
+    if len(fields) < 3:
+        return None
+    try:
+        return int(fields[2])
+    except ValueError:
+        return None
+
+
+def process_group_pids(pgid: int, proc_root: Path = Path("/proc")) -> list[int]:
+    pids: list[int] = []
+    for entry in proc_root.iterdir():
+        if entry.name.isdigit() and process_group_id(int(entry.name), proc_root) == pgid:
+            pids.append(int(entry.name))
+    return sorted(pids)
+
+
+def read_process_memory(
+    pids: list[int],
+    *,
+    proc_root: Path = Path("/proc"),
+) -> ProcessMemory:
+    result = ProcessMemory()
+    for pid in pids:
+        try:
+            status_values = parse_kib_lines(
+                (proc_root / str(pid) / "status").read_text(encoding="ascii")
+            )
+        except (FileNotFoundError, PermissionError, ProcessLookupError):
+            continue
+        result.process_count += 1
+        result.rss_bytes += status_values.get("VmRSS", 0)
+        result.vm_hwm_bytes += status_values.get("VmHWM", 0)
+    return result
+
+
+def read_process_pss(
+    pids: list[int], proc_root: Path = Path("/proc")
+) -> int | None:
+    total = 0
+    for pid in pids:
+        try:
+            rollup_values = parse_kib_lines(
+                (proc_root / str(pid) / "smaps_rollup").read_text(encoding="ascii")
+            )
+        except (FileNotFoundError, PermissionError, ProcessLookupError):
+            return None
+        total += rollup_values.get("Pss", 0)
+    return total
+
+
+def limit_reason(
+    process: ProcessMemory,
+    host: HostMemory,
+    *,
+    max_rss_bytes: int,
+    max_pss_bytes: int,
+    min_available_bytes: int,
+) -> str | None:
+    if host.mem_available_bytes <= min_available_bytes:
+        return "host_available"
+    if process.rss_bytes >= max_rss_bytes:
+        return "group_rss"
+    if process.pss_bytes is not None and process.pss_bytes >= max_pss_bytes:
+        return "group_pss"
+    return None
+
+
+def parse_nvidia_compute_apps(
+    output: str, monitored_pids: set[int]
+) -> tuple[int | None, str]:
+    """Return aggregate NVIDIA-reported bytes and an availability status."""
+    total_mib = 0
+    matched = False
+    unavailable = False
+    for line in output.splitlines():
+        pid_text, separator, memory_text = line.partition(",")
+        if not separator:
+            continue
+        try:
+            pid = int(pid_text.strip())
+        except ValueError:
+            continue
+        if pid not in monitored_pids:
+            continue
+        matched = True
+        memory_text = memory_text.strip()
+        try:
+            total_mib += int(memory_text)
+        except ValueError:
+            unavailable = True
+    if unavailable:
+        return None, "not_available"
+    return total_mib * MIB, "ok" if matched else "no_compute_process"
+
+
+def read_nvidia_memory(pids: list[int]) -> tuple[int | None, str]:
+    try:
+        completed = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-compute-apps=pid,used_gpu_memory",
+                "--format=csv,noheader,nounits",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=0.2,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None, "unavailable"
+    if completed.returncode != 0:
+        return None, "error"
+    return parse_nvidia_compute_apps(completed.stdout, set(pids))
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat(timespec="milliseconds")
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Sample and guard a command's Linux process-group memory."
+    )
+    parser.add_argument("--csv", type=Path, required=True, help="memory trace path")
+    parser.add_argument(
+        "--summary-json", type=Path, required=True, help="run summary path"
+    )
+    parser.add_argument(
+        "--interval-ms", type=positive_int, default=DEFAULT_INTERVAL_MS
+    )
+    parser.add_argument(
+        "--pss-interval-ms", type=positive_int, default=DEFAULT_PSS_INTERVAL_MS
+    )
+    parser.add_argument(
+        "--nvidia-interval-ms",
+        type=positive_int,
+        default=DEFAULT_NVIDIA_INTERVAL_MS,
+    )
+    parser.add_argument(
+        "--no-nvidia-smi",
+        action="store_true",
+        help="disable NVIDIA per-process accounting (CSV status: disabled)",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="replace existing CSV/JSON artifacts",
+    )
+    parser.add_argument(
+        "--max-rss-mib", type=positive_int, default=DEFAULT_MAX_GROUP_MIB
+    )
+    parser.add_argument(
+        "--max-pss-mib", type=positive_int, default=DEFAULT_MAX_GROUP_MIB
+    )
+    parser.add_argument(
+        "--min-available-mib",
+        type=positive_int,
+        default=DEFAULT_MIN_AVAILABLE_MIB,
+    )
+    parser.add_argument("--grace-seconds", type=float, default=10.0)
+    parser.add_argument(
+        "command", nargs=argparse.REMAINDER, help="command, preceded by --"
+    )
+    return parser
+
+
+def normalize_command(parser: argparse.ArgumentParser, command: list[str]) -> list[str]:
+    if command[:1] == ["--"]:
+        command = command[1:]
+    if not command:
+        parser.error("a command is required after --")
+    return command
+
+
+def safe_signal_group(pgid: int, sig: signal.Signals) -> None:
+    try:
+        os.killpg(pgid, sig)
+    except ProcessLookupError:
+        pass
+
+
+def write_summary(path: Path, summary: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    temporary.replace(path)
+
+
+def run(args: argparse.Namespace) -> int:
+    if args.grace_seconds < 0:
+        raise SystemExit("--grace-seconds must be non-negative")
+    if args.pss_interval_ms < args.interval_ms:
+        raise SystemExit("--pss-interval-ms must be >= --interval-ms")
+    if args.nvidia_interval_ms < args.interval_ms:
+        raise SystemExit("--nvidia-interval-ms must be >= --interval-ms")
+    if args.csv.resolve() == args.summary_json.resolve():
+        raise SystemExit("--csv and --summary-json must be different paths")
+    existing = [path for path in (args.csv, args.summary_json) if path.exists()]
+    if existing and not args.overwrite:
+        names = ", ".join(str(path) for path in existing)
+        raise SystemExit("refusing to overwrite existing artifact(s): " + names)
+
+    initial_host = read_host_memory()
+    if initial_host.mem_available_bytes <= args.min_available_mib * MIB:
+        raise SystemExit(
+            "refusing to start: MemAvailable is already at or below "
+            f"{args.min_available_mib} MiB"
+        )
+
+    args.csv.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_json.parent.mkdir(parents=True, exist_ok=True)
+    # Fail on output-path errors before a supervised command can allocate memory.
+    with args.csv.open("w", encoding="utf-8", newline=""):
+        pass
+
+    guard_signal: int | None = None
+
+    def handle_guard_signal(signum: int, _frame: object) -> None:
+        nonlocal guard_signal
+        guard_signal = signum
+
+    previous_handlers = {
+        sig: signal.signal(sig, handle_guard_signal)
+        for sig in (signal.SIGINT, signal.SIGTERM)
+    }
+
+    started_utc = utc_now()
+    started = time.monotonic()
+    try:
+        child = subprocess.Popen(args.command, start_new_session=True)
+    except BaseException:
+        for sig, previous in previous_handlers.items():
+            signal.signal(sig, previous)
+        raise
+    pgid = child.pid
+    max_rss = 0
+    max_pss = 0
+    max_hwm = 0
+    min_available: int | None = None
+    last_pss: int | None = None
+    next_pss_at = started
+    last_nvidia: int | None = None
+    last_nvidia_status = "disabled" if args.no_nvidia_smi else "not_sampled"
+    next_nvidia_at = started
+    max_nvidia: int | None = None
+    trigger: str | None = None
+    termination_started: float | None = None
+    sent_sigkill = False
+    samples = 0
+
+    fieldnames = [
+        "utc",
+        "elapsed_ms",
+        "root_pid",
+        "process_count",
+        "group_rss_bytes",
+        "group_pss_bytes",
+        "group_vm_hwm_bytes",
+        "mem_total_bytes",
+        "mem_available_bytes",
+        "swap_free_bytes",
+        "nvidia_process_used_bytes",
+        "nvidia_status",
+        "event",
+    ]
+
+    try:
+        with args.csv.open("w", encoding="utf-8", newline="") as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+            writer.writeheader()
+            csv_file.flush()
+
+            while True:
+                sample_started = time.monotonic()
+                pids = process_group_pids(pgid)
+                include_pss = sample_started >= next_pss_at
+                process = read_process_memory(pids)
+                process.pss_bytes = last_pss
+                host = read_host_memory()
+
+                max_rss = max(max_rss, process.rss_bytes)
+                if process.pss_bytes is not None:
+                    max_pss = max(max_pss, process.pss_bytes)
+                max_hwm = max(max_hwm, process.vm_hwm_bytes)
+                if last_nvidia is not None:
+                    max_nvidia = (
+                        last_nvidia
+                        if max_nvidia is None
+                        else max(max_nvidia, last_nvidia)
+                    )
+                min_available = (
+                    host.mem_available_bytes
+                    if min_available is None
+                    else min(min_available, host.mem_available_bytes)
+                )
+
+                event = ""
+                if guard_signal is not None and termination_started is None:
+                    event = "guard_signal:" + signal.Signals(guard_signal).name
+                    termination_started = sample_started
+                    safe_signal_group(pgid, signal.SIGTERM)
+                elif trigger is None and guard_signal is None:
+                    trigger = limit_reason(
+                        process,
+                        host,
+                        max_rss_bytes=args.max_rss_mib * MIB,
+                        max_pss_bytes=args.max_pss_mib * MIB,
+                        min_available_bytes=args.min_available_mib * MIB,
+                    )
+                    if trigger is not None:
+                        event = "watchdog_sigterm:" + trigger
+                        termination_started = sample_started
+                        safe_signal_group(pgid, signal.SIGTERM)
+                        print(
+                            "memory_guard: limit %s exceeded; sent SIGTERM to pgid %d"
+                            % (trigger, pgid),
+                            file=sys.stderr,
+                            flush=True,
+                        )
+                if trigger is None and guard_signal is None and include_pss:
+                    last_pss = read_process_pss(pids)
+                    process.pss_bytes = last_pss
+                    next_pss_at = sample_started + args.pss_interval_ms / 1000.0
+                    if process.pss_bytes is not None:
+                        max_pss = max(max_pss, process.pss_bytes)
+                    trigger = limit_reason(
+                        process,
+                        host,
+                        max_rss_bytes=args.max_rss_mib * MIB,
+                        max_pss_bytes=args.max_pss_mib * MIB,
+                        min_available_bytes=args.min_available_mib * MIB,
+                    )
+                    if trigger is not None:
+                        event = "watchdog_sigterm:" + trigger
+                        termination_started = time.monotonic()
+                        safe_signal_group(pgid, signal.SIGTERM)
+                        print(
+                            "memory_guard: limit %s exceeded; sent SIGTERM to pgid %d"
+                            % (trigger, pgid),
+                            file=sys.stderr,
+                            flush=True,
+                        )
+
+                if not args.no_nvidia_smi and sample_started >= next_nvidia_at:
+                    last_nvidia, last_nvidia_status = read_nvidia_memory(pids)
+                    if last_nvidia is not None:
+                        max_nvidia = (
+                            last_nvidia
+                            if max_nvidia is None
+                            else max(max_nvidia, last_nvidia)
+                        )
+                    next_nvidia_at = (
+                        sample_started + args.nvidia_interval_ms / 1000.0
+                    )
+                if (
+                    not sent_sigkill
+                    and termination_started is not None
+                    and sample_started - termination_started >= args.grace_seconds
+                    and pids
+                ):
+                    stop_reason = trigger or "guard_signal"
+                    event = "sigkill:" + stop_reason
+                    sent_sigkill = True
+                    safe_signal_group(pgid, signal.SIGKILL)
+                    print(
+                        "memory_guard: grace period expired; sent SIGKILL to pgid %d"
+                        % pgid,
+                        file=sys.stderr,
+                        flush=True,
+                    )
+
+                writer.writerow(
+                    {
+                        "utc": utc_now(),
+                        "elapsed_ms": round((sample_started - started) * 1000),
+                        "root_pid": child.pid,
+                        "process_count": process.process_count,
+                        "group_rss_bytes": process.rss_bytes,
+                        "group_pss_bytes": (
+                            "" if process.pss_bytes is None else process.pss_bytes
+                        ),
+                        "group_vm_hwm_bytes": process.vm_hwm_bytes,
+                        "mem_total_bytes": host.mem_total_bytes,
+                        "mem_available_bytes": host.mem_available_bytes,
+                        "swap_free_bytes": host.swap_free_bytes,
+                        "nvidia_process_used_bytes": (
+                            "" if last_nvidia is None else last_nvidia
+                        ),
+                        "nvidia_status": last_nvidia_status,
+                        "event": event,
+                    }
+                )
+                csv_file.flush()
+                samples += 1
+
+                child_status = child.poll()
+                if child_status is not None and not pids:
+                    break
+                sleep_for = args.interval_ms / 1000.0 - (
+                    time.monotonic() - sample_started
+                )
+                if sleep_for > 0:
+                    time.sleep(sleep_for)
+    except KeyboardInterrupt:  # Defensive fallback for unusual signal handling.
+        guard_signal = guard_signal or signal.SIGINT
+        safe_signal_group(pgid, signal.SIGTERM)
+        try:
+            child.wait(timeout=max(0.0, args.grace_seconds))
+        except subprocess.TimeoutExpired:
+            sent_sigkill = True
+            safe_signal_group(pgid, signal.SIGKILL)
+
+    finally:
+        for sig, previous in previous_handlers.items():
+            signal.signal(sig, previous)
+
+    child_status = child.wait()
+    finished = time.monotonic()
+    if trigger is not None:
+        exit_code = WATCHDOG_EXIT
+    elif guard_signal is not None:
+        exit_code = 128 + guard_signal
+    else:
+        exit_code = child_status
+    summary: dict[str, object] = {
+        "command": args.command,
+        "started_utc": started_utc,
+        "finished_utc": utc_now(),
+        "elapsed_seconds": round(finished - started, 3),
+        "sample_interval_ms": args.interval_ms,
+        "pss_interval_ms": args.pss_interval_ms,
+        "nvidia_interval_ms": args.nvidia_interval_ms,
+        "samples": samples,
+        "child_exit_code": child_status,
+        "exit_code": exit_code,
+        "watchdog_trigger": trigger,
+        "guard_signal": (
+            None if guard_signal is None else signal.Signals(guard_signal).name
+        ),
+        "sent_sigkill": sent_sigkill,
+        "limits": {
+            "max_rss_mib": args.max_rss_mib,
+            "max_pss_mib": args.max_pss_mib,
+            "min_available_mib": args.min_available_mib,
+            "grace_seconds": args.grace_seconds,
+        },
+        "peaks": {
+            "group_rss_bytes": max_rss,
+            "group_pss_bytes": max_pss,
+            "group_vm_hwm_bytes": max_hwm,
+            "nvidia_process_used_bytes": max_nvidia,
+            "min_mem_available_bytes": min_available,
+        },
+    }
+    write_summary(args.summary_json, summary)
+    return exit_code
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.command = normalize_command(parser, args.command)
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/generate_gb10_long_context_fixture.py
+++ b/tests/generate_gb10_long_context_fixture.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate the deterministic >100K-token GB10 benchmark fixture.
+
+The canonical story remains unchanged. This fixture repeats only its narrative
+body, keeps one final fact-recall query, and uses identical assignment facts in
+every copy so the expected answer is unambiguous.
+"""
+
+from pathlib import Path
+
+from generate_long_context_story_prompt import (
+    ASSISTANT,
+    BOS,
+    FACTS,
+    USER,
+    make_story,
+)
+
+
+FULL_BODY_COPIES = 3
+PARTIAL_BODY_PARAGRAPHS = 125
+OUTPUT_NAME = "long_context_story_prompt_gb10.txt"
+FINAL_MARKER = "\nFinal task:\n"
+
+
+def make_fixture() -> str:
+    story = make_story()
+    body, marker, final_tail = story.partition(FINAL_MARKER)
+    if not marker:
+        raise RuntimeError("canonical story is missing the final-task marker")
+
+    paragraphs = body.split("\n\n")
+    if PARTIAL_BODY_PARAGRAPHS > len(paragraphs):
+        raise RuntimeError("partial-copy paragraph count exceeds canonical body")
+
+    copies = []
+    for index in range(FULL_BODY_COPIES):
+        copies.append(
+            "\n\n===== IDENTICAL CANONICAL LEDGER COPY "
+            f"{index + 1} OF {FULL_BODY_COPIES} =====\n\n"
+        )
+        copies.append(body)
+
+    copies.append(
+        "\n\n===== DETERMINISTIC PREFIX OF CANONICAL LEDGER COPY 4 =====\n\n"
+    )
+    copies.append("\n\n".join(paragraphs[:PARTIAL_BODY_PARAGRAPHS]))
+
+    system = (
+        "You are a careful assistant. Read the repeated ledger, remember the "
+        "assignments, and answer the single final task exactly. Repeated copies "
+        "contain identical assignments and never create a new value."
+    )
+    fixture = (
+        BOS
+        + system
+        + USER
+        + "".join(copies)
+        + FINAL_MARKER
+        + final_tail
+        + ASSISTANT
+        + "</think>"
+    )
+    if fixture.count(FINAL_MARKER) != 1:
+        raise RuntimeError("extended fixture must contain exactly one final task")
+    for name, word, _value in FACTS:
+        assignment = f"{name} was assigned the number {word}."
+        if fixture.count(assignment) < FULL_BODY_COPIES:
+            raise RuntimeError(f"extended fixture is missing repeated fact: {name}")
+    return fixture
+
+
+def main() -> None:
+    output = Path(__file__).resolve().parent / OUTPUT_NAME
+    output.write_text(make_fixture(), encoding="utf-8")
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/long_context_story_prompt_gb10.txt
+++ b/tests/long_context_story_prompt_gb10.txt
@@ -1,0 +1,7637 @@
+<｜begin▁of▁sentence｜>You are a careful assistant. Read the repeated ledger, remember the assignments, and answer the single final task exactly. Repeated copies contain identical assignments and never create a new value.<｜User｜>
+
+===== IDENTICAL CANONICAL LEDGER COPY 1 OF 3 =====
+
+You are reading a long story from the harbor town of Bellwether. The story is
+ordinary on purpose: people speak, walk, remember, repair things, argue about
+weather, and sometimes receive a private assignment number written out in
+words. Your job at the end is to recover the assignment numbers.
+
+Important rule while reading: only assignments stated as "was assigned the
+number ..." count. Other ages, prices, dates, distances, room numbers, rumors,
+or guesses do not count. The assignment numbers in the story are written in
+words, not numerals.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Elena crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Nadia had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Elena and Nadia pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Owen bargained for twine while Jonas listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Iris carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Alice helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Nadia
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Hugo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Hugo carried a crate of lantern glass through the crowd while Bob read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara did not decorate the sentence; she wanted it to be easy to find later. During that same scene, Bob was assigned the number thirty-four. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Kira helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Greta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Nadia, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Felix crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Elena had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Felix and Elena pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Diego carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Kira helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Elena found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Nadia
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Hugo bargained for twine while Marta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Priya carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Bob helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Jonas found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+The phrase was spoken once, then folded into the rest of the day's business. During that same scene, Alice was assigned the number fifty-two. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Rain arrived after midnight and softened every sound in Bellwether. Elena
+stood beneath the awning of the rope-maker's shop, waiting for Leo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Elena crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Marta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Elena and Marta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Jonas bargained for twine while Kira listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Nadia read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Elena helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Kira found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Priya
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Felix crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Felix and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Diego listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Clara carried a crate of lantern glass through the crowd while Hugo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Diego found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Rain arrived after midnight and softened every sound in Bellwether. Alice
+stood beneath the awning of the rope-maker's shop, waiting for Leo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+A kettle whistled somewhere nearby and broke the silence at exactly the right moment. During that same scene, Clara was assigned the number seventy-one. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Jonas had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Jonas pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Diego bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Marta carried a crate of lantern glass through the crowd while Clara read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Priya helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Elena, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Leo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Leo and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Priya read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Iris helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Nadia found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Hugo
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Kira had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Kira pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+The phrase was spoken once, then folded into the rest of the day's business. During that same scene, Diego was assigned the number ninety-three. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Clara listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Alice carried a crate of lantern glass through the crowd while Elena read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Hugo
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Alice crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Alice and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Nadia bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Greta carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Diego helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Marta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Bob had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Bob pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Alice bargained for twine while Nadia listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Elena was assigned the number sixteen. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Diego carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Jonas helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Elena found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Iris listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Bob helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Marta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Kira
+stood beneath the awning of the rope-maker's shop, waiting for Greta, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Clara crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Iris had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Clara and Iris pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Bob bargained for twine while Felix listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Marta carried a crate of lantern glass through the crowd while Owen read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Felix was assigned the number eighty-eight. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Clara helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Kira
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Diego had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Diego pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Iris listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Priya helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Marta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Clara, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Nadia bargained for twine while Leo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Nadia read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Iris helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+The town talked around the matter without naming it directly. During that same scene, Greta was assigned the number forty-seven. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Leo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Leo and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Hugo carried a crate of lantern glass through the crowd while Alice read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Elena helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Iris
+stood beneath the awning of the rope-maker's shop, waiting for Owen, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Jonas had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Jonas pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Owen bargained for twine while Marta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Greta carried a crate of lantern glass through the crowd while Kira read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Rain arrived after midnight and softened every sound in Bellwether. Felix
+stood beneath the awning of the rope-maker's shop, waiting for Iris, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+The town talked around the matter without naming it directly. During that same scene, Hugo was assigned the number twenty-nine. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Diego crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Kira had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Diego and Kira pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Leo bargained for twine while Owen listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Greta carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Nadia helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Hugo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Owen, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Leo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Leo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Priya bargained for twine while Diego listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Diego carried a crate of lantern glass through the crowd while Leo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Jonas helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Owen found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Bob, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Priya crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Priya and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+The town talked around the matter without naming it directly. During that same scene, Iris was assigned the number sixty-four. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Hugo bargained for twine while Priya listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Felix read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Priya helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Kira found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Bob
+stood beneath the awning of the rope-maker's shop, waiting for Alice, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Alice crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Elena had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Alice and Elena pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Leo bargained for twine while Greta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Hugo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Bob helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Priya
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Iris crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Marta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Iris and Marta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Iris bargained for twine while Clara listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara did not decorate the sentence; she wanted it to be easy to find later. During that same scene, Jonas was assigned the number twelve. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Owen read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Nadia helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Bob found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Nadia
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Felix crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Felix and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Diego bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Felix carried a crate of lantern glass through the crowd while Bob read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Alice helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Clara crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Bob had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Clara and Bob pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Bob carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Kira was assigned the number eighty-one. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Leo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Owen found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Hugo
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Owen had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Owen pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Marta bargained for twine while Hugo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Iris carried a crate of lantern glass through the crowd while Felix read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Felix helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Priya
+stood beneath the awning of the rope-maker's shop, waiting for Bob, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Owen crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Diego had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Owen and Diego pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Iris bargained for twine while Jonas listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Owen found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+The phrase was spoken once, then folded into the rest of the day's business. During that same scene, Leo was assigned the number thirty-nine. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Rain arrived after midnight and softened every sound in Bellwether. Iris
+stood beneath the awning of the rope-maker's shop, waiting for Elena, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Nadia bargained for twine while Felix listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Owen carried a crate of lantern glass through the crowd while Leo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Owen helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Bob
+stood beneath the awning of the rope-maker's shop, waiting for Nadia, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Diego crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Nadia had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Diego and Nadia pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Bob bargained for twine while Marta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Iris carried a crate of lantern glass through the crowd while Bob read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Hugo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Nadia, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+The ledger page smelled of dust, salt, and the faint sweetness of drying glue. During that same scene, Marta was assigned the number seventy-six. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Alice crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Greta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Alice and Greta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Marta bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Bob carried a crate of lantern glass through the crowd while Clara read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Priya found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Kira
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Owen bargained for twine while Kira listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Greta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Jonas helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Leo
+stood beneath the awning of the rope-maker's shop, waiting for Greta, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Bob crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Bob and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A kettle whistled somewhere nearby and broke the silence at exactly the right moment. During that same scene, Nadia was assigned the number twenty-three. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Alice bargained for twine while Jonas listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Hugo carried a crate of lantern glass through the crowd while Kira read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Felix helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Hugo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Bob
+stood beneath the awning of the rope-maker's shop, waiting for Diego, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Alice listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Alice carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Leo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Nadia found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Marta, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Kira had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Kira pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Priya listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Owen was assigned the number fifty-eight. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Clara helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Priya, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Elena crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Elena and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Felix read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Iris found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Leo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Bob had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Bob pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Nadia listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Priya was assigned the number ninety-seven. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Iris found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Leo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Leo and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Marta bargained for twine while Leo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Jonas carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Elena helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Bob found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Priya crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Greta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Priya and Greta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Iris listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Bob carried a crate of lantern glass through the crowd while Priya read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Nadia helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Leo
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Owen crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Elena had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Owen and Elena pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Alice bargained for twine while Greta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Owen read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Greta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Owen
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+
+===== IDENTICAL CANONICAL LEDGER COPY 2 OF 3 =====
+
+You are reading a long story from the harbor town of Bellwether. The story is
+ordinary on purpose: people speak, walk, remember, repair things, argue about
+weather, and sometimes receive a private assignment number written out in
+words. Your job at the end is to recover the assignment numbers.
+
+Important rule while reading: only assignments stated as "was assigned the
+number ..." count. Other ages, prices, dates, distances, room numbers, rumors,
+or guesses do not count. The assignment numbers in the story are written in
+words, not numerals.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Elena crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Nadia had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Elena and Nadia pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Owen bargained for twine while Jonas listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Iris carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Alice helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Nadia
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Hugo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Hugo carried a crate of lantern glass through the crowd while Bob read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara did not decorate the sentence; she wanted it to be easy to find later. During that same scene, Bob was assigned the number thirty-four. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Kira helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Greta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Nadia, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Felix crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Elena had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Felix and Elena pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Diego carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Kira helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Elena found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Nadia
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Hugo bargained for twine while Marta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Priya carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Bob helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Jonas found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+The phrase was spoken once, then folded into the rest of the day's business. During that same scene, Alice was assigned the number fifty-two. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Rain arrived after midnight and softened every sound in Bellwether. Elena
+stood beneath the awning of the rope-maker's shop, waiting for Leo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Elena crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Marta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Elena and Marta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Jonas bargained for twine while Kira listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Nadia read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Elena helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Kira found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Priya
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Felix crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Felix and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Diego listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Clara carried a crate of lantern glass through the crowd while Hugo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Diego found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Rain arrived after midnight and softened every sound in Bellwether. Alice
+stood beneath the awning of the rope-maker's shop, waiting for Leo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+A kettle whistled somewhere nearby and broke the silence at exactly the right moment. During that same scene, Clara was assigned the number seventy-one. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Jonas had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Jonas pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Diego bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Marta carried a crate of lantern glass through the crowd while Clara read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Priya helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Elena, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Leo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Leo and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Priya read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Iris helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Nadia found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Hugo
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Kira had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Kira pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+The phrase was spoken once, then folded into the rest of the day's business. During that same scene, Diego was assigned the number ninety-three. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Clara listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Alice carried a crate of lantern glass through the crowd while Elena read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Hugo
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Alice crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Alice and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Nadia bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Greta carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Diego helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Marta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Bob had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Bob pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Alice bargained for twine while Nadia listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Elena was assigned the number sixteen. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Diego carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Jonas helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Elena found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Iris listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Bob helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Marta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Kira
+stood beneath the awning of the rope-maker's shop, waiting for Greta, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Clara crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Iris had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Clara and Iris pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Bob bargained for twine while Felix listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Marta carried a crate of lantern glass through the crowd while Owen read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Felix was assigned the number eighty-eight. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Clara helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Kira
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Diego had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Diego pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Iris listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Priya helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Marta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Clara, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Nadia bargained for twine while Leo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Nadia read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Iris helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+The town talked around the matter without naming it directly. During that same scene, Greta was assigned the number forty-seven. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Leo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Leo and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Hugo carried a crate of lantern glass through the crowd while Alice read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Elena helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Iris
+stood beneath the awning of the rope-maker's shop, waiting for Owen, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Jonas had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Jonas pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Owen bargained for twine while Marta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Greta carried a crate of lantern glass through the crowd while Kira read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Rain arrived after midnight and softened every sound in Bellwether. Felix
+stood beneath the awning of the rope-maker's shop, waiting for Iris, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+The town talked around the matter without naming it directly. During that same scene, Hugo was assigned the number twenty-nine. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Diego crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Kira had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Diego and Kira pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Leo bargained for twine while Owen listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Greta carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Nadia helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Hugo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Owen, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Leo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Leo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Priya bargained for twine while Diego listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Diego carried a crate of lantern glass through the crowd while Leo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Jonas helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Owen found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Bob, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Priya crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Priya and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+The town talked around the matter without naming it directly. During that same scene, Iris was assigned the number sixty-four. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Hugo bargained for twine while Priya listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Felix read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Priya helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Kira found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Bob
+stood beneath the awning of the rope-maker's shop, waiting for Alice, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Alice crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Elena had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Alice and Elena pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Leo bargained for twine while Greta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Hugo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Bob helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Priya
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Iris crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Marta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Iris and Marta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Iris bargained for twine while Clara listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara did not decorate the sentence; she wanted it to be easy to find later. During that same scene, Jonas was assigned the number twelve. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Owen read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Nadia helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Bob found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Nadia
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Felix crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Felix and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Diego bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Felix carried a crate of lantern glass through the crowd while Bob read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Alice helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Clara crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Bob had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Clara and Bob pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Bob carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Kira was assigned the number eighty-one. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Leo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Owen found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Hugo
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Owen had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Owen pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Marta bargained for twine while Hugo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Iris carried a crate of lantern glass through the crowd while Felix read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Felix helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Priya
+stood beneath the awning of the rope-maker's shop, waiting for Bob, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Owen crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Diego had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Owen and Diego pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Iris bargained for twine while Jonas listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Owen found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+The phrase was spoken once, then folded into the rest of the day's business. During that same scene, Leo was assigned the number thirty-nine. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Rain arrived after midnight and softened every sound in Bellwether. Iris
+stood beneath the awning of the rope-maker's shop, waiting for Elena, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Nadia bargained for twine while Felix listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Owen carried a crate of lantern glass through the crowd while Leo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Owen helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Bob
+stood beneath the awning of the rope-maker's shop, waiting for Nadia, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Diego crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Nadia had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Diego and Nadia pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Bob bargained for twine while Marta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Iris carried a crate of lantern glass through the crowd while Bob read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Hugo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Nadia, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+The ledger page smelled of dust, salt, and the faint sweetness of drying glue. During that same scene, Marta was assigned the number seventy-six. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Alice crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Greta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Alice and Greta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Marta bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Bob carried a crate of lantern glass through the crowd while Clara read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Priya found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Kira
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Owen bargained for twine while Kira listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Greta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Jonas helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Leo
+stood beneath the awning of the rope-maker's shop, waiting for Greta, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Bob crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Bob and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A kettle whistled somewhere nearby and broke the silence at exactly the right moment. During that same scene, Nadia was assigned the number twenty-three. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Alice bargained for twine while Jonas listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Hugo carried a crate of lantern glass through the crowd while Kira read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Felix helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Hugo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Bob
+stood beneath the awning of the rope-maker's shop, waiting for Diego, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Alice listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Alice carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Leo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Nadia found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Marta, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Kira had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Kira pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Priya listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Owen was assigned the number fifty-eight. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Clara helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Priya, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Elena crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Elena and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Felix read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Iris found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Leo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Bob had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Bob pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Nadia listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Priya was assigned the number ninety-seven. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Iris found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Leo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Leo and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Marta bargained for twine while Leo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Jonas carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Elena helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Bob found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Priya crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Greta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Priya and Greta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Iris listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Bob carried a crate of lantern glass through the crowd while Priya read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Nadia helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Leo
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Owen crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Elena had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Owen and Elena pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Alice bargained for twine while Greta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Owen read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Greta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Owen
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+
+===== IDENTICAL CANONICAL LEDGER COPY 3 OF 3 =====
+
+You are reading a long story from the harbor town of Bellwether. The story is
+ordinary on purpose: people speak, walk, remember, repair things, argue about
+weather, and sometimes receive a private assignment number written out in
+words. Your job at the end is to recover the assignment numbers.
+
+Important rule while reading: only assignments stated as "was assigned the
+number ..." count. Other ages, prices, dates, distances, room numbers, rumors,
+or guesses do not count. The assignment numbers in the story are written in
+words, not numerals.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Elena crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Nadia had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Elena and Nadia pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Owen bargained for twine while Jonas listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Iris carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Alice helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Nadia
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Hugo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Hugo carried a crate of lantern glass through the crowd while Bob read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara did not decorate the sentence; she wanted it to be easy to find later. During that same scene, Bob was assigned the number thirty-four. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Kira helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Greta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Nadia, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Felix crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Elena had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Felix and Elena pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Diego carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Kira helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Elena found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Nadia
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Hugo bargained for twine while Marta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Priya carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Bob helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Jonas found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+The phrase was spoken once, then folded into the rest of the day's business. During that same scene, Alice was assigned the number fifty-two. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Rain arrived after midnight and softened every sound in Bellwether. Elena
+stood beneath the awning of the rope-maker's shop, waiting for Leo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Elena crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Marta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Elena and Marta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Jonas bargained for twine while Kira listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Nadia read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Elena helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Kira found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Priya
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Felix crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Felix and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Diego listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Clara carried a crate of lantern glass through the crowd while Hugo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Diego found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Rain arrived after midnight and softened every sound in Bellwether. Alice
+stood beneath the awning of the rope-maker's shop, waiting for Leo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+A kettle whistled somewhere nearby and broke the silence at exactly the right moment. During that same scene, Clara was assigned the number seventy-one. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Jonas had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Jonas pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Diego bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Marta carried a crate of lantern glass through the crowd while Clara read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Priya helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Elena, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Leo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Leo and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Priya read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Iris helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Nadia found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Hugo
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Kira had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Kira pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+The phrase was spoken once, then folded into the rest of the day's business. During that same scene, Diego was assigned the number ninety-three. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Clara listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Alice carried a crate of lantern glass through the crowd while Elena read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Hugo
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Alice crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Alice and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Nadia bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Greta carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Diego helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Marta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Bob had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Bob pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Alice bargained for twine while Nadia listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Elena was assigned the number sixteen. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Diego carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Jonas helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Elena found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Iris listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Bob helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Marta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Kira
+stood beneath the awning of the rope-maker's shop, waiting for Greta, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Clara crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Iris had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Clara and Iris pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Bob bargained for twine while Felix listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Marta carried a crate of lantern glass through the crowd while Owen read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Felix was assigned the number eighty-eight. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Clara helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Kira
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Diego had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Diego pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Iris listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Priya helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Marta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Clara, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Nadia bargained for twine while Leo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Nadia read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Iris helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+The town talked around the matter without naming it directly. During that same scene, Greta was assigned the number forty-seven. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Leo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Leo and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Hugo carried a crate of lantern glass through the crowd while Alice read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Elena helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Iris
+stood beneath the awning of the rope-maker's shop, waiting for Owen, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Jonas had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Jonas pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Owen bargained for twine while Marta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Greta carried a crate of lantern glass through the crowd while Kira read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Rain arrived after midnight and softened every sound in Bellwether. Felix
+stood beneath the awning of the rope-maker's shop, waiting for Iris, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+The town talked around the matter without naming it directly. During that same scene, Hugo was assigned the number twenty-nine. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Diego crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Kira had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Diego and Kira pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Leo bargained for twine while Owen listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Greta carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Nadia helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Hugo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Owen, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Leo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Leo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Priya bargained for twine while Diego listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Diego carried a crate of lantern glass through the crowd while Leo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Jonas helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Owen found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Bob, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Priya crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Priya and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+The town talked around the matter without naming it directly. During that same scene, Iris was assigned the number sixty-four. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Hugo bargained for twine while Priya listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Felix read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Priya helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Kira found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Bob
+stood beneath the awning of the rope-maker's shop, waiting for Alice, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Alice crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Elena had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Alice and Elena pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Leo bargained for twine while Greta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Hugo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Bob helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Priya
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Iris crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Marta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Iris and Marta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Iris bargained for twine while Clara listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara did not decorate the sentence; she wanted it to be easy to find later. During that same scene, Jonas was assigned the number twelve. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Owen read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Nadia helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Bob found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Nadia
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Felix crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Felix and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Diego bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Felix carried a crate of lantern glass through the crowd while Bob read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Alice helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Clara crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Bob had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Clara and Bob pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Bob carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Kira was assigned the number eighty-one. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Leo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Owen found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Hugo
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Owen had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Owen pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Marta bargained for twine while Hugo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Iris carried a crate of lantern glass through the crowd while Felix read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Felix helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Priya
+stood beneath the awning of the rope-maker's shop, waiting for Bob, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Owen crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Diego had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Owen and Diego pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Iris bargained for twine while Jonas listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Owen found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+The phrase was spoken once, then folded into the rest of the day's business. During that same scene, Leo was assigned the number thirty-nine. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Rain arrived after midnight and softened every sound in Bellwether. Iris
+stood beneath the awning of the rope-maker's shop, waiting for Elena, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Nadia bargained for twine while Felix listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Owen carried a crate of lantern glass through the crowd while Leo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Owen helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Bob
+stood beneath the awning of the rope-maker's shop, waiting for Nadia, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Diego crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Nadia had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Diego and Nadia pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Bob bargained for twine while Marta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Iris carried a crate of lantern glass through the crowd while Bob read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Hugo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Nadia, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+The ledger page smelled of dust, salt, and the faint sweetness of drying glue. During that same scene, Marta was assigned the number seventy-six. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Alice crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Greta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Alice and Greta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Marta bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Bob carried a crate of lantern glass through the crowd while Clara read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Priya found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Kira
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Clara had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Clara pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Owen bargained for twine while Kira listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Greta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Jonas helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Leo
+stood beneath the awning of the rope-maker's shop, waiting for Greta, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Bob crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Bob and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A kettle whistled somewhere nearby and broke the silence at exactly the right moment. During that same scene, Nadia was assigned the number twenty-three. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Alice bargained for twine while Jonas listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Hugo carried a crate of lantern glass through the crowd while Kira read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Felix helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Hugo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Bob
+stood beneath the awning of the rope-maker's shop, waiting for Diego, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Alice listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Alice carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Leo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Nadia found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Marta, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Kira had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Kira pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Priya listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Owen was assigned the number fifty-eight. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Clara helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Priya, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Elena crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Elena and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Felix read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Iris found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Leo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Bob had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Bob pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Nadia listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Leo carried a crate of lantern glass through the crowd while Marta read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Priya was assigned the number ninety-seven. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Iris found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Marta
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Leo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Leo and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Marta bargained for twine while Leo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Jonas carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Elena helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Bob found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Priya crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Greta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Priya and Greta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Iris listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Bob carried a crate of lantern glass through the crowd while Priya read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Nadia helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Leo
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Owen crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Elena had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Owen and Elena pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Alice bargained for twine while Greta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Owen read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Greta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Owen
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+
+===== DETERMINISTIC PREFIX OF CANONICAL LEDGER COPY 4 =====
+
+You are reading a long story from the harbor town of Bellwether. The story is
+ordinary on purpose: people speak, walk, remember, repair things, argue about
+weather, and sometimes receive a private assignment number written out in
+words. Your job at the end is to recover the assignment numbers.
+
+Important rule while reading: only assignments stated as "was assigned the
+number ..." count. Other ages, prices, dates, distances, room numbers, rumors,
+or guesses do not count. The assignment numbers in the story are written in
+words, not numerals.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Elena crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Nadia had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Elena and Nadia pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Owen bargained for twine while Jonas listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Iris carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Alice helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Leo found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Nadia
+stood beneath the awning of the rope-maker's shop, waiting for Felix, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Hugo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Alice had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Hugo and Alice pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Hugo listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Hugo carried a crate of lantern glass through the crowd while Bob read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara did not decorate the sentence; she wanted it to be easy to find later. During that same scene, Bob was assigned the number thirty-four. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Kira helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Greta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Diego
+stood beneath the awning of the rope-maker's shop, waiting for Nadia, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Felix crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Elena had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Felix and Elena pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Clara bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Diego carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Kira helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Elena found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Nadia
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Hugo bargained for twine while Marta listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Priya carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Bob helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Jonas found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+The phrase was spoken once, then folded into the rest of the day's business. During that same scene, Alice was assigned the number fifty-two. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+Rain arrived after midnight and softened every sound in Bellwether. Elena
+stood beneath the awning of the rope-maker's shop, waiting for Leo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Elena crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Marta had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Elena and Marta pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Jonas bargained for twine while Kira listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Kira carried a crate of lantern glass through the crowd while Nadia read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Elena helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Kira found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Priya
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Felix crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Felix and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Felix bargained for twine while Diego listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Clara carried a crate of lantern glass through the crowd while Hugo read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Marta helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Diego found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+Rain arrived after midnight and softened every sound in Bellwether. Alice
+stood beneath the awning of the rope-maker's shop, waiting for Leo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+A kettle whistled somewhere nearby and broke the silence at exactly the right moment. During that same scene, Clara was assigned the number seventy-one. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Jonas had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Jonas pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Diego bargained for twine while Bob listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Marta carried a crate of lantern glass through the crowd while Clara read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Priya helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Clara found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Elena, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Leo crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Hugo had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Leo and Hugo pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Elena carried a crate of lantern glass through the crowd while Priya read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Iris helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Nadia found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Hugo
+stood beneath the awning of the rope-maker's shop, waiting for Kira, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Nadia crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Kira had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Nadia and Kira pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+The phrase was spoken once, then folded into the rest of the day's business. During that same scene, Diego was assigned the number ninety-three. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Kira bargained for twine while Clara listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Alice carried a crate of lantern glass through the crowd while Elena read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Hugo helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Alice found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Rain arrived after midnight and softened every sound in Bellwether. Hugo
+stood beneath the awning of the rope-maker's shop, waiting for Jonas, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Alice crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Priya had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Alice and Priya pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Nadia bargained for twine while Elena listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Greta carried a crate of lantern glass through the crowd while Diego read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Diego helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Marta found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+
+Mara heard someone mention an old rumor about a numbered key, but she crossed it out because it was not an assignment and did not belong in the final list.
+
+Rain arrived after midnight and softened every sound in Bellwether. Jonas
+stood beneath the awning of the rope-maker's shop, waiting for Hugo, who had
+gone back for a forgotten satchel. The street lamps shone in puddles like coins
+that nobody could spend. From the hill, the lighthouse blinked with patient
+regularity.
+
+Mara remained awake in the archive room. She sharpened a pencil, rejected it,
+and returned to brown ink. The festival ledger had grown heavy with the week:
+weather notes, repairs, errands, apologies, and a few facts she underlined only
+once so they would not look too important.
+
+At first light the harbor smelled of rope, rain, and cedar smoke. Marta crossed
+the quay with a folded map tucked under one arm, stopping whenever gulls made a
+mess of the chalk marks near the fish stalls. Bob had promised to fix the
+south gate before supper, but the hinges complained so loudly that everyone
+pretended not to hear them. In the bakery window, loaves cooled beneath linen
+while a child counted shells in a wooden bowl. No one was in a hurry, because
+Bellwether moved by tide and habit, not by the bells on the council tower.
+
+The archivist Mara wrote notes in brown ink, never black, because black ink made
+old ledgers look like court summonses. She watched Marta and Bob pass the
+fountain, then added a line about the morning fog. Her notes often wandered into
+small details: the color of a scarf, the chipped rim of a cup, the way a door
+kept opening after it had been firmly shut.
+
+A shop sign advertised a discount in careful words, but prices and discounts were not assignment numbers, so Mara ignored them.
+
+By noon the market had filled with baskets of pears, lamp oil, brass hooks, and
+paper flowers. Alice bargained for twine while Nadia listened to a sailor
+describe a storm that seemed to grow taller every time he retold it. The town
+clock had stopped again, but nobody agreed on when, so every shopkeeper chose a
+different hour and defended it with confidence.
+
+Mara sat outside the apothecary and copied the day's ordinary business into the
+festival ledger. She liked ordinary business best. Extraordinary business came
+with signatures, seals, and people who leaned over her shoulder. Ordinary
+business arrived quietly, sat down, and became history before anyone noticed.
+
+No one treated the entry like a puzzle, which is why it survived unchanged. During that same scene, Elena was assigned the number sixteen. Mara wrote the assignment in words, closed the ledger for a moment, and then returned to the smaller gossip of the harbor.
+
+In the afternoon, a rehearsal for the midsummer play blocked the west road.
+Diego carried a crate of lantern glass through the crowd while Iris read
+lines from a damp script. Someone had painted the moon too blue on the backdrop,
+and three people argued about whether a theatrical moon was allowed to be wrong.
+The argument lasted longer than the scene.
+
+The ledger lay open on a bench. Mara kept it weighted with two smooth stones
+from the beach. She recorded who borrowed the theater ladder, who returned the
+wrong kettle, and who claimed the missing red umbrella. The handwriting was calm
+even when the town was not.
+
+Evening brought a quiet wind and the sound of shutters being latched one after
+another. Jonas helped carry chairs into the assembly hall, where the floor had
+been scrubbed until it smelled faintly of salt. Elena found a lost button
+near the door and pinned it to the notice board with a note that said, simply,
+"lonely."
+
+Mara walked the perimeter of the hall with the ledger pressed to her chest. She
+had learned that important facts hid best inside unimportant days. A missing
+button, a changed route, a corrected name, a number assigned without ceremony:
+these were the things that later made sense of everything else.
+Final task:
+
+Compile the assignment ledger from the story. Convert the spelled-out numbers to
+ordinary decimal numerals. Write only lines in the form Name=number. The first
+example line is Bob=34; include that line and all remaining people.
+
+People to list: Bob, Alice, Clara, Diego, Elena, Felix, Greta, Hugo, Iris, Jonas, Kira, Leo, Marta, Nadia, Owen, Priya.
+
+No bullets, no prose, no explanation.
+<｜Assistant｜></think>

--- a/tests/test_bench_metrics.c
+++ b/tests/test_bench_metrics.c
@@ -1,0 +1,70 @@
+#include "ds4_bench_metrics.h"
+
+#include <math.h>
+#include <stdio.h>
+
+static int failures;
+
+#define CHECK(cond, message) do {                                           \
+    if (!(cond)) {                                                          \
+        fprintf(stderr, "FAIL: %s (line %d)\n", (message), __LINE__);      \
+        failures++;                                                         \
+    }                                                                       \
+} while (0)
+
+static int close_enough(double a, double b) {
+    return fabs(a - b) < 1e-9;
+}
+
+static void test_no_warmup_preserves_total_window(void) {
+    ds4_bench_decode_metrics m =
+        ds4_bench_decode_metrics_make(512, 0, 10.0, 99.0, 50.0);
+    CHECK(m.warmup_tokens == 0, "zero warmup token count");
+    CHECK(close_enough(m.warmup_sec, 0.0), "zero warmup duration");
+    CHECK(m.measured_tokens == 512, "all tokens measured");
+    CHECK(close_enough(m.measured_sec, 40.0), "total window measured");
+    CHECK(close_enough(m.measured_tps, 12.8), "total throughput preserved");
+}
+
+static void test_32_token_warmup(void) {
+    ds4_bench_decode_metrics m =
+        ds4_bench_decode_metrics_make(512, 32, 10.0, 14.0, 50.0);
+    CHECK(m.warmup_tokens == 32, "32 warmup tokens");
+    CHECK(close_enough(m.warmup_sec, 4.0), "warmup window");
+    CHECK(close_enough(m.warmup_tps, 8.0), "warmup throughput");
+    CHECK(m.measured_tokens == 480, "480 measured tokens");
+    CHECK(close_enough(m.measured_sec, 36.0), "measured window");
+    CHECK(close_enough(m.measured_tps, 480.0 / 36.0), "measured throughput");
+}
+
+static void test_warmup_consumes_short_run(void) {
+    ds4_bench_decode_metrics m =
+        ds4_bench_decode_metrics_make(16, 32, 5.0, 6.0, 7.0);
+    CHECK(m.warmup_tokens == 16, "warmup clamps to completed tokens");
+    CHECK(m.measured_tokens == 0, "no measured tokens remain");
+    CHECK(close_enough(m.warmup_sec, 2.0), "whole short run is warmup");
+    CHECK(close_enough(m.measured_sec, 0.0), "zero measured duration");
+    CHECK(close_enough(m.measured_tps, 0.0), "zero measured throughput");
+}
+
+static void test_zero_token_run(void) {
+    ds4_bench_decode_metrics m =
+        ds4_bench_decode_metrics_make(0, 0, 3.0, 3.0, 3.0);
+    CHECK(m.warmup_tokens == 0, "zero-run warmup tokens");
+    CHECK(m.measured_tokens == 0, "zero-run measured tokens");
+    CHECK(close_enough(m.warmup_tps, 0.0), "zero-run warmup throughput");
+    CHECK(close_enough(m.measured_tps, 0.0), "zero-run measured throughput");
+}
+
+int main(void) {
+    test_no_warmup_preserves_total_window();
+    test_32_token_warmup();
+    test_warmup_consumes_short_run();
+    test_zero_token_run();
+    if (failures) {
+        fprintf(stderr, "test_bench_metrics: %d failure(s)\n", failures);
+        return 1;
+    }
+    fprintf(stderr, "test_bench_metrics: PASS\n");
+    return 0;
+}

--- a/tests/test_bench_metrics_cli.sh
+++ b/tests/test_bench_metrics_cli.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+test_log=$(mktemp)
+trap 'rm -f "$test_log"' EXIT
+
+./ds4-bench --help benchmark >"$test_log" 2>&1
+if ! grep -q -- "--gen-warmup-tokens N" "$test_log"; then
+    echo "FAIL: benchmark help omits --gen-warmup-tokens" >&2
+    exit 1
+fi
+
+set +e
+./ds4-bench --prompt-file /dev/null -m /dev/null \
+    --gen-tokens 16 --gen-warmup-tokens 32 >"$test_log" 2>&1
+test_rc=$?
+set -e
+if [ "$test_rc" -ne 2 ] ||
+   ! grep -q -- "--gen-warmup-tokens must be <= --gen-tokens" "$test_log"; then
+    echo "FAIL: inconsistent warmup was not rejected during option parsing" >&2
+    sed -n '1,20p' "$test_log" >&2
+    exit 1
+fi
+
+set +e
+./ds4-bench --prompt-file /dev/null -m /dev/null \
+    --gen-warmup-tokens -1 >"$test_log" 2>&1
+test_rc=$?
+set -e
+if [ "$test_rc" -ne 2 ] ||
+   ! grep -q -- "invalid value for --gen-warmup-tokens" "$test_log"; then
+    echo "FAIL: negative warmup was not rejected during option parsing" >&2
+    sed -n '1,20p' "$test_log" >&2
+    exit 1
+fi
+
+echo "test_bench_metrics_cli: PASS"

--- a/tests/test_memory_guard.py
+++ b/tests/test_memory_guard.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Unit and synthetic-process tests for speed-bench/memory_guard.py."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "speed-bench" / "memory_guard.py"
+SPEC = importlib.util.spec_from_file_location("memory_guard", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+memory_guard = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = memory_guard
+SPEC.loader.exec_module(memory_guard)
+
+
+class MemoryGuardUnitTests(unittest.TestCase):
+    def test_parse_kib_lines(self):
+        values = memory_guard.parse_kib_lines(
+            "MemTotal: 123 kB\nMemAvailable: 45 kB\nignored\n"
+        )
+        self.assertEqual(values["MemTotal"], 123 * 1024)
+        self.assertEqual(values["MemAvailable"], 45 * 1024)
+
+    def test_limit_priority(self):
+        process = memory_guard.ProcessMemory(
+            process_count=1,
+            rss_bytes=20 * memory_guard.MIB,
+            pss_bytes=10 * memory_guard.MIB,
+        )
+        host = memory_guard.HostMemory(
+            mem_total_bytes=100 * memory_guard.MIB,
+            mem_available_bytes=5 * memory_guard.MIB,
+            swap_free_bytes=0,
+        )
+        self.assertEqual(
+            memory_guard.limit_reason(
+                process,
+                host,
+                max_rss_bytes=15 * memory_guard.MIB,
+                max_pss_bytes=15 * memory_guard.MIB,
+                min_available_bytes=6 * memory_guard.MIB,
+            ),
+            "host_available",
+        )
+
+    def test_parse_nvidia_compute_apps(self):
+        value, status = memory_guard.parse_nvidia_compute_apps(
+            "101, 256\n202, [N/A]\n303, 99\n", {101}
+        )
+        self.assertEqual(value, 256 * memory_guard.MIB)
+        self.assertEqual(status, "ok")
+
+        value, status = memory_guard.parse_nvidia_compute_apps(
+            "101, 256\n202, [N/A]\n", {202}
+        )
+        self.assertIsNone(value)
+        self.assertEqual(status, "not_available")
+
+
+class MemoryGuardIntegrationTests(unittest.TestCase):
+    def run_guard(self, directory: Path, extra: list[str], child: str):
+        csv_path = directory / "trace.csv"
+        summary_path = directory / "summary.json"
+        command = [
+            sys.executable,
+            str(SCRIPT),
+            "--csv",
+            str(csv_path),
+            "--summary-json",
+            str(summary_path),
+            "--interval-ms",
+            "25",
+            "--pss-interval-ms",
+            "25",
+            "--no-nvidia-smi",
+            *extra,
+            "--",
+            sys.executable,
+            "-c",
+            child,
+        ]
+        completed = subprocess.run(command, check=False, timeout=10)
+        with csv_path.open(newline="", encoding="utf-8") as fp:
+            rows = list(csv.DictReader(fp))
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        return completed, rows, summary
+
+    def test_success_propagates_child_status_and_writes_artifacts(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            completed, rows, summary = self.run_guard(
+                Path(temporary),
+                ["--max-rss-mib", "128", "--max-pss-mib", "128"],
+                "import time; time.sleep(0.08)",
+            )
+        self.assertEqual(completed.returncode, 0)
+        self.assertGreaterEqual(len(rows), 2)
+        self.assertIsNone(summary["watchdog_trigger"])
+        self.assertEqual(summary["child_exit_code"], 0)
+
+    def test_rss_limit_terminates_process_group(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            completed, rows, summary = self.run_guard(
+                Path(temporary),
+                [
+                    "--max-rss-mib",
+                    "12",
+                    "--max-pss-mib",
+                    "128",
+                    "--grace-seconds",
+                    "0.1",
+                ],
+                (
+                    "import subprocess,sys,time; "
+                    "subprocess.Popen([sys.executable,'-c',"
+                    "'import time; payload=bytearray(32*1024*1024); time.sleep(5)']); "
+                    "time.sleep(5)"
+                ),
+            )
+        self.assertEqual(completed.returncode, memory_guard.WATCHDOG_EXIT)
+        self.assertEqual(summary["watchdog_trigger"], "group_rss")
+        self.assertTrue(any(row["event"].startswith("watchdog_sigterm") for row in rows))
+
+    def test_sigterm_is_forwarded_and_recorded(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            csv_path = directory / "trace.csv"
+            summary_path = directory / "summary.json"
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--csv",
+                    str(csv_path),
+                    "--summary-json",
+                    str(summary_path),
+                    "--interval-ms",
+                    "25",
+                    "--pss-interval-ms",
+                    "25",
+                    "--no-nvidia-smi",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    "import time; time.sleep(5)",
+                ]
+            )
+            for _ in range(100):
+                if csv_path.exists() and csv_path.stat().st_size > 0:
+                    break
+                time.sleep(0.01)
+            os.kill(process.pid, signal.SIGTERM)
+            self.assertEqual(process.wait(timeout=5), 128 + signal.SIGTERM)
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        self.assertEqual(summary["guard_signal"], "SIGTERM")
+        self.assertIsNone(summary["watchdog_trigger"])
+
+    def test_sigkill_escalation_for_uncooperative_child(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            completed, rows, summary = self.run_guard(
+                Path(temporary),
+                [
+                    "--max-rss-mib",
+                    "12",
+                    "--max-pss-mib",
+                    "128",
+                    "--grace-seconds",
+                    "0.1",
+                ],
+                (
+                    "import signal,time; "
+                    "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                    "payload=bytearray(32*1024*1024); time.sleep(5)"
+                ),
+            )
+        self.assertEqual(completed.returncode, memory_guard.WATCHDOG_EXIT)
+        self.assertTrue(summary["sent_sigkill"])
+        self.assertTrue(any(row["event"] == "sigkill:group_rss" for row in rows))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a Linux process-group memory guard for model-backed benchmark runs
- add an optional decode warmup window while preserving the existing CSV columns and meanings
- add a deterministic fact-recall fixture sized for 65K and 100K context frontiers
- add synthetic tests and usage documentation for the new tooling

## Motivation

Long-context measurements on unified-memory systems need an explicit safety envelope and a reproducible workload. Decode throughput also benefits from reporting a post-warmup window without changing existing benchmark metrics.

## Compatibility

The warmup defaults to zero. The original nine CSV columns remain in their existing order and keep their current meaning; the warmup and measured-window fields are appended. The canonical story fixture is not modified.

## Validation

- `make test-memory-guard` — 7 tests passed
- `make test-bench-metrics` — C metrics and CLI tests passed
- deterministic fixture regeneration produced SHA-256 `31cb363cd5b5b7eaccffdf9c464ba491d6afea46b54b4d5baf3dde36299d7436`
- `git diff --check` passed

No model-backed performance result is claimed in this draft; those runs remain guarded campaign work.