### PR TITLE
fix(cuda): avoid null output-head dereference in distributed coordinators

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -16696,7 +16696,6 @@ static uint64_t metal_graph_q8_0_row_bytes(uint64_t in_dim) {
  * legacy 1-arg helpers when g_n_gpus <= 1. */
 static bool metal_graph_alloc_raw_cap(
         ds4_gpu_graph *g,
-        const ds4_weights     *weights,
         const ds4_layer_weights *layer,
         uint32_t                raw_cap,
         uint32_t                ctx_size,
@@ -16823,7 +16822,7 @@ static bool metal_graph_alloc_raw_cap(
     const uint64_t group_dim = (uint64_t)DS4_N_HEAD_DIM * (DS4_N_HEAD / DS4_N_OUT_GROUP);
     const uint64_t shared_dim = layer->ffn_gate_shexp->dim[1];
     const uint64_t routed_mid_dim = layer->ffn_gate_exps->dim[1];
-    const uint64_t vocab_dim = weights->output->dim[1];
+    const uint64_t vocab_dim = DS4_N_VOCAB;
     const uint64_t comp_width_max = 2ull * (DS4_N_HEAD_DIM > DS4_N_INDEXER_HEAD_DIM
         ? DS4_N_HEAD_DIM
         : DS4_N_INDEXER_HEAD_DIM);
@@ -17307,11 +17306,10 @@ static bool metal_graph_alloc_raw_cap(
 
 static bool metal_graph_alloc(
         ds4_gpu_graph *g,
-        const ds4_weights     *weights,
         const ds4_layer_weights *layer) {
     /* single-tier convenience wrapper; placement=NULL routes
      * all per-layer allocations to tier 0. */
-    return metal_graph_alloc_raw_cap(g, weights, layer, DS4_N_SWA, DS4_N_SWA,
+    return metal_graph_alloc_raw_cap(g, layer, DS4_N_SWA, DS4_N_SWA,
                                      1, false, NULL, false, NULL);
 }
 
@@ -25314,7 +25312,7 @@ static int metal_graph_decode_test(
     output_logits_one(cpu_logits, model, weights, cpu_after_ffn_hc);
 
     ds4_gpu_graph g;
-    bool ok = metal_graph_alloc(&g, weights, layer);
+    bool ok = metal_graph_alloc(&g, layer);
     g.quality = quality;
     g.materialize_ffn_out = true;
     if (ok) ok = ds4_gpu_begin_commands() != 0;
@@ -25470,7 +25468,7 @@ static int metal_graph_first_token_full_test(
     output_logits_one(cpu_logits, model, weights, cpu_hc);
 
     ds4_gpu_graph g;
-    bool ok = metal_graph_alloc(&g, weights, &weights->layer[0]);
+    bool ok = metal_graph_alloc(&g, &weights->layer[0]);
     g.quality = quality;
     const bool trace_layers = getenv("DS4_METAL_GRAPH_TRACE_LAYERS") != NULL;
     if (trace_layers && ok) {
@@ -34938,7 +34936,7 @@ static int metal_graph_prompt_logits_test(
 
     ds4_gpu_graph g;
     /* diagnostic single-tier callsite; placement=NULL. */
-    bool ok = metal_graph_alloc_raw_cap(&g, weights, &weights->layer[0],
+    bool ok = metal_graph_alloc_raw_cap(&g, &weights->layer[0],
                                         raw_cap, (uint32_t)ctx_size,
                                         (uint32_t)n_test, false, NULL, false, NULL);
     if (!ok) {
@@ -46662,7 +46660,7 @@ static int generate_metal_graph_raw_swa(
     }
     ds4_gpu_graph g;
     /* diagnostic single-tier callsite; placement=NULL. */
-    bool ok = metal_graph_alloc_raw_cap(&g, weights, &weights->layer[0],
+    bool ok = metal_graph_alloc_raw_cap(&g, &weights->layer[0],
                                         raw_cap, (uint32_t)ctx_size,
                                         prefill_cap, false, NULL, false, NULL);
     if (!ok) {
@@ -50460,7 +50458,7 @@ int ds4_engine_collect_imatrix(ds4_engine *e,
 
     ds4_gpu_graph g;
     /* diagnostic single-tier callsite; placement=NULL. */
-    bool ok = metal_graph_alloc_raw_cap(&g, weights, &weights->layer[0],
+    bool ok = metal_graph_alloc_raw_cap(&g, &weights->layer[0],
                                         raw_cap, (uint32_t)ctx_size,
                                         prefill_cap, false, NULL, false, NULL);
     if (!ok) {
@@ -56575,7 +56573,7 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
             ? &e->shared_prefill_workspace
             : NULL;
     s->graph.dspark_exec_tier = e->multi_tier ? e->dspark_exec_tier : 0;
-    if (!metal_graph_alloc_raw_cap(&s->graph, &e->weights, shape_layer,
+    if (!metal_graph_alloc_raw_cap(&s->graph, shape_layer,
                                    raw_cap, (uint32_t)ctx_size, s->prefill_cap,
                                    need_spec_verifier,
                                    placement,


### PR DESCRIPTION
## Summary

Fix a startup segmentation fault when CUDA distributed inference assigns the output head to a worker, for example a two-DGX-Spark pipeline with coordinator `--layers 0:19` and worker `--layers 20:output`.

`metal_graph_alloc_raw_cap()` sized the logits buffer through `weights->output->dim[1]`. A sliced coordinator intentionally does not map the worker-owned output tensor, so `weights->output` is `NULL` during `ds4_session_create()`.

Use the model shape metadata (`DS4_N_VOCAB`) instead. The allocator no longer needs `ds4_weights`, so this also removes that unused parameter and updates its call sites.

## Reproduction

Hardware:
- Two NVIDIA DGX Sparks, one GB10 GPU per node
- Direct ConnectX-7/DAC link, pipeline transport over TCP
- DeepSeek V4 Flash Q2 imatrix GGUF

Start the worker first:

```sh
./ds4 --cuda \
  -m "$MODEL" \
  --role worker \
  --layers 20:output \
  --coordinator 192.168.100.10 9911 \
  --ctx 8192 \
  --debug
```

Then start the coordinator:

```sh
./ds4 --cuda \
  -m "$MODEL" \
  --role coordinator \
  --layers 0:19 \
  --listen 192.168.100.10 9911 \
  --ctx 8192 \
  --tokens 64 \
  --temp 0 \
  --nothink \
  --debug \
  -p "In two sentences, explain why the sky appears blue."
```

Before this change, the coordinator completed model preparation and context planning, then exited with SIGSEGV before opening the listener.

GDB showed:

```text
#0 metal_graph_alloc_raw_cap  ds4.c:16826
#1 ds4_session_create         ds4.c:56578
#2 run_sampled_generation     ds4_cli.c:523
#3 main                       ds4_cli.c:2129
```

The faulting expression was:

```c
const uint64_t vocab_dim = weights->output->dim[1];
```

## Verification

After the fix, the same two-node command completes route registration and generation:

```text
distributed coordinator API: listening on 192.168.100.10:9911
distributed coordinator: registered worker ... layers=20:output
distributed coordinator: complete route ready: local 0:19 -> ... 20:output
distributed route ready
...
prefill: 17.14 t/s, generation: 14.68 t/s
```

The generated response was coherent and all 64 requested decode steps completed.

Additional checks on the DGX Spark coordinator:

```sh
make ds4
make cuda-regression
# cuda long-context regression: OK
make cpu
```

The regression requires a CUDA accelerator, a sliced distributed route, and the model artifacts; no source-text test was added.