### PR TITLE
cuda: copy model into VRAM on single-GPU via --gpu-resident

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -668,6 +668,12 @@ static agent_config parse_options(int argc, char **argv) {
             c.gpu_vram_arg = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--gpu-devices")) {
             c.gpu_devices_arg = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--gpu-resident")) {
+            /* CUDA: copy the whole model into VRAM at load instead of the
+             * zero-copy host mapping (which streams weights over PCIe). Maps
+             * to the DS4_CUDA_COPY_MODEL_CHUNKED path; requires VRAM >=
+             * model + KV + buffers, otherwise it falls back to host-mapping. */
+            setenv("DS4_CUDA_COPY_MODEL_CHUNKED", "1", 1);
         } else if (!strcmp(arg, "--cuda-tensor-parallel")) {
             c.engine.cuda_tensor_parallel = true;
         } else if (!strcmp(arg, "--cpu")) {

--- a/ds4_bench.c
+++ b/ds4_bench.c
@@ -277,6 +277,12 @@ static bench_config parse_options(int argc, char **argv) {
             c.gpu_vram_arg = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--gpu-devices")) {
             c.gpu_devices_arg = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--gpu-resident")) {
+            /* CUDA: copy the whole model into VRAM at load instead of the
+             * zero-copy host mapping (which streams weights over PCIe). Maps
+             * to the DS4_CUDA_COPY_MODEL_CHUNKED path; requires VRAM >=
+             * model + KV + buffers, otherwise it falls back to host-mapping. */
+            setenv("DS4_CUDA_COPY_MODEL_CHUNKED", "1", 1);
         } else if (!strcmp(arg, "--cuda-tensor-parallel")) {
             c.cuda_tensor_parallel = true;
         } else if (!strcmp(arg, "--cpu")) {

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -1950,6 +1950,12 @@ static cli_config parse_options(int argc, char **argv) {
             c.gpu_vram_arg = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--gpu-devices")) {
             c.gpu_devices_arg = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--gpu-resident")) {
+            /* CUDA: copy the whole model into VRAM at load instead of the
+             * zero-copy host mapping (which streams weights over PCIe). Maps
+             * to the DS4_CUDA_COPY_MODEL_CHUNKED path; requires VRAM >=
+             * model + KV + buffers, otherwise it falls back to host-mapping. */
+            setenv("DS4_CUDA_COPY_MODEL_CHUNKED", "1", 1);
         } else if (!strcmp(arg, "--cuda-tensor-parallel")) {
             c.engine.cuda_tensor_parallel = true;
         } else if (!strcmp(arg, "--dump-tokens")) {

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -3201,11 +3201,28 @@ extern "C" int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size)
 
 extern "C" int ds4_gpu_set_model_map_range(const void *model_map, uint64_t model_size, uint64_t map_offset, uint64_t map_size, uint64_t max_tensor_bytes) {
     (void)max_tensor_bytes;
-    if (!ds4_gpu_register_model_map_no_copy(model_map, model_size)) return 0;
-    if (getenv("DS4_CUDA_COPY_MODEL_CHUNKED") != NULL &&
-        !cuda_model_copy_chunked(model_map, model_size, map_offset, map_size)) {
-        (void)cuda_model_prefetch_range(model_map, model_size, map_offset, map_size);
+    /* PATCH: full-VRAM residency. Try the chunked device copy BEFORE the
+     * no-copy host registration so cuda_model_copy_chunked()'s guard
+     * (g_model_registered) does not short-circuit it. Active only when
+     * DS4_CUDA_COPY_MODEL_CHUNKED is set; on failure restore state and fall
+     * back to the original no-copy path. */
+    if (getenv("DS4_CUDA_COPY_MODEL_CHUNKED") != NULL) {
+        g_model_host_base               = model_map;
+        g_model_device_base             = (const char *)model_map;
+        g_model_registered_size         = model_size;
+        g_model_range_mapping_supported = 1;
+        g_model_hmm_direct              = 0;
+        g_model_cache_full              = 0;
+        if (g_model_fd >= 0 && g_model_fd_host_base == NULL) {
+            g_model_fd_host_base = model_map;
+        }
+        if (cuda_model_copy_chunked(model_map, model_size, map_offset, map_size)) {
+            return 1;
+        }
+        g_model_host_base       = NULL;
+        g_model_registered_size = 0;
     }
+    if (!ds4_gpu_register_model_map_no_copy(model_map, model_size)) return 0;
     return 1;
 }
 

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -155,6 +155,7 @@ static void print_model_runtime(FILE *fp, const help_colors *c,
     opt(fp, c, "--backend NAME", "Backend name: metal, cuda, or cpu.");
     opt(fp, c, "--gpu-vram N[,N,...]|auto", "CUDA VRAM budgets per device, in GiB, or auto-detect free VRAM.");
     opt(fp, c, "--gpu-devices N[,N,...]", "CUDA device indices used by multi-GPU placement.");
+    opt(fp, c, "--gpu-resident", "CUDA: copy the whole model into VRAM at load (needs VRAM >= model+KV+buffers); far faster decode when it fits, otherwise falls back to host-mapping.");
     if (tool != DS4_HELP_EVAL) {
         opt(fp, c, "--cuda-tensor-parallel", "Enable the paired DeepSeek tensor/expert path on an even multi-GPU CUDA placement.");
     }

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -12832,6 +12832,12 @@ static server_config parse_options(int argc, char **argv) {
             c.gpu_vram_arg = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--gpu-devices")) {
             c.gpu_devices_arg = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--gpu-resident")) {
+            /* CUDA: copy the whole model into VRAM at load instead of the
+             * zero-copy host mapping (which streams weights over PCIe). Maps
+             * to the DS4_CUDA_COPY_MODEL_CHUNKED path; requires VRAM >=
+             * model + KV + buffers, otherwise it falls back to host-mapping. */
+            setenv("DS4_CUDA_COPY_MODEL_CHUNKED", "1", 1);
         } else if (!strcmp(arg, "--cuda-tensor-parallel")) {
             c.engine.cuda_tensor_parallel = true;
         } else if (!strcmp(arg, "--backend")) {


### PR DESCRIPTION
## Summary
On a single discrete CUDA GPU whose VRAM is large enough to hold the whole model,
`ds4` never copies the weights into device memory. It keeps the model
host-mapped (zero-copy) and reads every routed-expert weight across PCIe on each
token. On an RTX PRO 6000 Blackwell (96 GB) running `DeepSeek-V4-Flash-IQ2XXS`
(~80.76 GiB) this pins decode at **~1 tok/s** with VRAM stuck at ~18 GB, even with
`--gpu-vram auto` (which reports a 90 GB budget).

This PR:
1. Fixes the copy-to-VRAM path, which was dead code on this configuration.
2. Exposes it as a first-class flag **`--gpu-resident`** (maps to the existing
   `DS4_CUDA_COPY_MODEL_CHUNKED` env var).

Result on the hardware above: **~55 tok/s** (a ~50× speedup), model fully
resident in VRAM.

## Root cause
The single-GPU, no-slice startup path calls `ds4_gpu_set_model_map_range()`:

```c
extern "C" int ds4_gpu_set_model_map_range(...) {
    (void)max_tensor_bytes;
    if (!ds4_gpu_register_model_map_no_copy(model_map, model_size)) return 0; // (1)
    if (getenv("DS4_CUDA_COPY_MODEL_CHUNKED") != NULL &&
        !cuda_model_copy_chunked(model_map, model_size, map_offset, map_size)) { // (2)
        (void)cuda_model_prefetch_range(model_map, model_size, map_offset, map_size);
    }
    return 1;
}
```

1. `ds4_gpu_register_model_map_no_copy()` does `cudaHostRegister(...)` and sets
   `g_model_registered = 1`.
2. `cuda_model_copy_chunked()` opens with
   `if (g_model_device_owned || g_model_registered) return 1;` — so, because (1)
   already set `g_model_registered = 1`, the copy is **always skipped** and every
   weight access goes over PCIe. `DS4_CUDA_COPY_MODEL_CHUNKED` is effectively a
   no-op on this path.

## Fix
1. **`ds4_cuda.cu`** — in `ds4_gpu_set_model_map_range()`, attempt the chunked
   device copy **before** the no-copy host registration, so the guard no longer
   short-circuits it. On failure (OOM, or the existing `DS4_CUDA_NO_MODEL_COPY` /
   `DS4_CUDA_DIRECT_MODEL` escape hatches) we restore state and fall back to the
   original no-copy path. Default behavior is unchanged unless the copy is
   explicitly requested.

   Execution already routes weight reads through the resolver
   `if (model_map == g_model_host_base && g_model_device_base) return g_model_device_base + offset;`,
   so once the copy sets `g_model_device_base` to the VRAM image, kernels read
   from VRAM with no further changes.

2. **`ds4_server.c`, `ds4_cli.c`, `ds4_agent.c`, `ds4_bench.c`** — new
   `--gpu-resident` flag sets `DS4_CUDA_COPY_MODEL_CHUNKED` via `setenv()` before
   engine creation, in each binary's arg parser. (Kept as a thin mapping over the
   env var so no cross-backend symbol/plumbing is added; can be promoted to a
   proper `ds4_engine_options` field if you prefer.)

3. **`ds4_help.c`** — shared help text for the new flag (shown by all binaries).

## Benchmark (RTX PRO 6000 Blackwell, 96 GB, sm_120, CUDA 13.0)
Model `DeepSeek-V4-Flash-IQ2XXS` (~80.76 GiB), `make ds4-server CUDA_ARCH=sm_120`.

| | before | after (`--gpu-resident`) |
|---|---|---|
| VRAM used | ~18 GB | ~94 GB (model resident) |
| startup | "no-copy … selective cache" | "CUDA chunk-copying 80.76 GiB … complete in 6.6s" |
| decode | ~1 tok/s | **~55 tok/s** (200 tok in 3.57s) |
| GPU util during decode | 100% (PCIe-bound) | ~92% (compute-bound) |
| output | coherent | coherent (no corruption) |

Both the flag and the raw env var were tested and produce identical behavior.

Run:
```sh
./ds4-server --gpu-resident --gpu-vram auto --ctx 64000
```

## Notes for the maintainer
- **Opt-in only.** Without `--gpu-resident` (or the env var), behavior is
  byte-for-byte the previous no-copy streaming path.
- **Single-tier only.** `engine_install_per_device_caches()` (multi-tier)
  deliberately uses the no-copy variant; untouched here.
- The original `cuda_model_prefetch_range()` fallback is dropped: it only ran in
  the "env set but copy skipped" case, which no longer exists. Can be re-added in
  the copy-failure branch as a host-page warm hint if desired.
- **Headroom:** needs VRAM ≥ model + KV + buffers + working set. ~80 GiB on a
  96 GB card lands at ~94–95 GB (`--ctx 64000`…`100000`). If it doesn't fit,
  `cudaMalloc` fails and we fall back to no-copy.
- `--gpu-resident` is wired into all four CUDA-capable binaries: `ds4-server`,
  `ds4` (CLI), `ds4-agent`, `ds4-bench`.

## Test plan
- [x] Builds with `make ds4-server ds4 ds4-agent ds4-bench CUDA_ARCH=sm_120`.
- [x] `--gpu-resident` on `ds4-server` (no env var): model copied to VRAM,
      ~55 tok/s, coherent output.
- [x] `--gpu-resident` on `ds4` CLI: triggers the VRAM copy end-to-end.
- [x] All four binaries accept the flag and list it in `--help`.
- [x] `DS4_CUDA_COPY_MODEL_CHUNKED=1` (no flag): same behavior.
- [x] Neither: unchanged no-copy streaming path.
- [ ] (maintainer) confirm no regression on multi-GPU / SSD-streaming / Metal /
      CPU paths (all untouched).

---

PS: ci vediamo a Campobello di Licata!!!
