### PR TITLE
rocm: fix build on gfx1201 (RDNA4, R9700) — gate the WMMA v1 kernel

### DIFF
--- a/rocm/ds4_rocm_matmul.cuh
+++ b/rocm/ds4_rocm_matmul.cuh
@@ -547,7 +547,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
             return cuda_ok(cudaGetLastError(),
                            "matmul_q8_0 f32 tiny exact8 launch");
         }
-        if (!g_quality_mode && (in_dim % 32u) == 0u &&
+        if (g_wmma_v1 && !g_quality_mode && (in_dim % 32u) == 0u &&
             out_dim >= 1024u &&
             n_tok >= 256u &&
             in_dim <= UINT32_MAX && out_dim <= UINT32_MAX && n_tok <= UINT32_MAX) {

--- a/rocm/ds4_rocm_q8.cuh
+++ b/rocm/ds4_rocm_q8.cuh
@@ -817,6 +817,9 @@ __global__ static void matmul_q8_0_f32_batch_wmma_rowtile_kernel(
             const _Float16 *xb = lds_x + nt * K_TILE;
             const ds4_q8_half16_t b0 = *(const ds4_q8_half16_t *)(xb);
             const ds4_q8_half16_t b1 = *(const ds4_q8_half16_t *)(xb + 16u);
+            /* gfx12xx (RDNA4) uses WMMA v2; the dispatch skips this kernel
+             * via g_wmma_v1, but the device code must compile on all arches. */
+#if !defined(__gfx1200__) && !defined(__gfx1201__)
             if (ntile == 0u) {
                 acc0 = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a0, b0, acc0);
                 acc0 = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a1, b1, acc0);
@@ -830,6 +833,7 @@ __global__ static void matmul_q8_0_f32_batch_wmma_rowtile_kernel(
                 acc3 = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a0, b0, acc3);
                 acc3 = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a1, b1, acc3);
             }
+#endif
         }
         __syncthreads();
     }

--- a/rocm/ds4_rocm_runtime.cuh
+++ b/rocm/ds4_rocm_runtime.cuh
@@ -34,6 +34,9 @@ static int g_rocblas_attention_b_solution_disabled;
 #endif
 static int g_quality_mode;
 static int g_glm_model;
+/* 1 if device supports RDNA3 WMMA v1 (__builtin_amdgcn_wmma_*_w32).
+ * 0 for RDNA4 (gfx12xx) which uses WMMA v2 — skip the _4w kernel. */
+static int g_wmma_v1;
 
 enum {
     DS4_ROCM_N_EXPERT = 256u,
@@ -5844,6 +5847,15 @@ extern "C" int ds4_gpu_init(void) {
     if (cudaGetDeviceProperties(&prop, dev) == cudaSuccess) {
         fprintf(stderr, DS4_GPU_LOG_PREFIX "backend initialized on %s (sm_%d%d)\n",
                 prop.name, prop.major, prop.minor);
+#ifdef __HIP_PLATFORM_AMD__
+        /* RDNA4 (gfx12xx) needs WMMA v2; gfx11xx (RDNA3/3.5) uses v1 builtins. */
+        g_wmma_v1 = (strstr(prop.gcnArchName, "gfx12") == NULL);
+        fprintf(stderr, DS4_GPU_LOG_PREFIX "WMMA v1 support: %s (arch: %s)\n",
+                g_wmma_v1 ? "yes" : "no (gfx12 RDNA4, using non-WMMA path)",
+                prop.gcnArchName);
+#else
+        g_wmma_v1 = 1;
+#endif
     }
     if (!g_cublas_ready) {
         if (!cublas_ok(cublasCreate(&g_cublas), "create handle")) return 0;


### PR DESCRIPTION
Fixes #521.

## Problem

Building on an AMD Radeon AI PRO R9700 (gfx1201, RDNA4 discrete GPU) fails
with:

```
Cannot select: intrinsic %llvm.amdgcn.wmma.f32.16x16x16.f16
```

`matmul_q8_0_f32_batch_wmma_4w_kernel` in `rocm/ds4_rocm_q8.cuh` uses
`__builtin_amdgcn_wmma_f32_16x16x16_f16_w32`, which is the RDNA3 (WMMA v1)
builtin. RDNA4 (gfx12xx) uses a different WMMA v2 intrinsic, so the compiler
can't select the RDNA3 builtin for a gfx1201 target and the build aborts.

## Fix

This is a compile/runtime **workaround**, not an RDNA4 WMMA v2
implementation:

- `ds4_rocm_runtime.cuh`: at `ds4_gpu_init()`, detect the arch from
  `prop.gcnArchName` and set a new `g_wmma_v1` flag (0 on any `gfx12*`
  target, 1 otherwise).
- `ds4_rocm_q8.cuh`: guard the RDNA3 WMMA v1 builtin calls inside
  `matmul_q8_0_f32_batch_wmma_4w_kernel` with
  `#if !defined(__gfx1200__) && !defined(__gfx1201__)`, so the kernel still
  *compiles* for gfx12xx targets (the guarded body becomes a no-op there)
  instead of failing at builtin selection.
- `ds4_rocm_matmul.cuh`: gate dispatch into that kernel on `g_wmma_v1`, so
  gfx12xx never calls into the no-op kernel at runtime — it falls back to
  the existing non-WMMA matmul path instead.

Net effect: the build succeeds on gfx1201, and inference runs correctly,
but the accelerated WMMA-4w kernel is not used there — gfx12xx runs on the
existing fallback path. A real RDNA4 WMMA v2 kernel would recover that
performance; this PR intentionally scopes to "unbreak the build and run
correctly" rather than attempting the v2 intrinsic without hardware to
validate the accumulator/layout semantics against.

## Testing

Running in production on the reported hardware (R9700, 32GB VRAM, ROCm
7.2.2) for two weeks with `--rocm --ssd-streaming`, serving DeepSeek V4
Flash inference daily without correctness issues.

Happy to adjust the detection (e.g. a proper `HIP_ARCH`/target macro instead
of the `gcnArchName` substring check) if there's a preferred convention in
the codebase — I didn't see one, so I went with what's inspectable at
runtime.