### PR TITLE
Laguna: mixed-precision quant support (APEX IQ4_XS/Q6_K, official BF16) + metadata-driven rope

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -848,6 +848,21 @@ typedef struct {
     uint16_t d;
 } block_q6_K;
 
+/* IQ4_XS: 4-bit non-linear codebook quant (llama.cpp layout).  256 elems in
+ * 8 sub-blocks of 32; per-sub-block 6-bit scale split across scales_l nibbles
+ * (low 4) and scales_h 2-bit pairs (high 2), applied as (scale - 32) times
+ * the shared f16 super scale; elements index the kvalues_iq4nl codebook. */
+typedef struct {
+    uint16_t d;                   /* f16 super-block scale */
+    uint16_t scales_h;            /* 8 x 2-bit high scale bits */
+    uint8_t  scales_l[QK_K / 64]; /* 8 x 4-bit low scale bits */
+    uint8_t  qs[QK_K / 2];        /* 4-bit codebook indices */
+} block_iq4_xs;
+
+static const int8_t kvalues_iq4nl[16] = {
+    -127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113,
+};
+
 typedef struct {
     float   d;
     int8_t  qs[QK_K];
@@ -2128,6 +2143,7 @@ enum {
     DS4_TENSOR_Q6_K     = 14,
     DS4_TENSOR_Q8_K     = 15,
     DS4_TENSOR_IQ2_XXS  = 16,
+    DS4_TENSOR_IQ4_XS   = 23,
     DS4_TENSOR_I32      = 26,
     DS4_TENSOR_BF16     = 30,
 };
@@ -3208,6 +3224,27 @@ static inline float f16_to_f32(uint16_t h) {
     memcpy(&f, &bits, sizeof(f));
     return f;
 #endif
+}
+
+/* Reference dequant for IQ4_XS rows (llama.cpp-compatible semantics). */
+static DS4_MAYBE_UNUSED void dequant_row_iq4_xs(
+        const block_iq4_xs *x, float *y, uint64_t n) {
+    const uint64_t nb = n / QK_K;
+    for (uint64_t i = 0; i < nb; i++) {
+        const float d = f16_to_f32(x[i].d);
+        const uint8_t *qs = x[i].qs;
+        for (int ib = 0; ib < QK_K / 32; ib++) {
+            const int ls = ((x[i].scales_l[ib / 2] >> (4 * (ib % 2))) & 0xf) |
+                           (((x[i].scales_h >> (2 * ib)) & 3) << 4);
+            const float dl = d * (float)(ls - 32);
+            for (int j = 0; j < 16; j++) {
+                y[j +  0] = dl * (float)kvalues_iq4nl[qs[j] & 0xf];
+                y[j + 16] = dl * (float)kvalues_iq4nl[qs[j] >> 4];
+            }
+            y  += 32;
+            qs += 16;
+        }
+    }
 }
 
 static inline uint16_t f32_to_f16(float f) {
@@ -4523,6 +4560,7 @@ static void tensor_expect_f16_or_q8_0_layout(
 static bool tensor_is_routed_expert_type(uint32_t type) {
     return type == DS4_TENSOR_Q8_0 ||
            type == DS4_TENSOR_IQ2_XXS ||
+           type == DS4_TENSOR_IQ4_XS ||
            type == DS4_TENSOR_Q2_K ||
            type == DS4_TENSOR_Q3_K ||
            type == DS4_TENSOR_Q4_K ||
@@ -4534,6 +4572,7 @@ static DS4_MAYBE_UNUSED uint64_t routed_expert_block_bytes(uint32_t type) {
     switch (type) {
     case DS4_TENSOR_Q8_0:    return 34;
     case DS4_TENSOR_IQ2_XXS: return sizeof(block_iq2_xxs);
+    case DS4_TENSOR_IQ4_XS:  return sizeof(block_iq4_xs);
     case DS4_TENSOR_Q2_K:    return sizeof(block_q2_K);
     case DS4_TENSOR_Q3_K:    return sizeof(block_q3_K);
     case DS4_TENSOR_Q4_K:    return sizeof(block_q4_K);
@@ -5123,13 +5162,17 @@ static void weights_validate_laguna_layout(
         ds4_die("cannot identify Laguna quantization layout");
     }
     const bool signal_q8 = layout_marker->type == DS4_TENSOR_Q8_0;
+    /* APEX recipe (community mixed-precision export): q6_k embedding and
+     * attention, q8_0 dense+shared experts, routed experts per-layer in
+     * {iq4_xs, q5_k, q6_k}. */
+    const bool apex_q6 = layout_marker->type == DS4_TENSOR_Q6_K;
     const bool legacy_layout =
         (w->token_embd && layout_marker->type == DS4_TENSOR_Q4_K) ||
         (!w->token_embd && layout_marker->type == DS4_TENSOR_F16);
-    if (!signal_q8 && !legacy_layout) {
+    if (!signal_q8 && !legacy_layout && !apex_q6) {
         fprintf(stderr,
                 "ds4: unsupported Laguna quantization layout marker %s; "
-                "expected legacy Q4_K/F16 or Q8_0 signal weights\n",
+                "expected legacy Q4_K/F16, Q8_0 signal, or Q6_K APEX weights\n",
                 tensor_type_name(layout_marker->type));
         exit(1);
     }
@@ -5137,7 +5180,8 @@ static void weights_validate_laguna_layout(
     if (require_token_embd && !w->token_embd) ds4_die("required token embedding tensor is missing");
     if (w->token_embd) {
         tensor_expect_layout(w->token_embd,
-                             signal_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_Q4_K,
+                             signal_q8 ? DS4_TENSOR_Q8_0 :
+                             apex_q6   ? DS4_TENSOR_Q6_K : DS4_TENSOR_Q4_K,
                              2, DS4_N_EMBD, DS4_N_VOCAB, 0);
     }
 
@@ -5165,7 +5209,8 @@ static void weights_validate_laguna_layout(
         tensor_expect_layout(l->attn_norm, DS4_TENSOR_F32,
                              1, DS4_N_EMBD, 0, 0);
         const uint32_t attn_type =
-            signal_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_F16;
+            signal_q8 ? DS4_TENSOR_Q8_0 :
+            apex_q6   ? DS4_TENSOR_Q6_K : DS4_TENSOR_F16;
         tensor_expect_layout(l->attn_q, attn_type,
                              2, DS4_N_EMBD, q_dim, 0);
         tensor_expect_layout(l->attn_k, attn_type,
@@ -5184,14 +5229,15 @@ static void weights_validate_laguna_layout(
                              1, DS4_N_EMBD, 0, 0);
 
         if (il < DS4_N_LEADING_DENSE) {
+            const bool dense_q8 = signal_q8 || apex_q6;
             tensor_expect_layout(l->ffn_gate,
-                                 signal_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_Q4_K,
+                                 dense_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_Q4_K,
                                  2, DS4_N_EMBD, DS4_N_FF_DENSE, 0);
             tensor_expect_layout(l->ffn_up,
-                                 signal_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_Q4_K,
+                                 dense_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_Q4_K,
                                  2, DS4_N_EMBD, DS4_N_FF_DENSE, 0);
             tensor_expect_layout(l->ffn_down,
-                                 signal_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_Q6_K,
+                                 dense_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_Q6_K,
                                  2, DS4_N_FF_DENSE, DS4_N_EMBD, 0);
             continue;
         }
@@ -5203,9 +5249,14 @@ static void weights_validate_laguna_layout(
         /* Mixed files may spend more bits on selected layers, but all three
          * routed projections within one layer must use a coherent layout. */
         const uint32_t layer_routed_type = l->ffn_gate_exps->type;
-        if (layer_routed_type != DS4_TENSOR_Q4_K &&
-            layer_routed_type != DS4_TENSOR_Q3_K &&
-            layer_routed_type != DS4_TENSOR_Q2_K) {
+        const bool routed_type_ok =
+            layer_routed_type == DS4_TENSOR_Q4_K ||
+            layer_routed_type == DS4_TENSOR_Q3_K ||
+            layer_routed_type == DS4_TENSOR_Q2_K ||
+            (apex_q6 && (layer_routed_type == DS4_TENSOR_IQ4_XS ||
+                         layer_routed_type == DS4_TENSOR_Q5_K ||
+                         layer_routed_type == DS4_TENSOR_Q6_K));
+        if (!routed_type_ok) {
             fprintf(stderr,
                     "ds4: Laguna routed experts for layer %u have unsupported type %s\n",
                     il, tensor_type_name(layer_routed_type));
@@ -5231,15 +5282,16 @@ static void weights_validate_laguna_layout(
         }
         tensor_expect_layout(l->ffn_down_exps, l->ffn_down_exps->type,
                              3, DS4_N_FF_EXP, DS4_N_EMBD, DS4_N_EXPERT);
+        const bool shexp_q8 = signal_q8 || apex_q6;
         tensor_expect_layout(l->ffn_gate_shexp,
-                             signal_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_Q4_K,
+                             shexp_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_Q4_K,
                              2, DS4_N_EMBD, DS4_N_FF_SHARED, 0);
         tensor_expect_layout(l->ffn_up_shexp,
-                             signal_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_Q4_K,
+                             shexp_q8 ? DS4_TENSOR_Q8_0 : DS4_TENSOR_Q4_K,
                              2, DS4_N_EMBD, DS4_N_FF_SHARED, 0);
         const uint32_t shared_down_type =
-            signal_q8 ? DS4_TENSOR_Q8_0 : l->ffn_down_shexp->type;
-        if (!signal_q8 &&
+            shexp_q8 ? DS4_TENSOR_Q8_0 : l->ffn_down_shexp->type;
+        if (!shexp_q8 &&
             shared_down_type != DS4_TENSOR_Q4_K &&
             shared_down_type != DS4_TENSOR_Q6_K) {
             fprintf(stderr,
@@ -6084,7 +6136,8 @@ static void config_validate_laguna_model(const ds4_model *m) {
     const uint32_t n_leading_dense = required_u32(m, "laguna.leading_dense_block_count");
 
     config_expect_u32("block_count", n_layer, DS4_N_LAYER);
-    config_expect_u64("context_length", n_ctx, DS4_CONTEXT_LENGTH);
+    /* context_length is export-dependent; validated against the rope config
+     * below and adopted into the runtime shape there. */
     config_expect_u32("embedding_length", n_embd, DS4_N_EMBD);
     config_expect_u32("vocab_size", n_vocab, DS4_N_VOCAB);
     config_expect_u32("feed_forward_length", n_ff_dense, DS4_N_FF_DENSE);
@@ -6142,12 +6195,32 @@ static void config_validate_laguna_model(const ds4_model *m) {
     config_expect_f32("rope.freq_base_swa",
                       required_f32(m, "laguna.rope.freq_base_swa"),
                       DS4_ROPE_FREQ_BASE_SWA);
-    config_expect_f32("rope.scaling.factor",
-                      required_f32(m, "laguna.rope.scaling.factor"),
-                      DS4_ROPE_SCALE_FACTOR);
-    config_expect_f32("rope.scaling.yarn_attn_factor",
-                      required_f32(m, "laguna.rope.scaling.yarn_attn_factor"),
-                      DS4_ROPE_YARN_ATTN_FACTOR);
+    /* context_length and the yarn scale/attn factors are export-dependent:
+     * the same Laguna weights ship as a conservative 256K export (factor 32,
+     * attn factor 1.0) and as the full 1M export (factor 128, attn ~1.485).
+     * Accept any coherent yarn config (orig_ctx * factor == context_length)
+     * and adopt it into the runtime shape instead of pinning one export. */
+    {
+        const float rope_scale_factor =
+            required_f32(m, "laguna.rope.scaling.factor");
+        const float rope_yarn_attn_factor =
+            required_f32(m, "laguna.rope.scaling.yarn_attn_factor");
+        if (rope_scale_factor < 1.0f || rope_scale_factor > 1024.0f ||
+            rope_yarn_attn_factor <= 0.0f || rope_yarn_attn_factor > 8.0f ||
+            (uint64_t)((double)DS4_ROPE_ORIG_CTX * (double)rope_scale_factor)
+                != n_ctx) {
+            fprintf(stderr,
+                    "ds4: incoherent Laguna yarn config: context_length=%" PRIu64
+                    " vs original_context_length=%" PRIu64 " * factor=%g "
+                    "(attn factor %g)\n",
+                    n_ctx, (uint64_t)DS4_ROPE_ORIG_CTX,
+                    (double)rope_scale_factor, (double)rope_yarn_attn_factor);
+            exit(1);
+        }
+        g_ds4_shape.context_length = n_ctx;
+        g_ds4_shape.rope_scale_factor = rope_scale_factor;
+        g_ds4_shape.rope_yarn_attn_factor = rope_yarn_attn_factor;
+    }
     config_expect_f32("rope.scaling.yarn_beta_fast",
                       required_f32(m, "laguna.rope.scaling.yarn_beta_fast"),
                       DS4_ROPE_YARN_BETA_FAST);
@@ -49121,6 +49194,17 @@ static bool laguna_graph_forward_token(
                         DS4_N_HEAD_KV * DS4_N_HEAD_DIM,
                         n_head,
                         g->attn_norm) != 0;
+            } else if (l->attn_q->type == DS4_TENSOR_Q6_K) {
+                /* APEX layout: q6_k attention projections via the generic
+                 * per-type matmul (no fused pair kernel for q6_k yet). */
+                ok = laguna_graph_matmul(g->q, model, l->attn_q,
+                                         g->attn_norm, 1) &&
+                     laguna_graph_matmul(g->k, model, l->attn_k,
+                                         g->attn_norm, 1) &&
+                     laguna_graph_matmul(g->v, model, l->attn_v,
+                                         g->attn_norm, 1) &&
+                     laguna_graph_matmul(g->gate, model, l->attn_gate,
+                                         g->attn_norm, 1);
             } else {
 #ifdef DS4_ROCM_BUILD
                 ok = ds4_gpu_matmul_q8_0_pair_decode_preq8_tensor(

--- a/ds4.c
+++ b/ds4.c
@@ -4561,6 +4561,7 @@ static bool tensor_is_routed_expert_type(uint32_t type) {
     return type == DS4_TENSOR_Q8_0 ||
            type == DS4_TENSOR_IQ2_XXS ||
            type == DS4_TENSOR_IQ4_XS ||
+           type == DS4_TENSOR_BF16 ||
            type == DS4_TENSOR_Q2_K ||
            type == DS4_TENSOR_Q3_K ||
            type == DS4_TENSOR_Q4_K ||
@@ -4571,6 +4572,7 @@ static bool tensor_is_routed_expert_type(uint32_t type) {
 static DS4_MAYBE_UNUSED uint64_t routed_expert_block_bytes(uint32_t type) {
     switch (type) {
     case DS4_TENSOR_Q8_0:    return 34;
+    case DS4_TENSOR_BF16:    return 2;   /* 1 element per "block" */
     case DS4_TENSOR_IQ2_XXS: return sizeof(block_iq2_xxs);
     case DS4_TENSOR_IQ4_XS:  return sizeof(block_iq4_xs);
     case DS4_TENSOR_Q2_K:    return sizeof(block_q2_K);
@@ -5253,6 +5255,9 @@ static void weights_validate_laguna_layout(
             layer_routed_type == DS4_TENSOR_Q4_K ||
             layer_routed_type == DS4_TENSOR_Q3_K ||
             layer_routed_type == DS4_TENSOR_Q2_K ||
+            /* Poolside's official mixed-precision export keeps the last
+             * routed layers in bf16 beside q4_k elsewhere. */
+            layer_routed_type == DS4_TENSOR_BF16 ||
             (apex_q6 && (layer_routed_type == DS4_TENSOR_IQ4_XS ||
                          layer_routed_type == DS4_TENSOR_Q5_K ||
                          layer_routed_type == DS4_TENSOR_Q6_K));

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -41,6 +41,7 @@ enum {
     DS4_METAL_TENSOR_Q4_K    = 12,
     DS4_METAL_TENSOR_Q5_K    = 13,
     DS4_METAL_TENSOR_Q6_K    = 14,
+    DS4_METAL_TENSOR_IQ4_XS  = 23,
     DS4_METAL_TENSOR_Q8_K    = 15,
     DS4_METAL_TENSOR_IQ2_XXS = 16,
 };
@@ -63,6 +64,7 @@ static id<MTLComputePipelineState> g_get_rows_i32_pipeline;
 static id<MTLComputePipelineState> g_get_rows_q8_0_pipeline;
 static id<MTLComputePipelineState> g_get_rows_q4_0_pipeline;
 static id<MTLComputePipelineState> g_get_rows_q4_K_pipeline;
+static id<MTLComputePipelineState> g_get_rows_q6_K_pipeline;
 static id<MTLComputePipelineState> g_repeat_f32_pipeline;
 static id<MTLComputePipelineState> g_concat_pipeline;
 static id<MTLComputePipelineState> g_cpy_f32_f32_pipeline;
@@ -230,6 +232,9 @@ static id<MTLComputePipelineState> g_glm_q5_k_pair_swiglu_mapped_f32_pipeline;
 static id<MTLComputePipelineState> g_glm_q5_k_pair_swiglu_mapped_row_f32_pipeline;
 static id<MTLComputePipelineState> g_glm_q5_k_down_f32_pipeline;
 static id<MTLComputePipelineState> g_glm_q6_k_down_f32_pipeline;
+static id<MTLComputePipelineState> g_glm_q6_k_pair_swiglu_f32_pipeline;
+static id<MTLComputePipelineState> g_glm_iq4_xs_pair_swiglu_f32_pipeline;
+static id<MTLComputePipelineState> g_glm_iq4_xs_down_f32_pipeline;
 static id<MTLComputePipelineState> g_laguna_routed_shared_pair_pipeline;
 static id<MTLComputePipelineState> g_laguna_routed_shared_q4_down_pipeline;
 static id<MTLComputePipelineState> g_laguna_routed_shared_q6_down_pipeline;
@@ -6047,6 +6052,23 @@ int ds4_gpu_init(void) {
             return 0;
         }
 
+        fn = [library newFunctionWithName:@"kernel_get_rows_q6_K_f32"];
+        if (!fn) {
+            fprintf(stderr, "ds4: Metal kernel_get_rows_q6_K_f32 function not found\n");
+            g_queue = nil;
+            g_device = nil;
+            return 0;
+        }
+
+        g_get_rows_q6_K_pipeline = [g_device newComputePipelineStateWithFunction:fn error:&error];
+        if (!g_get_rows_q6_K_pipeline) {
+            fprintf(stderr, "ds4: Metal kernel_get_rows_q6_K_f32 pipeline failed: %s\n",
+                    [[error localizedDescription] UTF8String]);
+            g_queue = nil;
+            g_device = nil;
+            return 0;
+        }
+
         fn = [library newFunctionWithName:@"kernel_repeat_f32"];
         if (!fn) {
             fprintf(stderr, "ds4: Metal kernel_repeat_f32 function not found\n");
@@ -7946,6 +7968,12 @@ int ds4_gpu_init(void) {
             ds4_gpu_get_pipeline("kernel_glm_q5_K_down_f32");
         g_glm_q6_k_down_f32_pipeline =
             ds4_gpu_get_pipeline("kernel_glm_q6_K_down_f32");
+        g_glm_q6_k_pair_swiglu_f32_pipeline =
+            ds4_gpu_get_pipeline("kernel_glm_q6_K_pair_swiglu_f32");
+        g_glm_iq4_xs_pair_swiglu_f32_pipeline =
+            ds4_gpu_get_pipeline("kernel_glm_iq4_xs_pair_swiglu_f32");
+        g_glm_iq4_xs_down_f32_pipeline =
+            ds4_gpu_get_pipeline("kernel_glm_iq4_xs_down_f32");
         g_laguna_routed_shared_pair_pipeline =
             ds4_gpu_get_pipeline(
                 "kernel_laguna_q4_K_routed_shared_pair_swiglu_f32");
@@ -8044,6 +8072,9 @@ int ds4_gpu_init(void) {
             !g_glm_q5_k_pair_swiglu_mapped_row_f32_pipeline ||
             !g_glm_q5_k_down_f32_pipeline ||
             !g_glm_q6_k_down_f32_pipeline ||
+            !g_glm_q6_k_pair_swiglu_f32_pipeline ||
+            !g_glm_iq4_xs_pair_swiglu_f32_pipeline ||
+            !g_glm_iq4_xs_down_f32_pipeline ||
             !g_laguna_routed_shared_pair_pipeline ||
             !g_laguna_routed_shared_q4_down_pipeline ||
             !g_laguna_routed_shared_q6_down_pipeline ||
@@ -9277,6 +9308,7 @@ void ds4_gpu_cleanup(void) {
         g_get_rows_q8_0_pipeline = nil;
         g_get_rows_q4_0_pipeline = nil;
         g_get_rows_q4_K_pipeline = nil;
+        g_get_rows_q6_K_pipeline = nil;
         g_repeat_f32_pipeline = nil;
         g_concat_pipeline = nil;
         g_cpy_f32_f32_pipeline = nil;
@@ -9440,6 +9472,9 @@ void ds4_gpu_cleanup(void) {
         g_glm_q2_k_addr_down_f32_pipeline = nil;
         g_glm_q4_k_addr_down_f32_pipeline = nil;
         g_glm_q5_k_pair_swiglu_f32_pipeline = nil;
+        g_glm_q6_k_pair_swiglu_f32_pipeline = nil;
+        g_glm_iq4_xs_pair_swiglu_f32_pipeline = nil;
+        g_glm_iq4_xs_down_f32_pipeline = nil;
         g_glm_q5_k_pair_swiglu_mapped_f32_pipeline = nil;
         g_glm_q5_k_pair_swiglu_mapped_row_f32_pipeline = nil;
         g_glm_q5_k_down_f32_pipeline = nil;
@@ -9626,6 +9661,10 @@ static int ds4_gpu_quant_row_bytes(
         if ((n_embd % 256u) != 0) return 0;
         *row_bytes_out = ((uint64_t)n_embd / 256u) * 144u;
         return 1;
+    case DS4_METAL_TENSOR_Q6_K:
+        if ((n_embd % 256u) != 0) return 0;
+        *row_bytes_out = ((uint64_t)n_embd / 256u) * 210u;
+        return 1;
     default:
         return 0;
     }
@@ -9756,6 +9795,9 @@ static int ds4_gpu_encode_get_rows_quant(
         block_width = 32u;
     } else if (weight_type == DS4_METAL_TENSOR_Q4_K) {
         pipeline = g_get_rows_q4_K_pipeline;
+        block_width = 256u;
+    } else if (weight_type == DS4_METAL_TENSOR_Q6_K) {
+        pipeline = g_get_rows_q6_K_pipeline;
         block_width = 256u;
     }
     if (!pipeline || block_width == 0) return 0;
@@ -27176,6 +27218,8 @@ static id<MTLComputePipelineState> ds4_gpu_routed_mm_pipeline(uint32_t type) {
         return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_q5_K_f32", false);
     case DS4_METAL_TENSOR_Q6_K:
         return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_q6_K_f32", false);
+    case DS4_METAL_TENSOR_IQ4_XS:
+        return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_iq4_xs_f32", false);
     default:
         return nil;
     }
@@ -27210,6 +27254,8 @@ static id<MTLComputePipelineState> ds4_gpu_routed_mm_f16_rhs_pipeline(uint32_t t
         return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_q5_K_f16", false);
     case DS4_METAL_TENSOR_Q6_K:
         return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_q6_K_f16", false);
+    case DS4_METAL_TENSOR_IQ4_XS:
+        return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_iq4_xs_f16", false);
     default:
         return nil;
     }
@@ -34578,7 +34624,9 @@ static bool ds4_gpu_glm_gate_pair_type_supported(
            (gate_type == DS4_METAL_TENSOR_Q2_K ||
             gate_type == DS4_METAL_TENSOR_Q3_K ||
             gate_type == DS4_METAL_TENSOR_Q4_K ||
-            gate_type == DS4_METAL_TENSOR_Q5_K);
+            gate_type == DS4_METAL_TENSOR_Q5_K ||
+            gate_type == DS4_METAL_TENSOR_Q6_K ||
+            gate_type == DS4_METAL_TENSOR_IQ4_XS);
 }
 
 static bool ds4_gpu_glm_down_type_supported(uint32_t down_type) {
@@ -34586,7 +34634,8 @@ static bool ds4_gpu_glm_down_type_supported(uint32_t down_type) {
            down_type == DS4_METAL_TENSOR_Q3_K ||
            down_type == DS4_METAL_TENSOR_Q4_K ||
            down_type == DS4_METAL_TENSOR_Q5_K ||
-           down_type == DS4_METAL_TENSOR_Q6_K;
+           down_type == DS4_METAL_TENSOR_Q6_K ||
+           down_type == DS4_METAL_TENSOR_IQ4_XS;
 }
 
 int ds4_gpu_glm_routed_moe_one_tensor(
@@ -34693,14 +34742,18 @@ int ds4_gpu_glm_routed_moe_one_tensor(
         const BOOL gate_pair_q2 = gate_type == DS4_METAL_TENSOR_Q2_K;
         const BOOL gate_pair_q3 = gate_type == DS4_METAL_TENSOR_Q3_K;
         const BOOL gate_pair_q5 = gate_type == DS4_METAL_TENSOR_Q5_K;
+        const BOOL gate_pair_q6 = gate_type == DS4_METAL_TENSOR_Q6_K;
+        const BOOL gate_pair_iq4xs = gate_type == DS4_METAL_TENSOR_IQ4_XS;
         const BOOL down_scalar_q2 = down_type == DS4_METAL_TENSOR_Q2_K;
         const BOOL down_simd_q3 = down_type == DS4_METAL_TENSOR_Q3_K;
         const BOOL down_scalar_q4 = down_type == DS4_METAL_TENSOR_Q4_K;
         const BOOL down_simd_q4 = down_scalar_q4;
         const BOOL down_simd_q5 = down_type == DS4_METAL_TENSOR_Q5_K;
         const BOOL down_simd_q6 = down_type == DS4_METAL_TENSOR_Q6_K;
+        const BOOL down_iq4xs = down_type == DS4_METAL_TENSOR_IQ4_XS;
         const BOOL down_simd =
-            down_simd_q3 || down_simd_q4 || down_simd_q5 || down_simd_q6;
+            down_simd_q3 || down_simd_q4 || down_simd_q5 || down_simd_q6 ||
+            down_iq4xs;
         const BOOL stream_addr_q2 =
             gate_pair_q2 && down_scalar_q2 &&
             g_glm_q2_k_addr_pair_swiglu2_f32_pipeline != nil &&
@@ -34983,6 +35036,12 @@ int ds4_gpu_glm_routed_moe_one_tensor(
              gate_pair_q5 ?
              ds4_gpu_hot_pipeline(g_glm_q5_k_pair_swiglu_f32_pipeline,
                                   "kernel_glm_q5_K_pair_swiglu_f32") :
+             gate_pair_q6 ?
+             ds4_gpu_hot_pipeline(g_glm_q6_k_pair_swiglu_f32_pipeline,
+                                  "kernel_glm_q6_K_pair_swiglu_f32") :
+             gate_pair_iq4xs ?
+             ds4_gpu_hot_pipeline(g_glm_iq4_xs_pair_swiglu_f32_pipeline,
+                                  "kernel_glm_iq4_xs_pair_swiglu_f32") :
              ds4_gpu_hot_pipeline(g_glm_q4_k_pair_swiglu2_f32_pipeline,
                                   "kernel_glm_q4_K_pair_swiglu2_f32"));
         id<MTLComputePipelineState> down_pipeline =
@@ -35001,6 +35060,9 @@ int ds4_gpu_glm_routed_moe_one_tensor(
              down_scalar_q4 ?
              ds4_gpu_hot_pipeline(g_glm_q4_k_down_f32_pipeline,
                                   "kernel_glm_q4_K_down_f32") :
+             down_iq4xs ?
+             ds4_gpu_hot_pipeline(g_glm_iq4_xs_down_f32_pipeline,
+                                  "kernel_glm_iq4_xs_down_f32") :
              down_simd_q5 ?
              ds4_gpu_hot_pipeline(g_glm_q5_k_down_f32_pipeline,
                                   "kernel_glm_q5_K_down_f32") :
@@ -35026,7 +35088,9 @@ int ds4_gpu_glm_routed_moe_one_tensor(
                             "q4_stream_addr_swiglu") :
             gate_pair_q2 ? "q2_scalar_swiglu" :
             gate_pair_q3 ? "q3_pair_simd_swiglu" :
-            gate_pair_q5 ? "q5_pair_simd_swiglu" : "q4_pair2_simd_swiglu";
+            gate_pair_q5 ? "q5_pair_simd_swiglu" :
+            gate_pair_q6 ? "q6_pair_simd_swiglu" :
+            gate_pair_iq4xs ? "iq4_xs_pair_simd_swiglu" : "q4_pair2_simd_swiglu";
         const char *glm_down_path =
             use_stream_expert_addr_table ?
             (down_scalar_q2 ? "q2_stream_addr_down" :
@@ -35034,6 +35098,7 @@ int ds4_gpu_glm_routed_moe_one_tensor(
             down_scalar_q2 ? "q2_down_simd" :
             down_simd_q3 ? "q3_down_simd" :
             down_scalar_q4 ? "q4_down_simd" :
+            down_iq4xs ? "iq4_xs_down_simd" :
             down_simd_q5 ? "q5_down_simd" : "q6_down_simd";
         double glm_moe_stage_t0 = 0.0;
         if (glm_moe_stage_profile) {
@@ -35101,6 +35166,8 @@ int ds4_gpu_glm_routed_moe_one_tensor(
                             (NSUInteger)((expert_mid_dim + 7u) / 8u)) :
             gate_pair_q3 ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             gate_pair_q5 ? (NSUInteger)((expert_mid_dim + 7u) / 8u) :
+            gate_pair_q6 ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
+            gate_pair_iq4xs ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             use_stream_expert_addr_table ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             (NSUInteger)((expert_mid_dim + 1u) / 2u);
         const NSUInteger pair_threadgroup_bytes = 0u;
@@ -35111,6 +35178,7 @@ int ds4_gpu_glm_routed_moe_one_tensor(
             down_simd_q4 ? (NSUInteger)((out_dim + 3u) / 4u) :
             down_simd_q5 ? (NSUInteger)((out_dim + 3u) / 4u) :
             down_simd_q6 ? (NSUInteger)((out_dim + 3u) / 4u) :
+            down_iq4xs ? (NSUInteger)((out_dim + 3u) / 4u) :
             (NSUInteger)out_dim;
         const NSUInteger down_threadgroup_bytes =
             (down_scalar_q2 || down_simd) ? 0u : 256u * sizeof(float);
@@ -36361,14 +36429,18 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
         const BOOL gate_pair_q2 = gate_type == DS4_METAL_TENSOR_Q2_K;
         const BOOL gate_pair_q3 = gate_type == DS4_METAL_TENSOR_Q3_K;
         const BOOL gate_pair_q5 = gate_type == DS4_METAL_TENSOR_Q5_K;
+        const BOOL gate_pair_q6 = gate_type == DS4_METAL_TENSOR_Q6_K;
+        const BOOL gate_pair_iq4xs = gate_type == DS4_METAL_TENSOR_IQ4_XS;
         const BOOL down_scalar_q2 = down_type == DS4_METAL_TENSOR_Q2_K;
         const BOOL down_simd_q3 = down_type == DS4_METAL_TENSOR_Q3_K;
         const BOOL down_scalar_q4 = down_type == DS4_METAL_TENSOR_Q4_K;
         const BOOL down_simd_q4 = down_scalar_q4;
         const BOOL down_simd_q5 = down_type == DS4_METAL_TENSOR_Q5_K;
         const BOOL down_simd_q6 = down_type == DS4_METAL_TENSOR_Q6_K;
+        const BOOL down_iq4xs = down_type == DS4_METAL_TENSOR_IQ4_XS;
         const BOOL down_simd =
-            down_simd_q3 || down_simd_q4 || down_simd_q5 || down_simd_q6;
+            down_simd_q3 || down_simd_q4 || down_simd_q5 || down_simd_q6 ||
+            down_iq4xs;
         const BOOL stream_addr_q2 =
             gate_pair_q2 && down_scalar_q2 &&
             g_glm_q2_k_addr_pair_swiglu2_f32_pipeline != nil &&
@@ -36421,6 +36493,12 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
             gate_pair_q5 ?
              ds4_gpu_hot_pipeline(g_glm_q5_k_pair_swiglu_f32_pipeline,
                                   "kernel_glm_q5_K_pair_swiglu_f32") :
+            gate_pair_q6 ?
+             ds4_gpu_hot_pipeline(g_glm_q6_k_pair_swiglu_f32_pipeline,
+                                  "kernel_glm_q6_K_pair_swiglu_f32") :
+            gate_pair_iq4xs ?
+             ds4_gpu_hot_pipeline(g_glm_iq4_xs_pair_swiglu_f32_pipeline,
+                                  "kernel_glm_iq4_xs_pair_swiglu_f32") :
             (q4_scalar_pair ?
              ds4_gpu_hot_pipeline(g_glm_q4_k_pair_swiglu_f32_pipeline,
                                   "kernel_glm_q4_K_pair_swiglu_f32") :
@@ -36445,6 +36523,9 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
             down_scalar_q4 ?
             ds4_gpu_hot_pipeline(g_glm_q4_k_down_f32_pipeline,
                                  "kernel_glm_q4_K_down_f32") :
+            down_iq4xs ?
+            ds4_gpu_hot_pipeline(g_glm_iq4_xs_down_f32_pipeline,
+                                 "kernel_glm_iq4_xs_down_f32") :
             down_simd_q5 ?
             ds4_gpu_hot_pipeline(g_glm_q5_k_down_f32_pipeline,
                                  "kernel_glm_q5_K_down_f32") :
@@ -36546,6 +36627,8 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
                                     gate_pair_q2 ? "q2_scalar_swiglu" :
                                     gate_pair_q3 ? "q3_pair_simd_swiglu" :
                                     gate_pair_q5 ? "q5_pair_simd_swiglu" :
+                                    gate_pair_q6 ? "q6_pair_simd_swiglu" :
+                                    gate_pair_iq4xs ? "iq4_xs_pair_simd_swiglu" :
                                     (q4_scalar_pair ? "q4_scalar_swiglu" :
                                     (q4_pair2 ? "q4_pair2_simd_swiglu" :
                                                 "q4_pair4_simd_swiglu"));
@@ -36555,6 +36638,7 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
             down_scalar_q2 ? "q2_down_scalar" :
             down_simd_q3 ? "q3_down_simd" :
             down_scalar_q4 ? "q4_down_simd" :
+            down_iq4xs ? "iq4_xs_down_simd" :
             down_simd_q5 ? "q5_down_simd" : "q6_down_simd";
         double glm_moe_stage_t0 = 0.0;
         if (glm_moe_stage_profile) {
@@ -36622,6 +36706,8 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
                             (NSUInteger)((expert_mid_dim + 7u) / 8u)) :
             gate_pair_q3 ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             gate_pair_q5 ? (NSUInteger)((expert_mid_dim + 7u) / 8u) :
+            gate_pair_q6 ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
+            gate_pair_iq4xs ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             use_stream_expert_addr_table ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             q4_scalar_pair ? (NSUInteger)expert_mid_dim :
             q4_pair2 ? (NSUInteger)((expert_mid_dim + 1u) / 2u) :
@@ -36636,6 +36722,7 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
             down_simd_q4 ? (NSUInteger)((out_dim + 3u) / 4u) :
             down_simd_q5 ? (NSUInteger)((out_dim + 3u) / 4u) :
             down_simd_q6 ? (NSUInteger)((out_dim + 3u) / 4u) :
+            down_iq4xs ? (NSUInteger)((out_dim + 3u) / 4u) :
             (NSUInteger)out_dim;
         const NSUInteger down_threadgroup_bytes =
             down_simd ? 0u : 256u * sizeof(float);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -17336,10 +17336,47 @@ int ds4_gpu_matmul_q6_K_tensor(
                                                        weight_offset,
                                                        weight_bytes,
                                                        &inner_offset);
+        if (!xbuf || !outbuf || !wbuf) return 0;
+
+        /* Batched tokens: use the tiled GEMM so weight tiles are reused
+         * across the token dimension.  The QMV below re-reads the entire
+         * weight matrix once per token, which dominates APEX q6_k attention
+         * prefill cost. */
+        if (n_tok >= 32u) {
+            const bool bc_inp = (in_dim % 32u) != 0;
+            const bool bc_out = (out_dim % 64u) != 0 || (n_tok % 32u) != 0;
+            id<MTLComputePipelineState> mm_pipeline =
+                ds4_gpu_get_mul_mm_pipeline("kernel_mul_mm_q6_K_f32", bc_inp, bc_out);
+            if (mm_pipeline) {
+                ds4_gpu_mul_mm_args mm_args =
+                    ds4_gpu_make_mm_args(in_dim, out_dim, n_tok, row_bytes);
+                int owned = 0;
+                id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
+                if (!cb) return 0;
+                id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
+                [enc setComputePipelineState:mm_pipeline];
+                [enc setBytes:&mm_args length:sizeof(mm_args) atIndex:0];
+                [enc setBuffer:wbuf offset:(NSUInteger)inner_offset atIndex:1];
+                [enc setBuffer:xbuf offset:ds4_gpu_tensor_offset(x) atIndex:2];
+                [enc setBuffer:outbuf offset:ds4_gpu_tensor_offset(out) atIndex:3];
+                [enc setThreadgroupMemoryLength:(bc_out ? 8192u : 6144u) atIndex:0];
+                [enc dispatchThreadgroups:MTLSizeMake(((NSUInteger)n_tok + 31u) / 32u,
+                                                      ((NSUInteger)out_dim + 63u) / 64u,
+                                                      1)
+                     threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+                ds4_gpu_end_compute_encoder(cb, enc);
+                if (!ds4_gpu_finish_command_buffer(cb, owned, "Q6_K tensor matmul")) {
+                    return 0;
+                }
+                return 1;
+            }
+            /* fall through to the QMV if the GEMM pipeline is unavailable */
+        }
+
         id<MTLComputePipelineState> pipeline = ds4_gpu_hot_pipeline(
             g_laguna_q6_k_matmul_pipeline,
             "kernel_laguna_q6_K_matmul_f32");
-        if (!xbuf || !outbuf || !wbuf || !pipeline) return 0;
+        if (!pipeline) return 0;
 
         ds4_gpu_laguna_q6_matmul_args args = {
             .in_dim = (uint32_t)in_dim,

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -17338,6 +17338,88 @@ int ds4_gpu_matmul_q6_K_tensor(
                                                        &inner_offset);
         if (!xbuf || !outbuf || !wbuf) return 0;
 
+        /* Batched tokens on Metal-4 hardware: the MPP direct-RHS GEMM (the
+         * same fast path dense q8_0/q4_K prefill uses).  Real prompt lengths
+         * are rarely 32-aligned, so run NAX on the aligned token prefix and
+         * finish the <=31-token remainder with the plain tiled GEMM in the
+         * same command buffer.  Falls through entirely on shape mismatch or
+         * older devices. */
+        const uint64_t nax_aligned = n_tok & ~(uint64_t)31u;
+        if (ds4_gpu_mpp_available() &&
+            nax_aligned >= 32u &&
+            (in_dim % 64u) == 0 &&
+            (out_dim % 64u) == 0) {
+            uint64_t nax_tile_n = 32u;
+            if ((nax_aligned % 128u) == 0) {
+                nax_tile_n = 128u;
+            } else if ((nax_aligned % 64u) == 0) {
+                nax_tile_n = 64u;
+            }
+            const char *nax_fn = nax_tile_n == 128u
+                ? "kernel_mul_mm_q6_K_f32_nax_direct_rhs_n128"
+                : (nax_tile_n == 64u
+                    ? "kernel_mul_mm_q6_K_f32_nax_direct_rhs_n64"
+                    : "kernel_mul_mm_q6_K_f32_nax_direct_rhs");
+            id<MTLComputePipelineState> nax_pipeline =
+                ds4_gpu_get_mul_mm_pipeline(nax_fn, false, false);
+            const uint64_t nax_rem = n_tok - nax_aligned;
+            id<MTLComputePipelineState> rem_pipeline = nil;
+            if (nax_pipeline && nax_rem != 0) {
+                const bool rem_bc_out = true;   /* nax_rem < 32 */
+                rem_pipeline = ds4_gpu_get_mul_mm_pipeline(
+                    "kernel_mul_mm_q6_K_f32", (in_dim % 32u) != 0, rem_bc_out);
+                if (!rem_pipeline) nax_pipeline = nil;   /* all-or-nothing */
+            }
+            if (nax_pipeline) {
+                int owned = 0;
+                id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
+                if (!cb) return 0;
+
+                ds4_gpu_mul_mm_args nax_args =
+                    ds4_gpu_make_mm_args(in_dim, out_dim, nax_aligned, row_bytes);
+                id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
+                [enc setComputePipelineState:nax_pipeline];
+                [enc setBytes:&nax_args length:sizeof(nax_args) atIndex:0];
+                [enc setBuffer:wbuf offset:(NSUInteger)inner_offset atIndex:1];
+                [enc setBuffer:xbuf offset:ds4_gpu_tensor_offset(x) atIndex:2];
+                [enc setBuffer:outbuf offset:ds4_gpu_tensor_offset(out) atIndex:3];
+                [enc setThreadgroupMemoryLength:2u * 64u * 32u * sizeof(uint16_t) atIndex:0];
+                [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(nax_aligned / nax_tile_n),
+                                                      (NSUInteger)out_dim / 64u,
+                                                      1)
+                     threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+                ds4_gpu_end_compute_encoder(cb, enc);
+
+                if (nax_rem != 0) {
+                    ds4_gpu_mul_mm_args rem_args =
+                        ds4_gpu_make_mm_args(in_dim, out_dim, nax_rem, row_bytes);
+                    id<MTLComputeCommandEncoder> renc = ds4_gpu_compute_encoder(cb);
+                    [renc setComputePipelineState:rem_pipeline];
+                    [renc setBytes:&rem_args length:sizeof(rem_args) atIndex:0];
+                    [renc setBuffer:wbuf offset:(NSUInteger)inner_offset atIndex:1];
+                    [renc setBuffer:xbuf
+                             offset:ds4_gpu_tensor_offset(x) +
+                                    (NSUInteger)(nax_aligned * in_dim * sizeof(float))
+                            atIndex:2];
+                    [renc setBuffer:outbuf
+                             offset:ds4_gpu_tensor_offset(out) +
+                                    (NSUInteger)(nax_aligned * out_dim * sizeof(float))
+                            atIndex:3];
+                    [renc setThreadgroupMemoryLength:8192u atIndex:0];
+                    [renc dispatchThreadgroups:MTLSizeMake(((NSUInteger)nax_rem + 31u) / 32u,
+                                                           ((NSUInteger)out_dim + 63u) / 64u,
+                                                           1)
+                          threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+                    ds4_gpu_end_compute_encoder(cb, renc);
+                }
+
+                if (!ds4_gpu_finish_command_buffer(cb, owned, "Q6_K NAX tensor matmul")) {
+                    return 0;
+                }
+                return 1;
+            }
+        }
+
         /* Batched tokens: use the tiled GEMM so weight tiles are reused
          * across the token dimension.  The QMV below re-reads the entire
          * weight matrix once per token, which dominates APEX q6_k attention

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -42,6 +42,7 @@ enum {
     DS4_METAL_TENSOR_Q5_K    = 13,
     DS4_METAL_TENSOR_Q6_K    = 14,
     DS4_METAL_TENSOR_IQ4_XS  = 23,
+    DS4_METAL_TENSOR_BF16    = 30,
     DS4_METAL_TENSOR_Q8_K    = 15,
     DS4_METAL_TENSOR_IQ2_XXS = 16,
 };
@@ -235,6 +236,8 @@ static id<MTLComputePipelineState> g_glm_q6_k_down_f32_pipeline;
 static id<MTLComputePipelineState> g_glm_q6_k_pair_swiglu_f32_pipeline;
 static id<MTLComputePipelineState> g_glm_iq4_xs_pair_swiglu_f32_pipeline;
 static id<MTLComputePipelineState> g_glm_iq4_xs_down_f32_pipeline;
+static id<MTLComputePipelineState> g_glm_bf16_pair_swiglu_f32_pipeline;
+static id<MTLComputePipelineState> g_glm_bf16_down_f32_pipeline;
 static id<MTLComputePipelineState> g_laguna_routed_shared_pair_pipeline;
 static id<MTLComputePipelineState> g_laguna_routed_shared_q4_down_pipeline;
 static id<MTLComputePipelineState> g_laguna_routed_shared_q6_down_pipeline;
@@ -7974,6 +7977,10 @@ int ds4_gpu_init(void) {
             ds4_gpu_get_pipeline("kernel_glm_iq4_xs_pair_swiglu_f32");
         g_glm_iq4_xs_down_f32_pipeline =
             ds4_gpu_get_pipeline("kernel_glm_iq4_xs_down_f32");
+        g_glm_bf16_pair_swiglu_f32_pipeline =
+            ds4_gpu_get_pipeline("kernel_glm_bf16_pair_swiglu_f32");
+        g_glm_bf16_down_f32_pipeline =
+            ds4_gpu_get_pipeline("kernel_glm_bf16_down_f32");
         g_laguna_routed_shared_pair_pipeline =
             ds4_gpu_get_pipeline(
                 "kernel_laguna_q4_K_routed_shared_pair_swiglu_f32");
@@ -8075,6 +8082,8 @@ int ds4_gpu_init(void) {
             !g_glm_q6_k_pair_swiglu_f32_pipeline ||
             !g_glm_iq4_xs_pair_swiglu_f32_pipeline ||
             !g_glm_iq4_xs_down_f32_pipeline ||
+            !g_glm_bf16_pair_swiglu_f32_pipeline ||
+            !g_glm_bf16_down_f32_pipeline ||
             !g_laguna_routed_shared_pair_pipeline ||
             !g_laguna_routed_shared_q4_down_pipeline ||
             !g_laguna_routed_shared_q6_down_pipeline ||
@@ -9475,6 +9484,8 @@ void ds4_gpu_cleanup(void) {
         g_glm_q6_k_pair_swiglu_f32_pipeline = nil;
         g_glm_iq4_xs_pair_swiglu_f32_pipeline = nil;
         g_glm_iq4_xs_down_f32_pipeline = nil;
+        g_glm_bf16_pair_swiglu_f32_pipeline = nil;
+        g_glm_bf16_down_f32_pipeline = nil;
         g_glm_q5_k_pair_swiglu_mapped_f32_pipeline = nil;
         g_glm_q5_k_pair_swiglu_mapped_row_f32_pipeline = nil;
         g_glm_q5_k_down_f32_pipeline = nil;
@@ -27339,6 +27350,8 @@ static id<MTLComputePipelineState> ds4_gpu_routed_mm_pipeline(uint32_t type) {
         return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_q6_K_f32", false);
     case DS4_METAL_TENSOR_IQ4_XS:
         return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_iq4_xs_f32", false);
+    case DS4_METAL_TENSOR_BF16:
+        return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_bf16_f32", false);
     default:
         return nil;
     }
@@ -27375,6 +27388,8 @@ static id<MTLComputePipelineState> ds4_gpu_routed_mm_f16_rhs_pipeline(uint32_t t
         return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_q6_K_f16", false);
     case DS4_METAL_TENSOR_IQ4_XS:
         return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_iq4_xs_f16", false);
+    case DS4_METAL_TENSOR_BF16:
+        return ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_bf16_f16", false);
     default:
         return nil;
     }
@@ -34745,7 +34760,8 @@ static bool ds4_gpu_glm_gate_pair_type_supported(
             gate_type == DS4_METAL_TENSOR_Q4_K ||
             gate_type == DS4_METAL_TENSOR_Q5_K ||
             gate_type == DS4_METAL_TENSOR_Q6_K ||
-            gate_type == DS4_METAL_TENSOR_IQ4_XS);
+            gate_type == DS4_METAL_TENSOR_IQ4_XS ||
+            gate_type == DS4_METAL_TENSOR_BF16);
 }
 
 static bool ds4_gpu_glm_down_type_supported(uint32_t down_type) {
@@ -34754,7 +34770,8 @@ static bool ds4_gpu_glm_down_type_supported(uint32_t down_type) {
            down_type == DS4_METAL_TENSOR_Q4_K ||
            down_type == DS4_METAL_TENSOR_Q5_K ||
            down_type == DS4_METAL_TENSOR_Q6_K ||
-           down_type == DS4_METAL_TENSOR_IQ4_XS;
+           down_type == DS4_METAL_TENSOR_IQ4_XS ||
+           down_type == DS4_METAL_TENSOR_BF16;
 }
 
 int ds4_gpu_glm_routed_moe_one_tensor(
@@ -34863,6 +34880,7 @@ int ds4_gpu_glm_routed_moe_one_tensor(
         const BOOL gate_pair_q5 = gate_type == DS4_METAL_TENSOR_Q5_K;
         const BOOL gate_pair_q6 = gate_type == DS4_METAL_TENSOR_Q6_K;
         const BOOL gate_pair_iq4xs = gate_type == DS4_METAL_TENSOR_IQ4_XS;
+        const BOOL gate_pair_bf16 = gate_type == DS4_METAL_TENSOR_BF16;
         const BOOL down_scalar_q2 = down_type == DS4_METAL_TENSOR_Q2_K;
         const BOOL down_simd_q3 = down_type == DS4_METAL_TENSOR_Q3_K;
         const BOOL down_scalar_q4 = down_type == DS4_METAL_TENSOR_Q4_K;
@@ -34870,9 +34888,10 @@ int ds4_gpu_glm_routed_moe_one_tensor(
         const BOOL down_simd_q5 = down_type == DS4_METAL_TENSOR_Q5_K;
         const BOOL down_simd_q6 = down_type == DS4_METAL_TENSOR_Q6_K;
         const BOOL down_iq4xs = down_type == DS4_METAL_TENSOR_IQ4_XS;
+        const BOOL down_bf16 = down_type == DS4_METAL_TENSOR_BF16;
         const BOOL down_simd =
             down_simd_q3 || down_simd_q4 || down_simd_q5 || down_simd_q6 ||
-            down_iq4xs;
+            down_iq4xs || down_bf16;
         const BOOL stream_addr_q2 =
             gate_pair_q2 && down_scalar_q2 &&
             g_glm_q2_k_addr_pair_swiglu2_f32_pipeline != nil &&
@@ -35161,6 +35180,12 @@ int ds4_gpu_glm_routed_moe_one_tensor(
              gate_pair_iq4xs ?
              ds4_gpu_hot_pipeline(g_glm_iq4_xs_pair_swiglu_f32_pipeline,
                                   "kernel_glm_iq4_xs_pair_swiglu_f32") :
+            gate_pair_bf16 ?
+             ds4_gpu_hot_pipeline(g_glm_bf16_pair_swiglu_f32_pipeline,
+                                  "kernel_glm_bf16_pair_swiglu_f32") :
+             gate_pair_bf16 ?
+             ds4_gpu_hot_pipeline(g_glm_bf16_pair_swiglu_f32_pipeline,
+                                  "kernel_glm_bf16_pair_swiglu_f32") :
              ds4_gpu_hot_pipeline(g_glm_q4_k_pair_swiglu2_f32_pipeline,
                                   "kernel_glm_q4_K_pair_swiglu2_f32"));
         id<MTLComputePipelineState> down_pipeline =
@@ -35182,6 +35207,9 @@ int ds4_gpu_glm_routed_moe_one_tensor(
              down_iq4xs ?
              ds4_gpu_hot_pipeline(g_glm_iq4_xs_down_f32_pipeline,
                                   "kernel_glm_iq4_xs_down_f32") :
+             down_bf16 ?
+             ds4_gpu_hot_pipeline(g_glm_bf16_down_f32_pipeline,
+                                  "kernel_glm_bf16_down_f32") :
              down_simd_q5 ?
              ds4_gpu_hot_pipeline(g_glm_q5_k_down_f32_pipeline,
                                   "kernel_glm_q5_K_down_f32") :
@@ -35209,7 +35237,8 @@ int ds4_gpu_glm_routed_moe_one_tensor(
             gate_pair_q3 ? "q3_pair_simd_swiglu" :
             gate_pair_q5 ? "q5_pair_simd_swiglu" :
             gate_pair_q6 ? "q6_pair_simd_swiglu" :
-            gate_pair_iq4xs ? "iq4_xs_pair_simd_swiglu" : "q4_pair2_simd_swiglu";
+            gate_pair_iq4xs ? "iq4_xs_pair_simd_swiglu" :
+            gate_pair_bf16 ? "bf16_pair_simd_swiglu" : "q4_pair2_simd_swiglu";
         const char *glm_down_path =
             use_stream_expert_addr_table ?
             (down_scalar_q2 ? "q2_stream_addr_down" :
@@ -35218,6 +35247,7 @@ int ds4_gpu_glm_routed_moe_one_tensor(
             down_simd_q3 ? "q3_down_simd" :
             down_scalar_q4 ? "q4_down_simd" :
             down_iq4xs ? "iq4_xs_down_simd" :
+            down_bf16 ? "bf16_down_simd" :
             down_simd_q5 ? "q5_down_simd" : "q6_down_simd";
         double glm_moe_stage_t0 = 0.0;
         if (glm_moe_stage_profile) {
@@ -35287,6 +35317,7 @@ int ds4_gpu_glm_routed_moe_one_tensor(
             gate_pair_q5 ? (NSUInteger)((expert_mid_dim + 7u) / 8u) :
             gate_pair_q6 ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             gate_pair_iq4xs ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
+            gate_pair_bf16 ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             use_stream_expert_addr_table ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             (NSUInteger)((expert_mid_dim + 1u) / 2u);
         const NSUInteger pair_threadgroup_bytes = 0u;
@@ -35298,6 +35329,7 @@ int ds4_gpu_glm_routed_moe_one_tensor(
             down_simd_q5 ? (NSUInteger)((out_dim + 3u) / 4u) :
             down_simd_q6 ? (NSUInteger)((out_dim + 3u) / 4u) :
             down_iq4xs ? (NSUInteger)((out_dim + 3u) / 4u) :
+            down_bf16 ? (NSUInteger)((out_dim + 3u) / 4u) :
             (NSUInteger)out_dim;
         const NSUInteger down_threadgroup_bytes =
             (down_scalar_q2 || down_simd) ? 0u : 256u * sizeof(float);
@@ -36550,6 +36582,7 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
         const BOOL gate_pair_q5 = gate_type == DS4_METAL_TENSOR_Q5_K;
         const BOOL gate_pair_q6 = gate_type == DS4_METAL_TENSOR_Q6_K;
         const BOOL gate_pair_iq4xs = gate_type == DS4_METAL_TENSOR_IQ4_XS;
+        const BOOL gate_pair_bf16 = gate_type == DS4_METAL_TENSOR_BF16;
         const BOOL down_scalar_q2 = down_type == DS4_METAL_TENSOR_Q2_K;
         const BOOL down_simd_q3 = down_type == DS4_METAL_TENSOR_Q3_K;
         const BOOL down_scalar_q4 = down_type == DS4_METAL_TENSOR_Q4_K;
@@ -36557,9 +36590,10 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
         const BOOL down_simd_q5 = down_type == DS4_METAL_TENSOR_Q5_K;
         const BOOL down_simd_q6 = down_type == DS4_METAL_TENSOR_Q6_K;
         const BOOL down_iq4xs = down_type == DS4_METAL_TENSOR_IQ4_XS;
+        const BOOL down_bf16 = down_type == DS4_METAL_TENSOR_BF16;
         const BOOL down_simd =
             down_simd_q3 || down_simd_q4 || down_simd_q5 || down_simd_q6 ||
-            down_iq4xs;
+            down_iq4xs || down_bf16;
         const BOOL stream_addr_q2 =
             gate_pair_q2 && down_scalar_q2 &&
             g_glm_q2_k_addr_pair_swiglu2_f32_pipeline != nil &&
@@ -36618,6 +36652,9 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
             gate_pair_iq4xs ?
              ds4_gpu_hot_pipeline(g_glm_iq4_xs_pair_swiglu_f32_pipeline,
                                   "kernel_glm_iq4_xs_pair_swiglu_f32") :
+            gate_pair_bf16 ?
+             ds4_gpu_hot_pipeline(g_glm_bf16_pair_swiglu_f32_pipeline,
+                                  "kernel_glm_bf16_pair_swiglu_f32") :
             (q4_scalar_pair ?
              ds4_gpu_hot_pipeline(g_glm_q4_k_pair_swiglu_f32_pipeline,
                                   "kernel_glm_q4_K_pair_swiglu_f32") :
@@ -36645,6 +36682,9 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
             down_iq4xs ?
             ds4_gpu_hot_pipeline(g_glm_iq4_xs_down_f32_pipeline,
                                  "kernel_glm_iq4_xs_down_f32") :
+            down_bf16 ?
+            ds4_gpu_hot_pipeline(g_glm_bf16_down_f32_pipeline,
+                                 "kernel_glm_bf16_down_f32") :
             down_simd_q5 ?
             ds4_gpu_hot_pipeline(g_glm_q5_k_down_f32_pipeline,
                                  "kernel_glm_q5_K_down_f32") :
@@ -36748,6 +36788,7 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
                                     gate_pair_q5 ? "q5_pair_simd_swiglu" :
                                     gate_pair_q6 ? "q6_pair_simd_swiglu" :
                                     gate_pair_iq4xs ? "iq4_xs_pair_simd_swiglu" :
+                                    gate_pair_bf16 ? "bf16_pair_simd_swiglu" :
                                     (q4_scalar_pair ? "q4_scalar_swiglu" :
                                     (q4_pair2 ? "q4_pair2_simd_swiglu" :
                                                 "q4_pair4_simd_swiglu"));
@@ -36758,6 +36799,7 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
             down_simd_q3 ? "q3_down_simd" :
             down_scalar_q4 ? "q4_down_simd" :
             down_iq4xs ? "iq4_xs_down_simd" :
+            down_bf16 ? "bf16_down_simd" :
             down_simd_q5 ? "q5_down_simd" : "q6_down_simd";
         double glm_moe_stage_t0 = 0.0;
         if (glm_moe_stage_profile) {
@@ -36827,6 +36869,7 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
             gate_pair_q5 ? (NSUInteger)((expert_mid_dim + 7u) / 8u) :
             gate_pair_q6 ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             gate_pair_iq4xs ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
+            gate_pair_bf16 ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             use_stream_expert_addr_table ? (NSUInteger)((expert_mid_dim + 3u) / 4u) :
             q4_scalar_pair ? (NSUInteger)expert_mid_dim :
             q4_pair2 ? (NSUInteger)((expert_mid_dim + 1u) / 2u) :
@@ -36842,6 +36885,7 @@ static int ds4_gpu_glm_routed_moe_batch_tensor_impl(
             down_simd_q5 ? (NSUInteger)((out_dim + 3u) / 4u) :
             down_simd_q6 ? (NSUInteger)((out_dim + 3u) / 4u) :
             down_iq4xs ? (NSUInteger)((out_dim + 3u) / 4u) :
+            down_bf16 ? (NSUInteger)((out_dim + 3u) / 4u) :
             (NSUInteger)out_dim;
         const NSUInteger down_threadgroup_bytes =
             down_simd ? 0u : 256u * sizeof(float);

--- a/metal/get_rows.metal
+++ b/metal/get_rows.metal
@@ -147,6 +147,55 @@ kernel void kernel_get_rows_q4_0_f32(
     }
 }
 
+struct ds4_get_rows_block_q6_K {
+    uchar ql[128];
+    uchar qh[64];
+    char  scales[16];
+    half  d;
+};
+
+kernel void kernel_get_rows_q6_K_f32(
+        constant ds4_metal_args_get_rows_q8_0 & args,
+        device const char    * src0,
+        device const char    * src1,
+        device       char    * dst,
+        uint3                  tgpig[[threadgroup_position_in_grid]],
+        ushort                 tiitg[[thread_index_in_threadgroup]],
+        ushort3                ntg [[threads_per_threadgroup]]) {
+    const int32_t block = (int32_t)tgpig.x;
+    const int32_t tok_i = (int32_t)tgpig.y;
+    if (tok_i >= args.n_tokens) return;
+
+    const int32_t token =
+        ((const device int32_t *)(src1 + (uint64_t)tok_i * args.token_stride))[0];
+    if (token < 0 || token >= args.n_vocab) return;
+
+    const device ds4_get_rows_block_q6_K *row =
+        (const device ds4_get_rows_block_q6_K *)(src0 + (uint64_t)token * args.src_row_bytes);
+    const device ds4_get_rows_block_q6_K *qb = row + block;
+    device float *out =
+        (device float *)(dst + (uint64_t)tok_i * args.dst_row_bytes);
+
+    const int32_t i0 = block * 256;
+    const float d = (float)qb->d;
+    for (int32_t i = (int32_t)tiitg; i < 256; i += (int32_t)ntg.x) {
+        const int32_t idx = i0 + i;
+        if (idx < args.n_embd) {
+            const uint half128 = (uint)i >> 7u;         /* which 128-elem half */
+            const uint pos = (uint)i & 127u;
+            const uint quarter = pos >> 5u;
+            const uint l = pos & 31u;
+            const uint ql_idx = half128 * 64u + ((quarter & 1u) ? 32u : 0u) + l;
+            const uint nib = (quarter < 2u)
+                ? ((uint)qb->ql[ql_idx] & 0x0Fu)
+                : ((uint)qb->ql[ql_idx] >> 4u);
+            const uint hb = ((uint)qb->qh[half128 * 32u + l] >> (2u * quarter)) & 3u;
+            const int v = (int)(nib | (hb << 4u)) - 32;
+            out[idx] = d * (float)((int)qb->scales[(uint)i >> 4u]) * (float)v;
+        }
+    }
+}
+
 kernel void kernel_get_rows_q4_K_f32(
         constant ds4_metal_args_get_rows_q8_0 & args,
         device const char    * src0,

--- a/metal/moe.metal
+++ b/metal/moe.metal
@@ -11,6 +11,9 @@
 #define N_R0_GLM_Q4_PAIR2_K 1
 #define N_R0_GLM_Q4_PAIR_K 4
 #define N_R0_Q5_PAIR_K 4
+#define N_R0_IQ4_XS_PAIR 2
+#define N_R0_IQ4_XS_DOWN 2
+#define N_R0_Q6_PAIR_K 2
 #define N_R0_Q5_K 4
 #define N_R0_Q6_K 2
 #define N_R0_IQ2_XXS 4
@@ -141,6 +144,29 @@ struct block_iq2_xxs {
     half d;
     ushort qs[QK_K/8];
 };
+
+/* IQ4_XS (llama.cpp layout): 8 sub-blocks of 32; 6-bit sub-block scales split
+ * across scales_l nibbles (low 4) and scales_h 2-bit pairs (high 2), applied
+ * as (scale - 32) x the f16 super scale; 4-bit elems index a non-linear
+ * codebook. */
+struct block_iq4_xs {
+    half   d;
+    ushort scales_h;
+    uchar  scales_l[QK_K/64];
+    uchar  qs[QK_K/2];
+};
+
+constant static const float ds4_kvalues_iq4nl_f[16] = {
+    -127.0f, -104.0f, -83.0f, -65.0f, -49.0f, -35.0f, -22.0f, -10.0f,
+       1.0f,   13.0f,  25.0f,  38.0f,  53.0f,  69.0f,  89.0f, 113.0f,
+};
+
+static inline float ds4_iq4_xs_subblock_scale(
+        device const block_iq4_xs *xb, short ib) {
+    const int ls = ((xb->scales_l[ib / 2] >> (4 * (ib & 1))) & 0x0F) |
+                   (((xb->scales_h >> (2 * ib)) & 3) << 4);
+    return (float)xb->d * (float)(ls - 32);
+}
 
 struct ds4_metal_glm_routed_moe_args {
     uint32_t in_dim;
@@ -2733,6 +2759,309 @@ kernel void kernel_glm_q6_K_down_f32(
         args, down, selected, mid, out, tgpig, tiisg, sgitg);
 }
 
+/* --- IQ4_XS routed experts (APEX Laguna) ---------------------------------
+ * Sub-block-per-thread QMV: tiisg = ix*8+it, ix strides blocks by 4, it picks
+ * the 32-element sub-block.  The codebook LUT stays in constant memory (a LUT
+ * inside a register-resident hot loop measured negative in the mlx.fast
+ * study, but iq4_xs has no arithmetic dequant alternative; constant-cache
+ * reads of a 64B table are the cheapest available form). */
+static inline void glm_iq4_xs_pair_swiglu_f32_impl(
+        constant ds4_metal_glm_routed_moe_args &args,
+        device const char *gate,
+        device const char *up,
+        device const float *x,
+        device const float *weights,
+        device float *mid,
+        uint3 tgpig,
+        uint slot,
+        uint token,
+        uint64_t selected_off,
+        int expert,
+        ushort tiisg,
+        ushort sgitg) {
+    const short NSG = 2;
+    const uint row0 = ((uint)tgpig.x * (uint)NSG + (uint)sgitg) * N_R0_IQ4_XS_PAIR;
+    if (row0 >= args.mid_dim || slot >= args.n_expert_used || token >= args.n_tokens) return;
+
+    const uint64_t mid_base = (uint64_t)token * args.mid_token_stride +
+                              (uint64_t)slot * args.mid_dim;
+    if (expert < 0 || (uint)expert >= args.n_total_expert) {
+        if (tiisg == 0u) {
+            for (short row = 0; row < N_R0_IQ4_XS_PAIR && row0 + (uint)row < args.mid_dim; row++) {
+                mid[mid_base + row0 + (uint)row] = 0.0f;
+            }
+        }
+        return;
+    }
+
+    const short ix = tiisg / 8;
+    const short it = tiisg % 8;
+    const int nb = args.in_dim / QK_K;
+
+    device const char *gate_base = gate + (uint64_t)(uint)expert * args.gate_expert_bytes;
+    device const char *up_base   = up + (uint64_t)(uint)expert * args.up_expert_bytes;
+    device const float *y = x + (uint64_t)token * args.in_dim;
+
+    float sumg[N_R0_IQ4_XS_PAIR] = {0.f};
+    float sumu[N_R0_IQ4_XS_PAIR] = {0.f};
+
+    for (int ib = ix; ib < nb; ib += 4) {
+        device const float *yb = y + (uint64_t)ib * QK_K + 32 * it;
+        float yl[16];
+        float yh[16];
+        for (short i = 0; i < 16; ++i) {
+            yl[i] = yb[i];
+            yh[i] = yb[i + 16];
+        }
+
+        for (short row = 0; row < N_R0_IQ4_XS_PAIR && row0 + (uint)row < args.mid_dim; row++) {
+            device const block_iq4_xs *g =
+                (device const block_iq4_xs *)(gate_base +
+                    (uint64_t)(row0 + (uint)row) * args.gate_row_bytes) + ib;
+            device const block_iq4_xs *u =
+                (device const block_iq4_xs *)(up_base +
+                    (uint64_t)(row0 + (uint)row) * args.up_row_bytes) + ib;
+            device const uchar *qg = g->qs + 16 * it;
+            device const uchar *qu = u->qs + 16 * it;
+            float accg = 0.f;
+            float accu = 0.f;
+            FOR_UNROLL (short j = 0; j < 16; ++j) {
+                accg += yl[j] * ds4_kvalues_iq4nl_f[qg[j] & 0x0F] +
+                        yh[j] * ds4_kvalues_iq4nl_f[qg[j] >> 4];
+                accu += yl[j] * ds4_kvalues_iq4nl_f[qu[j] & 0x0F] +
+                        yh[j] * ds4_kvalues_iq4nl_f[qu[j] >> 4];
+            }
+            sumg[row] += ds4_iq4_xs_subblock_scale(g, it) * accg;
+            sumu[row] += ds4_iq4_xs_subblock_scale(u, it) * accu;
+        }
+    }
+
+    for (short row = 0; row < N_R0_IQ4_XS_PAIR && row0 + (uint)row < args.mid_dim; row++) {
+        const float g = simd_sum(sumg[row]);
+        const float u = simd_sum(sumu[row]);
+        if (tiisg == 0u) {
+            const float sw = g / (1.0f + exp(-g));
+            mid[mid_base + row0 + (uint)row] = sw * u * weights[selected_off];
+        }
+    }
+}
+
+kernel void kernel_glm_iq4_xs_pair_swiglu_f32(
+        constant ds4_metal_glm_routed_moe_args &args,
+        device const char *gate,
+        device const char *up,
+        device const float *x,
+        device const int32_t *selected,
+        device const float *weights,
+        device float *mid,
+        threadgroup float *scratch [[threadgroup(0)]],
+        uint3 tgpig [[threadgroup_position_in_grid]],
+        ushort tiisg [[thread_index_in_simdgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]]) {
+    const uint slot = tgpig.y;
+    const uint token = tgpig.z;
+    if (slot >= args.n_expert_used || token >= args.n_tokens) return;
+    const uint64_t selected_off = (uint64_t)token * args.n_expert_used + slot;
+    const int expert = selected[selected_off];
+    (void)scratch;
+    glm_iq4_xs_pair_swiglu_f32_impl(
+        args, gate, up, x, weights, mid,
+        tgpig, slot, token, selected_off, expert, tiisg, sgitg);
+}
+
+static inline void glm_iq4_xs_down_f32_impl(
+        constant ds4_metal_glm_routed_moe_args &args,
+        device const char *down,
+        device const int32_t *selected,
+        device const float *mid,
+        device float *out,
+        uint3 tgpig,
+        ushort tiisg,
+        ushort sgitg) {
+    const short NSG = 2;
+    const uint row0 = ((uint)tgpig.x * (uint)NSG + (uint)sgitg) * N_R0_IQ4_XS_DOWN;
+    const uint token = tgpig.y;
+    if (row0 >= args.out_dim || token >= args.n_tokens) return;
+
+    const short ix = tiisg / 8;
+    const short it = tiisg % 8;
+    const int nb = args.mid_dim / QK_K;
+    float sumf[N_R0_IQ4_XS_DOWN] = {0.f};
+
+    const uint64_t selected_base = (uint64_t)token * args.n_expert_used;
+    const uint64_t mid_base = (uint64_t)token * args.mid_token_stride;
+    for (uint slot = 0; slot < args.n_expert_used; slot++) {
+        const int expert = selected[selected_base + slot];
+        if (expert < 0 || (uint)expert >= args.n_total_expert) continue;
+        device const char *down_base =
+            down + (uint64_t)(uint)expert * args.down_expert_bytes;
+        device const float *yy = mid + mid_base + (uint64_t)slot * args.mid_dim;
+
+        for (int ib = ix; ib < nb; ib += 4) {
+            device const float *yb = yy + (uint64_t)ib * QK_K + 32 * it;
+            float yl[16];
+            float yh[16];
+            for (short i = 0; i < 16; ++i) {
+                yl[i] = yb[i];
+                yh[i] = yb[i + 16];
+            }
+            for (short row = 0; row < N_R0_IQ4_XS_DOWN && row0 + (uint)row < args.out_dim; row++) {
+                device const block_iq4_xs *xq =
+                    (device const block_iq4_xs *)(down_base +
+                        (uint64_t)(row0 + (uint)row) * args.down_row_bytes) + ib;
+                device const uchar *qs = xq->qs + 16 * it;
+                float acc = 0.f;
+                FOR_UNROLL (short j = 0; j < 16; ++j) {
+                    acc += yl[j] * ds4_kvalues_iq4nl_f[qs[j] & 0x0F] +
+                           yh[j] * ds4_kvalues_iq4nl_f[qs[j] >> 4];
+                }
+                sumf[row] += ds4_iq4_xs_subblock_scale(xq, it) * acc;
+            }
+        }
+    }
+
+    for (short row = 0; row < N_R0_IQ4_XS_DOWN && row0 + (uint)row < args.out_dim; row++) {
+        const float sum_all = simd_sum(sumf[row]);
+        if (tiisg == 0u) {
+            out[(uint64_t)token * args.out_dim + row0 + (uint)row] = sum_all;
+        }
+    }
+}
+
+kernel void kernel_glm_iq4_xs_down_f32(
+        constant ds4_metal_glm_routed_moe_args &args,
+        device const char *down,
+        device const int32_t *selected,
+        device const float *mid,
+        device float *out,
+        uint3 tgpig [[threadgroup_position_in_grid]],
+        ushort tiisg [[thread_index_in_simdgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]]) {
+    glm_iq4_xs_down_f32_impl(
+        args, down, selected, mid, out, tgpig, tiisg, sgitg);
+}
+
+/* --- Q6_K routed gate/up pair (APEX Laguna edge layers) ------------------
+ * Same sub-block-per-thread skeleton; per-thread slice = one 32-element
+ * quarter-half of the block, two 16-wide scale groups. */
+static inline void glm_q6_K_pair_swiglu_f32_impl(
+        constant ds4_metal_glm_routed_moe_args &args,
+        device const char *gate,
+        device const char *up,
+        device const float *x,
+        device const float *weights,
+        device float *mid,
+        uint3 tgpig,
+        uint slot,
+        uint token,
+        uint64_t selected_off,
+        int expert,
+        ushort tiisg,
+        ushort sgitg) {
+    const short NSG = 2;
+    const uint row0 = ((uint)tgpig.x * (uint)NSG + (uint)sgitg) * N_R0_Q6_PAIR_K;
+    if (row0 >= args.mid_dim || slot >= args.n_expert_used || token >= args.n_tokens) return;
+
+    const uint64_t mid_base = (uint64_t)token * args.mid_token_stride +
+                              (uint64_t)slot * args.mid_dim;
+    if (expert < 0 || (uint)expert >= args.n_total_expert) {
+        if (tiisg == 0u) {
+            for (short row = 0; row < N_R0_Q6_PAIR_K && row0 + (uint)row < args.mid_dim; row++) {
+                mid[mid_base + row0 + (uint)row] = 0.0f;
+            }
+        }
+        return;
+    }
+
+    const short ix = tiisg / 8;
+    const short it = tiisg % 8;          /* 32-element slice */
+    const short half128 = it / 4;        /* which 128-element half */
+    const short quarter = it % 4;
+    const short ql_off = half128 * 64 + ((quarter & 1) ? 32 : 0);
+    const short qh_off = half128 * 32;
+    const uint hshift = 2u * (uint)quarter;
+    const bool lo_nib = quarter < 2;
+    const short sc0 = 2 * it;
+    const int nb = args.in_dim / QK_K;
+
+    device const char *gate_base = gate + (uint64_t)(uint)expert * args.gate_expert_bytes;
+    device const char *up_base   = up + (uint64_t)(uint)expert * args.up_expert_bytes;
+    device const float *y = x + (uint64_t)token * args.in_dim;
+
+    float sumg[N_R0_Q6_PAIR_K] = {0.f};
+    float sumu[N_R0_Q6_PAIR_K] = {0.f};
+
+    for (int ib = ix; ib < nb; ib += 4) {
+        device const float *yb = y + (uint64_t)ib * QK_K + 32 * it;
+        float yv[32];
+        for (short i = 0; i < 32; ++i) yv[i] = yb[i];
+
+        for (short row = 0; row < N_R0_Q6_PAIR_K && row0 + (uint)row < args.mid_dim; row++) {
+            device const block_q6_K *g =
+                (device const block_q6_K *)(gate_base +
+                    (uint64_t)(row0 + (uint)row) * args.gate_row_bytes) + ib;
+            device const block_q6_K *u =
+                (device const block_q6_K *)(up_base +
+                    (uint64_t)(row0 + (uint)row) * args.up_row_bytes) + ib;
+            device const uchar *glq = g->ql + ql_off;
+            device const uchar *ghq = g->qh + qh_off;
+            device const uchar *ulq = u->ql + ql_off;
+            device const uchar *uhq = u->qh + qh_off;
+            float g0 = 0.f, g1 = 0.f, u0 = 0.f, u1 = 0.f;
+            FOR_UNROLL (short j = 0; j < 16; ++j) {
+                const uint gv = (lo_nib ? ((uint)glq[j] & 0x0Fu) : ((uint)glq[j] >> 4u)) |
+                                ((((uint)ghq[j] >> hshift) & 3u) << 4u);
+                const uint gv2 = (lo_nib ? ((uint)glq[j + 16] & 0x0Fu) : ((uint)glq[j + 16] >> 4u)) |
+                                 ((((uint)ghq[j + 16] >> hshift) & 3u) << 4u);
+                const uint uv = (lo_nib ? ((uint)ulq[j] & 0x0Fu) : ((uint)ulq[j] >> 4u)) |
+                                ((((uint)uhq[j] >> hshift) & 3u) << 4u);
+                const uint uv2 = (lo_nib ? ((uint)ulq[j + 16] & 0x0Fu) : ((uint)ulq[j + 16] >> 4u)) |
+                                 ((((uint)uhq[j + 16] >> hshift) & 3u) << 4u);
+                g0 += yv[j]      * (float)((int)gv - 32);
+                g1 += yv[j + 16] * (float)((int)gv2 - 32);
+                u0 += yv[j]      * (float)((int)uv - 32);
+                u1 += yv[j + 16] * (float)((int)uv2 - 32);
+            }
+            sumg[row] += (float)g->d *
+                ((float)((int)g->scales[sc0]) * g0 + (float)((int)g->scales[sc0 + 1]) * g1);
+            sumu[row] += (float)u->d *
+                ((float)((int)u->scales[sc0]) * u0 + (float)((int)u->scales[sc0 + 1]) * u1);
+        }
+    }
+
+    for (short row = 0; row < N_R0_Q6_PAIR_K && row0 + (uint)row < args.mid_dim; row++) {
+        const float g = simd_sum(sumg[row]);
+        const float u = simd_sum(sumu[row]);
+        if (tiisg == 0u) {
+            const float sw = g / (1.0f + exp(-g));
+            mid[mid_base + row0 + (uint)row] = sw * u * weights[selected_off];
+        }
+    }
+}
+
+kernel void kernel_glm_q6_K_pair_swiglu_f32(
+        constant ds4_metal_glm_routed_moe_args &args,
+        device const char *gate,
+        device const char *up,
+        device const float *x,
+        device const int32_t *selected,
+        device const float *weights,
+        device float *mid,
+        threadgroup float *scratch [[threadgroup(0)]],
+        uint3 tgpig [[threadgroup_position_in_grid]],
+        ushort tiisg [[thread_index_in_simdgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]]) {
+    const uint slot = tgpig.y;
+    const uint token = tgpig.z;
+    if (slot >= args.n_expert_used || token >= args.n_tokens) return;
+    const uint64_t selected_off = (uint64_t)token * args.n_expert_used + slot;
+    const int expert = selected[selected_off];
+    (void)scratch;
+    glm_q6_K_pair_swiglu_f32_impl(
+        args, gate, up, x, weights, mid,
+        tgpig, slot, token, selected_off, expert, tiisg, sgitg);
+}
+
 kernel void kernel_laguna_q4_K_routed_shared_down_f32(
         constant ds4_metal_glm_routed_moe_args &routed_args,
         constant ds4_metal_glm_routed_moe_args &shared_args,
@@ -3315,6 +3644,20 @@ void dequantize_q6_K(device const block_q6_K *xb, short il, thread type4x4 &reg)
                 ((((uint)xb->qh[qh_base + l] >> 6u) & 3u) << 4u);
         }
         reg[i / 4][i % 4] = d * (float)((int)v - 32);
+    }
+}
+
+template <typename type4x4>
+void dequantize_iq4_xs(device const block_iq4_xs *xb, short il, thread type4x4 &reg) {
+    /* il indexes 16-element chunks in linear order: chunk pair (2k, 2k+1)
+     * covers sub-block k's low- and high-nibble halves. */
+    const short ib = il / 2;
+    const short hi = il & 1;
+    const float dl = ds4_iq4_xs_subblock_scale(xb, ib);
+    device const uchar *qs = xb->qs + 16 * ib;
+    for (int i = 0; i < 16; ++i) {
+        const uchar q = hi ? (qs[i] >> 4) : (qs[i] & 0x0F);
+        reg[i / 4][i % 4] = dl * ds4_kvalues_iq4nl_f[q];
     }
 }
 
@@ -8112,11 +8455,15 @@ kernel void kernel_mul_mm_id_pair_swiglu_f16_impl(
 typedef decltype(kernel_mul_mm_id_pair_swiglu_f16_impl<block_iq2_xxs, QK_NL, dequantize_iq2_xxs>) mul_mm_id_pair_swiglu_f16_iq2;
 typedef decltype(kernel_mul_mm_id_pair_swiglu_f16_impl<block_q4_K, QK_NL, dequantize_q4_K>) mul_mm_id_pair_swiglu_f16_q4;
 typedef decltype(kernel_mul_mm_id_pair_swiglu_f16_impl<block_q5_K, QK_NL, dequantize_q5_K>) mul_mm_id_pair_swiglu_f16_q5;
+typedef decltype(kernel_mul_mm_id_pair_swiglu_f16_impl<block_q6_K, QK_NL, dequantize_q6_K>) mul_mm_id_pair_swiglu_f16_q6;
+typedef decltype(kernel_mul_mm_id_pair_swiglu_f16_impl<block_iq4_xs, QK_NL, dequantize_iq4_xs>) mul_mm_id_pair_swiglu_f16_iq4xs;
 
 // Host-visible fused routed pair matmuls for the DS4 expert quant formats.
 template [[host_name("kernel_mul_mm_id_iq2_xxs_pair_swiglu_f16")]] kernel mul_mm_id_pair_swiglu_f16_iq2 kernel_mul_mm_id_pair_swiglu_f16_impl<block_iq2_xxs, QK_NL, dequantize_iq2_xxs>;
 template [[host_name("kernel_mul_mm_id_q4_K_pair_swiglu_f16")]] kernel mul_mm_id_pair_swiglu_f16_q4 kernel_mul_mm_id_pair_swiglu_f16_impl<block_q4_K, QK_NL, dequantize_q4_K>;
 template [[host_name("kernel_mul_mm_id_q5_K_pair_swiglu_f16")]] kernel mul_mm_id_pair_swiglu_f16_q5 kernel_mul_mm_id_pair_swiglu_f16_impl<block_q5_K, QK_NL, dequantize_q5_K>;
+template [[host_name("kernel_mul_mm_id_q6_K_pair_swiglu_f16")]] kernel mul_mm_id_pair_swiglu_f16_q6 kernel_mul_mm_id_pair_swiglu_f16_impl<block_q6_K, QK_NL, dequantize_q6_K>;
+template [[host_name("kernel_mul_mm_id_iq4_xs_pair_swiglu_f16")]] kernel mul_mm_id_pair_swiglu_f16_iq4xs kernel_mul_mm_id_pair_swiglu_f16_impl<block_iq4_xs, QK_NL, dequantize_iq4_xs>;
 
 typedef decltype(kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q2_K, QK_NL, dequantize_q2_K, float, float4x4, float, float2x4>) mul_mm_id;
 typedef decltype(kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q2_K, QK_NL, dequantize_q2_K, half, half4x4, half, half2x4>) mul_mm_id_f16_rhs;
@@ -8132,6 +8479,7 @@ template [[host_name("kernel_mul_mm_id_q4_K_f32")]]         kernel mul_mm_id ker
 template [[host_name("kernel_mul_mm_id_q5_K_f32")]]         kernel mul_mm_id kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q5_K,    QK_NL, dequantize_q5_K,    float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_q6_K_f32")]]         kernel mul_mm_id kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q6_K,    QK_NL, dequantize_q6_K,    float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_iq2_xxs_f32")]]      kernel mul_mm_id kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_iq2_xxs, QK_NL, dequantize_iq2_xxs, float, float4x4, float, float2x4>;
+template [[host_name("kernel_mul_mm_id_iq4_xs_f32")]]       kernel mul_mm_id kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_iq4_xs, QK_NL, dequantize_iq4_xs, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_q8_0_f16")]]         kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q8_0,    2,     dequantize_q8_0,    half, half4x4, half, half2x4>;
 template [[host_name("kernel_mul_mm_id_q2_K_f16")]]         kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q2_K,    QK_NL, dequantize_q2_K,    half, half4x4, half, half2x4>;
 template [[host_name("kernel_mul_mm_id_q3_K_f16")]]         kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q3_K,    QK_NL, dequantize_q3_K,    half, half4x4, half, half2x4>;
@@ -8139,9 +8487,11 @@ template [[host_name("kernel_mul_mm_id_q4_K_f16")]]         kernel mul_mm_id_f16
 template [[host_name("kernel_mul_mm_id_q5_K_f16")]]         kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q5_K,    QK_NL, dequantize_q5_K,    half, half4x4, half, half2x4>;
 template [[host_name("kernel_mul_mm_id_q6_K_f16")]]         kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q6_K,    QK_NL, dequantize_q6_K,    half, half4x4, half, half2x4>;
 template [[host_name("kernel_mul_mm_id_iq2_xxs_f16")]]      kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_iq2_xxs, QK_NL, dequantize_iq2_xxs, half, half4x4, half, half2x4>;
+template [[host_name("kernel_mul_mm_id_iq4_xs_f16")]]       kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_iq4_xs, QK_NL, dequantize_iq4_xs, half, half4x4, half, half2x4>;
 template [[host_name("kernel_mul_mm_id_q4_K_ff32")]]        kernel mul_mm_id_ff32 kernel_mul_mm_id<32, float, float4x4, simdgroup_float8x8, float, float2x4, simdgroup_float8x8, block_q4_K, QK_NL, dequantize_q4_K, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_q5_K_ff32")]]        kernel mul_mm_id_ff32 kernel_mul_mm_id<32, float, float4x4, simdgroup_float8x8, float, float2x4, simdgroup_float8x8, block_q5_K, QK_NL, dequantize_q5_K, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_q6_K_ff32")]]        kernel mul_mm_id_ff32 kernel_mul_mm_id<32, float, float4x4, simdgroup_float8x8, float, float2x4, simdgroup_float8x8, block_q6_K, QK_NL, dequantize_q6_K, float, float4x4, float, float2x4>;
+template [[host_name("kernel_mul_mm_id_iq4_xs_ff32")]]      kernel mul_mm_id_ff32 kernel_mul_mm_id<32, float, float4x4, simdgroup_float8x8, float, float2x4, simdgroup_float8x8, block_iq4_xs, QK_NL, dequantize_iq4_xs, float, float4x4, float, float2x4>;
 
 template [[host_name("kernel_mul_mm_id_addr_q2_K_f32")]]    kernel mul_mm_id_addr kernel_mul_mm_id_addr<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q2_K, QK_NL, dequantize_q2_K, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_addr_q4_K_f32")]]    kernel mul_mm_id_addr kernel_mul_mm_id_addr<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q4_K, QK_NL, dequantize_q4_K, float, float4x4, float, float2x4>;

--- a/metal/moe.metal
+++ b/metal/moe.metal
@@ -2806,12 +2806,18 @@ static inline void glm_iq4_xs_pair_swiglu_f32_impl(
     float sumu[N_R0_IQ4_XS_PAIR] = {0.f};
 
     for (int ib = ix; ib < nb; ib += 4) {
-        device const float *yb = y + (uint64_t)ib * QK_K + 32 * it;
+        /* 32*it and ib*QK_K are 128B-aligned float offsets: vector loads. */
+        device const float4 *yb4 =
+            (device const float4 *)(y + (uint64_t)ib * QK_K + 32 * it);
         float yl[16];
         float yh[16];
-        for (short i = 0; i < 16; ++i) {
-            yl[i] = yb[i];
-            yh[i] = yb[i + 16];
+        FOR_UNROLL (short v = 0; v < 4; ++v) {
+            const float4 lo = yb4[v];
+            const float4 hi = yb4[v + 4];
+            yl[4 * v + 0] = lo.x; yl[4 * v + 1] = lo.y;
+            yl[4 * v + 2] = lo.z; yl[4 * v + 3] = lo.w;
+            yh[4 * v + 0] = hi.x; yh[4 * v + 1] = hi.y;
+            yh[4 * v + 2] = hi.z; yh[4 * v + 3] = hi.w;
         }
 
         for (short row = 0; row < N_R0_IQ4_XS_PAIR && row0 + (uint)row < args.mid_dim; row++) {
@@ -2821,15 +2827,30 @@ static inline void glm_iq4_xs_pair_swiglu_f32_impl(
             device const block_iq4_xs *u =
                 (device const block_iq4_xs *)(up_base +
                     (uint64_t)(row0 + (uint)row) * args.up_row_bytes) + ib;
-            device const uchar *qg = g->qs + 16 * it;
-            device const uchar *qu = u->qs + 16 * it;
+            /* qs + 16*it is 4-byte aligned (8B header + 16B strides). */
+            device const uint *qg32 = (device const uint *)(g->qs + 16 * it);
+            device const uint *qu32 = (device const uint *)(u->qs + 16 * it);
             float accg = 0.f;
             float accu = 0.f;
-            FOR_UNROLL (short j = 0; j < 16; ++j) {
-                accg += yl[j] * ds4_kvalues_iq4nl_f[qg[j] & 0x0F] +
-                        yh[j] * ds4_kvalues_iq4nl_f[qg[j] >> 4];
-                accu += yl[j] * ds4_kvalues_iq4nl_f[qu[j] & 0x0F] +
-                        yh[j] * ds4_kvalues_iq4nl_f[qu[j] >> 4];
+            FOR_UNROLL (short k = 0; k < 4; ++k) {
+                const uint gw = qg32[k];
+                const uint uw = qu32[k];
+                accg += yl[4 * k + 0] * ds4_kvalues_iq4nl_f[gw & 0x0Fu] +
+                        yh[4 * k + 0] * ds4_kvalues_iq4nl_f[(gw >> 4u) & 0x0Fu] +
+                        yl[4 * k + 1] * ds4_kvalues_iq4nl_f[(gw >> 8u) & 0x0Fu] +
+                        yh[4 * k + 1] * ds4_kvalues_iq4nl_f[(gw >> 12u) & 0x0Fu] +
+                        yl[4 * k + 2] * ds4_kvalues_iq4nl_f[(gw >> 16u) & 0x0Fu] +
+                        yh[4 * k + 2] * ds4_kvalues_iq4nl_f[(gw >> 20u) & 0x0Fu] +
+                        yl[4 * k + 3] * ds4_kvalues_iq4nl_f[(gw >> 24u) & 0x0Fu] +
+                        yh[4 * k + 3] * ds4_kvalues_iq4nl_f[gw >> 28u];
+                accu += yl[4 * k + 0] * ds4_kvalues_iq4nl_f[uw & 0x0Fu] +
+                        yh[4 * k + 0] * ds4_kvalues_iq4nl_f[(uw >> 4u) & 0x0Fu] +
+                        yl[4 * k + 1] * ds4_kvalues_iq4nl_f[(uw >> 8u) & 0x0Fu] +
+                        yh[4 * k + 1] * ds4_kvalues_iq4nl_f[(uw >> 12u) & 0x0Fu] +
+                        yl[4 * k + 2] * ds4_kvalues_iq4nl_f[(uw >> 16u) & 0x0Fu] +
+                        yh[4 * k + 2] * ds4_kvalues_iq4nl_f[(uw >> 20u) & 0x0Fu] +
+                        yl[4 * k + 3] * ds4_kvalues_iq4nl_f[(uw >> 24u) & 0x0Fu] +
+                        yh[4 * k + 3] * ds4_kvalues_iq4nl_f[uw >> 28u];
             }
             sumg[row] += ds4_iq4_xs_subblock_scale(g, it) * accg;
             sumu[row] += ds4_iq4_xs_subblock_scale(u, it) * accu;
@@ -2898,22 +2919,34 @@ static inline void glm_iq4_xs_down_f32_impl(
         device const float *yy = mid + mid_base + (uint64_t)slot * args.mid_dim;
 
         for (int ib = ix; ib < nb; ib += 4) {
-            device const float *yb = yy + (uint64_t)ib * QK_K + 32 * it;
+            device const float4 *yb4 =
+                (device const float4 *)(yy + (uint64_t)ib * QK_K + 32 * it);
             float yl[16];
             float yh[16];
-            for (short i = 0; i < 16; ++i) {
-                yl[i] = yb[i];
-                yh[i] = yb[i + 16];
+            FOR_UNROLL (short v = 0; v < 4; ++v) {
+                const float4 lo = yb4[v];
+                const float4 hi = yb4[v + 4];
+                yl[4 * v + 0] = lo.x; yl[4 * v + 1] = lo.y;
+                yl[4 * v + 2] = lo.z; yl[4 * v + 3] = lo.w;
+                yh[4 * v + 0] = hi.x; yh[4 * v + 1] = hi.y;
+                yh[4 * v + 2] = hi.z; yh[4 * v + 3] = hi.w;
             }
             for (short row = 0; row < N_R0_IQ4_XS_DOWN && row0 + (uint)row < args.out_dim; row++) {
                 device const block_iq4_xs *xq =
                     (device const block_iq4_xs *)(down_base +
                         (uint64_t)(row0 + (uint)row) * args.down_row_bytes) + ib;
-                device const uchar *qs = xq->qs + 16 * it;
+                device const uint *qs32 = (device const uint *)(xq->qs + 16 * it);
                 float acc = 0.f;
-                FOR_UNROLL (short j = 0; j < 16; ++j) {
-                    acc += yl[j] * ds4_kvalues_iq4nl_f[qs[j] & 0x0F] +
-                           yh[j] * ds4_kvalues_iq4nl_f[qs[j] >> 4];
+                FOR_UNROLL (short k = 0; k < 4; ++k) {
+                    const uint w = qs32[k];
+                    acc += yl[4 * k + 0] * ds4_kvalues_iq4nl_f[w & 0x0Fu] +
+                           yh[4 * k + 0] * ds4_kvalues_iq4nl_f[(w >> 4u) & 0x0Fu] +
+                           yl[4 * k + 1] * ds4_kvalues_iq4nl_f[(w >> 8u) & 0x0Fu] +
+                           yh[4 * k + 1] * ds4_kvalues_iq4nl_f[(w >> 12u) & 0x0Fu] +
+                           yl[4 * k + 2] * ds4_kvalues_iq4nl_f[(w >> 16u) & 0x0Fu] +
+                           yh[4 * k + 2] * ds4_kvalues_iq4nl_f[(w >> 20u) & 0x0Fu] +
+                           yl[4 * k + 3] * ds4_kvalues_iq4nl_f[(w >> 24u) & 0x0Fu] +
+                           yh[4 * k + 3] * ds4_kvalues_iq4nl_f[w >> 28u];
                 }
                 sumf[row] += ds4_iq4_xs_subblock_scale(xq, it) * acc;
             }
@@ -8492,6 +8525,12 @@ template [[host_name("kernel_mul_mm_id_q4_K_ff32")]]        kernel mul_mm_id_ff3
 template [[host_name("kernel_mul_mm_id_q5_K_ff32")]]        kernel mul_mm_id_ff32 kernel_mul_mm_id<32, float, float4x4, simdgroup_float8x8, float, float2x4, simdgroup_float8x8, block_q5_K, QK_NL, dequantize_q5_K, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_q6_K_ff32")]]        kernel mul_mm_id_ff32 kernel_mul_mm_id<32, float, float4x4, simdgroup_float8x8, float, float2x4, simdgroup_float8x8, block_q6_K, QK_NL, dequantize_q6_K, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_iq4_xs_ff32")]]      kernel mul_mm_id_ff32 kernel_mul_mm_id<32, float, float4x4, simdgroup_float8x8, float, float2x4, simdgroup_float8x8, block_iq4_xs, QK_NL, dequantize_iq4_xs, float, float4x4, float, float2x4>;
+
+/* Dense GEMM instantiations for the APEX q6_k attention/embedding
+ * projections at prefill (the QMV kernel re-reads the whole weight matrix
+ * per token).  The mul_mm template and mul_mm_t typedef come from
+ * dense.metal, which precedes this file in the concatenated library. */
+template [[host_name("kernel_mul_mm_q6_K_f32")]] kernel mul_mm_t kernel_mul_mm<half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q6_K, QK_NL, dequantize_q6_K, float, float4x4, float, float2x4>;
 
 template [[host_name("kernel_mul_mm_id_addr_q2_K_f32")]]    kernel mul_mm_id_addr kernel_mul_mm_id_addr<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q2_K, QK_NL, dequantize_q2_K, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_addr_q4_K_f32")]]    kernel mul_mm_id_addr kernel_mul_mm_id_addr<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q4_K, QK_NL, dequantize_q4_K, float, float4x4, float, float2x4>;

--- a/metal/moe.metal
+++ b/metal/moe.metal
@@ -3651,46 +3651,49 @@ void dequantize_q5_K(device const block_q5_K *xb, short il, thread type4x4 &reg)
 
 template <typename type4x4>
 void dequantize_q6_K(device const block_q6_K *xb, short il, thread type4x4 &reg) {
+    /* Branchless + word-load form of the quarter decode above; identical
+     * arithmetic per element (GEMM tile staging is the hot caller). */
     const short n128 = il / 8;
     const short il128 = il & 7;
-    const short quarter = il128 / 2;
+    const short quarter = il128 >> 1;
     const short l0 = (il128 & 1) * 16;
-    const uint ql_base = (uint)n128 * 64u;
-    const uint qh_base = (uint)n128 * 32u;
-    const uint sc_base = (uint)n128 * 8u + (uint)quarter * 2u + (uint)(il128 & 1);
-    const float d = (float)xb->d * (float)((int)xb->scales[sc_base]);
+    /* block_q6_K is 210 bytes, so blocks alternate between 0- and 2-mod-4
+     * addresses: 16-bit loads are the widest always-aligned access. */
+    device const ushort *ql = (device const ushort *)
+        (xb->ql + (uint)n128 * 64u + ((quarter & 1) ? 32u : 0u) + (uint)l0);
+    device const ushort *qh = (device const ushort *)
+        (xb->qh + (uint)n128 * 32u + (uint)l0);
+    const uint nib_shift = (quarter < 2) ? 0u : 4u;
+    const uint h_shift = 2u * (uint)quarter;
+    const float d = (float)xb->d * (float)((int)xb->scales[il]);
 
-    for (int i = 0; i < 16; ++i) {
-        const uint l = (uint)l0 + (uint)i;
-        uint v;
-        if (quarter == 0) {
-            v = ((uint)xb->ql[ql_base + l] & 0x0Fu) |
-                ((((uint)xb->qh[qh_base + l] >> 0u) & 3u) << 4u);
-        } else if (quarter == 1) {
-            v = ((uint)xb->ql[ql_base + 32u + l] & 0x0Fu) |
-                ((((uint)xb->qh[qh_base + l] >> 2u) & 3u) << 4u);
-        } else if (quarter == 2) {
-            v = ((uint)xb->ql[ql_base + l] >> 4u) |
-                ((((uint)xb->qh[qh_base + l] >> 4u) & 3u) << 4u);
-        } else {
-            v = ((uint)xb->ql[ql_base + 32u + l] >> 4u) |
-                ((((uint)xb->qh[qh_base + l] >> 6u) & 3u) << 4u);
+    FOR_UNROLL (short v = 0; v < 8; ++v) {
+        const uint qlv = (uint)ql[v];
+        const uint qhv = (uint)qh[v];
+        FOR_UNROLL (short j = 0; j < 2; ++j) {
+            const uint nib = (qlv >> (8u * (uint)j + nib_shift)) & 0x0Fu;
+            const uint hb = (qhv >> (8u * (uint)j + h_shift)) & 3u;
+            const short i = 2 * v + j;
+            reg[i / 4][i % 4] = d * (float)((int)(nib | (hb << 4u)) - 32);
         }
-        reg[i / 4][i % 4] = d * (float)((int)v - 32);
     }
 }
 
 template <typename type4x4>
 void dequantize_iq4_xs(device const block_iq4_xs *xb, short il, thread type4x4 &reg) {
     /* il indexes 16-element chunks in linear order: chunk pair (2k, 2k+1)
-     * covers sub-block k's low- and high-nibble halves. */
+     * covers sub-block k's low- and high-nibble halves.  Word loads +
+     * in-register nibble extraction; identical arithmetic per element. */
     const short ib = il / 2;
-    const short hi = il & 1;
+    const uint nib_shift = (il & 1) ? 4u : 0u;
     const float dl = ds4_iq4_xs_subblock_scale(xb, ib);
-    device const uchar *qs = xb->qs + 16 * ib;
-    for (int i = 0; i < 16; ++i) {
-        const uchar q = hi ? (qs[i] >> 4) : (qs[i] & 0x0F);
-        reg[i / 4][i % 4] = dl * ds4_kvalues_iq4nl_f[q];
+    device const uint *qs = (device const uint *)(xb->qs + 16 * ib);
+    FOR_UNROLL (short v = 0; v < 4; ++v) {
+        const uint w = qs[v] >> nib_shift;
+        reg[v][0] = dl * ds4_kvalues_iq4nl_f[w & 0x0Fu];
+        reg[v][1] = dl * ds4_kvalues_iq4nl_f[(w >> 8u) & 0x0Fu];
+        reg[v][2] = dl * ds4_kvalues_iq4nl_f[(w >> 16u) & 0x0Fu];
+        reg[v][3] = dl * ds4_kvalues_iq4nl_f[(w >> 24u) & 0x0Fu];
     }
 }
 
@@ -8531,6 +8534,13 @@ template [[host_name("kernel_mul_mm_id_iq4_xs_ff32")]]      kernel mul_mm_id_ff3
  * per token).  The mul_mm template and mul_mm_t typedef come from
  * dense.metal, which precedes this file in the concatenated library. */
 template [[host_name("kernel_mul_mm_q6_K_f32")]] kernel mul_mm_t kernel_mul_mm<half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q6_K, QK_NL, dequantize_q6_K, float, float4x4, float, float2x4>;
+
+/* Metal-4 tensor-API (MPP direct-RHS) variants of the q6_K dense GEMM, the
+ * same fast path the q8_0/q4_K prefill uses: dequantize 64x32 weight tiles
+ * to half in threadgroup memory, direct-RHS MPP for the activation tile. */
+template [[host_name("kernel_mul_mm_q6_K_f32_nax_direct_rhs")]] kernel mul_mm_mpp_direct_rhs_t kernel_mul_mm_mpp_direct_rhs<32, half, half4x4, block_q6_K, QK_NL, dequantize_q6_K, float, float4x4, float>;
+template [[host_name("kernel_mul_mm_q6_K_f32_nax_direct_rhs_n64")]] kernel mul_mm_mpp_direct_rhs_t kernel_mul_mm_mpp_direct_rhs<64, half, half4x4, block_q6_K, QK_NL, dequantize_q6_K, float, float4x4, float>;
+template [[host_name("kernel_mul_mm_q6_K_f32_nax_direct_rhs_n128")]] kernel mul_mm_mpp_direct_rhs_t kernel_mul_mm_mpp_direct_rhs<128, half, half4x4, block_q6_K, QK_NL, dequantize_q6_K, float, float4x4, float>;
 
 template [[host_name("kernel_mul_mm_id_addr_q2_K_f32")]]    kernel mul_mm_id_addr kernel_mul_mm_id_addr<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q2_K, QK_NL, dequantize_q2_K, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_addr_q4_K_f32")]]    kernel mul_mm_id_addr kernel_mul_mm_id_addr<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q4_K, QK_NL, dequantize_q4_K, float, float4x4, float, float2x4>;

--- a/metal/moe.metal
+++ b/metal/moe.metal
@@ -14,6 +14,8 @@
 #define N_R0_IQ4_XS_PAIR 2
 #define N_R0_IQ4_XS_DOWN 2
 #define N_R0_Q6_PAIR_K 2
+#define N_R0_BF16_PAIR 2
+#define N_R0_BF16_DOWN 2
 #define N_R0_Q5_K 4
 #define N_R0_Q6_K 2
 #define N_R0_IQ2_XXS 4
@@ -155,6 +157,13 @@ struct block_iq4_xs {
     uchar  scales_l[QK_K/64];
     uchar  qs[QK_K/2];
 };
+
+/* BF16: the top 16 bits of an IEEE-754 f32.  Poolside's official
+ * mixed-precision Laguna export stores its most sensitive routed-expert
+ * layers this way. */
+static inline float ds4_bf16_to_f32(ushort b) {
+    return as_type<float>((uint)b << 16);
+}
 
 constant static const float ds4_kvalues_iq4nl_f[16] = {
     -127.0f, -104.0f, -83.0f, -65.0f, -49.0f, -35.0f, -22.0f, -10.0f,
@@ -2759,6 +2768,158 @@ kernel void kernel_glm_q6_K_down_f32(
         args, down, selected, mid, out, tgpig, tiisg, sgitg);
 }
 
+/* --- BF16 routed experts (poolside official mixed-precision Laguna) ------
+ * Straight 16-bit weights: no blocks, no scales.  Same sub-block-per-thread
+ * skeleton as the quantized pair kernels so grid math stays uniform. */
+static inline void glm_bf16_pair_swiglu_f32_impl(
+        constant ds4_metal_glm_routed_moe_args &args,
+        device const char *gate,
+        device const char *up,
+        device const float *x,
+        device const float *weights,
+        device float *mid,
+        uint3 tgpig,
+        uint slot,
+        uint token,
+        uint64_t selected_off,
+        int expert,
+        ushort tiisg,
+        ushort sgitg) {
+    const short NSG = 2;
+    const uint row0 = ((uint)tgpig.x * (uint)NSG + (uint)sgitg) * N_R0_BF16_PAIR;
+    if (row0 >= args.mid_dim || slot >= args.n_expert_used || token >= args.n_tokens) return;
+
+    const uint64_t mid_base = (uint64_t)token * args.mid_token_stride +
+                              (uint64_t)slot * args.mid_dim;
+    if (expert < 0 || (uint)expert >= args.n_total_expert) {
+        if (tiisg == 0u) {
+            for (short row = 0; row < N_R0_BF16_PAIR && row0 + (uint)row < args.mid_dim; row++) {
+                mid[mid_base + row0 + (uint)row] = 0.0f;
+            }
+        }
+        return;
+    }
+
+    device const char *gate_base = gate + (uint64_t)(uint)expert * args.gate_expert_bytes;
+    device const char *up_base   = up + (uint64_t)(uint)expert * args.up_expert_bytes;
+    device const float *y = x + (uint64_t)token * args.in_dim;
+
+    float sumg[N_R0_BF16_PAIR] = {0.f};
+    float sumu[N_R0_BF16_PAIR] = {0.f};
+
+    /* Each lane strides the row by 32 elements (simd width), 8 at a time. */
+    for (uint base = (uint)tiisg * 8u; base < args.in_dim; base += 32u * 8u) {
+        float yv[8];
+        FOR_UNROLL (short i = 0; i < 8; ++i) yv[i] = y[base + (uint)i];
+        for (short row = 0; row < N_R0_BF16_PAIR && row0 + (uint)row < args.mid_dim; row++) {
+            device const ushort *g = (device const ushort *)(gate_base +
+                (uint64_t)(row0 + (uint)row) * args.gate_row_bytes) + base;
+            device const ushort *u = (device const ushort *)(up_base +
+                (uint64_t)(row0 + (uint)row) * args.up_row_bytes) + base;
+            float ag = 0.f, au = 0.f;
+            FOR_UNROLL (short i = 0; i < 8; ++i) {
+                ag += yv[i] * ds4_bf16_to_f32(g[i]);
+                au += yv[i] * ds4_bf16_to_f32(u[i]);
+            }
+            sumg[row] += ag;
+            sumu[row] += au;
+        }
+    }
+
+    for (short row = 0; row < N_R0_BF16_PAIR && row0 + (uint)row < args.mid_dim; row++) {
+        const float g = simd_sum(sumg[row]);
+        const float u = simd_sum(sumu[row]);
+        if (tiisg == 0u) {
+            const float sw = g / (1.0f + exp(-g));
+            mid[mid_base + row0 + (uint)row] = sw * u * weights[selected_off];
+        }
+    }
+}
+
+kernel void kernel_glm_bf16_pair_swiglu_f32(
+        constant ds4_metal_glm_routed_moe_args &args,
+        device const char *gate,
+        device const char *up,
+        device const float *x,
+        device const int32_t *selected,
+        device const float *weights,
+        device float *mid,
+        threadgroup float *scratch [[threadgroup(0)]],
+        uint3 tgpig [[threadgroup_position_in_grid]],
+        ushort tiisg [[thread_index_in_simdgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]]) {
+    const uint slot = tgpig.y;
+    const uint token = tgpig.z;
+    if (slot >= args.n_expert_used || token >= args.n_tokens) return;
+    const uint64_t selected_off = (uint64_t)token * args.n_expert_used + slot;
+    const int expert = selected[selected_off];
+    (void)scratch;
+    glm_bf16_pair_swiglu_f32_impl(
+        args, gate, up, x, weights, mid,
+        tgpig, slot, token, selected_off, expert, tiisg, sgitg);
+}
+
+static inline void glm_bf16_down_f32_impl(
+        constant ds4_metal_glm_routed_moe_args &args,
+        device const char *down,
+        device const int32_t *selected,
+        device const float *mid,
+        device float *out,
+        uint3 tgpig,
+        ushort tiisg,
+        ushort sgitg) {
+    const short NSG = 2;
+    const uint row0 = ((uint)tgpig.x * (uint)NSG + (uint)sgitg) * N_R0_BF16_DOWN;
+    const uint token = tgpig.y;
+    if (row0 >= args.out_dim || token >= args.n_tokens) return;
+
+    float sumf[N_R0_BF16_DOWN] = {0.f};
+    const uint64_t selected_base = (uint64_t)token * args.n_expert_used;
+    const uint64_t mid_base = (uint64_t)token * args.mid_token_stride;
+
+    for (uint slot = 0; slot < args.n_expert_used; slot++) {
+        const int expert = selected[selected_base + slot];
+        if (expert < 0 || (uint)expert >= args.n_total_expert) continue;
+        device const char *down_base =
+            down + (uint64_t)(uint)expert * args.down_expert_bytes;
+        device const float *yy = mid + mid_base + (uint64_t)slot * args.mid_dim;
+
+        for (uint base = (uint)tiisg * 8u; base < args.mid_dim; base += 32u * 8u) {
+            float yv[8];
+            FOR_UNROLL (short i = 0; i < 8; ++i) yv[i] = yy[base + (uint)i];
+            for (short row = 0; row < N_R0_BF16_DOWN && row0 + (uint)row < args.out_dim; row++) {
+                device const ushort *w = (device const ushort *)(down_base +
+                    (uint64_t)(row0 + (uint)row) * args.down_row_bytes) + base;
+                float acc = 0.f;
+                FOR_UNROLL (short i = 0; i < 8; ++i) {
+                    acc += yv[i] * ds4_bf16_to_f32(w[i]);
+                }
+                sumf[row] += acc;
+            }
+        }
+    }
+
+    for (short row = 0; row < N_R0_BF16_DOWN && row0 + (uint)row < args.out_dim; row++) {
+        const float sum_all = simd_sum(sumf[row]);
+        if (tiisg == 0u) {
+            out[(uint64_t)token * args.out_dim + row0 + (uint)row] = sum_all;
+        }
+    }
+}
+
+kernel void kernel_glm_bf16_down_f32(
+        constant ds4_metal_glm_routed_moe_args &args,
+        device const char *down,
+        device const int32_t *selected,
+        device const float *mid,
+        device float *out,
+        uint3 tgpig [[threadgroup_position_in_grid]],
+        ushort tiisg [[thread_index_in_simdgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]]) {
+    glm_bf16_down_f32_impl(
+        args, down, selected, mid, out, tgpig, tiisg, sgitg);
+}
+
 /* --- IQ4_XS routed experts (APEX Laguna) ---------------------------------
  * Sub-block-per-thread QMV: tiisg = ix*8+it, ix strides blocks by 4, it picks
  * the 32-element sub-block.  The codebook LUT stays in constant memory (a LUT
@@ -3676,6 +3837,18 @@ void dequantize_q6_K(device const block_q6_K *xb, short il, thread type4x4 &reg)
             const short i = 2 * v + j;
             reg[i / 4][i % 4] = d * (float)((int)(nib | (hb << 4u)) - 32);
         }
+    }
+}
+
+/* GEMM-tile staging hook for bf16 weights; "block" is 16 contiguous
+ * elements so the mul_mm/mul_mm_id nl parameter is 16. */
+struct block_bf16_16 { ushort v[16]; };
+
+template <typename type4x4>
+void dequantize_bf16_16(device const block_bf16_16 *xb, short il, thread type4x4 &reg) {
+    device const ushort *s = xb->v + 16 * il;
+    FOR_UNROLL (short i = 0; i < 16; ++i) {
+        reg[i / 4][i % 4] = ds4_bf16_to_f32(s[i]);
     }
 }
 
@@ -8516,6 +8689,7 @@ template [[host_name("kernel_mul_mm_id_q5_K_f32")]]         kernel mul_mm_id ker
 template [[host_name("kernel_mul_mm_id_q6_K_f32")]]         kernel mul_mm_id kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q6_K,    QK_NL, dequantize_q6_K,    float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_iq2_xxs_f32")]]      kernel mul_mm_id kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_iq2_xxs, QK_NL, dequantize_iq2_xxs, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_iq4_xs_f32")]]       kernel mul_mm_id kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_iq4_xs, QK_NL, dequantize_iq4_xs, float, float4x4, float, float2x4>;
+template [[host_name("kernel_mul_mm_id_bf16_f32")]]         kernel mul_mm_id kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_bf16_16, 16, dequantize_bf16_16, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_q8_0_f16")]]         kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q8_0,    2,     dequantize_q8_0,    half, half4x4, half, half2x4>;
 template [[host_name("kernel_mul_mm_id_q2_K_f16")]]         kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q2_K,    QK_NL, dequantize_q2_K,    half, half4x4, half, half2x4>;
 template [[host_name("kernel_mul_mm_id_q3_K_f16")]]         kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q3_K,    QK_NL, dequantize_q3_K,    half, half4x4, half, half2x4>;
@@ -8524,6 +8698,7 @@ template [[host_name("kernel_mul_mm_id_q5_K_f16")]]         kernel mul_mm_id_f16
 template [[host_name("kernel_mul_mm_id_q6_K_f16")]]         kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_q6_K,    QK_NL, dequantize_q6_K,    half, half4x4, half, half2x4>;
 template [[host_name("kernel_mul_mm_id_iq2_xxs_f16")]]      kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_iq2_xxs, QK_NL, dequantize_iq2_xxs, half, half4x4, half, half2x4>;
 template [[host_name("kernel_mul_mm_id_iq4_xs_f16")]]       kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_iq4_xs, QK_NL, dequantize_iq4_xs, half, half4x4, half, half2x4>;
+template [[host_name("kernel_mul_mm_id_bf16_f16")]]         kernel mul_mm_id_f16_rhs kernel_mul_mm_id<32, half, half4x4, simdgroup_half8x8, half, half2x4, simdgroup_half8x8, block_bf16_16, 16, dequantize_bf16_16, half, half4x4, half, half2x4>;
 template [[host_name("kernel_mul_mm_id_q4_K_ff32")]]        kernel mul_mm_id_ff32 kernel_mul_mm_id<32, float, float4x4, simdgroup_float8x8, float, float2x4, simdgroup_float8x8, block_q4_K, QK_NL, dequantize_q4_K, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_q5_K_ff32")]]        kernel mul_mm_id_ff32 kernel_mul_mm_id<32, float, float4x4, simdgroup_float8x8, float, float2x4, simdgroup_float8x8, block_q5_K, QK_NL, dequantize_q5_K, float, float4x4, float, float2x4>;
 template [[host_name("kernel_mul_mm_id_q6_K_ff32")]]        kernel mul_mm_id_ff32 kernel_mul_mm_id<32, float, float4x4, simdgroup_float8x8, float, float2x4, simdgroup_float8x8, block_q6_K, QK_NL, dequantize_q6_K, float, float4x4, float, float2x4>;


### PR DESCRIPTION
# Laguna: mixed-precision quant support (APEX IQ4_XS/Q6_K, official BF16) + metadata-driven rope

Adds support for the mixed-precision Laguna S 2.1 exports that ds4 currently
rejects, closes the resulting prefill gap, and reports two artifact issues
found along the way.

Branch: `laguna-apex-quants` (four commits on top of `laguna-s2.1`).
All numbers measured on an M5 Max 128 GB, Metal backend, **on this branch as
submitted**, so they should reproduce directly.

## What this enables

| Export | Before | After |
|---|---|---|
| `Myric/Laguna-S-2.1-APEX-GGUF` i-quality (68.9 GiB, 5.03 bpw) | `unsupported Laguna quantization layout marker q6_k` | loads and runs |
| poolside official `Q4_K_Mx40-BF16x8` (89.4 GiB) | routed bf16 rejected | loads and runs |
| Any 1M-rope Laguna export | `expected context_length=262144 … got 1048576` | loads |

## Commits

1. **`d3935ba` — APEX quant support.** New IQ4_XS type end-to-end (block struct,
   codebook, CPU reference dequant, Metal QMV pair-swiglu/down kernels,
   `mul_mm_id` instantiations), a Q6_K routed pair-swiglu kernel, Q6_K
   attention/embedding/output acceptance, a third Laguna weight layout beside
   legacy and signal-q8, and Laguna `context_length`/rope scale+attn factors
   adopted from GGUF metadata after a coherence check
   (`orig_ctx × factor == context_length`) instead of pinning one export.
2. **`0f2d58d` — first optimisations.** Batched Q6_K dense matmuls routed
   through the tiled GEMM instead of a per-token QMV; vectorised IQ4_XS QMV
   inner loops.
3. **`552bc4c` — close the prefill gap.** Vectorised the `dequantize_q6_K` /
   `dequantize_iq4_xs` tile-staging hooks (word loads, branchless extraction,
   identical per-element arithmetic).
4. **`96a710c` — bf16 routed experts** for the official mixed-precision export.

## Measured (vs the Q4_K_M export)

Perplexity: wikitext-style local corpus, 8160 scored tokens, ctx 8192.
Prefill: 15K-token prompt, 6 interleaved pairs with cooldowns.

| | Q4_K_M | APEX i-quality |
|---|---|---|
| perplexity | 14.098 | **13.265 (−5.9 %)** |
| prefill | 454 ±24 t/s | 442 ±18 t/s (−2.6 % ±3.0 — parity) |
| decode | 52–54 t/s | parity |
| size | 63.6 GiB | 68.9 GiB |
| max context | 262 144 | 1 048 576 |

The prefill deficit was −12.4 % ±1.7 before commit `552bc4c`; the tile-dequant
hooks were essentially the whole gap, since they stage every `mul_mm`
(attention) and `mul_mm_id` (routed-expert) tile.

## Two findings worth flagging

**1. `block_q6_K` is 210 bytes, so its payload is not 4-byte aligned.**
Consecutive blocks alternate between 0- and 2-mod-4 addresses, making `ushort`
the widest always-safe load. An earlier `uint` version of the dequant hook
silently misdecoded the misaligned half of the blocks: **perplexity moved only
+0.25 %, but greedy generation degenerated into loops.** Teacher-forced scoring
barely notices; autoregressive decode compounds it. Every kernel change here is
gated on bit-exact perplexity (`ppl=13.265259871` on this branch) rather than a tolerance, which
is what caught it. Alignment should be derived from the block *stride*, not the
field offset — `block_iq4_xs` (136 B) keeps 32-bit loads for that reason.

**2. The three mixed-precision exports rank in a surprising order.** Same
corpus, same settings:

| export | size | perplexity |
|---|---|---|
| `Q4_K_M` | 63.6 GiB | 14.098 |
| **`Myric/…-APEX-GGUF` i-quality** | **68.9 GiB** | **13.265** |
| poolside official `Q4_K_Mx40-BF16x8` | 89.4 GiB | 13.399 |

The community APEX build edges out the official mixed-precision build by
1.0 % while being 23 % smaller. The two recipes make opposite
bets: APEX raises precision on the *edge* layers (q5_k/q6_k on layers 1-9 and
38-47) and compresses the middle to iq4_xs, while the official build leaves
layers 1-39 at q4_k and raises only the last eight to bf16. On this corpus the
edge-weighted allocation wins, which is consistent with quantisation error
mattering more in early layers than late ones.

Sizing note for 128 GB machines: the official build plans 89.88 GiB at ctx
8192 and roughly 107 GiB at 256K, and Laguna has no `--ssd-streaming`
fallback (`--ssd-streaming is not implemented for Laguna S 2.1 yet`). It needs
a mostly idle machine — a first attempt with ~30 GiB held by other
applications thrashed and never became resident. Since it now ships under the
same `laguna-s-2.1-Q4_K_M.gguf` filename as the 63.6 GiB build it replaced,
users re-pulling "Q4_K_M" get a substantially larger model than before.

## Notes for reviewers

- Metal-4 tensor matmuls remain suppressed in the Laguna graph prefill path
  (existing `ds4_gpu_set_tensor_matmul_suppressed(true)` call and its
  route-stability comment). The Q6_K MPP direct-RHS instantiations added here
  are consequently dormant on that path by design; they engage wherever MPP is
  otherwise permitted.
- The rope change validates rather than trusts: a GGUF whose
  `context_length` disagrees with `original_context_length × factor` is
  rejected with a diagnostic instead of loading.
- APEX perplexity is bit-identical before and after the bf16 commit, i.e. the
  new type does not disturb existing paths.
- Decode throughput across the three: official bf16 build 56.9 t/s, APEX
  51-57 t/s, `Q4_K_M` 52-54 t/s. bf16 needs no unpacking at all, so it is
  marginally the fastest per token despite being the largest to stream.

## Related

- #613 (corrected GGUF revision) — while testing this branch, the stale
  `706fa69` revision pinned in `download_model.sh` reproduced the looping /
  "never emits the tool call" behaviour that revision `e2ccc05` fixes. Weights
  are identical between the two (416-byte file delta; perplexity agrees to nine
  significant digits on the same build); only the chat template differs, by 121 lines including
  `enable_thinking` default `false`→`true`. With the stale artifact a thinking
  agent run never produced output; with the corrected one it succeeded in 3 of
  4 runs. Worth merging.
- #614 (KV-ring commits for oversized prefills) — not exercised here, but
  sweep-style workloads prefill far past the 512-row window, so it likely
  affects the same users.
