### PR TITLE
fix: keep distributed layer-slice HC on active tier

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -57783,6 +57783,18 @@ int ds4_session_eval_layer_slice(ds4_session *s,
             return 1;
         }
 
+        if (g->placement) {
+            const int seed_tier = input_hc ? g->placement[layer_start + 1u]
+                                           : g->emb_tier;
+            if (!metal_graph_set_active_tier_no_copy(g, seed_tier)) {
+                if (errlen) snprintf(err, errlen,
+                                     "%s layer-slice decode could not select input GPU tier %d",
+                                     ds4_backend_name(e->backend), seed_tier);
+                s->checkpoint_valid = false;
+                return 1;
+            }
+        }
+
         bool ok = true;
         if (g->ssd_streaming && !input_hc) {
             g->streaming_static_decode_map_current = false;
@@ -57892,6 +57904,18 @@ int ds4_session_eval_layer_slice(ds4_session *s,
         .cap = (int)n_tokens,
     };
 
+    if (g->placement) {
+        const int seed_tier = input_hc ? g->placement[layer_start + 1u]
+                                       : g->emb_tier;
+        if (!metal_graph_set_active_tier_no_copy(g, seed_tier)) {
+            if (errlen) snprintf(err, errlen,
+                                 "%s layer-slice could not select input GPU tier %d",
+                                 ds4_backend_name(e->backend), seed_tier);
+            s->checkpoint_valid = false;
+            return 1;
+        }
+    }
+
     bool ok = true;
     if (g->ssd_streaming && !input_hc) {
         g->streaming_static_decode_map_current = false;
@@ -57911,8 +57935,6 @@ int ds4_session_eval_layer_slice(ds4_session *s,
     }
 
     ds4_gpu_tensor *last_hc = NULL;
-    ds4_gpu_tensor *saved_cur = NULL;
-    const int src_tier = g->active_tier;
     const bool batch_selected_addr =
         g->ssd_streaming &&
         layer_start == 0 &&
@@ -57947,7 +57969,8 @@ int ds4_session_eval_layer_slice(ds4_session *s,
         }
     }
     if (ok && output_logits) {
-        saved_cur = g->cur_hc_by_tier[src_tier];
+        const int src_tier = g->active_tier;
+        ds4_gpu_tensor *saved_cur = g->cur_hc_by_tier[src_tier];
         last_hc = metal_graph_tensor_row_view(metal_graph_batch_cur_hc(g), n_tokens - 1u, hc_dim);
         ok = last_hc != NULL;
         if (ok && g->ssd_streaming) {
@@ -57963,7 +57986,6 @@ int ds4_session_eval_layer_slice(ds4_session *s,
         }
     }
     if (ok && !g->ssd_streaming) ok = ds4_gpu_end_commands() != 0;
-    if (saved_cur) g->cur_hc_by_tier[src_tier] = saved_cur;
     if (last_hc) ds4_gpu_tensor_free(last_hc);
 
     if (ok && !output_hc && !output_logits) ok = ds4_gpu_synchronize() != 0;


### PR DESCRIPTION
Hi, I was tring to run DS4 on two nodes with 4 l40s gpus each. 
The distributed deployment wasn't working, so I've asked GPT5.6 Sol to fix it and identified this minimal changes that were needed.
Below is output of codex after completion:

## Summary

- select the embedding or first local layer GPU tier before distributed decode and batched-prefill input writes
- bind the final batched hidden-state row to the GPU tier active after the local layer loop
- keep the change isolated to distributed multi-GPU layer-slice evaluation

## Errors fixed

1. `active_tier` could still point at the preceding request's output tier when a new distributed hop wrote token embeddings or a remote hidden state.
2. Batched prefill captured its output source tier before processing local layers, so a slice spanning multiple GPU tiers could attach the final hidden state to its input tier.
3. The output head could consequently consume stale hidden state and sample EOS immediately on later requests.

## Reproduction

Tested with DeepSeek V4 Flash Q4 imatrix on a two-node CUDA pipeline. The coordinator owned layers `0:21`; the worker owned `22:output` and used multiple L40S GPUs.

Against one long-lived `ds4-server` process:

```text
request 1: correct response
request 2: finish_reason=stop, completion_tokens=0, empty content
request 3: finish_reason=stop, completion_tokens=0, empty content
```

Restarting the server restored only the next first response.

## Verification

After the fix, repeated and unrelated requests through the same server remained valid:

```text
request 1: "The capital of France is Paris."
request 2: "2 plus 2 equals 4."
request 3: non-empty response explaining why the sky is blue
```

Consecutive non-streaming and streaming requests also completed through the OpenAI-compatible endpoint at a 1,048,576-token context.

Build and regression checks:

```text
git diff --check
make -j8 tests/test_engine_mgpu_placement tests/test_gpu_model_cache
./tests/test_engine_mgpu_placement
./tests/test_gpu_model_cache
make -j8 ds4 ds4-server CUDA_ARCH=native
```

Results:

```text
test_engine_mgpu_placement: 98/98 checks passed
test_gpu_model_cache PASS (devs=4)
ds4 and ds4-server CUDA builds completed successfully
```

The sequential-request regression requires a sliced multi-node CUDA route and model artifacts, so no source-only test was added.

`make test` was also attempted. The CUDA build node did not have the default `ds4flash.gguf` test path, and the idle L40S validation node did not have `/usr/local/cuda/bin/nvcc`. The targeted CPU build, CUDA build, placement test, GPU cache test, and live distributed regression above completed successfully.
