### PR TITLE
Laguna S 2.1: mlxfast-challenge ports + DFlash cycle optimization (+81.6% generation)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -47755,6 +47755,7 @@ typedef struct {
     ds4_gpu_tensor *spec_logits;
     ds4_gpu_tensor *spec_argmax;
     ds4_gpu_tensor *spec_key_backup[DS4_MAX_LAYER];
+    void *spec_copy_table;
     ds4_gpu_tensor *spec_value_backup[DS4_MAX_LAYER];
     ds4_gpu_tensor *key_cache[DS4_MAX_LAYER];
     ds4_gpu_tensor *value_cache[DS4_MAX_LAYER];
@@ -47799,6 +47800,12 @@ static void laguna_graph_free(ds4_laguna_gpu_graph *g) {
     DS4_LAGUNA_FREE(spec_logits);
     DS4_LAGUNA_FREE(spec_argmax);
 #undef DS4_LAGUNA_FREE
+#ifdef __APPLE__
+    if (g->spec_copy_table) {
+        ds4_gpu_laguna_spec_table_free(g->spec_copy_table);
+        g->spec_copy_table = NULL;
+    }
+#endif
     for (uint32_t il = 0; il < DS4_MAX_LAYER; il++) {
         ds4_gpu_tensor_free(g->spec_key_backup[il]);
         ds4_gpu_tensor_free(g->spec_value_backup[il]);
@@ -47949,6 +47956,26 @@ static bool laguna_graph_ensure_spec_scratch(ds4_laguna_gpu_graph *g) {
             return false;
         }
     }
+#ifdef __APPLE__
+    if (!g->spec_copy_table &&
+        getenv("DS4_METAL_DISABLE_SPEC_COPY_ALL") == NULL) {
+        ds4_gpu_tensor *kc[DS4_MAX_LAYER];
+        ds4_gpu_tensor *vc[DS4_MAX_LAYER];
+        ds4_gpu_tensor *kb[DS4_MAX_LAYER];
+        ds4_gpu_tensor *vb[DS4_MAX_LAYER];
+        uint32_t n_swa = 0;
+        for (uint32_t il = 0; il < DS4_N_LAYER; il++) {
+            if (!ds4_laguna_layer_is_swa(il)) continue;
+            kc[n_swa] = g->key_cache[il];
+            vc[n_swa] = g->value_cache[il];
+            kb[n_swa] = g->spec_key_backup[il];
+            vb[n_swa] = g->spec_value_backup[il];
+            n_swa++;
+        }
+        g->spec_copy_table =
+            ds4_gpu_laguna_spec_table_build(kc, vc, kb, vb, n_swa);
+    }
+#endif
     return true;
 }
 
@@ -48018,6 +48045,17 @@ static bool laguna_graph_spec_snapshot(
     const uint64_t row_bytes =
         (uint64_t)DS4_N_HEAD_KV * DS4_N_HEAD_DIM * sizeof(uint16_t);
     bool ok = ds4_gpu_begin_commands() != 0;
+#ifdef __APPLE__
+    if (ok && g->spec_copy_table) {
+        uint32_t swa_cap = 0;
+        for (uint32_t il = 0; il < DS4_N_LAYER && swa_cap == 0u; il++) {
+            if (ds4_laguna_layer_is_swa(il)) swa_cap = g->cache_cap[il];
+        }
+        ok = ds4_gpu_laguna_spec_copy_all_tensor(
+                 g->spec_copy_table, pos0, 0, n_rows, swa_cap,
+                 DS4_N_HEAD_KV * DS4_N_HEAD_DIM, 1) != 0;
+    } else
+#endif
     for (uint32_t il = 0; ok && il < DS4_N_LAYER; il++) {
         if (!ds4_laguna_layer_is_swa(il)) continue;
         ok = laguna_graph_spec_ring_copy(g->key_cache[il],
@@ -48051,6 +48089,17 @@ static bool laguna_graph_spec_restore(
     const uint64_t row_bytes =
         (uint64_t)DS4_N_HEAD_KV * DS4_N_HEAD_DIM * sizeof(uint16_t);
     bool ok = ds4_gpu_begin_commands() != 0;
+#ifdef __APPLE__
+    if (ok && g->spec_copy_table) {
+        uint32_t swa_cap = 0;
+        for (uint32_t il = 0; il < DS4_N_LAYER && swa_cap == 0u; il++) {
+            if (ds4_laguna_layer_is_swa(il)) swa_cap = g->cache_cap[il];
+        }
+        ok = ds4_gpu_laguna_spec_copy_all_tensor(
+                 g->spec_copy_table, pos0, first_row, n_rows, swa_cap,
+                 DS4_N_HEAD_KV * DS4_N_HEAD_DIM, 0) != 0;
+    } else
+#endif
     for (uint32_t il = 0; ok && il < DS4_N_LAYER; il++) {
         if (!ds4_laguna_layer_is_swa(il)) continue;
         ok = laguna_graph_spec_ring_copy(g->key_cache[il],

--- a/ds4.c
+++ b/ds4.c
@@ -48206,6 +48206,40 @@ static bool laguna_graph_routed_moe_decode_rows(
     const uint64_t weight_bytes =
         (uint64_t)DS4_N_EXPERT_USED * sizeof(float);
 
+    /* Diagnostic: measure how many routed-expert selections are shared
+     * between the rows of a multi-row decode (DFlash verification).  The
+     * unique/total ratio bounds what expert-level weight-read dedup could
+     * save.  Costs one sync per layer; diagnostics only. */
+    if (n_rows > 1u && getenv("DS4_LAGUNA_MOE_OVERLAP_STATS") != NULL &&
+        ds4_gpu_commands_active() && ds4_gpu_end_commands() != 0) {
+        int32_t sel[DS4_DFLASH_BLOCK_SIZE * 32];
+        const uint32_t n_sel = n_rows * DS4_N_EXPERT_USED;
+        if (n_sel <= sizeof(sel) / sizeof(sel[0]) &&
+            ds4_gpu_tensor_read(g->router_selected, 0, sel,
+                                (uint64_t)n_sel * sizeof(int32_t)) != 0) {
+            static uint64_t total_pairs, unique_pairs, calls;
+            uint32_t unique = 0;
+            for (uint32_t i = 0; i < n_sel; i++) {
+                bool seen = false;
+                for (uint32_t j = 0; j < i && !seen; j++) {
+                    seen = sel[j] == sel[i];
+                }
+                if (!seen) unique++;
+            }
+            total_pairs += n_sel;
+            unique_pairs += unique;
+            if ((++calls % 470u) == 0u) {
+                fprintf(stderr,
+                        "ds4: laguna verify expert overlap: unique %.1f%% "
+                        "of %llu selections over %llu layer passes\n",
+                        100.0 * (double)unique_pairs / (double)total_pairs,
+                        (unsigned long long)total_pairs,
+                        (unsigned long long)calls);
+            }
+        }
+        if (ds4_gpu_begin_commands() == 0) return false;
+    }
+
 #if defined(__APPLE__)
     if (l->ffn_gate_exps->type == DS4_TENSOR_Q4_K &&
         l->ffn_up_exps->type == DS4_TENSOR_Q4_K &&
@@ -68767,6 +68801,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
         }
     }
 
+    const double conf_done = now_sec();
     verify_tokens[0] = first_token;
     ds4_laguna_feature_capture capture =
         ds4_session_dflash_capture(s, 0, n_rows);
@@ -68785,6 +68820,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
             NULL,
             NULL,
             0);
+    const double verify_encoded = now_sec();
     bool inject_ok = false;
     if (verify_ok) {
         inject_ok = ds4_session_dflash_finish_capture(s, pos0, n_rows);
@@ -68804,6 +68840,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
                 (uint64_t)n_rows * sizeof(draft_top[0])) != 0;
         }
     }
+    const double reads_done = now_sec();
     if (!verify_ok || !inject_ok || !target_read_ok || !draft_read_ok) {
         (void)laguna_graph_spec_restore(
             &s->laguna_graph, pos0, 0, n_rows);
@@ -68848,6 +68885,31 @@ static int ds4_session_eval_dflash_speculative_argmax(
     s->dflash_synced = true;
 
     const double verify_done = now_sec();
+    if (getenv("DS4_DFLASH_TIMING") != NULL) {
+        /* Phase attribution: draft = snapshot + draft-block encode/submit;
+         * conf = wait for draft + confidence readback; enc = verifier encode
+         * (near zero when the pre-encoded verifier is committed); read =
+         * verifier execution + argmax readback; tail = full-row logits read
+         * + ring restore.  Sample adds the host-side pick from logits. */
+        static double acc[6];
+        static uint32_t acc_cycles;
+        acc[0] += (submit_done - cycle_t0) * 1000.0;
+        acc[1] += (conf_done - submit_done) * 1000.0;
+        acc[2] += (verify_encoded - conf_done) * 1000.0;
+        acc[3] += (reads_done - verify_encoded) * 1000.0;
+        acc[4] += (verify_done - reads_done) * 1000.0;
+        acc[5] += s->last_sample_ms;
+        if ((++acc_cycles % 64u) == 0u) {
+            fprintf(stderr,
+                    "ds4: DFlash phases ms/cycle over %u cycles: "
+                    "draft %.2f conf %.2f enc %.2f read %.2f tail %.2f "
+                    "sample %.2f\n",
+                    64u,
+                    acc[0] / 64.0, acc[1] / 64.0, acc[2] / 64.0,
+                    acc[3] / 64.0, acc[4] / 64.0, acc[5] / 64.0);
+            memset(acc, 0, sizeof(acc));
+        }
+    }
     /* CUDA installs the anonymous F16 support mapping lazily. Its first draft
      * cycle faults roughly 2 GiB of weights and is intentionally a one-time
      * warmup, not evidence that steady-state speculation is unprofitable. */

--- a/ds4.c
+++ b/ds4.c
@@ -49194,6 +49194,12 @@ static uint32_t g_laguna_stage_tokens;
 static double   g_laguna_stage_t0;
 static double   g_laguna_stage_busy0;
 
+static int laguna_dflash_timing_enabled(void) {
+    static int cached = -1;
+    if (cached < 0) cached = getenv("DS4_DFLASH_TIMING") != NULL ? 1 : 0;
+    return cached;
+}
+
 static double laguna_stage_busy_ms(void) {
 #ifdef __APPLE__
     return ds4_gpu_busy_accum_ms();
@@ -69285,7 +69291,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
 
     const double verify_done = now_sec();
     const double busy_verify = laguna_stage_busy_ms();
-    if (getenv("DS4_DFLASH_TIMING") != NULL) {
+    if (laguna_dflash_timing_enabled()) {
         /* Phase attribution: draft = snapshot + draft-block encode/submit;
          * conf = wait for draft + confidence readback; enc = verifier encode
          * (near zero when the pre-encoded verifier is committed); read =
@@ -69423,7 +69429,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
                     uint32_t next = s->dflash_active_draft * 2u + 1u;
                     if (next > requested_draft) next = requested_draft;
                     s->dflash_active_draft = next;
-                    if (getenv("DS4_DFLASH_TIMING") != NULL) {
+                    if (laguna_dflash_timing_enabled()) {
                         fprintf(stderr,
                                 "ds4: DFlash testing draft depth %u "
                                 "after %.2f ms/token at depth %u\n",
@@ -69435,7 +69441,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
                     if (s->dflash_cycles >= 10u) {
                         s->dflash_guard_decided = true;
                     }
-                    if (getenv("DS4_DFLASH_TIMING") != NULL) {
+                    if (laguna_dflash_timing_enabled()) {
                         fprintf(stderr,
                                 "ds4: DFlash retaining draft depth %u; "
                                 "only %u/5 calibration blocks were fully "
@@ -69475,7 +69481,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
                    cumulative_ms_per_token <
                        s->dflash_baseline_ms * 0.98) {
             s->dflash_guard_decided = true;
-            if (getenv("DS4_DFLASH_TIMING") != NULL) {
+            if (laguna_dflash_timing_enabled()) {
                 fprintf(stderr,
                         "ds4: DFlash retaining draft depth %u after local "
                         "slowdown; cumulative cost is %.2f ms/token\n",
@@ -69484,7 +69490,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
             }
         } else if (s->dflash_cycles < 10u &&
                    spec_ms_per_token < s->dflash_baseline_ms * 1.05) {
-            if (getenv("DS4_DFLASH_TIMING") != NULL) {
+            if (laguna_dflash_timing_enabled()) {
                 fprintf(stderr,
                         "ds4: DFlash calibration is within startup noise "
                         "(%.2f vs %.2f ms/token); measuring another window\n",
@@ -69529,7 +69535,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
         s->dflash_window_tokens = 0;
         s->dflash_window_cycles = 0;
     }
-    if (getenv("DS4_DFLASH_TIMING") != NULL) {
+    if (laguna_dflash_timing_enabled()) {
         fprintf(stderr,
                 "ds4: DFlash cycle drafted=%u verified=%u accepted=%d "
                 "pipeline=%.3f ms\n",

--- a/ds4.c
+++ b/ds4.c
@@ -36129,6 +36129,7 @@ struct ds4_engine {
     int mtp_draft_tokens;
     int dflash_draft_tokens;
     float dflash_p_min;
+    bool dflash_p_min_default;
     float mtp_margin;
     float dspark_confidence_threshold;
     char *directional_steering_file;
@@ -49731,6 +49732,24 @@ static bool laguna_graph_forward_token(
                                  logits_out,
                                  (uint64_t)DS4_N_VOCAB * sizeof(float)) != 0;
     }
+    /* Diagnostic: clean per-token GPU-busy without stage drains, for
+     * comparison against the DFlash verifier's read-phase busy. */
+    if (ok && getenv("DS4_LAGUNA_DECODE_BUSY") != NULL) {
+        static double busy_prev;
+        static double busy_acc;
+        static uint32_t busy_tokens;
+        const double busy_now = laguna_stage_busy_ms();
+        if (busy_prev != 0.0) {
+            busy_acc += busy_now - busy_prev;
+            if ((++busy_tokens % 64u) == 0u) {
+                fprintf(stderr,
+                        "ds4: laguna decode GPU-busy %.2f ms/token over "
+                        "64 tokens\n", busy_acc / 64.0);
+                busy_acc = 0.0;
+            }
+        }
+        busy_prev = busy_now;
+    }
     if (ok) laguna_stage_token_done();
     return ok;
 }
@@ -59654,9 +59673,14 @@ static int ds4_engine_open_internal(ds4_engine **out,
 #ifdef DS4_NATIVE_CUDA_BUILD
     e->dflash_p_min =
         opt->dflash_p_min_set ? opt->dflash_p_min : 0.4f;
+    e->dflash_p_min_default = false;
 #else
     e->dflash_p_min =
         opt->dflash_p_min_set ? opt->dflash_p_min : 0.5f;
+    /* Without an explicit --dflash-p-min, deeper positions prune harder
+     * (0.50/0.55/0.65): chain acceptance decays with position, so a
+     * marginal tail row rarely earns its 2.5 GB verify cost. */
+    e->dflash_p_min_default = !opt->dflash_p_min_set;
 #endif
     e->mtp_margin = opt->mtp_margin >= 0.0f ? opt->mtp_margin : 3.0f;
     if (opt->dspark_confidence_threshold_set) {
@@ -68962,8 +68986,36 @@ static int ds4_session_eval_dflash_speculative_argmax(
                 (uint64_t)n_rows *
                     sizeof(draft_probabilities[0])) != 0;
 #endif
+        /* Diagnostic: per-position confidence thresholds, e.g.
+         * DS4_DFLASH_P_MIN_SCHED=0.40,0.55,0.65 (later positions keep the
+         * last value); unset positions fall back to the uniform p-min. */
+        static float p_min_sched[DS4_DFLASH_BLOCK_SIZE];
+        static int p_min_sched_n = -1;
+        if (p_min_sched_n < 0) {
+            p_min_sched_n = 0;
+            const char *sched_env = getenv("DS4_DFLASH_P_MIN_SCHED");
+            while (sched_env != NULL && *sched_env != '\0' &&
+                   p_min_sched_n < (int)DS4_DFLASH_BLOCK_SIZE) {
+                char *end = NULL;
+                const float v = strtof(sched_env, &end);
+                if (end == sched_env) break;
+                p_min_sched[p_min_sched_n++] = v;
+                sched_env = *end == ',' ? end + 1 : end;
+            }
+        }
+        static const float p_min_sched_default[3] = {0.50f, 0.55f, 0.65f};
         for (uint32_t i = 0; draft_read_ok && i < n_draft; i++) {
-            if (draft_probabilities[i + 1u] < draft_p_min) {
+            float threshold;
+            if (p_min_sched_n > 0) {
+                threshold = (int)i < p_min_sched_n ?
+                    p_min_sched[i] : p_min_sched[p_min_sched_n - 1];
+            } else if (e->dflash_p_min_default) {
+                threshold = i < 3u ?
+                    p_min_sched_default[i] : p_min_sched_default[2];
+            } else {
+                threshold = draft_p_min;
+            }
+            if (draft_probabilities[i + 1u] < threshold) {
                 n_draft = i;
                 n_rows = n_draft + 1u;
                 break;

--- a/ds4.c
+++ b/ds4.c
@@ -48118,6 +48118,30 @@ static bool laguna_graph_matmul(
         const ds4_gpu_tensor *x,
         uint64_t              n_tokens) {
     if (!out || !model || !weight || !x || weight->ndim < 2) return false;
+#ifdef __APPLE__
+    /* The Metal 4 tensor matmul path requires 32-row batches, so a prompt of
+     * arbitrary length would fall back entirely to the legacy kernels.
+     * Split off the aligned head; only the sub-32-row tail takes the legacy
+     * path. */
+    if (n_tokens > 32u && (n_tokens % 32u) != 0u) {
+        const uint64_t head_rows = n_tokens & ~31ull;
+        const uint64_t tail_rows = n_tokens - head_rows;
+        ds4_gpu_tensor *x_tail = ds4_gpu_tensor_view(
+                x,
+                head_rows * weight->dim[0] * sizeof(float),
+                tail_rows * weight->dim[0] * sizeof(float));
+        ds4_gpu_tensor *out_tail = ds4_gpu_tensor_view(
+                out,
+                head_rows * weight->dim[1] * sizeof(float),
+                tail_rows * weight->dim[1] * sizeof(float));
+        const bool ok = x_tail && out_tail &&
+            laguna_graph_matmul(out, model, weight, x, head_rows) &&
+            laguna_graph_matmul(out_tail, model, weight, x_tail, tail_rows);
+        ds4_gpu_tensor_free(out_tail);
+        ds4_gpu_tensor_free(x_tail);
+        return ok;
+    }
+#endif
 #ifdef DS4_ROCM_BUILD
     if (weight->type == DS4_TENSOR_Q8_0 && n_tokens == 1u) {
         return ds4_gpu_matmul_q8_0_decode_preq_tensor(
@@ -49095,7 +49119,7 @@ typedef struct {
     double      busy_ms;
 } laguna_stage_profile_slot;
 
-static laguna_stage_profile_slot g_laguna_stage_slots[24];
+static laguna_stage_profile_slot g_laguna_stage_slots[40];
 static uint32_t g_laguna_stage_tokens;
 static double   g_laguna_stage_t0;
 static double   g_laguna_stage_busy0;
@@ -49169,6 +49193,30 @@ static void laguna_stage_token_done(void) {
     }
     fprintf(stderr, "  %-10s %8.3f %8.3f\n", "total",
             total / (double)window, busy_total / (double)window);
+}
+
+/* Print and reset accumulated stage totals normalized by denom (e.g. the
+ * token count of a prefill chunk). */
+static void laguna_stage_dump(const char *what, double denom) {
+    if (!laguna_stage_profile_enabled() || denom <= 0.0) return;
+    const size_t n_slots =
+        sizeof(g_laguna_stage_slots) / sizeof(g_laguna_stage_slots[0]);
+    double total = 0.0;
+    double busy_total = 0.0;
+    fprintf(stderr, "ds4: laguna %s stages, wall/gpu ms per token:\n", what);
+    for (size_t i = 0; i < n_slots; i++) {
+        laguna_stage_profile_slot *slot = &g_laguna_stage_slots[i];
+        if (!slot->name) break;
+        if (slot->total_ms == 0.0 && slot->busy_ms == 0.0) continue;
+        fprintf(stderr, "  %-10s %8.4f %8.4f\n", slot->name,
+                slot->total_ms / denom, slot->busy_ms / denom);
+        total += slot->total_ms;
+        busy_total += slot->busy_ms;
+        slot->total_ms = 0.0;
+        slot->busy_ms = 0.0;
+    }
+    fprintf(stderr, "  %-10s %8.4f %8.4f\n", "total",
+            total / denom, busy_total / denom);
 }
 
 static bool laguna_graph_forward_token(
@@ -49880,6 +49928,15 @@ static bool laguna_graph_forward_batch(
      * lower-overhead single-command path. */
     const bool live_progress = display_progress != NULL && n_tokens >= 32u;
     const bool exact_q8_rows = row_argmax_out != NULL;
+    /* Stage attribution for plain prefill only: DFlash verification shares
+     * its command stream with the draft graph and must not be drained at
+     * stage boundaries. */
+    const bool stage_prof =
+        laguna_stage_profile_enabled() && gpu_draft_tokens == NULL;
+    if (stage_prof) {
+        g_laguna_stage_t0 = now_sec() * 1000.0;
+        g_laguna_stage_busy0 = laguna_stage_busy_ms();
+    }
     if (gpu_draft_tokens) {
         ok = gpu_draft_pipeline_ready;
     } else {
@@ -49960,6 +50017,7 @@ static bool laguna_graph_forward_batch(
                                                  n_tokens,
                                                  exact_q8_rows);
         }
+        if (ok && stage_prof) ok = laguna_stage_mark("p_qkvg");
         if (ok && exact_q8_rows) {
             failed_stage = "Q/K norm/RoPE";
             ok = ds4_gpu_laguna_qk_head_rms_norm_rope_tensor(
@@ -50027,6 +50085,7 @@ static bool laguna_graph_forward_batch(
                         DS4_RMS_EPS) != 0;
             }
         }
+        if (ok && stage_prof) ok = laguna_stage_mark("p_rope");
         if (ok) {
             failed_stage = "causal attention";
             /* Ask the backend to replay decode's split-key attention per
@@ -50059,6 +50118,7 @@ static bool laguna_graph_forward_batch(
                     1.0f / sqrtf((float)DS4_N_HEAD_DIM),
                     split_decode_rows) != 0;
         }
+        if (ok && stage_prof) ok = laguna_stage_mark("p_attn");
         if (ok) {
             failed_stage = "attention output projection";
             ok = laguna_graph_matmul_decode_rows(g->attn_out,
@@ -50068,6 +50128,7 @@ static bool laguna_graph_forward_batch(
                                                  n_tokens,
                                                  exact_q8_rows);
         }
+        if (ok && stage_prof) ok = laguna_stage_mark("p_attn_out");
         if (ok) {
             failed_stage = "attention residual";
             ok = ds4_gpu_add_tensor(g->after_attn,
@@ -50087,6 +50148,7 @@ static bool laguna_graph_forward_batch(
                     n_tokens,
                     DS4_RMS_EPS) != 0;
         }
+        if (ok && stage_prof) ok = laguna_stage_mark("p_norms");
         if (ok && il < DS4_N_LEADING_DENSE) {
             failed_stage = "dense FFN gate/up";
             ok = laguna_graph_matmul_decode_rows(g->ffn_gate,
@@ -50127,6 +50189,7 @@ static bool laguna_graph_forward_batch(
                                         g->ffn_out,
                                         (uint64_t)n_tokens * DS4_N_EMBD) != 0;
             }
+            if (ok && stage_prof) ok = laguna_stage_mark("p_dense");
         } else if (ok) {
             if (exact_q8_rows) {
                 failed_stage = "decode-row router";
@@ -50160,6 +50223,7 @@ static bool laguna_graph_forward_batch(
                         n_tokens) != 0;
             }
 
+        if (ok && stage_prof) ok = laguna_stage_mark("p_router");
             const uint64_t gate_row_bytes =
                 routed_expert_row_bytes(l->ffn_gate_exps);
             const uint64_t up_row_bytes =
@@ -50219,6 +50283,7 @@ static bool laguna_graph_forward_batch(
                             true) != 0;
                 }
             }
+        if (ok && stage_prof) ok = laguna_stage_mark("p_moe");
             const bool exact_q8_shared =
                 exact_q8_rows &&
                 l->ffn_gate_shexp->type == DS4_TENSOR_Q8_0 &&
@@ -50275,6 +50340,7 @@ static bool laguna_graph_forward_batch(
                          n_tokens,
                          exact_q8_rows);
             }
+        if (ok && stage_prof) ok = laguna_stage_mark("p_shexp");
             if (ok) {
                 failed_stage = "MoE residual";
                 ok = ds4_gpu_add3_tensor(
@@ -50285,6 +50351,7 @@ static bool laguna_graph_forward_batch(
                         (uint64_t)n_tokens * DS4_N_EMBD) != 0;
             }
         }
+        if (ok && stage_prof) ok = laguna_stage_mark("p_resid");
 
         if (ok) {
             ds4_gpu_tensor *tmp = g->cur;
@@ -50394,6 +50461,7 @@ static bool laguna_graph_forward_batch(
                                      1);
         }
     }
+    if (ok && stage_prof) ok = laguna_stage_mark("p_head");
     /* A speculative cycle appends support-cache injection before completing
      * the shared snapshot/draft/verify command stream. */
     const bool defer_completion = ok && gpu_draft_tokens != NULL;
@@ -50402,6 +50470,7 @@ static bool laguna_graph_forward_batch(
         ok = false;
     }
     ds4_gpu_tensor_free(last);
+    if (ok && stage_prof) laguna_stage_dump("prefill", (double)n_tokens);
     if (ok && row_argmax_out && !defer_completion) {
         ok = ds4_gpu_tensor_read(g->spec_argmax,
                                  0,

--- a/ds4.c
+++ b/ds4.c
@@ -50119,24 +50119,55 @@ static bool laguna_graph_forward_batch(
                     split_decode_rows) != 0;
         }
         if (ok && stage_prof) ok = laguna_stage_mark("p_attn");
-        if (ok) {
+        /* Beyond its KV store, the last layer of a plain prefill only feeds
+         * the final row's logits: run the FFN/MoE chain on that single row
+         * (or skip it entirely for non-final chunks). */
+        const bool last_row_tail =
+            il + 1u == (uint32_t)DS4_N_LAYER && n_tokens > 1u &&
+            capture == NULL && row_argmax_out == NULL;
+        const bool tail_skip = last_row_tail && logits_out == NULL;
+        const uint32_t tail_rows = last_row_tail ? 1u : n_tokens;
+        ds4_gpu_tensor *tail_heads = g->heads;
+        ds4_gpu_tensor *tail_cur = g->cur;
+        ds4_gpu_tensor *tail_next = g->next;
+        ds4_gpu_tensor *tail_views[3] = {NULL, NULL, NULL};
+        if (ok && last_row_tail && !tail_skip) {
+            const uint64_t embd_off =
+                (uint64_t)(n_tokens - 1u) * DS4_N_EMBD * sizeof(float);
+            const uint64_t embd_len = (uint64_t)DS4_N_EMBD * sizeof(float);
+            const uint64_t head_len =
+                (uint64_t)n_head * DS4_N_HEAD_DIM * sizeof(float);
+            tail_views[0] = ds4_gpu_tensor_view(
+                    g->heads, (uint64_t)(n_tokens - 1u) * head_len, head_len);
+            tail_views[1] = ds4_gpu_tensor_view(g->cur, embd_off, embd_len);
+            tail_views[2] = ds4_gpu_tensor_view(g->next, embd_off, embd_len);
+            ok = tail_views[0] && tail_views[1] && tail_views[2];
+            if (ok) {
+                tail_heads = tail_views[0];
+                tail_cur = tail_views[1];
+                tail_next = tail_views[2];
+            } else {
+                failed_stage = "last-row tail views";
+            }
+        }
+        if (ok && !tail_skip) {
             failed_stage = "attention output projection";
             ok = laguna_graph_matmul_decode_rows(g->attn_out,
                                                  model,
                                                  l->attn_output,
-                                                 g->heads,
-                                                 n_tokens,
+                                                 tail_heads,
+                                                 tail_rows,
                                                  exact_q8_rows);
         }
         if (ok && stage_prof) ok = laguna_stage_mark("p_attn_out");
-        if (ok) {
+        if (ok && !tail_skip) {
             failed_stage = "attention residual";
             ok = ds4_gpu_add_tensor(g->after_attn,
-                                    g->cur,
+                                    tail_cur,
                                     g->attn_out,
-                                    (uint64_t)n_tokens * DS4_N_EMBD) != 0;
+                                    (uint64_t)tail_rows * DS4_N_EMBD) != 0;
         }
-        if (ok) {
+        if (ok && !tail_skip) {
             failed_stage = "FFN norm";
             ok = ds4_gpu_rms_norm_weight_rows_tensor(
                     g->ffn_norm,
@@ -50145,7 +50176,7 @@ static bool laguna_graph_forward_batch(
                     model->size,
                     l->ffn_norm->abs_offset,
                     DS4_N_EMBD,
-                    n_tokens,
+                    tail_rows,
                     DS4_RMS_EPS) != 0;
         }
         if (ok && stage_prof) ok = laguna_stage_mark("p_norms");
@@ -50190,7 +50221,7 @@ static bool laguna_graph_forward_batch(
                                         (uint64_t)n_tokens * DS4_N_EMBD) != 0;
             }
             if (ok && stage_prof) ok = laguna_stage_mark("p_dense");
-        } else if (ok) {
+        } else if (ok && !tail_skip) {
             if (exact_q8_rows) {
                 failed_stage = "decode-row router";
                 ok = laguna_graph_router_decode_rows(
@@ -50205,7 +50236,7 @@ static bool laguna_graph_forward_batch(
                         DS4_N_EMBD,
                         DS4_N_EXPERT,
                         g->ffn_norm,
-                        n_tokens) != 0;
+                        tail_rows) != 0;
             }
             if (ok && !exact_q8_rows) {
                 failed_stage = "router selection";
@@ -50220,7 +50251,7 @@ static bool laguna_graph_forward_batch(
                         DS4_N_EXPERT,
                         DS4_N_EXPERT_USED,
                         DS4_EXPERT_WEIGHT_SCALE,
-                        n_tokens) != 0;
+                        tail_rows) != 0;
             }
 
         if (ok && stage_prof) ok = laguna_stage_mark("p_router");
@@ -50278,7 +50309,7 @@ static bool laguna_graph_forward_batch(
                             DS4_N_EXPERT_USED,
                             il,
                             g->ffn_norm,
-                            n_tokens,
+                            tail_rows,
                             DS4_N_EXPERT_USED * DS4_N_FF_EXP,
                             true) != 0;
                 }
@@ -50310,14 +50341,14 @@ static bool laguna_graph_forward_batch(
                          model,
                          l->ffn_gate_shexp,
                          g->ffn_norm,
-                         n_tokens,
+                         tail_rows,
                          exact_q8_rows) &&
                      laguna_graph_matmul_decode_rows(
                          g->ffn_up,
                          model,
                          l->ffn_up_shexp,
                          g->ffn_norm,
-                         n_tokens,
+                         tail_rows,
                          exact_q8_rows);
                 if (ok) {
                     failed_stage = "shared expert SwiGLU";
@@ -50325,7 +50356,7 @@ static bool laguna_graph_forward_batch(
                             g->ffn_mid,
                             g->ffn_gate,
                             g->ffn_up,
-                            (uint64_t)n_tokens * DS4_N_FF_SHARED,
+                            (uint64_t)tail_rows * DS4_N_FF_SHARED,
                             0.0f,
                             1.0f) != 0;
                 }
@@ -50337,22 +50368,25 @@ static bool laguna_graph_forward_batch(
                          model,
                          l->ffn_down_shexp,
                          g->ffn_mid,
-                         n_tokens,
+                         tail_rows,
                          exact_q8_rows);
             }
         if (ok && stage_prof) ok = laguna_stage_mark("p_shexp");
             if (ok) {
                 failed_stage = "MoE residual";
                 ok = ds4_gpu_add3_tensor(
-                        g->next,
+                        tail_next,
                         g->after_attn,
                         g->ffn_out,
                         g->shared_out,
-                        (uint64_t)n_tokens * DS4_N_EMBD) != 0;
+                        (uint64_t)tail_rows * DS4_N_EMBD) != 0;
             }
         }
         if (ok && stage_prof) ok = laguna_stage_mark("p_resid");
 
+        ds4_gpu_tensor_free(tail_views[0]);
+        ds4_gpu_tensor_free(tail_views[1]);
+        ds4_gpu_tensor_free(tail_views[2]);
         if (ok) {
             ds4_gpu_tensor *tmp = g->cur;
             g->cur = g->next;

--- a/ds4.c
+++ b/ds4.c
@@ -68906,6 +68906,55 @@ static int ds4_sessions_eval_batch_with_prefill_cuda(
 }
 
 #ifndef DS4_NO_GPU
+/* Training-data harvest sink (diagnostic): one record per verified
+ * position — captured aux features (f16), token, absolute position. */
+static void ds4_session_dflash_dump_rows(
+        ds4_session *s,
+        uint32_t     pos0,
+        const int   *tokens,
+        int          n_rows) {
+    static FILE *dump_fp;
+    static int dump_state;
+    if (dump_state == 0) {
+        const char *dump_path = getenv("DS4_DFLASH_DUMP");
+        if (dump_path != NULL && dump_path[0] != '\0') {
+            dump_fp = fopen(dump_path, "ab");
+            if (dump_fp != NULL && ftell(dump_fp) == 0) {
+                const uint32_t header[4] = {
+                    0x44344446u, /* "D4DF" */
+                    1u, DS4_DFLASH_N_AUX, DS4_N_EMBD,
+                };
+                fwrite(header, sizeof(header), 1, dump_fp);
+            }
+        }
+        dump_state = dump_fp != NULL ? 1 : -1;
+    }
+    if (dump_state != 1) return;
+    const uint32_t feat_elems = DS4_DFLASH_N_AUX * DS4_N_EMBD;
+    float *feat = malloc((size_t)feat_elems * sizeof(float));
+    uint16_t *half = malloc((size_t)feat_elems * sizeof(uint16_t));
+    if (!feat || !half) { free(feat); free(half); return; }
+    for (int r = 0; r < n_rows; r++) {
+        if (!ds4_gpu_tensor_read(
+                s->dflash_graph.features,
+                (uint64_t)r * feat_elems * sizeof(float),
+                feat, (uint64_t)feat_elems * sizeof(float))) {
+            break;
+        }
+        for (uint32_t i = 0; i < feat_elems; i++) {
+            _Float16 h = (_Float16)feat[i];
+            memcpy(&half[i], &h, sizeof(uint16_t));
+        }
+        const uint32_t rec_pos = pos0 + (uint32_t)r;
+        const int32_t rec_token = tokens[r];
+        fwrite(&rec_pos, sizeof(rec_pos), 1, dump_fp);
+        fwrite(&rec_token, sizeof(rec_token), 1, dump_fp);
+        fwrite(half, sizeof(uint16_t), feat_elems, dump_fp);
+    }
+    free(feat);
+    free(half);
+}
+
 static int ds4_session_eval_dflash_speculative_argmax(
         ds4_session *s,
         int          first_token,
@@ -68956,6 +69005,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
          * than their first few tokens. Periodically spend one ordinary target
          * token to refresh the break-even estimate under current conditions. */
         const double decode_t0 = now_sec();
+        const uint32_t refresh_pos = (uint32_t)s->checkpoint.len;
         if (ds4_session_eval(s, first_token, err, errlen) != 0) return -1;
         const double current_ms =
             (now_sec() - decode_t0) * 1000.0 + s->last_sample_ms;
@@ -68963,6 +69013,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
             0.5 * s->dflash_baseline_ms + 0.5 * current_ms;
         s->dflash_cycles_since_baseline = 0;
         accepted[0] = first_token;
+        ds4_session_dflash_dump_rows(s, refresh_pos, accepted, 1);
         return 1;
     }
 
@@ -69289,28 +69340,14 @@ static int ds4_session_eval_dflash_speculative_argmax(
      * its host-side scan of the vocabulary. */
     s->dflash_greedy_next = target_top[n_accept - 1];
 
-    /* Training-data harvest (diagnostic): append one record per accepted
-     * position — the captured aux features the draft conditions on, the
-     * verified token, and its absolute position.  The greedy stream itself
-     * provides the prediction labels at training time. */
+    /* Training-data harvest (diagnostic). */
     do {
-        static FILE *dump_fp;
-        static int dump_state;
-        if (dump_state == 0) {
-            const char *dump_path = getenv("DS4_DFLASH_DUMP");
-            if (dump_path != NULL && dump_path[0] != '\0') {
-                dump_fp = fopen(dump_path, "ab");
-                if (dump_fp != NULL && ftell(dump_fp) == 0) {
-                    const uint32_t header[4] = {
-                        0x44344446u, /* "D4DF" */
-                        1u, DS4_DFLASH_N_AUX, DS4_N_EMBD,
-                    };
-                    fwrite(header, sizeof(header), 1, dump_fp);
-                }
-            }
-            dump_state = dump_fp != NULL ? 1 : -1;
+        static int dump_enabled = -1;
+        if (dump_enabled < 0) {
+            const char *dp = getenv("DS4_DFLASH_DUMP");
+            dump_enabled = dp != NULL && dp[0] != '\0' ? 1 : 0;
         }
-        if (dump_state != 1) break;
+        if (!dump_enabled) break;
         /* Sidecar: per-cycle draft proposals and confidences, the golden
          * reference for validating a retrained draft's forward pass. */
         static FILE *cycle_fp;
@@ -69334,30 +69371,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
             fwrite(target_top, sizeof(int32_t), DS4_DFLASH_BLOCK_SIZE,
                    cycle_fp);
         }
-        const uint32_t feat_elems = DS4_DFLASH_N_AUX * DS4_N_EMBD;
-        float *feat = malloc((size_t)feat_elems * sizeof(float));
-        uint16_t *half = malloc((size_t)feat_elems * sizeof(uint16_t));
-        if (!feat || !half) { free(feat); free(half); break; }
-        for (int r = 0; r < n_accept; r++) {
-            if (!ds4_gpu_tensor_read(
-                    s->dflash_graph.features,
-                    (uint64_t)r * feat_elems * sizeof(float),
-                    feat, (uint64_t)feat_elems * sizeof(float))) {
-                break;
-            }
-            for (uint32_t i = 0; i < feat_elems; i++) {
-                /* f32 -> f16 via the compiler's conversion */
-                _Float16 h = (_Float16)feat[i];
-                memcpy(&half[i], &h, sizeof(uint16_t));
-            }
-            const uint32_t rec_pos = pos0 + (uint32_t)r;
-            const int32_t rec_token = accepted[r];
-            fwrite(&rec_pos, sizeof(rec_pos), 1, dump_fp);
-            fwrite(&rec_token, sizeof(rec_token), 1, dump_fp);
-            fwrite(half, sizeof(uint16_t), feat_elems, dump_fp);
-        }
-        free(feat);
-        free(half);
+        ds4_session_dflash_dump_rows(s, pos0, accepted, n_accept);
     } while (0);
 
     const double verify_done = now_sec();

--- a/ds4.c
+++ b/ds4.c
@@ -48991,21 +48991,33 @@ static bool dflash_graph_draft_block(
                                      l->attn_output,
                                      g->heads,
                                      n_rows) &&
-                 ds4_gpu_add_tensor(g->after_attn,
-                                    g->cur,
-                                    g->attn_out,
-                                    (uint64_t)n_rows * embd) != 0;
-        }
-        if (ok) {
-            ok = ds4_gpu_rms_norm_weight_rows_tensor(
+#ifdef __APPLE__
+                 ds4_gpu_add_rms_norm_weight_rows_tensor(
                      g->ffn_norm,
                      g->after_attn,
+                     g->cur,
+                     g->attn_out,
                      weight_map,
                      weight_map_size,
                      l->ffn_norm->abs_offset,
                      embd,
                      n_rows,
                      DS4_SHAPE_LAGUNA_S21.rms_eps) != 0;
+#else
+                 (ds4_gpu_add_tensor(g->after_attn,
+                                     g->cur,
+                                     g->attn_out,
+                                     (uint64_t)n_rows * embd) != 0 &&
+                  ds4_gpu_rms_norm_weight_rows_tensor(
+                      g->ffn_norm,
+                      g->after_attn,
+                      weight_map,
+                      weight_map_size,
+                      l->ffn_norm->abs_offset,
+                      embd,
+                      n_rows,
+                      DS4_SHAPE_LAGUNA_S21.rms_eps) != 0);
+#endif
         }
         if (ok) {
             ok = dflash_graph_matmul(g->ffn_gate,
@@ -50161,15 +50173,25 @@ static bool laguna_graph_forward_batch(
         }
         if (ok && stage_prof) ok = laguna_stage_mark("p_attn_out");
         if (ok && !tail_skip) {
-            failed_stage = "attention residual";
+            failed_stage = "attention residual + FFN norm";
+#ifdef __APPLE__
+            ok = ds4_gpu_add_rms_norm_weight_rows_tensor(
+                    g->ffn_norm,
+                    g->after_attn,
+                    tail_cur,
+                    g->attn_out,
+                    model->map,
+                    model->size,
+                    l->ffn_norm->abs_offset,
+                    DS4_N_EMBD,
+                    tail_rows,
+                    DS4_RMS_EPS) != 0;
+#else
             ok = ds4_gpu_add_tensor(g->after_attn,
                                     tail_cur,
                                     g->attn_out,
-                                    (uint64_t)tail_rows * DS4_N_EMBD) != 0;
-        }
-        if (ok && !tail_skip) {
-            failed_stage = "FFN norm";
-            ok = ds4_gpu_rms_norm_weight_rows_tensor(
+                                    (uint64_t)tail_rows * DS4_N_EMBD) != 0 &&
+                 ds4_gpu_rms_norm_weight_rows_tensor(
                     g->ffn_norm,
                     g->after_attn,
                     model->map,
@@ -50178,6 +50200,7 @@ static bool laguna_graph_forward_batch(
                     DS4_N_EMBD,
                     tail_rows,
                     DS4_RMS_EPS) != 0;
+#endif
         }
         if (ok && stage_prof) ok = laguna_stage_mark("p_norms");
         if (ok && il < DS4_N_LEADING_DENSE) {

--- a/ds4.c
+++ b/ds4.c
@@ -68969,62 +68969,45 @@ static int ds4_session_eval_dflash_speculative_argmax(
     bool target_preencoded = false;
 #ifdef __APPLE__
     uint32_t preenc_open_rows = 0;
-    bool preenc_full_held = false;
+    uint32_t preenc_held_rows[3] = {0};
+    uint32_t preenc_n_held = 0;
     if (draft_p_min > 0.0f && ds4_gpu_flush_commands() != 0) {
         /*
-         * Encode the two most likely post-prune verifier widths while the
-         * draft is executing: the full block, then one row narrower.  The
-         * confidence read keeps whichever matches and drops the other, so
-         * the serial re-encode only remains for the rarer widths.
+         * Encode every plausible post-prune verifier width while the draft
+         * is executing (widest first, narrower ones behind the held-batch
+         * stack).  The confidence read keeps exactly the matching width,
+         * so the serial re-encode disappears for draft depths <= 4.
          */
         verify_tokens[0] = first_token;
-        ds4_laguna_feature_capture speculative_capture =
-            ds4_session_dflash_capture(s, 0, n_rows);
-        const bool full_encoded = laguna_graph_forward_batch(
-            &s->laguna_graph,
-            &e->model,
-            &e->weights,
-            verify_tokens,
-            s->dflash_graph.argmax,
-            n_rows,
-            pos0,
-            NULL,
-            target_top,
-            &speculative_capture,
-            NULL,
-            NULL,
-            0);
-        if (full_encoded && n_rows >= 3u && ds4_gpu_hold_commands() != 0) {
-            preenc_full_held = true;
-            const uint32_t short_rows = n_rows - 1u;
-            ds4_laguna_feature_capture short_capture =
-                ds4_session_dflash_capture(s, 0, short_rows);
-            target_preencoded = laguna_graph_forward_batch(
+        for (uint32_t w = n_rows; w >= 1u; w--) {
+            ds4_laguna_feature_capture w_capture =
+                ds4_session_dflash_capture(s, 0, w);
+            const bool encoded = laguna_graph_forward_batch(
                 &s->laguna_graph,
                 &e->model,
                 &e->weights,
                 verify_tokens,
                 s->dflash_graph.argmax,
-                short_rows,
+                w,
                 pos0,
                 NULL,
                 target_top,
-                &short_capture,
+                &w_capture,
                 NULL,
                 NULL,
                 0);
-            if (target_preencoded) {
-                preenc_open_rows = short_rows;
-            } else if (ds4_gpu_commands_active()) {
-                (void)ds4_gpu_discard_open_commands();
+            if (!encoded) {
+                if (ds4_gpu_commands_active()) {
+                    (void)ds4_gpu_discard_open_commands();
+                }
+                break;
             }
-        } else {
-            target_preencoded = full_encoded;
-            if (target_preencoded) {
-                preenc_open_rows = n_rows;
-            } else if (ds4_gpu_commands_active()) {
-                (void)ds4_gpu_discard_open_commands();
+            if (w == 1u || ds4_gpu_hold_commands() == 0) {
+                target_preencoded = true;
+                preenc_open_rows = w;
+                break;
             }
+            preenc_held_rows[preenc_n_held++] = w;
         }
     }
 #endif
@@ -69095,31 +69078,30 @@ static int ds4_session_eval_dflash_speculative_argmax(
             }
         }
 #ifdef __APPLE__
-        if (preenc_full_held) {
-            if (n_rows == generated_draft + 1u) {
-                if (ds4_gpu_commands_active() &&
-                    ds4_gpu_discard_open_commands() == 0) {
-                    draft_read_ok = false;
+        if (target_preencoded && preenc_open_rows == n_rows) {
+            (void)ds4_gpu_drop_held_commands();
+        } else {
+            uint32_t match = UINT32_MAX;
+            for (uint32_t i = 0; i < preenc_n_held; i++) {
+                if (preenc_held_rows[i] == n_rows) {
+                    match = i;
+                    break;
                 }
-                if (draft_read_ok && ds4_gpu_unhold_commands() != 0) {
-                    target_preencoded = true;
-                    preenc_open_rows = n_rows;
-                } else {
-                    target_preencoded = false;
-                    preenc_open_rows = 0;
-                }
-            } else {
-                (void)ds4_gpu_drop_held_commands();
             }
-            preenc_full_held = false;
-        }
-        if (target_preencoded && preenc_open_rows != n_rows) {
             if (ds4_gpu_commands_active() &&
                 ds4_gpu_discard_open_commands() == 0) {
                 draft_read_ok = false;
             }
-            target_preencoded = false;
+            if (draft_read_ok && match != UINT32_MAX &&
+                ds4_gpu_unhold_commands_at(match) != 0) {
+                target_preencoded = true;
+                preenc_open_rows = n_rows;
+            } else {
+                (void)ds4_gpu_drop_held_commands();
+                target_preencoded = false;
+            }
         }
+        preenc_n_held = 0;
 #else
         if (target_preencoded && n_draft != generated_draft) {
             draft_read_ok = ds4_gpu_discard_commands() != 0;

--- a/ds4.c
+++ b/ds4.c
@@ -59609,7 +59609,10 @@ static int ds4_engine_open_internal(ds4_engine **out,
 #ifdef DS4_NATIVE_CUDA_BUILD
         e->dflash_draft_tokens = 15;
 #else
-        e->dflash_draft_tokens = 3;
+        /* Deep drafts under confidence pruning: with the NAX/gqa3 verify,
+         * (5, 0.50) beats the old (3, 0.40) optimum — cold paired runs
+         * 84.5 vs 83.9 tok/s, identical greedy output. */
+        e->dflash_draft_tokens = 5;
 #endif
     }
     if (opt->dflash_p_min_set &&
@@ -59621,8 +59624,13 @@ static int ds4_engine_open_internal(ds4_engine **out,
         *out = NULL;
         return 1;
     }
+#ifdef DS4_NATIVE_CUDA_BUILD
     e->dflash_p_min =
         opt->dflash_p_min_set ? opt->dflash_p_min : 0.4f;
+#else
+    e->dflash_p_min =
+        opt->dflash_p_min_set ? opt->dflash_p_min : 0.5f;
+#endif
     e->mtp_margin = opt->mtp_margin >= 0.0f ? opt->mtp_margin : 3.0f;
     if (opt->dspark_confidence_threshold_set) {
         e->dspark_confidence_threshold = opt->dspark_confidence_threshold;
@@ -68844,6 +68852,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
     bool draft_read_ok = false;
 
     const double cycle_t0 = now_sec();
+    const double busy_t0 = laguna_stage_busy_ms();
     if (!laguna_graph_spec_snapshot(&s->laguna_graph, pos0, n_rows)) {
         if (errlen) snprintf(err, errlen, "Laguna verifier snapshot failed");
         return -1;
@@ -68864,6 +68873,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
         return 1;
     }
     const double submit_done = now_sec();
+    const double busy_submit = laguna_stage_busy_ms();
     bool target_preencoded = false;
 #ifdef __APPLE__
     if (draft_p_min > 0.0f && ds4_gpu_flush_commands() != 0) {
@@ -68949,6 +68959,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
     }
 
     const double conf_done = now_sec();
+    const double busy_conf = laguna_stage_busy_ms();
     verify_tokens[0] = first_token;
     ds4_laguna_feature_capture capture =
         ds4_session_dflash_capture(s, 0, n_rows);
@@ -68968,6 +68979,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
             NULL,
             0);
     const double verify_encoded = now_sec();
+    const double busy_encoded = laguna_stage_busy_ms();
     bool inject_ok = false;
     if (verify_ok) {
         inject_ok = ds4_session_dflash_finish_capture(s, pos0, n_rows);
@@ -68988,6 +69000,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
         }
     }
     const double reads_done = now_sec();
+    const double busy_reads = laguna_stage_busy_ms();
     if (!verify_ok || !inject_ok || !target_read_ok || !draft_read_ok) {
         (void)laguna_graph_spec_restore(
             &s->laguna_graph, pos0, 0, n_rows);
@@ -69032,6 +69045,7 @@ static int ds4_session_eval_dflash_speculative_argmax(
     s->dflash_synced = true;
 
     const double verify_done = now_sec();
+    const double busy_verify = laguna_stage_busy_ms();
     if (getenv("DS4_DFLASH_TIMING") != NULL) {
         /* Phase attribution: draft = snapshot + draft-block encode/submit;
          * conf = wait for draft + confidence readback; enc = verifier encode
@@ -69040,12 +69054,22 @@ static int ds4_session_eval_dflash_speculative_argmax(
          * + ring restore.  Sample adds the host-side pick from logits. */
         static double acc[6];
         static uint32_t acc_cycles;
+        static uint64_t accept_len_hist[DS4_DFLASH_BLOCK_SIZE + 1u];
+        static uint64_t draft_len_hist[DS4_DFLASH_BLOCK_SIZE + 1u];
         acc[0] += (submit_done - cycle_t0) * 1000.0;
         acc[1] += (conf_done - submit_done) * 1000.0;
         acc[2] += (verify_encoded - conf_done) * 1000.0;
         acc[3] += (reads_done - verify_encoded) * 1000.0;
         acc[4] += (verify_done - reads_done) * 1000.0;
         acc[5] += s->last_sample_ms;
+        static double busy[5];
+        busy[0] += busy_submit - busy_t0;
+        busy[1] += busy_conf - busy_submit;
+        busy[2] += busy_encoded - busy_conf;
+        busy[3] += busy_reads - busy_encoded;
+        busy[4] += busy_verify - busy_reads;
+        accept_len_hist[n_accept - 1]++;
+        draft_len_hist[n_draft]++;
         if ((++acc_cycles % 64u) == 0u) {
             fprintf(stderr,
                     "ds4: DFlash phases ms/cycle over %u cycles: "
@@ -69054,7 +69078,30 @@ static int ds4_session_eval_dflash_speculative_argmax(
                     64u,
                     acc[0] / 64.0, acc[1] / 64.0, acc[2] / 64.0,
                     acc[3] / 64.0, acc[4] / 64.0, acc[5] / 64.0);
+            fprintf(stderr,
+                    "ds4: DFlash GPU-busy ms/cycle: draft %.2f conf %.2f "
+                    "enc %.2f read %.2f tail %.2f\n",
+                    busy[0] / 64.0, busy[1] / 64.0, busy[2] / 64.0,
+                    busy[3] / 64.0, busy[4] / 64.0);
             memset(acc, 0, sizeof(acc));
+            memset(busy, 0, sizeof(busy));
+            fprintf(stderr,
+                    "ds4: DFlash accept-length hist 0..5: "
+                    "%llu %llu %llu %llu %llu %llu | "
+                    "post-prune draft-length hist 0..5: "
+                    "%llu %llu %llu %llu %llu %llu\n",
+                    (unsigned long long)accept_len_hist[0],
+                    (unsigned long long)accept_len_hist[1],
+                    (unsigned long long)accept_len_hist[2],
+                    (unsigned long long)accept_len_hist[3],
+                    (unsigned long long)accept_len_hist[4],
+                    (unsigned long long)accept_len_hist[5],
+                    (unsigned long long)draft_len_hist[0],
+                    (unsigned long long)draft_len_hist[1],
+                    (unsigned long long)draft_len_hist[2],
+                    (unsigned long long)draft_len_hist[3],
+                    (unsigned long long)draft_len_hist[4],
+                    (unsigned long long)draft_len_hist[5]);
         }
     }
     /* CUDA installs the anonymous F16 support mapping lazily. Its first draft

--- a/ds4.c
+++ b/ds4.c
@@ -49049,6 +49049,84 @@ static bool dflash_graph_draft_block(
     return ok;
 }
 
+/* Diagnostic stage timer for the Laguna decode graph.  When
+ * DS4_LAGUNA_DECODE_STAGE_PROFILE is set, every stage boundary submits and
+ * drains the pending command batch so per-stage wall time becomes visible, at
+ * the cost of one extra synchronization per boundary.  The synthetic "sync"
+ * stage measures an empty boundary: subtract its average from a small stage to
+ * approximate its pure GPU time. */
+typedef struct {
+    const char *name;
+    double      total_ms;
+    double      busy_ms;
+} laguna_stage_profile_slot;
+
+static laguna_stage_profile_slot g_laguna_stage_slots[24];
+static uint32_t g_laguna_stage_tokens;
+static double   g_laguna_stage_t0;
+static double   g_laguna_stage_busy0;
+
+static double laguna_stage_busy_ms(void) {
+#ifdef __APPLE__
+    return ds4_gpu_busy_accum_ms();
+#else
+    return 0.0;
+#endif
+}
+
+static bool laguna_stage_profile_enabled(void) {
+    static int enabled = -1;
+    if (enabled < 0) enabled = getenv("DS4_LAGUNA_DECODE_STAGE_PROFILE") != NULL;
+    return enabled == 1;
+}
+
+static bool laguna_stage_mark(const char *name) {
+    if (!laguna_stage_profile_enabled()) return true;
+    if (!ds4_gpu_commands_active() || ds4_gpu_end_commands() == 0) return false;
+    const double now = now_sec() * 1000.0;
+    const double busy = laguna_stage_busy_ms();
+    const size_t n_slots =
+        sizeof(g_laguna_stage_slots) / sizeof(g_laguna_stage_slots[0]);
+    for (size_t i = 0; i < n_slots; i++) {
+        laguna_stage_profile_slot *slot = &g_laguna_stage_slots[i];
+        if (!slot->name) slot->name = name;
+        if (slot->name == name || strcmp(slot->name, name) == 0) {
+            slot->total_ms += now - g_laguna_stage_t0;
+            slot->busy_ms += busy - g_laguna_stage_busy0;
+            break;
+        }
+    }
+    g_laguna_stage_t0 = now;
+    g_laguna_stage_busy0 = busy;
+    return ds4_gpu_begin_commands() != 0;
+}
+
+static void laguna_stage_token_done(void) {
+    if (!laguna_stage_profile_enabled()) return;
+    const uint32_t window = 16u;
+    if (++g_laguna_stage_tokens % window) return;
+    const size_t n_slots =
+        sizeof(g_laguna_stage_slots) / sizeof(g_laguna_stage_slots[0]);
+    double total = 0.0;
+    double busy_total = 0.0;
+    fprintf(stderr,
+            "ds4: laguna decode stages, wall/gpu ms per token over %u tokens:\n",
+            window);
+    for (size_t i = 0; i < n_slots; i++) {
+        laguna_stage_profile_slot *slot = &g_laguna_stage_slots[i];
+        if (!slot->name) break;
+        fprintf(stderr, "  %-10s %8.3f %8.3f\n", slot->name,
+                slot->total_ms / (double)window,
+                slot->busy_ms / (double)window);
+        total += slot->total_ms;
+        busy_total += slot->busy_ms;
+        slot->total_ms = 0.0;
+        slot->busy_ms = 0.0;
+    }
+    fprintf(stderr, "  %-10s %8.3f %8.3f\n", "total",
+            total / (double)window, busy_total / (double)window);
+}
+
 static bool laguna_graph_forward_token(
         ds4_laguna_gpu_graph *g,
         const ds4_model      *model,
@@ -49062,6 +49140,10 @@ static bool laguna_graph_forward_token(
         return false;
     }
 
+    if (laguna_stage_profile_enabled()) {
+        g_laguna_stage_t0 = now_sec() * 1000.0;
+        g_laguna_stage_busy0 = laguna_stage_busy_ms();
+    }
     bool ok = ds4_gpu_begin_commands() != 0;
     if (ok) {
         ok = ds4_gpu_embed_token_quant_tensor(g->cur,
@@ -49073,6 +49155,7 @@ static bool laguna_graph_forward_token(
                                               (uint32_t)token,
                                               DS4_N_EMBD) != 0;
     }
+    if (ok) ok = laguna_stage_mark("embed");
 
     for (uint32_t il = 0; ok && il < DS4_N_LAYER; il++) {
         const ds4_layer_weights *l = &weights->layer[il];
@@ -49103,6 +49186,7 @@ static bool laguna_graph_forward_token(
                                              l->attn_norm->abs_offset,
                                              DS4_N_EMBD,
                                              DS4_RMS_EPS) != 0;
+        if (ok) ok = laguna_stage_mark("attn_norm") && laguna_stage_mark("sync");
         if (ok) {
             if (l->attn_q->type == DS4_TENSOR_F16) {
                 ok = ds4_gpu_laguna_qkvg_f16_tensor(
@@ -49173,6 +49257,7 @@ static bool laguna_graph_forward_token(
 #endif
             }
         }
+        if (ok) ok = laguna_stage_mark("qkvg");
         if (ok) {
             ok = ds4_gpu_laguna_qk_head_rms_norm_rope_tensor(
                     g->q,
@@ -49196,6 +49281,7 @@ static bool laguna_graph_forward_token(
                     beta_slow,
                     DS4_RMS_EPS) != 0;
         }
+        if (ok) ok = laguna_stage_mark("qk_rope");
         uint32_t key_count = pos + 1u;
         if (key_count > g->cache_cap[il]) key_count = g->cache_cap[il];
         const uint32_t key_start = pos + 1u - key_count;
@@ -49217,6 +49303,7 @@ static bool laguna_graph_forward_token(
                     DS4_N_HEAD_DIM,
                     1.0f / sqrtf((float)DS4_N_HEAD_DIM)) != 0;
         }
+        if (ok) ok = laguna_stage_mark("attn");
         if (ok) {
             if (l->attn_output->type == DS4_TENSOR_F16) {
                 ok = ds4_gpu_laguna_attn_output_residual_f16_tensor(
@@ -49240,6 +49327,7 @@ static bool laguna_graph_forward_token(
                                         DS4_N_EMBD) != 0;
             }
         }
+        if (ok) ok = laguna_stage_mark("attn_out");
         if (ok) {
             ok = ds4_gpu_rms_norm_weight_tensor(g->ffn_norm,
                                                  g->after_attn,
@@ -49249,6 +49337,7 @@ static bool laguna_graph_forward_token(
                                                  DS4_N_EMBD,
                                                  DS4_RMS_EPS) != 0;
         }
+        if (ok) ok = laguna_stage_mark("ffn_norm");
         if (ok && il < DS4_N_LEADING_DENSE) {
             ok = laguna_graph_matmul(g->ffn_gate,
                                      model,
@@ -49281,6 +49370,7 @@ static bool laguna_graph_forward_token(
                                         g->ffn_out,
                                         DS4_N_EMBD) != 0;
             }
+            if (ok) ok = laguna_stage_mark("dense");
         } else if (ok) {
             ok = ds4_gpu_matmul_f32_tensor(g->router_logits,
                                             model->map,
@@ -49303,6 +49393,7 @@ static bool laguna_graph_forward_token(
                         DS4_N_EXPERT_USED,
                         DS4_EXPERT_WEIGHT_SCALE) != 0;
             }
+            if (ok) ok = laguna_stage_mark("router");
 
             const uint64_t gate_row_bytes =
                 routed_expert_row_bytes(l->ffn_gate_exps);
@@ -49424,6 +49515,7 @@ static bool laguna_graph_forward_token(
                                              1);
                 }
             }
+            if (ok) ok = laguna_stage_mark("moe");
             if (ok) {
                 ok = ds4_gpu_add3_tensor(g->next,
                                          g->after_attn,
@@ -49431,6 +49523,7 @@ static bool laguna_graph_forward_token(
                                          g->shared_out,
                                          DS4_N_EMBD) != 0;
             }
+            if (ok) ok = laguna_stage_mark("resid");
         }
 
         if (ok) {
@@ -49458,6 +49551,7 @@ static bool laguna_graph_forward_token(
                                      g->output_norm,
                                      1);
         }
+        if (ok) ok = laguna_stage_mark("head");
     }
     if (ds4_gpu_commands_active() && ds4_gpu_end_commands() == 0) ok = false;
     if (ok && logits_out) {
@@ -49466,6 +49560,7 @@ static bool laguna_graph_forward_token(
                                  logits_out,
                                  (uint64_t)DS4_N_VOCAB * sizeof(float)) != 0;
     }
+    if (ok) laguna_stage_token_done();
     return ok;
 }
 

--- a/ds4.c
+++ b/ds4.c
@@ -49303,6 +49303,34 @@ static bool laguna_graph_forward_token(
         }
         if (ok) ok = laguna_stage_mark("qkvg");
         if (ok) {
+#ifdef __APPLE__
+            /* The fused kernel also commits this row's K/V to the ring, so
+             * the attention call below skips its store dispatch. */
+            ok = ds4_gpu_laguna_qk_head_rms_norm_rope_store_tensor(
+                    g->q,
+                    g->k,
+                    model->map,
+                    model->size,
+                    l->attn_q_norm->abs_offset,
+                    l->attn_k_norm->abs_offset,
+                    n_head,
+                    DS4_N_HEAD_KV,
+                    DS4_N_HEAD_DIM,
+                    n_rot,
+                    pos,
+                    rope_ctx,
+                    freq_base,
+                    freq_scale,
+                    ext_factor,
+                    attn_factor,
+                    beta_fast,
+                    beta_slow,
+                    DS4_RMS_EPS,
+                    g->v,
+                    g->key_cache[il],
+                    g->value_cache[il],
+                    g->cache_cap[il]) != 0;
+#else
             ok = ds4_gpu_laguna_qk_head_rms_norm_rope_tensor(
                     g->q,
                     g->k,
@@ -49324,6 +49352,7 @@ static bool laguna_graph_forward_token(
                     beta_fast,
                     beta_slow,
                     DS4_RMS_EPS) != 0;
+#endif
         }
         if (ok) ok = laguna_stage_mark("qk_rope");
         uint32_t key_count = pos + 1u;
@@ -49335,8 +49364,13 @@ static bool laguna_graph_forward_token(
                     g->key_cache[il],
                     g->value_cache[il],
                     g->q,
+#ifdef __APPLE__
+                    NULL,
+                    NULL,
+#else
                     g->k,
                     g->v,
+#endif
                     g->gate,
                     pos,
                     g->cache_cap[il],
@@ -49541,6 +49575,7 @@ static bool laguna_graph_forward_token(
                         il,
                         g->ffn_norm,
                         true) != 0;
+                if (ok) ok = laguna_stage_mark("moe_routed");
                 if (ok) {
                     ok = ds4_gpu_shared_mid_swiglu_q8_0_tensor(
                             g->ffn_mid,
@@ -49553,6 +49588,7 @@ static bool laguna_graph_forward_token(
                             g->ffn_norm,
                             0.0f) != 0;
                 }
+                if (ok) ok = laguna_stage_mark("moe_shsw");
                 if (ok) {
 #ifdef __APPLE__
                     /* Fold the layer's three-way residual into the shared
@@ -68664,7 +68700,11 @@ static int ds4_session_eval_dflash_speculative_argmax(
         requested_draft = DS4_DFLASH_BLOCK_SIZE - 1u;
     }
     if (s->dflash_active_draft == 0u) {
-        s->dflash_active_draft = requested_draft < 3u ? requested_draft : 3u;
+        /* Diagnostic: start at the requested depth instead of the adaptive
+         * calibration's conservative depth-3 opening. */
+        s->dflash_active_draft =
+            getenv("DS4_DFLASH_FORCE_DRAFT") != NULL ? requested_draft :
+            requested_draft < 3u ? requested_draft : 3u;
     }
     uint32_t n_draft = requested_draft;
     if (n_draft > s->dflash_active_draft) {

--- a/ds4.c
+++ b/ds4.c
@@ -49942,9 +49942,13 @@ static bool laguna_graph_forward_batch(
     const bool exact_q8_rows = row_argmax_out != NULL;
     /* Stage attribution for plain prefill only: DFlash verification shares
      * its command stream with the draft graph and must not be drained at
-     * stage boundaries. */
+     * stage boundaries.  DS4_LAGUNA_VERIFY_STAGE_PROFILE opts the verifier
+     * in anyway (diagnostics; the drains distort wall time but the GPU-busy
+     * column still localizes execution cost). */
     const bool stage_prof =
-        laguna_stage_profile_enabled() && gpu_draft_tokens == NULL;
+        laguna_stage_profile_enabled() &&
+        (gpu_draft_tokens == NULL ||
+         getenv("DS4_LAGUNA_VERIFY_STAGE_PROFILE") != NULL);
     if (stage_prof) {
         g_laguna_stage_t0 = now_sec() * 1000.0;
         g_laguna_stage_busy0 = laguna_stage_busy_ms();

--- a/ds4.c
+++ b/ds4.c
@@ -69311,6 +69311,29 @@ static int ds4_session_eval_dflash_speculative_argmax(
             dump_state = dump_fp != NULL ? 1 : -1;
         }
         if (dump_state != 1) break;
+        /* Sidecar: per-cycle draft proposals and confidences, the golden
+         * reference for validating a retrained draft's forward pass. */
+        static FILE *cycle_fp;
+        if (cycle_fp == NULL) {
+            const char *dump_path = getenv("DS4_DFLASH_DUMP");
+            char side[1024];
+            snprintf(side, sizeof(side), "%s.cycles", dump_path);
+            cycle_fp = fopen(side, "ab");
+        }
+        if (cycle_fp != NULL) {
+            const uint32_t cpos = pos0;
+            const uint32_t cdraft = generated_draft;
+            const int32_t cfirst = first_token;
+            fwrite(&cpos, sizeof(cpos), 1, cycle_fp);
+            fwrite(&cdraft, sizeof(cdraft), 1, cycle_fp);
+            fwrite(&cfirst, sizeof(cfirst), 1, cycle_fp);
+            fwrite(draft_top, sizeof(int32_t), DS4_DFLASH_BLOCK_SIZE,
+                   cycle_fp);
+            fwrite(draft_top2, sizeof(int32_t), DS4_DFLASH_BLOCK_SIZE,
+                   cycle_fp);
+            fwrite(target_top, sizeof(int32_t), DS4_DFLASH_BLOCK_SIZE,
+                   cycle_fp);
+        }
         const uint32_t feat_elems = DS4_DFLASH_N_AUX * DS4_N_EMBD;
         float *feat = malloc((size_t)feat_elems * sizeof(float));
         uint16_t *half = malloc((size_t)feat_elems * sizeof(uint16_t));

--- a/ds4.c
+++ b/ds4.c
@@ -68968,16 +68968,19 @@ static int ds4_session_eval_dflash_speculative_argmax(
     const double busy_submit = laguna_stage_busy_ms();
     bool target_preencoded = false;
 #ifdef __APPLE__
+    uint32_t preenc_open_rows = 0;
+    bool preenc_full_held = false;
     if (draft_p_min > 0.0f && ds4_gpu_flush_commands() != 0) {
         /*
-         * Confidence keeps the full draft on most cycles. Encode that common
-         * verifier while the draft is executing, then either commit it after
-         * reading confidence or discard it and encode the shorter verifier.
+         * Encode the two most likely post-prune verifier widths while the
+         * draft is executing: the full block, then one row narrower.  The
+         * confidence read keeps whichever matches and drops the other, so
+         * the serial re-encode only remains for the rarer widths.
          */
         verify_tokens[0] = first_token;
         ds4_laguna_feature_capture speculative_capture =
             ds4_session_dflash_capture(s, 0, n_rows);
-        target_preencoded = laguna_graph_forward_batch(
+        const bool full_encoded = laguna_graph_forward_batch(
             &s->laguna_graph,
             &e->model,
             &e->weights,
@@ -68991,8 +68994,37 @@ static int ds4_session_eval_dflash_speculative_argmax(
             NULL,
             NULL,
             0);
-        if (!target_preencoded && ds4_gpu_commands_active()) {
-            (void)ds4_gpu_discard_commands();
+        if (full_encoded && n_rows >= 3u && ds4_gpu_hold_commands() != 0) {
+            preenc_full_held = true;
+            const uint32_t short_rows = n_rows - 1u;
+            ds4_laguna_feature_capture short_capture =
+                ds4_session_dflash_capture(s, 0, short_rows);
+            target_preencoded = laguna_graph_forward_batch(
+                &s->laguna_graph,
+                &e->model,
+                &e->weights,
+                verify_tokens,
+                s->dflash_graph.argmax,
+                short_rows,
+                pos0,
+                NULL,
+                target_top,
+                &short_capture,
+                NULL,
+                NULL,
+                0);
+            if (target_preencoded) {
+                preenc_open_rows = short_rows;
+            } else if (ds4_gpu_commands_active()) {
+                (void)ds4_gpu_discard_open_commands();
+            }
+        } else {
+            target_preencoded = full_encoded;
+            if (target_preencoded) {
+                preenc_open_rows = n_rows;
+            } else if (ds4_gpu_commands_active()) {
+                (void)ds4_gpu_discard_open_commands();
+            }
         }
     }
 #endif
@@ -69062,12 +69094,43 @@ static int ds4_session_eval_dflash_speculative_argmax(
                 break;
             }
         }
+#ifdef __APPLE__
+        if (preenc_full_held) {
+            if (n_rows == generated_draft + 1u) {
+                if (ds4_gpu_commands_active() &&
+                    ds4_gpu_discard_open_commands() == 0) {
+                    draft_read_ok = false;
+                }
+                if (draft_read_ok && ds4_gpu_unhold_commands() != 0) {
+                    target_preencoded = true;
+                    preenc_open_rows = n_rows;
+                } else {
+                    target_preencoded = false;
+                    preenc_open_rows = 0;
+                }
+            } else {
+                (void)ds4_gpu_drop_held_commands();
+            }
+            preenc_full_held = false;
+        }
+        if (target_preencoded && preenc_open_rows != n_rows) {
+            if (ds4_gpu_commands_active() &&
+                ds4_gpu_discard_open_commands() == 0) {
+                draft_read_ok = false;
+            }
+            target_preencoded = false;
+        }
+#else
         if (target_preencoded && n_draft != generated_draft) {
             draft_read_ok = ds4_gpu_discard_commands() != 0;
             target_preencoded = false;
         }
+#endif
         if (!draft_read_ok ||
             (!target_preencoded && ds4_gpu_begin_commands() == 0)) {
+#ifdef __APPLE__
+            (void)ds4_gpu_drop_held_commands();
+#endif
             if (ds4_gpu_commands_active()) {
                 (void)ds4_gpu_discard_commands();
             }

--- a/ds4.c
+++ b/ds4.c
@@ -49382,6 +49382,7 @@ static bool laguna_graph_forward_token(
             }
             if (ok) ok = laguna_stage_mark("dense");
         } else if (ok) {
+            bool resid_added = false;
             ok = ds4_gpu_matmul_f32_tensor(g->router_logits,
                                             model->map,
                                             model->size,
@@ -49519,15 +49520,35 @@ static bool laguna_graph_forward_token(
                             0.0f) != 0;
                 }
                 if (ok) {
-                    ok = laguna_graph_matmul(g->shared_out,
-                                             model,
-                                             l->ffn_down_shexp,
-                                             g->ffn_mid,
-                                             1);
+#ifdef __APPLE__
+                    /* Fold the layer's three-way residual into the shared
+                     * down matvec epilogue: one dispatch writes the layer
+                     * output instead of a matvec plus an add3. */
+                    if (l->ffn_down_shexp->type == DS4_TENSOR_Q8_0) {
+                        ok = ds4_gpu_matmul_q8_0_add2_tensor(
+                                g->next,
+                                model->map,
+                                model->size,
+                                l->ffn_down_shexp->abs_offset,
+                                l->ffn_down_shexp->dim[0],
+                                l->ffn_down_shexp->dim[1],
+                                g->ffn_mid,
+                                g->after_attn,
+                                g->ffn_out) != 0;
+                        resid_added = ok;
+                    } else
+#endif
+                    {
+                        ok = laguna_graph_matmul(g->shared_out,
+                                                 model,
+                                                 l->ffn_down_shexp,
+                                                 g->ffn_mid,
+                                                 1);
+                    }
                 }
             }
             if (ok) ok = laguna_stage_mark("moe");
-            if (ok) {
+            if (ok && !resid_added) {
                 ok = ds4_gpu_add3_tensor(g->next,
                                          g->after_attn,
                                          g->ffn_out,

--- a/ds4.c
+++ b/ds4.c
@@ -49080,6 +49080,16 @@ static bool laguna_stage_profile_enabled(void) {
     return enabled == 1;
 }
 
+static uint32_t laguna_decode_flush_stride(void) {
+    static int stride = -1;
+    if (stride < 0) {
+        const char *env = getenv("DS4_LAGUNA_DECODE_FLUSH_STRIDE");
+        stride = env ? atoi(env) : 6;
+        if (stride < 0) stride = 0;
+    }
+    return (uint32_t)stride;
+}
+
 static bool laguna_stage_mark(const char *name) {
     if (!laguna_stage_profile_enabled()) return true;
     if (!ds4_gpu_commands_active() || ds4_gpu_end_commands() == 0) return false;
@@ -49380,6 +49390,7 @@ static bool laguna_graph_forward_token(
                                             DS4_N_EXPERT,
                                             g->ffn_norm,
                                             1) != 0;
+            if (ok) ok = laguna_stage_mark("router_mm");
             if (ok) {
                 ok = ds4_gpu_glm_router_select_tensor(
                         g->router_selected,
@@ -49530,6 +49541,15 @@ static bool laguna_graph_forward_token(
             ds4_gpu_tensor *tmp = g->cur;
             g->cur = g->next;
             g->next = tmp;
+        }
+        /* Commit encoded layers early so the GPU starts this token while the
+         * host is still encoding the remaining layers.  The front-loaded
+         * schedule matters: the widest GPU idle gap is at the start of the
+         * token, before anything has been submitted.  The final
+         * end_commands drains these pipelined submissions. */
+        if (ok && laguna_decode_flush_stride() != 0 &&
+            (il == 0 || il % laguna_decode_flush_stride() == 0)) {
+            ok = ds4_gpu_flush_commands() != 0;
         }
     }
 

--- a/ds4.c
+++ b/ds4.c
@@ -69289,6 +69289,54 @@ static int ds4_session_eval_dflash_speculative_argmax(
      * its host-side scan of the vocabulary. */
     s->dflash_greedy_next = target_top[n_accept - 1];
 
+    /* Training-data harvest (diagnostic): append one record per accepted
+     * position — the captured aux features the draft conditions on, the
+     * verified token, and its absolute position.  The greedy stream itself
+     * provides the prediction labels at training time. */
+    do {
+        static FILE *dump_fp;
+        static int dump_state;
+        if (dump_state == 0) {
+            const char *dump_path = getenv("DS4_DFLASH_DUMP");
+            if (dump_path != NULL && dump_path[0] != '\0') {
+                dump_fp = fopen(dump_path, "ab");
+                if (dump_fp != NULL && ftell(dump_fp) == 0) {
+                    const uint32_t header[4] = {
+                        0x44344446u, /* "D4DF" */
+                        1u, DS4_DFLASH_N_AUX, DS4_N_EMBD,
+                    };
+                    fwrite(header, sizeof(header), 1, dump_fp);
+                }
+            }
+            dump_state = dump_fp != NULL ? 1 : -1;
+        }
+        if (dump_state != 1) break;
+        const uint32_t feat_elems = DS4_DFLASH_N_AUX * DS4_N_EMBD;
+        float *feat = malloc((size_t)feat_elems * sizeof(float));
+        uint16_t *half = malloc((size_t)feat_elems * sizeof(uint16_t));
+        if (!feat || !half) { free(feat); free(half); break; }
+        for (int r = 0; r < n_accept; r++) {
+            if (!ds4_gpu_tensor_read(
+                    s->dflash_graph.features,
+                    (uint64_t)r * feat_elems * sizeof(float),
+                    feat, (uint64_t)feat_elems * sizeof(float))) {
+                break;
+            }
+            for (uint32_t i = 0; i < feat_elems; i++) {
+                /* f32 -> f16 via the compiler's conversion */
+                _Float16 h = (_Float16)feat[i];
+                memcpy(&half[i], &h, sizeof(uint16_t));
+            }
+            const uint32_t rec_pos = pos0 + (uint32_t)r;
+            const int32_t rec_token = accepted[r];
+            fwrite(&rec_pos, sizeof(rec_pos), 1, dump_fp);
+            fwrite(&rec_token, sizeof(rec_token), 1, dump_fp);
+            fwrite(half, sizeof(uint16_t), feat_elems, dump_fp);
+        }
+        free(feat);
+        free(half);
+    } while (0);
+
     const double verify_done = now_sec();
     const double busy_verify = laguna_stage_busy_ms();
     if (laguna_dflash_timing_enabled()) {

--- a/ds4.c
+++ b/ds4.c
@@ -47711,6 +47711,8 @@ typedef struct {
     ds4_gpu_tensor *logits;
     ds4_gpu_tensor *argmax;
     ds4_gpu_tensor *probabilities;
+    ds4_gpu_tensor *top2;
+    ds4_gpu_tensor *probabilities2;
     ds4_gpu_tensor *key_cache[DS4_DFLASH_N_LAYER];
     ds4_gpu_tensor *value_cache[DS4_DFLASH_N_LAYER];
 } ds4_dflash_gpu_graph;
@@ -48618,6 +48620,8 @@ static void dflash_graph_free(ds4_dflash_gpu_graph *g) {
     DS4_DFLASH_FREE(logits);
     DS4_DFLASH_FREE(argmax);
     DS4_DFLASH_FREE(probabilities);
+    DS4_DFLASH_FREE(top2);
+    DS4_DFLASH_FREE(probabilities2);
 #undef DS4_DFLASH_FREE
     for (uint32_t il = 0; il < DS4_DFLASH_N_LAYER; il++) {
         ds4_gpu_tensor_free(g->key_cache[il]);
@@ -48680,6 +48684,8 @@ static bool dflash_graph_alloc(ds4_dflash_gpu_graph *g) {
     DS4_DFLASH_ALLOC(logits, block_rows * DS4_N_VOCAB * f32);
     DS4_DFLASH_ALLOC(argmax, block_rows * sizeof(int32_t));
     DS4_DFLASH_ALLOC(probabilities, block_rows * f32);
+    DS4_DFLASH_ALLOC(top2, block_rows * sizeof(int32_t));
+    DS4_DFLASH_ALLOC(probabilities2, block_rows * f32);
 #undef DS4_DFLASH_ALLOC
 
     const uint64_t cache_bytes =
@@ -49107,6 +49113,8 @@ static bool dflash_graph_draft_block(
     if (ok && e->dflash_p_min > 0.0f) {
         ok = ds4_gpu_dflash_probabilities_tensor(
                  g->probabilities,
+                 g->top2,
+                 g->probabilities2,
                  g->logits,
                  g->argmax,
                  n_rows,
@@ -51585,6 +51593,7 @@ struct ds4_session {
     uint64_t dflash_proposed;
     uint64_t dflash_pruned;
     uint64_t dflash_accepted;
+    int dflash_greedy_next;
     double dflash_draft_ms;
     double dflash_verify_ms;
     double dflash_baseline_ms;
@@ -68938,6 +68947,8 @@ static int ds4_session_eval_dflash_speculative_argmax(
     uint32_t n_rows = n_draft + 1u;
     const uint32_t generated_draft = n_draft;
     int draft_top[DS4_DFLASH_BLOCK_SIZE] = {0};
+    int draft_top2[DS4_DFLASH_BLOCK_SIZE] = {0};
+    float draft_p2[DS4_DFLASH_BLOCK_SIZE] = {0};
     int target_top[DS4_DFLASH_BLOCK_SIZE] = {0};
     int verify_tokens[DS4_DFLASH_BLOCK_SIZE] = {0};
     const float draft_p_min = e->dflash_p_min;
@@ -69026,7 +69037,17 @@ static int ds4_session_eval_dflash_speculative_argmax(
                 0,
                 draft_probabilities,
                 (uint64_t)n_rows *
-                    sizeof(draft_probabilities[0])) != 0;
+                    sizeof(draft_probabilities[0])) != 0 &&
+            ds4_gpu_tensor_read(
+                s->dflash_graph.top2,
+                0,
+                draft_top2,
+                (uint64_t)n_rows * sizeof(draft_top2[0])) != 0 &&
+            ds4_gpu_tensor_read(
+                s->dflash_graph.probabilities2,
+                0,
+                draft_p2,
+                (uint64_t)n_rows * sizeof(draft_p2[0])) != 0;
 #else
         draft_read_ok =
             ds4_gpu_end_commands() != 0 &&
@@ -69208,6 +69229,10 @@ static int ds4_session_eval_dflash_speculative_argmax(
     s->checkpoint_valid = true;
     s->mtp_draft_valid = false;
     s->dflash_synced = true;
+    /* The verifier argmax of the last accepted row is exactly the greedy
+     * sample of s->logits; expose it so a temperature-0 caller can skip
+     * its host-side scan of the vocabulary. */
+    s->dflash_greedy_next = target_top[n_accept - 1];
 
     const double verify_done = now_sec();
     const double busy_verify = laguna_stage_busy_ms();
@@ -69218,7 +69243,12 @@ static int ds4_session_eval_dflash_speculative_argmax(
          * verifier execution + argmax readback; tail = full-row logits read
          * + ring restore.  Sample adds the host-side pick from logits. */
         static double acc[6];
+        static double inter_cycle_acc;
+        static double last_cycle_end;
         static uint32_t acc_cycles;
+        if (last_cycle_end != 0.0) {
+            inter_cycle_acc += (cycle_t0 - last_cycle_end) * 1000.0;
+        }
         static uint64_t accept_len_hist[DS4_DFLASH_BLOCK_SIZE + 1u];
         static uint64_t draft_len_hist[DS4_DFLASH_BLOCK_SIZE + 1u];
         acc[0] += (submit_done - cycle_t0) * 1000.0;
@@ -69235,6 +69265,15 @@ static int ds4_session_eval_dflash_speculative_argmax(
         busy[4] += busy_verify - busy_reads;
         accept_len_hist[n_accept - 1]++;
         draft_len_hist[n_draft]++;
+        static uint64_t p1_rejects, p1_top2_hits;
+        static double p1_top2_p2_sum;
+        if (n_draft >= 1u && target_top[0] != draft_top[1]) {
+            p1_rejects++;
+            if (target_top[0] == draft_top2[1]) {
+                p1_top2_hits++;
+                p1_top2_p2_sum += draft_p2[1];
+            }
+        }
         if ((++acc_cycles % 64u) == 0u) {
             fprintf(stderr,
                     "ds4: DFlash phases ms/cycle over %u cycles: "
@@ -69267,7 +69306,18 @@ static int ds4_session_eval_dflash_speculative_argmax(
                     (unsigned long long)draft_len_hist[3],
                     (unsigned long long)draft_len_hist[4],
                     (unsigned long long)draft_len_hist[5]);
+            fprintf(stderr,
+                    "ds4: DFlash position-1 rejects %llu, draft-top2 would "
+                    "have hit %llu (mean p2 %.3f); inter-cycle %.2f "
+                    "ms/cycle\n",
+                    (unsigned long long)p1_rejects,
+                    (unsigned long long)p1_top2_hits,
+                    p1_top2_hits != 0u ?
+                        p1_top2_p2_sum / (double)p1_top2_hits : 0.0,
+                    inter_cycle_acc / 64.0);
+            inter_cycle_acc = 0.0;
         }
+        last_cycle_end = now_sec();
     }
     /* CUDA installs the anonymous F16 support mapping lazily. Its first draft
      * cycle faults roughly 2 GiB of weights and is intentionally a one-time
@@ -69443,11 +69493,16 @@ static int ds4_session_eval_dflash_speculative_argmax(
 }
 #endif
 
+int ds4_session_greedy_next(const ds4_session *s) {
+    return s ? s->dflash_greedy_next : -1;
+}
+
 int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                                         int max_tokens, int eos_token,
                                         int *accepted, int accepted_cap,
                                         char *err, size_t errlen) {
     if (!s || max_tokens <= 0 || accepted_cap <= 0) return 0;
+    s->dflash_greedy_next = -1;
     if (s->distributed) {
         if (!accepted) return 0;
         if (ds4_session_eval(s, first_token, err, errlen) != 0) return -1;

--- a/ds4.c
+++ b/ds4.c
@@ -49864,11 +49864,15 @@ static bool laguna_graph_forward_batch(
                                                   display_total,
                                                   true);
 
-    /* Metal 4 Tensor matmuls introduce enough low-bit accumulation drift in
-     * Laguna prefill to change sliding-attention routes after a few hundred
-     * tokens. The legacy batched kernels are both stable against the Poolside
-     * reference and slightly faster on these shapes. */
-    ds4_gpu_set_tensor_matmul_suppressed(true);
+    /* Metal 4 Tensor matmuls change low-bit accumulation order in Laguna
+     * prefill, so tokens can drift from the Poolside bit-reference on long
+     * prompts.  Measured on M5 Max the drift is quality-neutral jitter
+     * (teacher-forced NLL moves under +/-1% with the sign flipping between
+     * text and code slices) while prefill runs 12-19% faster, so the tensor
+     * path is the default.  DS4_LAGUNA_DISABLE_TENSOR_PREFILL restores the
+     * legacy batched kernels for bit-reference comparisons. */
+    ds4_gpu_set_tensor_matmul_suppressed(
+        getenv("DS4_LAGUNA_DISABLE_TENSOR_PREFILL") != NULL);
     /* A long Laguna prefill otherwise lives in one command buffer and cannot
      * report real progress until the whole chunk completes.  When a frontend
      * asks for display progress, finish one layer at a time so each callback

--- a/ds4.c
+++ b/ds4.c
@@ -50053,8 +50053,49 @@ static bool laguna_graph_forward_batch(
                                                  exact_q8_rows);
         }
         if (ok && stage_prof) ok = laguna_stage_mark("p_qkvg");
+        /* Verifier rows that stay inside the ring can commit their roped
+         * K and V straight from the rope kernel and let attention skip its
+         * store dispatches (Metal-only twin of the decode fusion). */
+        const bool fused_rope_store_rows =
+#ifdef __APPLE__
+            exact_q8_rows && row_argmax_out != NULL &&
+            n_tokens <= 16u &&
+            (uint64_t)pos0 + n_tokens > 256u &&
+            (uint64_t)pos0 + n_tokens <= g->cache_cap[il];
+#else
+            false;
+#endif
         if (ok && exact_q8_rows) {
             failed_stage = "Q/K norm/RoPE";
+#ifdef __APPLE__
+            if (fused_rope_store_rows) {
+                ok = ds4_gpu_laguna_qk_head_rms_norm_rope_store_rows_tensor(
+                        g->q,
+                        g->k,
+                        g->v,
+                        g->key_cache[il],
+                        g->value_cache[il],
+                        pos0,
+                        model->map,
+                        model->size,
+                        l->attn_q_norm->abs_offset,
+                        l->attn_k_norm->abs_offset,
+                        n_tokens,
+                        n_head,
+                        DS4_N_HEAD_KV,
+                        DS4_N_HEAD_DIM,
+                        n_rot,
+                        pos0,
+                        rope_ctx,
+                        freq_base,
+                        freq_scale,
+                        ext_factor,
+                        attn_factor,
+                        beta_fast,
+                        beta_slow,
+                        DS4_RMS_EPS) != 0;
+            } else
+#endif
             ok = ds4_gpu_laguna_qk_head_rms_norm_rope_tensor(
                     g->q,
                     g->k,
@@ -50141,8 +50182,8 @@ static bool laguna_graph_forward_batch(
                     g->staged_key,
                     g->staged_value,
                     g->q,
-                    g->k,
-                    g->v,
+                    fused_rope_store_rows ? NULL : g->k,
+                    fused_rope_store_rows ? NULL : g->v,
                     g->gate,
                     pos0,
                     n_tokens,

--- a/ds4.h
+++ b/ds4.h
@@ -411,6 +411,11 @@ int ds4_sessions_eval_batch_with_prefill(
         ds4_decode_item *items, int count,
         ds4_session *prefill_session, const ds4_tokens *prefill_prompt,
         char *err, size_t errlen);
+/* After a successful ds4_session_eval_speculative_argmax at temperature 0,
+ * returns the verifier's own argmax of the freshly exposed logits (the
+ * greedy next token), or -1 when unavailable. */
+int ds4_session_greedy_next(const ds4_session *s);
+
 int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                                         int max_tokens, int eos_token,
                                         int *accepted, int accepted_cap,

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -663,11 +663,11 @@ static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, con
             size_t piece_len = 0;
             char *piece = ds4_token_text(engine, toks[j], &piece_len);
             token_printer_write_text(&printer, piece, piece_len);
-            fflush(stdout);
             free(piece);
             generated++;
             if (generated >= max_tokens) break;
         }
+        fflush(stdout);
         if (stop) break;
     }
     const double t_decode1 = cli_now_sec();

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -1101,8 +1101,14 @@ static int run_perplexity_file(ds4_engine *engine, const cli_config *cfg) {
     free(text);
 
     /* Seed the graph with enough real context to stay on the normal Metal
-     * prefill path; scoring starts immediately after this fixed prefix. */
-    const int prefix_len = 32;
+     * prefill path; scoring starts immediately after the prefix.  Text
+     * beyond the context window extends the prefix instead of being
+     * dropped, so the scored tail always sees its true preceding context
+     * and long files exercise the batched prefill path. */
+    int prefix_len = 32;
+    if (tokens.len > cfg->gen.ctx_size) {
+        prefix_len = tokens.len - (cfg->gen.ctx_size - prefix_len);
+    }
     if (tokens.len <= prefix_len) {
         fprintf(stderr, "ds4: --perplexity-file needs more than %d tokens\n", prefix_len);
         ds4_tokens_free(&tokens);

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -54,7 +54,10 @@ static bool cli_greedy_fast_attention_requested(void) {
 
 static bool cli_greedy_argmax_requested(bool speculative_requested) {
     if (cli_greedy_fast_attention_requested()) return true;
-    if (speculative_requested) return false;
+    /* Speculative sessions expose the verifier's own argmax through
+     * ds4_session_greedy_next; paths that don't provide it return -1 and
+     * fall back to the sampled scan. */
+    if (speculative_requested) return true;
     return cli_env_flag_enabled("DS4_CUDA_GREEDY_TOP1", true);
 }
 
@@ -624,6 +627,10 @@ static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, con
                 fprintf(stderr, "ds4: decode failed: %s\n", err);
                 ds4_session_free(session);
                 return 1;
+            }
+            if (greedy_argmax) {
+                greedy_next = ds4_session_greedy_next(session);
+                have_greedy_next = greedy_next >= 0;
             }
         } else {
             size_t piece_len = 0;
@@ -1537,6 +1544,10 @@ static int run_chat_turn(ds4_engine *engine, cli_config *cfg, repl_chat *chat, c
             if (ntok < 0) {
                 fprintf(stderr, "ds4: decode failed: %s\n", err);
                 return 1;
+            }
+            if (greedy_argmax) {
+                greedy_next = ds4_session_greedy_next(chat->session);
+                have_greedy_next = greedy_next >= 0;
             }
         } else {
             size_t piece_len = 0;

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -105,6 +105,37 @@ double ds4_gpu_busy_accum_ms(void);
  * the roped K row and the V row to the attention ring, replacing the
  * separate KV store dispatch.  The paired attention call then passes NULL
  * k/v to ds4_gpu_laguna_store_attention_tensor to skip its store. */
+/* Metal only, verifier rows: fused Q/K per-head RMSNorm + RoPE that also
+ * commits the roped K rows and the V rows to consecutive cache slots
+ * cache_row .. cache_row + n_tokens - 1 (the caller guarantees the block
+ * does not wrap the sliding ring).  The paired attention call then passes
+ * NULL k/v so the row paths skip their stores. */
+int ds4_gpu_laguna_qk_head_rms_norm_rope_store_rows_tensor(
+        ds4_gpu_tensor       *q,
+        ds4_gpu_tensor       *k,
+        const ds4_gpu_tensor *v,
+        ds4_gpu_tensor       *key_cache,
+        ds4_gpu_tensor       *value_cache,
+        uint32_t              cache_row,
+        const void           *model_map,
+        uint64_t              model_size,
+        uint64_t              q_weight_offset,
+        uint64_t              k_weight_offset,
+        uint32_t              n_tokens,
+        uint32_t              n_q_head,
+        uint32_t              n_k_head,
+        uint32_t              head_dim,
+        uint32_t              n_rot,
+        uint32_t              pos0,
+        uint32_t              n_ctx_orig,
+        float                 freq_base,
+        float                 freq_scale,
+        float                 ext_factor,
+        float                 attn_factor,
+        float                 beta_fast,
+        float                 beta_slow,
+        float                 eps);
+
 int ds4_gpu_laguna_qk_head_rms_norm_rope_store_tensor(
         ds4_gpu_tensor       *q,
         ds4_gpu_tensor       *k,

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -81,6 +81,12 @@ int ds4_gpu_flush_commands(void);
 int ds4_gpu_submit_commands(void);
 int ds4_gpu_wait_submitted_commands(void);
 int ds4_gpu_discard_commands(void);
+/* Metal only: stash the open uncommitted batch so an alternative can be
+ * encoded, then restore or drop it (dual-width verifier pre-encode). */
+int ds4_gpu_hold_commands(void);
+int ds4_gpu_unhold_commands(void);
+int ds4_gpu_drop_held_commands(void);
+int ds4_gpu_discard_open_commands(void);
 int ds4_gpu_commands_active(void);
 int ds4_gpu_signal_selected_readback_ready(uint64_t *event_value);
 int ds4_gpu_commit_and_wait_selected_readback(uint64_t event_value, const char *label);

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -100,6 +100,35 @@ int ds4_gpu_synchronize(void);
  * buffers.  Deltas across ds4_gpu_end_commands() give exact per-stage GPU
  * time for diagnostics, independent of host-side sync overhead. */
 double ds4_gpu_busy_accum_ms(void);
+
+/* Metal only, decode: fused Q/K per-head RMSNorm + RoPE that also commits
+ * the roped K row and the V row to the attention ring, replacing the
+ * separate KV store dispatch.  The paired attention call then passes NULL
+ * k/v to ds4_gpu_laguna_store_attention_tensor to skip its store. */
+int ds4_gpu_laguna_qk_head_rms_norm_rope_store_tensor(
+        ds4_gpu_tensor       *q,
+        ds4_gpu_tensor       *k,
+        const void           *model_map,
+        uint64_t              model_size,
+        uint64_t              q_weight_offset,
+        uint64_t              k_weight_offset,
+        uint32_t              n_q_head,
+        uint32_t              n_k_head,
+        uint32_t              head_dim,
+        uint32_t              n_rot,
+        uint32_t              pos0,
+        uint32_t              n_ctx_orig,
+        float                 freq_base,
+        float                 freq_scale,
+        float                 ext_factor,
+        float                 attn_factor,
+        float                 beta_fast,
+        float                 beta_slow,
+        float                 eps,
+        const ds4_gpu_tensor *v,
+        ds4_gpu_tensor       *key_cache,
+        ds4_gpu_tensor       *value_cache,
+        uint32_t              cache_cap);
 #endif
 
 int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size);

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -85,6 +85,7 @@ int ds4_gpu_discard_commands(void);
  * encoded, then restore or drop it (dual-width verifier pre-encode). */
 int ds4_gpu_hold_commands(void);
 int ds4_gpu_unhold_commands(void);
+int ds4_gpu_unhold_commands_at(uint32_t idx);
 int ds4_gpu_drop_held_commands(void);
 int ds4_gpu_discard_open_commands(void);
 int ds4_gpu_commands_active(void);

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -922,6 +922,18 @@ int ds4_gpu_add_rms_norm_weight_tensor(
         uint32_t                n,
         float                   eps);
 
+int ds4_gpu_add_rms_norm_weight_rows_tensor(
+        ds4_gpu_tensor       *norm_out,
+        ds4_gpu_tensor       *sum_out,
+        const ds4_gpu_tensor *a,
+        const ds4_gpu_tensor *b,
+        const void             *model_map,
+        uint64_t                model_size,
+        uint64_t                weight_offset,
+        uint32_t                n,
+        uint32_t                rows,
+        float                   eps);
+
 int ds4_gpu_dsv4_qkv_rms_norm_rows_tensor(
         ds4_gpu_tensor       *q_out,
         const ds4_gpu_tensor *q,

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -639,6 +639,19 @@ int ds4_gpu_matmul_q8_0_pair_tensor(
         const ds4_gpu_tensor *x,
         uint64_t                n_tok);
 
+/* One-token Q8_0 matvec with a fused two-residual epilogue:
+ * out = res_a + res_b + W.x.  Metal only. */
+int ds4_gpu_matmul_q8_0_add2_tensor(
+        ds4_gpu_tensor       *out,
+        const void           *model_map,
+        uint64_t              model_size,
+        uint64_t              weight_offset,
+        uint64_t              in_dim,
+        uint64_t              out_dim,
+        const ds4_gpu_tensor *x,
+        const ds4_gpu_tensor *res_a,
+        const ds4_gpu_tensor *res_b);
+
 /* Multi-row decode projections that preserve the one-row reduction order. */
 int ds4_gpu_matmul_q8_0_decode_rows_exact_tensor(
         ds4_gpu_tensor       *out,

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -83,6 +83,25 @@ int ds4_gpu_wait_submitted_commands(void);
 int ds4_gpu_discard_commands(void);
 /* Metal only: stash the open uncommitted batch so an alternative can be
  * encoded, then restore or drop it (dual-width verifier pre-encode). */
+/* Metal only: consolidated DFlash snapshot/restore — an address table over
+ * the sliding-window caches and their speculative backups lets one dispatch
+ * replace the per-layer blit loops. */
+void *ds4_gpu_laguna_spec_table_build(
+        ds4_gpu_tensor **key_caches,
+        ds4_gpu_tensor **value_caches,
+        ds4_gpu_tensor **key_backups,
+        ds4_gpu_tensor **value_backups,
+        uint32_t         n_layers);
+void ds4_gpu_laguna_spec_table_free(void *table);
+int ds4_gpu_laguna_spec_copy_all_tensor(
+        void    *table,
+        uint32_t pos0,
+        uint32_t first_row,
+        uint32_t n_rows,
+        uint32_t cache_cap,
+        uint32_t row_elems,
+        int      to_backup);
+
 int ds4_gpu_hold_commands(void);
 int ds4_gpu_unhold_commands(void);
 int ds4_gpu_unhold_commands_at(uint32_t idx);

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -95,6 +95,12 @@ int ds4_gpu_tensor_read_after_selected_event(const ds4_gpu_tensor *tensor,
 #endif
 int ds4_gpu_end_commands(void);
 int ds4_gpu_synchronize(void);
+#ifdef __APPLE__
+/* Metal only: cumulative GPU busy milliseconds over all waited command
+ * buffers.  Deltas across ds4_gpu_end_commands() give exact per-stage GPU
+ * time for diagnostics, independent of host-side sync overhead. */
+double ds4_gpu_busy_accum_ms(void);
+#endif
 
 int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size);
 int ds4_gpu_set_model_fd(int fd);

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -1239,6 +1239,8 @@ int ds4_gpu_dflash_commit_kv_tensor(
 
 int ds4_gpu_dflash_probabilities_tensor(
         ds4_gpu_tensor       *probabilities,
+        ds4_gpu_tensor       *top2,
+        ds4_gpu_tensor       *probabilities2,
         const ds4_gpu_tensor *logits,
         const ds4_gpu_tensor *argmax,
         uint32_t              n_rows,

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -16846,9 +16846,15 @@ int ds4_gpu_matmul_q8_0_decode_rows_exact_tensor(
         args.ne1 = (int32_t)n_rows;
         args.nr0 = dispatch.nr0;
 
-        const uint32_t rows_per_group =
+        uint32_t rows_per_group =
             n_rows >= 4u ? 4u : n_rows == 3u ? 3u :
             n_rows == 2u ? 2u : 1u;
+        /* Diagnostic: cap the exact-rows kernel's tokens per threadgroup. */
+        const char *rows_cap_env = getenv("DS4_METAL_Q8_ROWS_EXACT_MAX");
+        if (rows_cap_env != NULL) {
+            const uint32_t cap = (uint32_t)atoi(rows_cap_env);
+            if (cap >= 1u && cap < rows_per_group) rows_per_group = cap;
+        }
         const char *function_name =
             rows_per_group == 4u ?
                 "kernel_mul_mv_q8_0_f32_rows4_exact" :

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -32491,8 +32491,15 @@ int ds4_gpu_laguna_attention_prefill_tensor(
             threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
 
+        /* The register-resident tensor-unit kernel replaces the serial
+         * per-key simdgroup walk whenever the M5 tensor path is live. */
+        id<MTLComputePipelineState> nax_pipeline =
+            ds4_gpu_mpp_available() && head_dim == 128u ?
+            ds4_gpu_get_pipeline("kernel_laguna_attention_prefill_nax_f16") :
+            nil;
         enc = ds4_gpu_compute_encoder(cb);
-        [enc setComputePipelineState:attention_pipeline];
+        [enc setComputePipelineState:nax_pipeline ? nax_pipeline
+                                                  : attention_pipeline];
         [enc setBytes:&args length:sizeof(args) atIndex:0];
         [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
         [enc setBuffer:gatebuf offset:ds4_gpu_tensor_offset(gate) atIndex:2];
@@ -32503,12 +32510,19 @@ int ds4_gpu_laguna_attention_prefill_tensor(
         [enc setBuffer:stagedvaluebuf offset:ds4_gpu_tensor_offset(staged_value)
                 atIndex:6];
         [enc setBuffer:headsbuf offset:ds4_gpu_tensor_offset(heads) atIndex:7];
-        const uint32_t attention_groups = use_gqa6 ?
-            n_head / 6u : use_gqa3 ? n_head / 3u : n_head;
-        [enc dispatchThreadgroups:MTLSizeMake(attention_groups,
-                                              n_tokens,
-                                              1)
-             threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
+        if (nax_pipeline) {
+            [enc dispatchThreadgroups:MTLSizeMake((n_tokens + 63u) / 64u,
+                                                  n_head,
+                                                  1)
+                 threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+        } else {
+            const uint32_t attention_groups = use_gqa6 ?
+                n_head / 6u : use_gqa3 ? n_head / 3u : n_head;
+            [enc dispatchThreadgroups:MTLSizeMake(attention_groups,
+                                                  n_tokens,
+                                                  1)
+                 threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
+        }
         ds4_gpu_end_compute_encoder(cb, enc);
 
         enc = ds4_gpu_compute_encoder(cb);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -17496,8 +17496,10 @@ int ds4_gpu_matmul_q8_0_pair_tensor(
         ds4_gpu_q8_0_matvec_args args1 = ds4_gpu_make_q8_0_mv_args(in_dim, out1_dim);
         args0.nr0 = dispatch0.nr0;
         args1.nr0 = dispatch1.nr0;
+        const char *pair_fn = dispatch0.nr0 == 4 ?
+            "kernel_mul_mv_q8_0_f32_pair_r4" : "kernel_mul_mv_q8_0_f32_pair";
         id<MTLComputePipelineState> pipeline =
-            ds4_gpu_get_mul_mv_pipeline("kernel_mul_mv_q8_0_f32_pair", dispatch0.nsg);
+            ds4_gpu_get_mul_mv_pipeline(pair_fn, dispatch0.nsg);
         if (!pipeline) return 0;
 
         int owned = 0;

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -35957,10 +35957,26 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_tensor(
 
         id<MTLComputePipelineState> map_pipeline =
             ds4_gpu_get_pipeline(ds4_gpu_mul_mm_id_map0_name(n_expert));
-        id<MTLComputePipelineState> gate_pipeline = ds4_gpu_routed_mm_pipeline(gate_type);
-        id<MTLComputePipelineState> up_pipeline = ds4_gpu_routed_mm_pipeline(up_type);
-        id<MTLComputePipelineState> down_pipeline =
+        /* All-Q4_K expert stacks take the TensorOps twin of the tiled
+         * expert matmul: same tile shape and staging precision, cooperative
+         * matmul instead of simdgroup MMA. */
+        const bool mm_id_mpp =
+            ds4_gpu_mpp_available() &&
+            gate_type == DS4_METAL_TENSOR_Q4_K &&
+            up_type == DS4_METAL_TENSOR_Q4_K &&
+            down_type == DS4_METAL_TENSOR_Q4_K &&
+            getenv("DS4_METAL_DISABLE_MOE_MM_ID_MPP") == NULL;
+        id<MTLComputePipelineState> gate_pipeline = mm_id_mpp ?
+            ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_q4_K_f32_mpp", false) :
+            ds4_gpu_routed_mm_pipeline(gate_type);
+        id<MTLComputePipelineState> up_pipeline = mm_id_mpp ?
+            gate_pipeline :
+            ds4_gpu_routed_mm_pipeline(up_type);
+        id<MTLComputePipelineState> down_pipeline = mm_id_mpp ?
+            ds4_gpu_get_mul_mm_id_pipeline("kernel_mul_mm_id_q4_K_f16_mpp", false) :
             ds4_gpu_routed_mm_f16_rhs_pipeline(down_type);
+        const NSUInteger mm_id_tile_threadgroup_bytes =
+            mm_id_mpp ? 20736u : mm_id_threadgroup_bytes;
         if (!map_pipeline || !gate_pipeline || !up_pipeline || !down_pipeline) {
             return 0;
         }
@@ -36054,7 +36070,7 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_tensor(
                                                        ds4_gpu_tensor_offset(x),
                                                        g_moe_gate_scratch_buffer,
                                                        0,
-                                                       mm_id_threadgroup_bytes);
+                                                       mm_id_tile_threadgroup_bytes);
         }
         DS4_METAL_PROFILE_GLM_GROUPED_MOE_STAGE("gate");
         if (ok) {
@@ -36067,7 +36083,7 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_tensor(
                                                        ds4_gpu_tensor_offset(x),
                                                        g_moe_gate_scratch_buffer,
                                                        (NSUInteger)gate_scratch_bytes,
-                                                       mm_id_threadgroup_bytes);
+                                                       mm_id_tile_threadgroup_bytes);
         }
         DS4_METAL_PROFILE_GLM_GROUPED_MOE_STAGE("up");
         if (ok) {
@@ -36099,7 +36115,7 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_tensor(
                                                        ds4_gpu_tensor_offset(mid),
                                                        down_dst,
                                                        down_dst_off,
-                                                       mm_id_threadgroup_bytes);
+                                                       mm_id_tile_threadgroup_bytes);
         }
         DS4_METAL_PROFILE_GLM_GROUPED_MOE_STAGE("down");
         if (ok && n_expert > 1) {

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -233,9 +233,9 @@ static id<MTLComputePipelineState> g_glm_q6_k_down_f32_pipeline;
 static id<MTLComputePipelineState> g_laguna_routed_shared_pair_pipeline;
 static id<MTLComputePipelineState> g_laguna_routed_shared_q4_down_pipeline;
 static id<MTLComputePipelineState> g_laguna_routed_shared_q6_down_pipeline;
-static id<MTLComputePipelineState> g_laguna_head_norm_rope_pipeline;
-static id<MTLComputePipelineState> g_laguna_qk_head_norm_rope_pipeline;
 static id<MTLComputePipelineState> g_laguna_qk_head_norm_rope_store_pipeline;
+static id<MTLComputePipelineState> g_laguna_head_norm_rope_simd_pipeline;
+static id<MTLComputePipelineState> g_laguna_qk_head_norm_rope_simd_pipeline;
 static id<MTLComputePipelineState> g_laguna_store_kv_pipeline;
 static id<MTLComputePipelineState> g_laguna_attention_pipeline;
 static id<MTLComputePipelineState> g_laguna_stage_kv_pipeline;
@@ -7961,13 +7961,13 @@ int ds4_gpu_init(void) {
         g_laguna_routed_shared_q6_down_pipeline =
             ds4_gpu_get_pipeline(
                 "kernel_laguna_q6_K_routed_shared_down_f32");
-        g_laguna_head_norm_rope_pipeline =
-            ds4_gpu_get_pipeline("kernel_laguna_head_rms_norm_rope_neox");
-        g_laguna_qk_head_norm_rope_pipeline =
-            ds4_gpu_get_pipeline("kernel_laguna_qk_head_rms_norm_rope_neox");
         g_laguna_qk_head_norm_rope_store_pipeline =
             ds4_gpu_get_pipeline(
                 "kernel_laguna_qk_head_rms_norm_rope_store_neox");
+        g_laguna_head_norm_rope_simd_pipeline =
+            ds4_gpu_get_pipeline("kernel_laguna_head_rms_norm_rope_simd");
+        g_laguna_qk_head_norm_rope_simd_pipeline =
+            ds4_gpu_get_pipeline("kernel_laguna_qk_head_rms_norm_rope_simd");
         g_laguna_store_kv_pipeline =
             ds4_gpu_get_pipeline("kernel_laguna_store_kv_f16");
         g_laguna_attention_pipeline =
@@ -8056,8 +8056,8 @@ int ds4_gpu_init(void) {
             !g_laguna_routed_shared_pair_pipeline ||
             !g_laguna_routed_shared_q4_down_pipeline ||
             !g_laguna_routed_shared_q6_down_pipeline ||
-            !g_laguna_head_norm_rope_pipeline ||
-            !g_laguna_qk_head_norm_rope_pipeline ||
+            !g_laguna_head_norm_rope_simd_pipeline ||
+            !g_laguna_qk_head_norm_rope_simd_pipeline ||
             !g_laguna_store_kv_pipeline ||
             !g_laguna_attention_pipeline ||
             !g_laguna_stage_kv_pipeline ||
@@ -9456,9 +9456,9 @@ void ds4_gpu_cleanup(void) {
         g_laguna_routed_shared_pair_pipeline = nil;
         g_laguna_routed_shared_q4_down_pipeline = nil;
         g_laguna_routed_shared_q6_down_pipeline = nil;
-        g_laguna_head_norm_rope_pipeline = nil;
-        g_laguna_qk_head_norm_rope_pipeline = nil;
         g_laguna_qk_head_norm_rope_store_pipeline = nil;
+        g_laguna_head_norm_rope_simd_pipeline = nil;
+        g_laguna_qk_head_norm_rope_simd_pipeline = nil;
         g_laguna_store_kv_pipeline = nil;
         g_laguna_attention_pipeline = nil;
         g_laguna_stage_kv_pipeline = nil;
@@ -31360,8 +31360,7 @@ int ds4_gpu_laguna_head_rms_norm_rope_tensor(
         float           eps) {
     if (!g_initialized && !ds4_gpu_init()) return 0;
     if (!x || !model_map || n_tokens == 0 || n_head == 0 ||
-        head_dim == 0 || head_dim > 128u || n_rot == 0 ||
-        n_rot > head_dim || (n_rot & 1u) != 0u ||
+        head_dim != 128u || (n_rot != 64u && n_rot != 128u) ||
         pos0 > UINT32_MAX - n_tokens ||
         !isfinite(freq_base) || freq_base <= 0.0f ||
         !isfinite(freq_scale) || freq_scale <= 0.0f ||
@@ -31389,8 +31388,8 @@ int ds4_gpu_laguna_head_rms_norm_rope_tensor(
                                                             weight_bytes,
                                                             &weight_inner);
         id<MTLComputePipelineState> pipeline = ds4_gpu_hot_pipeline(
-            g_laguna_head_norm_rope_pipeline,
-            "kernel_laguna_head_rms_norm_rope_neox");
+            g_laguna_head_norm_rope_simd_pipeline,
+            "kernel_laguna_head_rms_norm_rope_simd");
         if (!xbuf || !weightbuf || !pipeline) return 0;
 
         ds4_gpu_laguna_norm_rope_args args = {
@@ -31416,8 +31415,8 @@ int ds4_gpu_laguna_head_rms_norm_rope_tensor(
         [enc setBytes:&args length:sizeof(args) atIndex:0];
         [enc setBuffer:xbuf offset:ds4_gpu_tensor_offset(x) atIndex:1];
         [enc setBuffer:weightbuf offset:(NSUInteger)weight_inner atIndex:2];
-        [enc setThreadgroupMemoryLength:128u * sizeof(float) atIndex:0];
-        [enc dispatchThreadgroups:MTLSizeMake(n_head, n_tokens, 1)
+        [enc dispatchThreadgroups:MTLSizeMake((n_head + 3u) / 4u,
+                                              n_tokens, 1)
              threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
         if (!ds4_gpu_finish_command_buffer(cb, owned, "Laguna head norm/RoPE")) return 0;
@@ -31449,8 +31448,7 @@ int ds4_gpu_laguna_qk_head_rms_norm_rope_tensor(
     if (!g_initialized && !ds4_gpu_init()) return 0;
     if (!q || !k || !model_map || n_tokens == 0 || n_q_head == 0 ||
         n_k_head == 0 || n_q_head > UINT32_MAX - n_k_head ||
-        head_dim == 0 || head_dim > 128u || n_rot == 0 ||
-        n_rot > head_dim || (n_rot & 1u) != 0u ||
+        head_dim != 128u || (n_rot != 64u && n_rot != 128u) ||
         pos0 > UINT32_MAX - n_tokens ||
         !isfinite(freq_base) || freq_base <= 0.0f ||
         !isfinite(freq_scale) || freq_scale <= 0.0f ||
@@ -31485,8 +31483,8 @@ int ds4_gpu_laguna_qk_head_rms_norm_rope_tensor(
             model_map, model_size, k_weight_offset, weight_bytes,
             &k_weight_inner);
         id<MTLComputePipelineState> pipeline = ds4_gpu_hot_pipeline(
-            g_laguna_qk_head_norm_rope_pipeline,
-            "kernel_laguna_qk_head_rms_norm_rope_neox");
+            g_laguna_qk_head_norm_rope_simd_pipeline,
+            "kernel_laguna_qk_head_rms_norm_rope_simd");
         if (!qbuf || !kbuf || !q_weightbuf || !k_weightbuf || !pipeline) {
             return 0;
         }
@@ -31517,8 +31515,8 @@ int ds4_gpu_laguna_qk_head_rms_norm_rope_tensor(
         [enc setBuffer:q_weightbuf offset:(NSUInteger)q_weight_inner atIndex:3];
         [enc setBuffer:k_weightbuf offset:(NSUInteger)k_weight_inner atIndex:4];
         [enc setBytes:&n_q_head length:sizeof(n_q_head) atIndex:5];
-        [enc setThreadgroupMemoryLength:128u * sizeof(float) atIndex:0];
-        [enc dispatchThreadgroups:MTLSizeMake(n_q_head + n_k_head, n_tokens, 1)
+        [enc dispatchThreadgroups:MTLSizeMake(
+                (n_q_head + n_k_head + 3u) / 4u, n_tokens, 1)
              threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
         if (!ds4_gpu_finish_command_buffer(
@@ -31557,8 +31555,7 @@ int ds4_gpu_laguna_qk_head_rms_norm_rope_store_tensor(
     if (!q || !k || !v || !key_cache || !value_cache || !model_map ||
         n_q_head == 0 || n_k_head == 0 ||
         n_q_head > UINT32_MAX - n_k_head ||
-        head_dim == 0 || head_dim > 128u || n_rot == 0 ||
-        n_rot > head_dim || (n_rot & 1u) != 0u ||
+        head_dim != 128u || (n_rot != 64u && n_rot != 128u) ||
         cache_cap == 0 || pos0 == UINT32_MAX ||
         !isfinite(freq_base) || freq_base <= 0.0f ||
         !isfinite(freq_scale) || freq_scale <= 0.0f ||
@@ -31637,8 +31634,8 @@ int ds4_gpu_laguna_qk_head_rms_norm_rope_store_tensor(
         [enc setBuffer:vbuf offset:ds4_gpu_tensor_offset(v) atIndex:6];
         [enc setBuffer:keybuf offset:ds4_gpu_tensor_offset(key_cache) atIndex:7];
         [enc setBuffer:valuebuf offset:ds4_gpu_tensor_offset(value_cache) atIndex:8];
-        [enc setThreadgroupMemoryLength:128u * sizeof(float) atIndex:0];
-        [enc dispatchThreadgroups:MTLSizeMake(n_q_head + n_k_head, 1, 1)
+        [enc dispatchThreadgroups:MTLSizeMake((n_q_head + n_k_head + 3u) / 4u,
+                                              1, 1)
              threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
         if (!ds4_gpu_finish_command_buffer(

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -8414,6 +8414,62 @@ int ds4_gpu_wait_submitted_commands(void) {
     return ds4_gpu_wait_pending_command_buffers("submitted command batch");
 }
 
+/* One stashed uncommitted batch, so a speculative verifier can be encoded
+ * at two widths while the draft executes: hold the first, encode the
+ * second, then keep whichever width the confidence prune selects. */
+static id<MTLCommandBuffer> g_held_cb;
+static BOOL g_held_has_work;
+static uint64_t g_held_expert_seq;
+
+int ds4_gpu_hold_commands(void) {
+    if (!g_initialized && !ds4_gpu_init()) return 0;
+    if (!g_batch_cb || g_held_cb) return 0;
+    ds4_gpu_close_batch_encoder();
+    g_held_cb = g_batch_cb;
+    g_held_has_work = g_batch_has_work;
+    g_held_expert_seq = g_stream_expert_cache_batch_seq;
+    g_stream_expert_cache_batch_seq = 0;
+    g_batch_cb = ds4_gpu_new_command_buffer();
+    g_batch_has_work = NO;
+    if (g_batch_cb) ds4_gpu_stream_expert_cache_note_batch_created();
+    return g_batch_cb != nil;
+}
+
+int ds4_gpu_unhold_commands(void) {
+    if (!g_held_cb || g_batch_cb) return 0;
+    g_batch_cb = g_held_cb;
+    g_batch_has_work = g_held_has_work;
+    g_stream_expert_cache_batch_seq = g_held_expert_seq;
+    g_held_cb = nil;
+    g_held_has_work = NO;
+    g_held_expert_seq = 0;
+    return 1;
+}
+
+int ds4_gpu_drop_held_commands(void) {
+    if (!g_held_cb) return 1;
+    g_held_cb = nil;
+    g_held_has_work = NO;
+    if (g_held_expert_seq > g_stream_expert_cache_done_seq) {
+        g_stream_expert_cache_done_seq = g_held_expert_seq;
+    }
+    g_held_expert_seq = 0;
+    return 1;
+}
+
+int ds4_gpu_discard_open_commands(void) {
+    if (!g_batch_cb) return 0;
+    ds4_gpu_close_batch_encoder();
+    g_batch_cb = nil;
+    g_batch_has_work = NO;
+    const uint64_t discarded_seq = g_stream_expert_cache_batch_seq;
+    g_stream_expert_cache_batch_seq = 0;
+    if (discarded_seq > g_stream_expert_cache_done_seq) {
+        g_stream_expert_cache_done_seq = discarded_seq;
+    }
+    return 1;
+}
+
 int ds4_gpu_discard_commands(void) {
     if (!g_initialized && !ds4_gpu_init()) return 0;
     if (!g_batch_cb) return 0;

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -2147,9 +2147,28 @@ static id<MTLComputePipelineState> ds4_gpu_get_mul_mm_id_pipeline(
 
 static id<MTLComputePipelineState> ds4_gpu_get_pipeline(
         const char *function_name) {
-    NSString *key = [NSString stringWithFormat:@"%s", function_name];
+    /* Call sites pass string literals, so the pointer itself is a stable
+     * key: steady-state lookups skip NSString creation and the dictionary
+     * hash entirely (both showed up in CPU samples of the DFlash cycle). */
+    enum { DS4_PIPELINE_PTR_CACHE = 96 };
+    static const char *ptr_keys[DS4_PIPELINE_PTR_CACHE];
+    static void *ptr_vals[DS4_PIPELINE_PTR_CACHE];
+    static uint32_t ptr_count;
+    for (uint32_t i = 0; i < ptr_count; i++) {
+        if (ptr_keys[i] == function_name) {
+            return (__bridge id<MTLComputePipelineState>)ptr_vals[i];
+        }
+    }
+    NSString *key = [NSString stringWithUTF8String:function_name];
     id<MTLComputePipelineState> cached = [g_pipeline_cache objectForKey:key];
-    if (cached) return cached;
+    if (cached) {
+        if (ptr_count < DS4_PIPELINE_PTR_CACHE) {
+            ptr_keys[ptr_count] = function_name;
+            ptr_vals[ptr_count] = (void *)CFBridgingRetain(cached);
+            ptr_count++;
+        }
+        return cached;
+    }
 
     NSError *error = nil;
     NSString *name = [NSString stringWithUTF8String:function_name];
@@ -2167,6 +2186,11 @@ static id<MTLComputePipelineState> ds4_gpu_get_pipeline(
     }
 
     [g_pipeline_cache setObject:pipeline forKey:key];
+    if (ptr_count < DS4_PIPELINE_PTR_CACHE) {
+        ptr_keys[ptr_count] = function_name;
+        ptr_vals[ptr_count] = (void *)CFBridgingRetain(pipeline);
+        ptr_count++;
+    }
     return pipeline;
 }
 
@@ -17070,10 +17094,14 @@ int ds4_gpu_matmul_q8_0_decode_rows_exact_tensor(
             n_rows >= 4u ? 4u : n_rows == 3u ? 3u :
             n_rows == 2u ? 2u : 1u;
         /* Diagnostic: cap the exact-rows kernel's tokens per threadgroup. */
-        const char *rows_cap_env = getenv("DS4_METAL_Q8_ROWS_EXACT_MAX");
-        if (rows_cap_env != NULL) {
-            const uint32_t cap = (uint32_t)atoi(rows_cap_env);
-            if (cap >= 1u && cap < rows_per_group) rows_per_group = cap;
+        static int rows_cap_cached = -2;
+        if (rows_cap_cached == -2) {
+            const char *rows_cap_env = getenv("DS4_METAL_Q8_ROWS_EXACT_MAX");
+            rows_cap_cached = rows_cap_env != NULL ? atoi(rows_cap_env) : -1;
+        }
+        if (rows_cap_cached >= 1 &&
+            (uint32_t)rows_cap_cached < rows_per_group) {
+            rows_per_group = (uint32_t)rows_cap_cached;
         }
         const char *function_name =
             rows_per_group == 4u ?
@@ -32014,6 +32042,14 @@ int ds4_gpu_laguna_qk_head_rms_norm_rope_store_tensor(
     return 1;
 }
 
+static int ds4_gpu_swa_decode_gqa3_enabled(void) {
+    static int cached = -1;
+    if (cached < 0) {
+        cached = getenv("DS4_METAL_DISABLE_SWA_DECODE_GQA3") == NULL ? 1 : 0;
+    }
+    return cached;
+}
+
 static int ds4_gpu_encode_laguna_flash_attention_decode(
         id<MTLCommandBuffer> cb,
         id<MTLBuffer>        headsbuf,
@@ -32047,7 +32083,7 @@ static int ds4_gpu_encode_laguna_flash_attention_decode(
     const bool use_gqa3 =
         (cache_cap > 512u ||
          (key_count == cache_cap &&
-          getenv("DS4_METAL_DISABLE_SWA_DECODE_GQA3") == NULL)) &&
+          ds4_gpu_swa_decode_gqa3_enabled())) &&
         (n_head % 3u) == 0u &&
         ((n_head / n_head_kv) % 3u) == 0u;
     const NSUInteger head_bytes = (NSUInteger)head_dim * sizeof(uint16_t);
@@ -32642,21 +32678,32 @@ int ds4_gpu_laguna_attention_prefill_tensor(
 
             /* Three query heads of one KV head share every K/V read when
              * the head grouping allows it (72/8 sliding geometry). */
+            static int rows_gqa3_env = -1;
+            if (rows_gqa3_env < 0) {
+                rows_gqa3_env =
+                    getenv("DS4_METAL_DISABLE_ROWS_GQA3") == NULL ? 1 : 0;
+            }
             const bool rows_gqa3_geom =
                 (n_head % 3u) == 0u &&
                 n_head_kv != 0u &&
                 ((n_head / n_head_kv) % 3u) == 0u &&
-                getenv("DS4_METAL_DISABLE_ROWS_GQA3") == NULL;
+                rows_gqa3_env != 0;
             /* Once the ring has wrapped, the block's own keys are served
              * from the staging buffer so the batched store can wait until
              * after attention instead of falling back to row-at-a-time
              * store/attend pairs. */
+            static int staged_env = -1;
+            if (staged_env < 0) {
+                staged_env =
+                    getenv("DS4_METAL_DISABLE_SWA_ROWS_STAGED") == NULL ?
+                    1 : 0;
+            }
             const bool use_batched_swa_rows_staged =
                 n_tokens >= 2u && n_tokens <= 16u &&
                 cache_cap == 512u &&
                 pos0 + n_tokens > cache_cap &&
                 rows_gqa3_geom &&
-                getenv("DS4_METAL_DISABLE_SWA_ROWS_STAGED") == NULL;
+                staged_env != 0;
             if (use_batched_swa_rows_staged) {
                 if (!have_kv) return 0;
                 id<MTLComputePipelineState> stage_pipeline =

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -31554,6 +31554,127 @@ int ds4_gpu_laguna_qk_head_rms_norm_rope_tensor(
     return 1;
 }
 
+int ds4_gpu_laguna_qk_head_rms_norm_rope_store_rows_tensor(
+        ds4_gpu_tensor       *q,
+        ds4_gpu_tensor       *k,
+        const ds4_gpu_tensor *v,
+        ds4_gpu_tensor       *key_cache,
+        ds4_gpu_tensor       *value_cache,
+        uint32_t              cache_row,
+        const void           *model_map,
+        uint64_t              model_size,
+        uint64_t              q_weight_offset,
+        uint64_t              k_weight_offset,
+        uint32_t              n_tokens,
+        uint32_t              n_q_head,
+        uint32_t              n_k_head,
+        uint32_t              head_dim,
+        uint32_t              n_rot,
+        uint32_t              pos0,
+        uint32_t              n_ctx_orig,
+        float                 freq_base,
+        float                 freq_scale,
+        float                 ext_factor,
+        float                 attn_factor,
+        float                 beta_fast,
+        float                 beta_slow,
+        float                 eps) {
+    if (!g_initialized && !ds4_gpu_init()) return 0;
+    if (!q || !k || !v || !key_cache || !value_cache || !model_map ||
+        n_tokens == 0 || n_q_head == 0 ||
+        n_k_head == 0 || n_q_head > UINT32_MAX - n_k_head ||
+        head_dim != 128u || (n_rot != 64u && n_rot != 128u) ||
+        pos0 > UINT32_MAX - n_tokens ||
+        cache_row > UINT32_MAX - n_tokens ||
+        !isfinite(freq_base) || freq_base <= 0.0f ||
+        !isfinite(freq_scale) || freq_scale <= 0.0f ||
+        !isfinite(ext_factor) || !isfinite(attn_factor) ||
+        !isfinite(beta_fast) || !isfinite(beta_slow) ||
+        !isfinite(eps) || eps <= 0.0f) {
+        return 0;
+    }
+
+    const uint64_t q_values = (uint64_t)n_tokens * n_q_head * head_dim;
+    const uint64_t k_values = (uint64_t)n_tokens * n_k_head * head_dim;
+    const uint64_t cache_values =
+        ((uint64_t)cache_row + n_tokens) * n_k_head * head_dim;
+    const uint64_t weight_bytes = (uint64_t)head_dim * sizeof(float);
+    if (ds4_gpu_tensor_bytes(q) < q_values * sizeof(float) ||
+        ds4_gpu_tensor_bytes(k) < k_values * sizeof(float) ||
+        ds4_gpu_tensor_bytes(v) < k_values * sizeof(float) ||
+        ds4_gpu_tensor_bytes(key_cache) < cache_values * sizeof(uint16_t) ||
+        ds4_gpu_tensor_bytes(value_cache) < cache_values * sizeof(uint16_t) ||
+        q_weight_offset > model_size ||
+        weight_bytes > model_size - q_weight_offset ||
+        k_weight_offset > model_size ||
+        weight_bytes > model_size - k_weight_offset) {
+        fprintf(stderr, "ds4: Metal Laguna fused rope+store rows received an invalid buffer or weight range\n");
+        return 0;
+    }
+
+    @autoreleasepool {
+        id<MTLBuffer> qbuf = ds4_gpu_tensor_buffer(q);
+        id<MTLBuffer> kbuf = ds4_gpu_tensor_buffer(k);
+        id<MTLBuffer> vbuf = ds4_gpu_tensor_buffer(v);
+        id<MTLBuffer> keybuf = ds4_gpu_tensor_buffer(key_cache);
+        id<MTLBuffer> valuebuf = ds4_gpu_tensor_buffer(value_cache);
+        uint64_t q_weight_inner = 0;
+        uint64_t k_weight_inner = 0;
+        id<MTLBuffer> q_weightbuf = ds4_gpu_wrap_model_range(
+            model_map, model_size, q_weight_offset, weight_bytes,
+            &q_weight_inner);
+        id<MTLBuffer> k_weightbuf = ds4_gpu_wrap_model_range(
+            model_map, model_size, k_weight_offset, weight_bytes,
+            &k_weight_inner);
+        id<MTLComputePipelineState> pipeline = ds4_gpu_get_pipeline(
+            "kernel_laguna_qk_head_rms_norm_rope_store_rows_neox");
+        if (!qbuf || !kbuf || !vbuf || !keybuf || !valuebuf ||
+            !q_weightbuf || !k_weightbuf || !pipeline) {
+            return 0;
+        }
+
+        ds4_gpu_laguna_norm_rope_args args = {
+            .n_tokens = n_tokens,
+            .n_head = n_q_head + n_k_head,
+            .head_dim = head_dim,
+            .n_rot = n_rot,
+            .pos0 = pos0,
+            .n_ctx_orig = n_ctx_orig,
+            .eps = eps,
+            .freq_base = freq_base,
+            .freq_scale = freq_scale,
+            .ext_factor = ext_factor,
+            .attn_factor = attn_factor,
+            .beta_fast = beta_fast,
+            .beta_slow = beta_slow,
+            .cache_row = cache_row,
+        };
+        int owned = 0;
+        id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
+        if (!cb) return 0;
+        id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
+        [enc setComputePipelineState:pipeline];
+        [enc setBytes:&args length:sizeof(args) atIndex:0];
+        [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
+        [enc setBuffer:kbuf offset:ds4_gpu_tensor_offset(k) atIndex:2];
+        [enc setBuffer:q_weightbuf offset:(NSUInteger)q_weight_inner atIndex:3];
+        [enc setBuffer:k_weightbuf offset:(NSUInteger)k_weight_inner atIndex:4];
+        [enc setBytes:&n_q_head length:sizeof(n_q_head) atIndex:5];
+        [enc setBuffer:vbuf offset:ds4_gpu_tensor_offset(v) atIndex:6];
+        [enc setBuffer:keybuf offset:ds4_gpu_tensor_offset(key_cache) atIndex:7];
+        [enc setBuffer:valuebuf offset:ds4_gpu_tensor_offset(value_cache) atIndex:8];
+        [enc dispatchThreadgroups:MTLSizeMake(
+                (n_q_head + n_k_head + 3u) / 4u, n_tokens, 1)
+             threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+        ds4_gpu_end_compute_encoder(cb, enc);
+        if (!ds4_gpu_finish_command_buffer(
+                cb, owned, "Laguna fused Q/K rope + rows KV store")) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 int ds4_gpu_laguna_qk_head_rms_norm_rope_store_tensor(
         ds4_gpu_tensor       *q,
         ds4_gpu_tensor       *k,
@@ -32134,8 +32255,12 @@ int ds4_gpu_laguna_attention_prefill_tensor(
         float                 scale,
         int                   split_decode_rows) {
     if (!g_initialized && !ds4_gpu_init()) return 0;
+    /* NULL k/v means the caller already committed the roped K and the V
+     * rows to the cache (fused rope+store); only the row paths that would
+     * re-store them accept that contract. */
+    const bool have_kv = k != NULL && v != NULL;
     if (!heads || !key_cache || !value_cache || !staged_key ||
-        !staged_value || !q || !k || !v || !gate || n_tokens == 0 ||
+        !staged_value || !q || !gate || n_tokens == 0 ||
         pos0 > UINT32_MAX - n_tokens || cache_cap == 0 || n_head == 0 ||
         n_head_kv == 0 || n_head % n_head_kv != 0 || head_dim != 128u ||
         !isfinite(scale) || scale <= 0.0f) {
@@ -32148,8 +32273,9 @@ int ds4_gpu_laguna_attention_prefill_tensor(
     const uint64_t cache_values =
         (uint64_t)cache_cap * n_head_kv * head_dim;
     if (ds4_gpu_tensor_bytes(q) < q_values * sizeof(float) ||
-        ds4_gpu_tensor_bytes(k) < kv_values * sizeof(float) ||
-        ds4_gpu_tensor_bytes(v) < kv_values * sizeof(float) ||
+        (have_kv &&
+         (ds4_gpu_tensor_bytes(k) < kv_values * sizeof(float) ||
+          ds4_gpu_tensor_bytes(v) < kv_values * sizeof(float))) ||
         ds4_gpu_tensor_bytes(gate) <
             (uint64_t)n_tokens * n_head * sizeof(float) ||
         ds4_gpu_tensor_bytes(heads) < q_values * sizeof(float) ||
@@ -32168,8 +32294,8 @@ int ds4_gpu_laguna_attention_prefill_tensor(
         id<MTLBuffer> stagedkeybuf = ds4_gpu_tensor_buffer(staged_key);
         id<MTLBuffer> stagedvaluebuf = ds4_gpu_tensor_buffer(staged_value);
         id<MTLBuffer> qbuf = ds4_gpu_tensor_buffer(q);
-        id<MTLBuffer> kbuf = ds4_gpu_tensor_buffer(k);
-        id<MTLBuffer> vbuf = ds4_gpu_tensor_buffer(v);
+        id<MTLBuffer> kbuf = have_kv ? ds4_gpu_tensor_buffer(k) : nil;
+        id<MTLBuffer> vbuf = have_kv ? ds4_gpu_tensor_buffer(v) : nil;
         id<MTLBuffer> gatebuf = ds4_gpu_tensor_buffer(gate);
         id<MTLComputePipelineState> store_pipeline = ds4_gpu_hot_pipeline(
             g_laguna_store_kv_pipeline, "kernel_laguna_store_kv_f16");
@@ -32192,7 +32318,8 @@ int ds4_gpu_laguna_attention_prefill_tensor(
         id<MTLComputePipelineState> commit_pipeline = ds4_gpu_hot_pipeline(
             g_laguna_commit_kv_pipeline, "kernel_laguna_commit_kv_f16");
         if (!headsbuf || !keybuf || !valuebuf || !stagedkeybuf ||
-            !stagedvaluebuf || !qbuf || !kbuf || !vbuf || !gatebuf ||
+            !stagedvaluebuf || !qbuf || (have_kv && (!kbuf || !vbuf)) ||
+            !gatebuf ||
             !store_pipeline || !stage_pipeline || !attention_pipeline ||
             !decode_attention_pipeline || !commit_pipeline) {
             return 0;
@@ -32231,7 +32358,7 @@ int ds4_gpu_laguna_attention_prefill_tensor(
                 ds4_gpu_flash_attn_vec_nsg(
                     first_key_count + n_tokens - 1u, 32u, 32u);
             if (use_batched_global_rows) {
-                for (uint32_t row = 0; row < n_tokens; row++) {
+                for (uint32_t row = 0; have_kv && row < n_tokens; row++) {
                     const uint32_t pos = pos0 + row;
                     const ds4_gpu_laguna_kv_store_args store_args = {
                         .cache_cap = cache_cap,
@@ -32311,6 +32438,7 @@ int ds4_gpu_laguna_attention_prefill_tensor(
                 rows_gqa3_geom &&
                 getenv("DS4_METAL_DISABLE_SWA_ROWS_STAGED") == NULL;
             if (use_batched_swa_rows_staged) {
+                if (!have_kv) return 0;
                 id<MTLComputePipelineState> stage_pipeline =
                     ds4_gpu_get_pipeline("kernel_laguna_stage_kv_f16");
                 id<MTLComputePipelineState> rows_store_pipeline =
@@ -32447,27 +32575,30 @@ int ds4_gpu_laguna_attention_prefill_tensor(
                     .scale = scale,
                     .pad0 = 0u,
                 };
-                id<MTLComputeCommandEncoder> enc =
-                    ds4_gpu_compute_encoder(cb);
-                [enc setComputePipelineState:rows_store_pipeline];
-                [enc setBytes:&rows_args
-                       length:sizeof(rows_args)
-                      atIndex:0];
-                [enc setBuffer:kbuf
-                        offset:ds4_gpu_tensor_offset(k)
-                       atIndex:1];
-                [enc setBuffer:vbuf
-                        offset:ds4_gpu_tensor_offset(v)
-                       atIndex:2];
-                [enc setBuffer:keybuf
-                        offset:ds4_gpu_tensor_offset(key_cache)
-                       atIndex:3];
-                [enc setBuffer:valuebuf
-                        offset:ds4_gpu_tensor_offset(value_cache)
-                       atIndex:4];
-                [enc dispatchThreads:MTLSizeMake((NSUInteger)kv_values, 1, 1)
-                    threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
-                ds4_gpu_end_compute_encoder(cb, enc);
+                id<MTLComputeCommandEncoder> enc = nil;
+                if (have_kv) {
+                    enc = ds4_gpu_compute_encoder(cb);
+                    [enc setComputePipelineState:rows_store_pipeline];
+                    [enc setBytes:&rows_args
+                           length:sizeof(rows_args)
+                          atIndex:0];
+                    [enc setBuffer:kbuf
+                            offset:ds4_gpu_tensor_offset(k)
+                           atIndex:1];
+                    [enc setBuffer:vbuf
+                            offset:ds4_gpu_tensor_offset(v)
+                           atIndex:2];
+                    [enc setBuffer:keybuf
+                            offset:ds4_gpu_tensor_offset(key_cache)
+                           atIndex:3];
+                    [enc setBuffer:valuebuf
+                            offset:ds4_gpu_tensor_offset(value_cache)
+                           atIndex:4];
+                    [enc dispatchThreads:
+                            MTLSizeMake((NSUInteger)kv_values, 1, 1)
+                        threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+                    ds4_gpu_end_compute_encoder(cb, enc);
+                }
 
                 enc = ds4_gpu_compute_encoder(cb);
                 [enc setComputePipelineState:rows_attention_pipeline];
@@ -32523,14 +32654,16 @@ int ds4_gpu_laguna_attention_prefill_tensor(
                 const uint32_t pos = pos0 + row;
                 const uint32_t key_count = MIN(pos + 1u, cache_cap);
                 const uint32_t key_start = pos + 1u - key_count;
+                if (!have_kv && pos0 + n_tokens > cache_cap) return 0;
                 const ds4_gpu_laguna_kv_store_args store_args = {
                     .cache_cap = cache_cap,
                     .cache_row = pos % cache_cap,
                     .n_head_kv = n_head_kv,
                     .head_dim = head_dim,
                 };
-                id<MTLComputeCommandEncoder> enc =
-                    ds4_gpu_compute_encoder(cb);
+                id<MTLComputeCommandEncoder> enc = nil;
+                if (have_kv) {
+                enc = ds4_gpu_compute_encoder(cb);
                 [enc setComputePipelineState:store_pipeline];
                 [enc setBytes:&store_args
                        length:sizeof(store_args)
@@ -32553,6 +32686,7 @@ int ds4_gpu_laguna_attention_prefill_tensor(
                         MTLSizeMake((NSUInteger)n_head_kv * head_dim, 1, 1)
                     threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
                 ds4_gpu_end_compute_encoder(cb, enc);
+                }
 
                 const bool full_sliding_ring =
                     cache_cap == 512u && key_count == cache_cap;
@@ -32636,6 +32770,7 @@ int ds4_gpu_laguna_attention_prefill_tensor(
             return 1;
         }
 
+        if (!have_kv) return 0;
         const ds4_gpu_laguna_prefill_attention_args args = {
             .n_tokens = n_tokens,
             .pos0 = pos0,

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -8202,6 +8202,153 @@ int ds4_gpu_tensor_fill_f32(ds4_gpu_tensor *tensor, float value, uint64_t count)
     return 1;
 }
 
+/* Consolidated speculative ring copies: an address table over every
+ * sliding-window layer's cache and backup buffers lets one dispatch
+ * replace the per-layer blit loops of DFlash snapshot/restore. */
+@interface DS4MetalSpecCopyTable : NSObject
+@property(nonatomic, strong) id<MTLBuffer> addressBuffer;
+@property(nonatomic, strong) id residencySet;
+@property(nonatomic, assign) uint32_t layers;
+@end
+@implementation DS4MetalSpecCopyTable
+- (void)dealloc {
+    if (@available(macOS 15.0, *)) {
+        if (_residencySet && g_queue &&
+            [g_queue respondsToSelector:@selector(removeResidencySet:)]) {
+            [g_queue removeResidencySet:_residencySet];
+        }
+        if (_residencySet) [_residencySet endResidency];
+    }
+}
+@end
+
+void *ds4_gpu_laguna_spec_table_build(
+        ds4_gpu_tensor **key_caches,
+        ds4_gpu_tensor **value_caches,
+        ds4_gpu_tensor **key_backups,
+        ds4_gpu_tensor **value_backups,
+        uint32_t         n_layers) {
+    if (!g_initialized && !ds4_gpu_init()) return NULL;
+    if (!key_caches || !value_caches || !key_backups || !value_backups ||
+        n_layers == 0u) {
+        return NULL;
+    }
+    if (@available(macOS 15.0, *)) {
+        uint64_t *addrs = calloc((size_t)n_layers * 4u, sizeof(uint64_t));
+        if (!addrs) return NULL;
+        NSMutableArray *buffers = [NSMutableArray array];
+        bool ok = true;
+        for (uint32_t il = 0; ok && il < n_layers; il++) {
+            ds4_gpu_tensor *slots[4] = {
+                key_caches[il], value_caches[il],
+                key_backups[il], value_backups[il],
+            };
+            for (uint32_t j = 0; ok && j < 4u; j++) {
+                id<MTLBuffer> buf = ds4_gpu_tensor_buffer(slots[j]);
+                if (!buf) { ok = false; break; }
+                addrs[(size_t)il * 4u + j] =
+                    (uint64_t)[buf gpuAddress] +
+                    (uint64_t)ds4_gpu_tensor_offset(slots[j]);
+                [buffers addObject:buf];
+            }
+        }
+        if (!ok) { free(addrs); return NULL; }
+        id<MTLBuffer> address_buffer =
+            [g_device newBufferWithBytes:addrs
+                                  length:(NSUInteger)n_layers * 4u *
+                                         sizeof(uint64_t)
+                                 options:MTLResourceStorageModeShared];
+        free(addrs);
+        if (!address_buffer) return NULL;
+
+        MTLResidencySetDescriptor *desc =
+            [[MTLResidencySetDescriptor alloc] init];
+        desc.label = @"ds4_laguna_spec_copy";
+        desc.initialCapacity = [buffers count] + 1u;
+        NSError *error = nil;
+        id residency_set =
+            [g_device newResidencySetWithDescriptor:desc error:&error];
+        if (!residency_set) return NULL;
+        for (id<MTLBuffer> buf in buffers) {
+            [residency_set addAllocation:buf];
+        }
+        [residency_set addAllocation:address_buffer];
+        [residency_set commit];
+        [residency_set requestResidency];
+        if (g_queue &&
+            [g_queue respondsToSelector:@selector(addResidencySet:)]) {
+            [g_queue addResidencySet:residency_set];
+        }
+
+        DS4MetalSpecCopyTable *table = [[DS4MetalSpecCopyTable alloc] init];
+        table.addressBuffer = address_buffer;
+        table.residencySet = residency_set;
+        table.layers = n_layers;
+        return (void *)CFBridgingRetain(table);
+    }
+    return NULL;
+}
+
+void ds4_gpu_laguna_spec_table_free(void *table) {
+    if (table) CFBridgingRelease(table);
+}
+
+typedef struct {
+    uint32_t pos0;
+    uint32_t first_row;
+    uint32_t n_rows;
+    uint32_t cache_cap;
+    uint32_t row_elems;
+    uint32_t n_layers;
+    uint32_t to_backup;
+    uint32_t pad0;
+} ds4_gpu_laguna_spec_copy_args;
+
+int ds4_gpu_laguna_spec_copy_all_tensor(
+        void    *table_ptr,
+        uint32_t pos0,
+        uint32_t first_row,
+        uint32_t n_rows,
+        uint32_t cache_cap,
+        uint32_t row_elems,
+        int      to_backup) {
+    if (!g_initialized && !ds4_gpu_init()) return 0;
+    DS4MetalSpecCopyTable *table =
+        (__bridge DS4MetalSpecCopyTable *)table_ptr;
+    if (!table || !table.addressBuffer || first_row >= n_rows ||
+        cache_cap == 0u || (row_elems & 7u) != 0u) {
+        return 0;
+    }
+    @autoreleasepool {
+        id<MTLComputePipelineState> pipeline =
+            ds4_gpu_get_pipeline("kernel_laguna_spec_ring_copy_all_f16");
+        if (!pipeline) return 0;
+        const ds4_gpu_laguna_spec_copy_args args = {
+            .pos0 = pos0,
+            .first_row = first_row,
+            .n_rows = n_rows,
+            .cache_cap = cache_cap,
+            .row_elems = row_elems,
+            .n_layers = table.layers,
+            .to_backup = to_backup ? 1u : 0u,
+            .pad0 = 0u,
+        };
+        int owned = 0;
+        id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
+        if (!cb) return 0;
+        id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
+        [enc setComputePipelineState:pipeline];
+        [enc setBytes:&args length:sizeof(args) atIndex:0];
+        [enc setBuffer:table.addressBuffer offset:0 atIndex:1];
+        [enc dispatchThreadgroups:MTLSizeMake(table.layers,
+                                              n_rows - first_row, 1)
+             threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        ds4_gpu_end_compute_encoder(cb, enc);
+        return ds4_gpu_finish_command_buffer(
+                cb, owned, "Laguna speculative ring copy");
+    }
+}
+
 int ds4_gpu_tensor_write(ds4_gpu_tensor *tensor, uint64_t offset, const void *data, uint64_t bytes) {
     if (!tensor || (!data && bytes != 0)) return 0;
     DS4MetalTensor *obj = ds4_gpu_tensor_obj(tensor);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -19196,8 +19196,27 @@ int ds4_gpu_add_rms_norm_weight_tensor(
         uint64_t                weight_offset,
         uint32_t                n,
         float                   eps) {
+    return ds4_gpu_add_rms_norm_weight_rows_tensor(
+        norm_out, sum_out, a, b, model_map, model_size,
+        weight_offset, n, 1u, eps);
+}
+
+int ds4_gpu_add_rms_norm_weight_rows_tensor(
+        ds4_gpu_tensor       *norm_out,
+        ds4_gpu_tensor       *sum_out,
+        const ds4_gpu_tensor *a,
+        const ds4_gpu_tensor *b,
+        const void             *model_map,
+        uint64_t                model_size,
+        uint64_t                weight_offset,
+        uint32_t                n,
+        uint32_t                rows,
+        float                   eps) {
     if (!g_initialized && !ds4_gpu_init()) return 0;
-    if (!norm_out || !sum_out || !a || !b || n == 0 || (n & 3u) != 0) return 0;
+    if (!norm_out || !sum_out || !a || !b || n == 0 || rows == 0 ||
+        (n & 3u) != 0) {
+        return 0;
+    }
 
     @autoreleasepool {
         id<MTLBuffer> abuf = ds4_gpu_tensor_buffer(a);
@@ -19205,11 +19224,12 @@ int ds4_gpu_add_rms_norm_weight_tensor(
         id<MTLBuffer> sumbuf = ds4_gpu_tensor_buffer(sum_out);
         id<MTLBuffer> normbuf = ds4_gpu_tensor_buffer(norm_out);
         const uint64_t row_bytes = (uint64_t)n * sizeof(float);
+        const uint64_t total_bytes = row_bytes * rows;
         if (!abuf || !bbuf || !sumbuf || !normbuf ||
-            ds4_gpu_tensor_bytes(a) < row_bytes ||
-            ds4_gpu_tensor_bytes(b) < row_bytes ||
-            ds4_gpu_tensor_bytes(sum_out) < row_bytes ||
-            ds4_gpu_tensor_bytes(norm_out) < row_bytes) {
+            ds4_gpu_tensor_bytes(a) < total_bytes ||
+            ds4_gpu_tensor_bytes(b) < total_bytes ||
+            ds4_gpu_tensor_bytes(sum_out) < total_bytes ||
+            ds4_gpu_tensor_bytes(norm_out) < total_bytes) {
             fprintf(stderr, "ds4: Metal add+RMS norm received undersized activation buffers\n");
             return 0;
         }
@@ -19219,6 +19239,7 @@ int ds4_gpu_add_rms_norm_weight_tensor(
         }
 
         const bool exact_decode_weight_view =
+            rows == 1u &&
             row_bytes <= (1ull << 20) &&
             getenv("DS4_METAL_ENABLE_DECODE_NORM_EXACT_VIEWS") != NULL &&
             getenv("DS4_METAL_DISABLE_DECODE_NORM_EXACT_VIEWS") == NULL;
@@ -19236,7 +19257,7 @@ int ds4_gpu_add_rms_norm_weight_tensor(
                                      &inner_offset);
         if (!wbuf) return 0;
 
-        ds4_gpu_rms_norm_args args = ds4_gpu_make_rms_norm_args(n, 1, eps);
+        ds4_gpu_rms_norm_args args = ds4_gpu_make_rms_norm_args(n, rows, eps);
         int owned = 0;
         id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
         if (!cb) return 0;
@@ -19250,7 +19271,7 @@ int ds4_gpu_add_rms_norm_weight_tensor(
         [enc setBuffer:sumbuf offset:ds4_gpu_tensor_offset(sum_out) atIndex:4];
         [enc setBuffer:normbuf offset:ds4_gpu_tensor_offset(norm_out) atIndex:5];
         [enc setThreadgroupMemoryLength:32u * sizeof(float) atIndex:0];
-        [enc dispatchThreadgroups:MTLSizeMake(1, 1, 1)
+        [enc dispatchThreadgroups:MTLSizeMake(rows, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(ds4_gpu_rms_norm_threads(n), 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
 

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -33154,14 +33154,20 @@ typedef struct {
 
 int ds4_gpu_dflash_probabilities_tensor(
         ds4_gpu_tensor       *probabilities,
+        ds4_gpu_tensor       *top2,
+        ds4_gpu_tensor       *probabilities2,
         const ds4_gpu_tensor *logits,
         const ds4_gpu_tensor *argmax,
         uint32_t              n_rows,
         uint32_t              n_vocab) {
     if (!g_initialized && !ds4_gpu_init()) return 0;
-    if (!probabilities || !logits || !argmax ||
+    if (!probabilities || !top2 || !probabilities2 || !logits || !argmax ||
         n_rows == 0u || n_vocab == 0u ||
         ds4_gpu_tensor_bytes(probabilities) <
+            (uint64_t)n_rows * sizeof(float) ||
+        ds4_gpu_tensor_bytes(top2) <
+            (uint64_t)n_rows * sizeof(int32_t) ||
+        ds4_gpu_tensor_bytes(probabilities2) <
             (uint64_t)n_rows * sizeof(float) ||
         ds4_gpu_tensor_bytes(logits) <
             (uint64_t)n_rows * n_vocab * sizeof(float) ||
@@ -33173,11 +33179,15 @@ int ds4_gpu_dflash_probabilities_tensor(
     @autoreleasepool {
         id<MTLBuffer> probabilitiesbuf =
             ds4_gpu_tensor_buffer(probabilities);
+        id<MTLBuffer> top2buf = ds4_gpu_tensor_buffer(top2);
+        id<MTLBuffer> probabilities2buf =
+            ds4_gpu_tensor_buffer(probabilities2);
         id<MTLBuffer> logitsbuf = ds4_gpu_tensor_buffer(logits);
         id<MTLBuffer> argmaxbuf = ds4_gpu_tensor_buffer(argmax);
         id<MTLComputePipelineState> pipeline =
             ds4_gpu_get_pipeline("kernel_dflash_probabilities");
-        if (!probabilitiesbuf || !logitsbuf || !argmaxbuf || !pipeline) {
+        if (!probabilitiesbuf || !top2buf || !probabilities2buf ||
+            !logitsbuf || !argmaxbuf || !pipeline) {
             return 0;
         }
 
@@ -33200,7 +33210,13 @@ int ds4_gpu_dflash_probabilities_tensor(
         [enc setBuffer:probabilitiesbuf
                 offset:ds4_gpu_tensor_offset(probabilities)
                atIndex:3];
-        [enc setThreadgroupMemoryLength:256u * sizeof(float) atIndex:0];
+        [enc setBuffer:top2buf
+                offset:ds4_gpu_tensor_offset(top2)
+               atIndex:4];
+        [enc setBuffer:probabilities2buf
+                offset:ds4_gpu_tensor_offset(probabilities2)
+               atIndex:5];
+        [enc setThreadgroupMemoryLength:256u * 3u * sizeof(float) atIndex:0];
         [enc dispatchThreadgroups:MTLSizeMake(n_rows, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -17529,6 +17529,90 @@ int ds4_gpu_matmul_q8_0_pair_tensor(
     return 1;
 }
 
+int ds4_gpu_matmul_q8_0_add2_tensor(
+        ds4_gpu_tensor       *out,
+        const void           *model_map,
+        uint64_t              model_size,
+        uint64_t              weight_offset,
+        uint64_t              in_dim,
+        uint64_t              out_dim,
+        const ds4_gpu_tensor *x,
+        const ds4_gpu_tensor *res_a,
+        const ds4_gpu_tensor *res_b) {
+    if (!g_initialized && !ds4_gpu_init()) return 0;
+    if (!out || !model_map || !x || !res_a || !res_b ||
+        out_dim == 0 || (in_dim & 31u) != 0 ||
+        in_dim > UINT32_MAX || out_dim > UINT32_MAX) {
+        return 0;
+    }
+
+    @autoreleasepool {
+        id<MTLBuffer> xbuf = ds4_gpu_tensor_buffer(x);
+        id<MTLBuffer> outbuf = ds4_gpu_tensor_buffer(out);
+        id<MTLBuffer> resabuf = ds4_gpu_tensor_buffer(res_a);
+        id<MTLBuffer> resbbuf = ds4_gpu_tensor_buffer(res_b);
+        const uint64_t out_bytes = out_dim * sizeof(float);
+        if (!xbuf || !outbuf || !resabuf || !resbbuf ||
+            ds4_gpu_tensor_bytes(x) < in_dim * sizeof(float) ||
+            ds4_gpu_tensor_bytes(out) < out_bytes ||
+            ds4_gpu_tensor_bytes(res_a) < out_bytes ||
+            ds4_gpu_tensor_bytes(res_b) < out_bytes) {
+            fprintf(stderr, "ds4: Metal Q8_0 add2 matvec received undersized buffers\n");
+            return 0;
+        }
+
+        const uint64_t row_bytes = (in_dim / 32u) * 34u;
+        const uint64_t weight_bytes = out_dim * row_bytes;
+        if (weight_offset > model_size ||
+            weight_bytes > model_size - weight_offset) {
+            fprintf(stderr, "ds4: Metal Q8_0 add2 matvec range is outside the mapped model\n");
+            return 0;
+        }
+
+        uint64_t inner_offset = 0;
+        id<MTLBuffer> wbuf =
+            ds4_gpu_wrap_model_range(model_map, model_size,
+                                     weight_offset, weight_bytes,
+                                     &inner_offset);
+        if (!wbuf) return 0;
+
+        ds4_gpu_q8_0_matvec_args mv_args = ds4_gpu_make_q8_0_mv_args(in_dim, out_dim);
+        ds4_gpu_mv_dispatch mv_dispatch = ds4_gpu_make_q8_0_mv_dispatch();
+        mv_dispatch.function_name = "kernel_mul_mv_q8_0_f32_add2";
+        mv_dispatch.nr0 = 2;
+        mv_dispatch.smem = 32u * 2u * sizeof(float);
+        mv_args.nr0 = mv_dispatch.nr0;
+        id<MTLComputePipelineState> pipeline =
+            ds4_gpu_get_mul_mv_pipeline(mv_dispatch.function_name, mv_dispatch.nsg);
+        if (!pipeline) return 0;
+
+        int owned = 0;
+        id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
+        if (!cb) return 0;
+
+        id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
+        [enc setComputePipelineState:pipeline];
+        [enc setBytes:&mv_args length:sizeof(mv_args) atIndex:0];
+        [enc setBuffer:wbuf offset:(NSUInteger)inner_offset atIndex:1];
+        [enc setBuffer:xbuf offset:ds4_gpu_tensor_offset(x) atIndex:2];
+        [enc setBuffer:resabuf offset:ds4_gpu_tensor_offset(res_a) atIndex:3];
+        [enc setBuffer:resbbuf offset:ds4_gpu_tensor_offset(res_b) atIndex:4];
+        [enc setBuffer:outbuf offset:ds4_gpu_tensor_offset(out) atIndex:5];
+        [enc setThreadgroupMemoryLength:mv_dispatch.smem atIndex:0];
+        [enc dispatchThreadgroups:MTLSizeMake(((NSUInteger)out_dim +
+                                               (NSUInteger)mv_dispatch.nr0 - 1u) /
+                                              (NSUInteger)mv_dispatch.nr0,
+                                              1,
+                                              1)
+             threadsPerThreadgroup:MTLSizeMake(32, (NSUInteger)mv_dispatch.nsg, 1)];
+        ds4_gpu_end_compute_encoder(cb, enc);
+
+        if (!ds4_gpu_finish_command_buffer(cb, owned, "Q8_0 add2 matvec")) return 0;
+    }
+
+    return 1;
+}
+
 int ds4_gpu_matmul_q8_0_pair_decode_rows_exact_tensor(
         ds4_gpu_tensor       *out0,
         ds4_gpu_tensor       *out1,

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -31674,8 +31674,13 @@ static int ds4_gpu_encode_laguna_flash_attention_decode(
     const uint32_t nwg = 32u;
     const uint32_t nsg = ds4_gpu_flash_attn_vec_nsg(key_count, nwg, ncpsg);
     const bool has_pad = (key_count % ncpsg) != 0u;
+    /* A full sliding ring is an unmasked reduction over exactly the live key
+     * set, so it can take the shared-K/V gqa3 kernel like global layers. */
     const bool use_gqa3 =
-        cache_cap > 512u && (n_head % 3u) == 0u &&
+        (cache_cap > 512u ||
+         (key_count == cache_cap &&
+          getenv("DS4_METAL_DISABLE_SWA_DECODE_GQA3") == NULL)) &&
+        (n_head % 3u) == 0u &&
         ((n_head / n_head_kv) % 3u) == 0u;
     const NSUInteger head_bytes = (NSUInteger)head_dim * sizeof(uint16_t);
     const NSUInteger cache_row_bytes =

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -235,6 +235,7 @@ static id<MTLComputePipelineState> g_laguna_routed_shared_q4_down_pipeline;
 static id<MTLComputePipelineState> g_laguna_routed_shared_q6_down_pipeline;
 static id<MTLComputePipelineState> g_laguna_head_norm_rope_pipeline;
 static id<MTLComputePipelineState> g_laguna_qk_head_norm_rope_pipeline;
+static id<MTLComputePipelineState> g_laguna_qk_head_norm_rope_store_pipeline;
 static id<MTLComputePipelineState> g_laguna_store_kv_pipeline;
 static id<MTLComputePipelineState> g_laguna_attention_pipeline;
 static id<MTLComputePipelineState> g_laguna_stage_kv_pipeline;
@@ -5462,7 +5463,7 @@ typedef struct {
     float    attn_factor;
     float    beta_fast;
     float    beta_slow;
-    uint32_t pad0;
+    uint32_t cache_row;   /* used only by the fused rope+store variant */
 } ds4_gpu_laguna_norm_rope_args;
 
 typedef struct {
@@ -7964,6 +7965,9 @@ int ds4_gpu_init(void) {
             ds4_gpu_get_pipeline("kernel_laguna_head_rms_norm_rope_neox");
         g_laguna_qk_head_norm_rope_pipeline =
             ds4_gpu_get_pipeline("kernel_laguna_qk_head_rms_norm_rope_neox");
+        g_laguna_qk_head_norm_rope_store_pipeline =
+            ds4_gpu_get_pipeline(
+                "kernel_laguna_qk_head_rms_norm_rope_store_neox");
         g_laguna_store_kv_pipeline =
             ds4_gpu_get_pipeline("kernel_laguna_store_kv_f16");
         g_laguna_attention_pipeline =
@@ -9454,6 +9458,7 @@ void ds4_gpu_cleanup(void) {
         g_laguna_routed_shared_q6_down_pipeline = nil;
         g_laguna_head_norm_rope_pipeline = nil;
         g_laguna_qk_head_norm_rope_pipeline = nil;
+        g_laguna_qk_head_norm_rope_store_pipeline = nil;
         g_laguna_store_kv_pipeline = nil;
         g_laguna_attention_pipeline = nil;
         g_laguna_stage_kv_pipeline = nil;
@@ -31524,6 +31529,126 @@ int ds4_gpu_laguna_qk_head_rms_norm_rope_tensor(
     return 1;
 }
 
+int ds4_gpu_laguna_qk_head_rms_norm_rope_store_tensor(
+        ds4_gpu_tensor       *q,
+        ds4_gpu_tensor       *k,
+        const void           *model_map,
+        uint64_t              model_size,
+        uint64_t              q_weight_offset,
+        uint64_t              k_weight_offset,
+        uint32_t              n_q_head,
+        uint32_t              n_k_head,
+        uint32_t              head_dim,
+        uint32_t              n_rot,
+        uint32_t              pos0,
+        uint32_t              n_ctx_orig,
+        float                 freq_base,
+        float                 freq_scale,
+        float                 ext_factor,
+        float                 attn_factor,
+        float                 beta_fast,
+        float                 beta_slow,
+        float                 eps,
+        const ds4_gpu_tensor *v,
+        ds4_gpu_tensor       *key_cache,
+        ds4_gpu_tensor       *value_cache,
+        uint32_t              cache_cap) {
+    if (!g_initialized && !ds4_gpu_init()) return 0;
+    if (!q || !k || !v || !key_cache || !value_cache || !model_map ||
+        n_q_head == 0 || n_k_head == 0 ||
+        n_q_head > UINT32_MAX - n_k_head ||
+        head_dim == 0 || head_dim > 128u || n_rot == 0 ||
+        n_rot > head_dim || (n_rot & 1u) != 0u ||
+        cache_cap == 0 || pos0 == UINT32_MAX ||
+        !isfinite(freq_base) || freq_base <= 0.0f ||
+        !isfinite(freq_scale) || freq_scale <= 0.0f ||
+        !isfinite(ext_factor) || !isfinite(attn_factor) ||
+        !isfinite(beta_fast) || !isfinite(beta_slow) ||
+        !isfinite(eps) || eps <= 0.0f) {
+        return 0;
+    }
+
+    const uint64_t q_values = (uint64_t)n_q_head * head_dim;
+    const uint64_t kv_values = (uint64_t)n_k_head * head_dim;
+    const uint64_t cache_values = (uint64_t)cache_cap * kv_values;
+    const uint64_t weight_bytes = (uint64_t)head_dim * sizeof(float);
+    if (ds4_gpu_tensor_bytes(q) < q_values * sizeof(float) ||
+        ds4_gpu_tensor_bytes(k) < kv_values * sizeof(float) ||
+        ds4_gpu_tensor_bytes(v) < kv_values * sizeof(float) ||
+        ds4_gpu_tensor_bytes(key_cache) < cache_values * sizeof(uint16_t) ||
+        ds4_gpu_tensor_bytes(value_cache) < cache_values * sizeof(uint16_t) ||
+        q_weight_offset > model_size ||
+        weight_bytes > model_size - q_weight_offset ||
+        k_weight_offset > model_size ||
+        weight_bytes > model_size - k_weight_offset) {
+        fprintf(stderr, "ds4: Metal Laguna fused rope/store received an invalid buffer or weight range\n");
+        return 0;
+    }
+
+    @autoreleasepool {
+        id<MTLBuffer> qbuf = ds4_gpu_tensor_buffer(q);
+        id<MTLBuffer> kbuf = ds4_gpu_tensor_buffer(k);
+        id<MTLBuffer> vbuf = ds4_gpu_tensor_buffer(v);
+        id<MTLBuffer> keybuf = ds4_gpu_tensor_buffer(key_cache);
+        id<MTLBuffer> valuebuf = ds4_gpu_tensor_buffer(value_cache);
+        uint64_t q_weight_inner = 0;
+        uint64_t k_weight_inner = 0;
+        id<MTLBuffer> q_weightbuf = ds4_gpu_wrap_model_range(
+            model_map, model_size, q_weight_offset, weight_bytes,
+            &q_weight_inner);
+        id<MTLBuffer> k_weightbuf = ds4_gpu_wrap_model_range(
+            model_map, model_size, k_weight_offset, weight_bytes,
+            &k_weight_inner);
+        id<MTLComputePipelineState> pipeline = ds4_gpu_hot_pipeline(
+            g_laguna_qk_head_norm_rope_store_pipeline,
+            "kernel_laguna_qk_head_rms_norm_rope_store_neox");
+        if (!qbuf || !kbuf || !vbuf || !keybuf || !valuebuf ||
+            !q_weightbuf || !k_weightbuf || !pipeline) {
+            return 0;
+        }
+
+        ds4_gpu_laguna_norm_rope_args args = {
+            .n_tokens = 1u,
+            .n_head = n_q_head + n_k_head,
+            .head_dim = head_dim,
+            .n_rot = n_rot,
+            .pos0 = pos0,
+            .n_ctx_orig = n_ctx_orig,
+            .eps = eps,
+            .freq_base = freq_base,
+            .freq_scale = freq_scale,
+            .ext_factor = ext_factor,
+            .attn_factor = attn_factor,
+            .beta_fast = beta_fast,
+            .beta_slow = beta_slow,
+            .cache_row = pos0 % cache_cap,
+        };
+        int owned = 0;
+        id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
+        if (!cb) return 0;
+        id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
+        [enc setComputePipelineState:pipeline];
+        [enc setBytes:&args length:sizeof(args) atIndex:0];
+        [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
+        [enc setBuffer:kbuf offset:ds4_gpu_tensor_offset(k) atIndex:2];
+        [enc setBuffer:q_weightbuf offset:(NSUInteger)q_weight_inner atIndex:3];
+        [enc setBuffer:k_weightbuf offset:(NSUInteger)k_weight_inner atIndex:4];
+        [enc setBytes:&n_q_head length:sizeof(n_q_head) atIndex:5];
+        [enc setBuffer:vbuf offset:ds4_gpu_tensor_offset(v) atIndex:6];
+        [enc setBuffer:keybuf offset:ds4_gpu_tensor_offset(key_cache) atIndex:7];
+        [enc setBuffer:valuebuf offset:ds4_gpu_tensor_offset(value_cache) atIndex:8];
+        [enc setThreadgroupMemoryLength:128u * sizeof(float) atIndex:0];
+        [enc dispatchThreadgroups:MTLSizeMake(n_q_head + n_k_head, 1, 1)
+             threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+        ds4_gpu_end_compute_encoder(cb, enc);
+        if (!ds4_gpu_finish_command_buffer(
+                cb, owned, "Laguna fused Q/K rope + KV store")) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 static int ds4_gpu_encode_laguna_flash_attention_decode(
         id<MTLCommandBuffer> cb,
         id<MTLBuffer>        headsbuf,
@@ -31739,7 +31864,11 @@ int ds4_gpu_laguna_store_attention_tensor(
         uint32_t              head_dim,
         float                 scale) {
     if (!g_initialized && !ds4_gpu_init()) return 0;
-    if (!heads || !key_cache || !value_cache || !q || !k || !v || !gate ||
+    /* k and v may both be NULL when a fused upstream kernel has already
+     * committed the current row to the ring; only the attention runs then. */
+    const bool store_kv = k != NULL || v != NULL;
+    if (!heads || !key_cache || !value_cache || !q || !gate ||
+        (store_kv && (!k || !v)) ||
         cache_cap == 0 || key_count == 0 || key_count > cache_cap ||
         n_head == 0 || n_head_kv == 0 || n_head % n_head_kv != 0 ||
         head_dim != 128u || !isfinite(scale) || scale <= 0.0f) {
@@ -31749,8 +31878,9 @@ int ds4_gpu_laguna_store_attention_tensor(
     const uint64_t kv_values = (uint64_t)n_head_kv * head_dim;
     const uint64_t cache_values = (uint64_t)cache_cap * kv_values;
     if (ds4_gpu_tensor_bytes(q) < q_values * sizeof(float) ||
-        ds4_gpu_tensor_bytes(k) < kv_values * sizeof(float) ||
-        ds4_gpu_tensor_bytes(v) < kv_values * sizeof(float) ||
+        (store_kv &&
+         (ds4_gpu_tensor_bytes(k) < kv_values * sizeof(float) ||
+          ds4_gpu_tensor_bytes(v) < kv_values * sizeof(float))) ||
         ds4_gpu_tensor_bytes(gate) < (uint64_t)n_head * sizeof(float) ||
         ds4_gpu_tensor_bytes(heads) < q_values * sizeof(float) ||
         ds4_gpu_tensor_bytes(key_cache) < cache_values * sizeof(uint16_t) ||
@@ -31764,15 +31894,16 @@ int ds4_gpu_laguna_store_attention_tensor(
         id<MTLBuffer> keybuf = ds4_gpu_tensor_buffer(key_cache);
         id<MTLBuffer> valuebuf = ds4_gpu_tensor_buffer(value_cache);
         id<MTLBuffer> qbuf = ds4_gpu_tensor_buffer(q);
-        id<MTLBuffer> kbuf = ds4_gpu_tensor_buffer(k);
-        id<MTLBuffer> vbuf = ds4_gpu_tensor_buffer(v);
+        id<MTLBuffer> kbuf = store_kv ? ds4_gpu_tensor_buffer(k) : nil;
+        id<MTLBuffer> vbuf = store_kv ? ds4_gpu_tensor_buffer(v) : nil;
         id<MTLBuffer> gatebuf = ds4_gpu_tensor_buffer(gate);
         id<MTLComputePipelineState> store_pipeline = ds4_gpu_hot_pipeline(
             g_laguna_store_kv_pipeline, "kernel_laguna_store_kv_f16");
         id<MTLComputePipelineState> attention_pipeline = ds4_gpu_hot_pipeline(
             g_laguna_attention_pipeline,
             "kernel_laguna_attention_decode_gqa_f16");
-        if (!headsbuf || !keybuf || !valuebuf || !qbuf || !kbuf || !vbuf ||
+        if (!headsbuf || !keybuf || !valuebuf || !qbuf ||
+            (store_kv && (!kbuf || !vbuf)) ||
             !gatebuf || !store_pipeline || !attention_pipeline) {
             return 0;
         }
@@ -31780,22 +31911,25 @@ int ds4_gpu_laguna_store_attention_tensor(
         int owned = 0;
         id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
         if (!cb) return 0;
-        ds4_gpu_laguna_kv_store_args store_args = {
-            .cache_cap = cache_cap,
-            .cache_row = pos % cache_cap,
-            .n_head_kv = n_head_kv,
-            .head_dim = head_dim,
-        };
-        id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
-        [enc setComputePipelineState:store_pipeline];
-        [enc setBytes:&store_args length:sizeof(store_args) atIndex:0];
-        [enc setBuffer:kbuf offset:ds4_gpu_tensor_offset(k) atIndex:1];
-        [enc setBuffer:vbuf offset:ds4_gpu_tensor_offset(v) atIndex:2];
-        [enc setBuffer:keybuf offset:ds4_gpu_tensor_offset(key_cache) atIndex:3];
-        [enc setBuffer:valuebuf offset:ds4_gpu_tensor_offset(value_cache) atIndex:4];
-        [enc dispatchThreads:MTLSizeMake((NSUInteger)kv_values, 1, 1)
-            threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
-        ds4_gpu_end_compute_encoder(cb, enc);
+        id<MTLComputeCommandEncoder> enc = nil;
+        if (store_kv) {
+            ds4_gpu_laguna_kv_store_args store_args = {
+                .cache_cap = cache_cap,
+                .cache_row = pos % cache_cap,
+                .n_head_kv = n_head_kv,
+                .head_dim = head_dim,
+            };
+            enc = ds4_gpu_compute_encoder(cb);
+            [enc setComputePipelineState:store_pipeline];
+            [enc setBytes:&store_args length:sizeof(store_args) atIndex:0];
+            [enc setBuffer:kbuf offset:ds4_gpu_tensor_offset(k) atIndex:1];
+            [enc setBuffer:vbuf offset:ds4_gpu_tensor_offset(v) atIndex:2];
+            [enc setBuffer:keybuf offset:ds4_gpu_tensor_offset(key_cache) atIndex:3];
+            [enc setBuffer:valuebuf offset:ds4_gpu_tensor_offset(value_cache) atIndex:4];
+            [enc dispatchThreads:MTLSizeMake((NSUInteger)kv_values, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+            ds4_gpu_end_compute_encoder(cb, enc);
+        }
 
         /* The global-attention cache is contiguous until it reaches capacity.
          * A full sliding ring also contains exactly the active key set; its

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -32269,8 +32269,16 @@ int ds4_gpu_laguna_attention_prefill_tensor(
                 id<MTLComputePipelineState> rows_store_pipeline =
                     ds4_gpu_get_pipeline(
                         "kernel_laguna_store_kv_rows_f16");
+                /* Three query heads of one KV head share every K/V read when
+                 * the head grouping allows it (72/8 sliding geometry). */
+                const bool rows_gqa3 =
+                    (n_head % 3u) == 0u &&
+                    n_head_kv != 0u &&
+                    ((n_head / n_head_kv) % 3u) == 0u &&
+                    getenv("DS4_METAL_DISABLE_ROWS_GQA3") == NULL;
                 id<MTLComputePipelineState> rows_attention_pipeline =
-                    ds4_gpu_get_pipeline(
+                    ds4_gpu_get_pipeline(rows_gqa3 ?
+                        "kernel_laguna_attention_decode_rows_gqa3_f16" :
                         "kernel_laguna_attention_decode_rows_gqa_f16");
                 if (!rows_store_pipeline || !rows_attention_pipeline) {
                     return 0;
@@ -32327,16 +32335,26 @@ int ds4_gpu_laguna_attention_prefill_tensor(
                 [enc setBuffer:headsbuf
                         offset:ds4_gpu_tensor_offset(heads)
                        atIndex:5];
-                [enc setThreadgroupMemoryLength:
-                        (8u + 8u + 8u * 128u) * sizeof(float)
-                                        atIndex:0];
-                const uint32_t last_key_count = pos0 + n_tokens;
-                const NSUInteger threads =
-                    last_key_count > 256u ? 256u : 32u;
-                [enc dispatchThreadgroups:
-                        MTLSizeMake(n_head, n_tokens, 1)
-                     threadsPerThreadgroup:
-                        MTLSizeMake(threads, 1, 1)];
+                if (rows_gqa3) {
+                    [enc setThreadgroupMemoryLength:
+                            3u * (8u + 8u + 8u * 128u) * sizeof(float)
+                                            atIndex:0];
+                    [enc dispatchThreadgroups:
+                            MTLSizeMake(n_head / 3u, n_tokens, 1)
+                         threadsPerThreadgroup:
+                            MTLSizeMake(256, 1, 1)];
+                } else {
+                    [enc setThreadgroupMemoryLength:
+                            (8u + 8u + 8u * 128u) * sizeof(float)
+                                            atIndex:0];
+                    const uint32_t last_key_count = pos0 + n_tokens;
+                    const NSUInteger threads =
+                        last_key_count > 256u ? 256u : 32u;
+                    [enc dispatchThreadgroups:
+                            MTLSizeMake(n_head, n_tokens, 1)
+                         threadsPerThreadgroup:
+                            MTLSizeMake(threads, 1, 1)];
+                }
                 ds4_gpu_end_compute_encoder(cb, enc);
 
                 if (!ds4_gpu_finish_command_buffer(

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -32293,6 +32293,134 @@ int ds4_gpu_laguna_attention_prefill_tensor(
                 return 1;
             }
 
+            /* Three query heads of one KV head share every K/V read when
+             * the head grouping allows it (72/8 sliding geometry). */
+            const bool rows_gqa3_geom =
+                (n_head % 3u) == 0u &&
+                n_head_kv != 0u &&
+                ((n_head / n_head_kv) % 3u) == 0u &&
+                getenv("DS4_METAL_DISABLE_ROWS_GQA3") == NULL;
+            /* Once the ring has wrapped, the block's own keys are served
+             * from the staging buffer so the batched store can wait until
+             * after attention instead of falling back to row-at-a-time
+             * store/attend pairs. */
+            const bool use_batched_swa_rows_staged =
+                n_tokens >= 2u && n_tokens <= 16u &&
+                cache_cap == 512u &&
+                pos0 + n_tokens > cache_cap &&
+                rows_gqa3_geom &&
+                getenv("DS4_METAL_DISABLE_SWA_ROWS_STAGED") == NULL;
+            if (use_batched_swa_rows_staged) {
+                id<MTLComputePipelineState> stage_pipeline =
+                    ds4_gpu_get_pipeline("kernel_laguna_stage_kv_f16");
+                id<MTLComputePipelineState> rows_store_pipeline =
+                    ds4_gpu_get_pipeline(
+                        "kernel_laguna_store_kv_rows_f16");
+                id<MTLComputePipelineState> staged_attention_pipeline =
+                    ds4_gpu_get_pipeline(
+                        "kernel_laguna_attention_decode_rows_gqa3_staged_f16");
+                id<MTLBuffer> skbuf = ds4_gpu_tensor_buffer(staged_key);
+                id<MTLBuffer> svbuf = ds4_gpu_tensor_buffer(staged_value);
+                if (!stage_pipeline || !rows_store_pipeline ||
+                    !staged_attention_pipeline || !skbuf || !svbuf) {
+                    return 0;
+                }
+                const ds4_gpu_laguna_prefill_attention_args rows_args = {
+                    .n_tokens = n_tokens,
+                    .pos0 = pos0,
+                    .cache_cap = cache_cap,
+                    .n_head = n_head,
+                    .n_head_kv = n_head_kv,
+                    .head_dim = head_dim,
+                    .scale = scale,
+                    .pad0 = 0u,
+                };
+                id<MTLComputeCommandEncoder> enc =
+                    ds4_gpu_compute_encoder(cb);
+                [enc setComputePipelineState:stage_pipeline];
+                [enc setBytes:&rows_args
+                       length:sizeof(rows_args)
+                      atIndex:0];
+                [enc setBuffer:kbuf
+                        offset:ds4_gpu_tensor_offset(k)
+                       atIndex:1];
+                [enc setBuffer:vbuf
+                        offset:ds4_gpu_tensor_offset(v)
+                       atIndex:2];
+                [enc setBuffer:skbuf
+                        offset:ds4_gpu_tensor_offset(staged_key)
+                       atIndex:3];
+                [enc setBuffer:svbuf
+                        offset:ds4_gpu_tensor_offset(staged_value)
+                       atIndex:4];
+                [enc dispatchThreads:MTLSizeMake((NSUInteger)kv_values, 1, 1)
+                    threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+                ds4_gpu_end_compute_encoder(cb, enc);
+
+                enc = ds4_gpu_compute_encoder(cb);
+                [enc setComputePipelineState:staged_attention_pipeline];
+                [enc setBytes:&rows_args
+                       length:sizeof(rows_args)
+                      atIndex:0];
+                [enc setBuffer:qbuf
+                        offset:ds4_gpu_tensor_offset(q)
+                       atIndex:1];
+                [enc setBuffer:gatebuf
+                        offset:ds4_gpu_tensor_offset(gate)
+                       atIndex:2];
+                [enc setBuffer:keybuf
+                        offset:ds4_gpu_tensor_offset(key_cache)
+                       atIndex:3];
+                [enc setBuffer:valuebuf
+                        offset:ds4_gpu_tensor_offset(value_cache)
+                       atIndex:4];
+                [enc setBuffer:skbuf
+                        offset:ds4_gpu_tensor_offset(staged_key)
+                       atIndex:5];
+                [enc setBuffer:svbuf
+                        offset:ds4_gpu_tensor_offset(staged_value)
+                       atIndex:6];
+                [enc setBuffer:headsbuf
+                        offset:ds4_gpu_tensor_offset(heads)
+                       atIndex:7];
+                [enc setThreadgroupMemoryLength:
+                        3u * (8u + 8u + 8u * 128u) * sizeof(float)
+                                        atIndex:0];
+                [enc dispatchThreadgroups:
+                        MTLSizeMake(n_head / 3u, n_tokens, 1)
+                     threadsPerThreadgroup:
+                        MTLSizeMake(256, 1, 1)];
+                ds4_gpu_end_compute_encoder(cb, enc);
+
+                enc = ds4_gpu_compute_encoder(cb);
+                [enc setComputePipelineState:rows_store_pipeline];
+                [enc setBytes:&rows_args
+                       length:sizeof(rows_args)
+                      atIndex:0];
+                [enc setBuffer:kbuf
+                        offset:ds4_gpu_tensor_offset(k)
+                       atIndex:1];
+                [enc setBuffer:vbuf
+                        offset:ds4_gpu_tensor_offset(v)
+                       atIndex:2];
+                [enc setBuffer:keybuf
+                        offset:ds4_gpu_tensor_offset(key_cache)
+                       atIndex:3];
+                [enc setBuffer:valuebuf
+                        offset:ds4_gpu_tensor_offset(value_cache)
+                       atIndex:4];
+                [enc dispatchThreads:MTLSizeMake((NSUInteger)kv_values, 1, 1)
+                    threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+                ds4_gpu_end_compute_encoder(cb, enc);
+
+                if (!ds4_gpu_finish_command_buffer(
+                        cb, owned,
+                        "Laguna batched sliding-window attention (staged)")) {
+                    return 0;
+                }
+                return 1;
+            }
+
             const bool use_batched_swa_rows =
                 n_tokens >= 2u && n_tokens <= 16u &&
                 cache_cap == 512u &&
@@ -32301,13 +32429,7 @@ int ds4_gpu_laguna_attention_prefill_tensor(
                 id<MTLComputePipelineState> rows_store_pipeline =
                     ds4_gpu_get_pipeline(
                         "kernel_laguna_store_kv_rows_f16");
-                /* Three query heads of one KV head share every K/V read when
-                 * the head grouping allows it (72/8 sliding geometry). */
-                const bool rows_gqa3 =
-                    (n_head % 3u) == 0u &&
-                    n_head_kv != 0u &&
-                    ((n_head / n_head_kv) % 3u) == 0u &&
-                    getenv("DS4_METAL_DISABLE_ROWS_GQA3") == NULL;
+                const bool rows_gqa3 = rows_gqa3_geom;
                 id<MTLComputePipelineState> rows_attention_pipeline =
                     ds4_gpu_get_pipeline(rows_gqa3 ?
                         "kernel_laguna_attention_decode_rows_gqa3_f16" :

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -8414,20 +8414,23 @@ int ds4_gpu_wait_submitted_commands(void) {
     return ds4_gpu_wait_pending_command_buffers("submitted command batch");
 }
 
-/* One stashed uncommitted batch, so a speculative verifier can be encoded
- * at two widths while the draft executes: hold the first, encode the
- * second, then keep whichever width the confidence prune selects. */
-static id<MTLCommandBuffer> g_held_cb;
-static BOOL g_held_has_work;
-static uint64_t g_held_expert_seq;
+/* A small stack of stashed uncommitted batches, so a speculative verifier
+ * can be encoded at every plausible post-prune width while the draft
+ * executes; the confidence read keeps exactly one and drops the rest. */
+#define DS4_GPU_HELD_MAX 3
+static id<MTLCommandBuffer> g_held_cbs[DS4_GPU_HELD_MAX];
+static BOOL g_held_has_work[DS4_GPU_HELD_MAX];
+static uint64_t g_held_expert_seq[DS4_GPU_HELD_MAX];
+static uint32_t g_held_count;
 
 int ds4_gpu_hold_commands(void) {
     if (!g_initialized && !ds4_gpu_init()) return 0;
-    if (!g_batch_cb || g_held_cb) return 0;
+    if (!g_batch_cb || g_held_count >= DS4_GPU_HELD_MAX) return 0;
     ds4_gpu_close_batch_encoder();
-    g_held_cb = g_batch_cb;
-    g_held_has_work = g_batch_has_work;
-    g_held_expert_seq = g_stream_expert_cache_batch_seq;
+    g_held_cbs[g_held_count] = g_batch_cb;
+    g_held_has_work[g_held_count] = g_batch_has_work;
+    g_held_expert_seq[g_held_count] = g_stream_expert_cache_batch_seq;
+    g_held_count++;
     g_stream_expert_cache_batch_seq = 0;
     g_batch_cb = ds4_gpu_new_command_buffer();
     g_batch_has_work = NO;
@@ -8435,25 +8438,39 @@ int ds4_gpu_hold_commands(void) {
     return g_batch_cb != nil;
 }
 
-int ds4_gpu_unhold_commands(void) {
-    if (!g_held_cb || g_batch_cb) return 0;
-    g_batch_cb = g_held_cb;
-    g_batch_has_work = g_held_has_work;
-    g_stream_expert_cache_batch_seq = g_held_expert_seq;
-    g_held_cb = nil;
-    g_held_has_work = NO;
-    g_held_expert_seq = 0;
+int ds4_gpu_unhold_commands_at(uint32_t idx) {
+    if (idx >= g_held_count || g_batch_cb) return 0;
+    g_batch_cb = g_held_cbs[idx];
+    g_batch_has_work = g_held_has_work[idx];
+    g_stream_expert_cache_batch_seq = g_held_expert_seq[idx];
+    g_held_cbs[idx] = nil;
+    for (uint32_t i = 0; i < g_held_count; i++) {
+        if (i == idx || g_held_cbs[i] == nil) continue;
+        g_held_cbs[i] = nil;
+        g_held_has_work[i] = NO;
+        if (g_held_expert_seq[i] > g_stream_expert_cache_done_seq) {
+            g_stream_expert_cache_done_seq = g_held_expert_seq[i];
+        }
+        g_held_expert_seq[i] = 0;
+    }
+    g_held_count = 0;
     return 1;
 }
 
+int ds4_gpu_unhold_commands(void) {
+    return ds4_gpu_unhold_commands_at(0);
+}
+
 int ds4_gpu_drop_held_commands(void) {
-    if (!g_held_cb) return 1;
-    g_held_cb = nil;
-    g_held_has_work = NO;
-    if (g_held_expert_seq > g_stream_expert_cache_done_seq) {
-        g_stream_expert_cache_done_seq = g_held_expert_seq;
+    for (uint32_t i = 0; i < g_held_count; i++) {
+        g_held_cbs[i] = nil;
+        g_held_has_work[i] = NO;
+        if (g_held_expert_seq[i] > g_stream_expert_cache_done_seq) {
+            g_stream_expert_cache_done_seq = g_held_expert_seq[i];
+        }
+        g_held_expert_seq[i] = 0;
     }
-    g_held_expert_seq = 0;
+    g_held_count = 0;
     return 1;
 }
 

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -926,12 +926,17 @@ static void ds4_gpu_close_batch_encoder(void) {
 static double g_gpu_busy_accum;
 static uint64_t g_gpu_busy_cbs;
 
+double ds4_gpu_busy_accum_ms(void) {
+    return g_gpu_busy_accum * 1000.0;
+}
+
 static int ds4_gpu_wait_command_buffer(id<MTLCommandBuffer> cb, const char *label) {
     [cb waitUntilCompleted];
-    if (getenv("DS4_METAL_GPU_BUSY_PROFILE")) {
+    {
         const double busy = cb.GPUEndTime - cb.GPUStartTime;
         if (busy > 0) g_gpu_busy_accum += busy;
-        if ((++g_gpu_busy_cbs % 64u) == 0u) {
+        if (getenv("DS4_METAL_GPU_BUSY_PROFILE") &&
+            (++g_gpu_busy_cbs % 64u) == 0u) {
             fprintf(stderr, "ds4: gpu busy accum %.1f ms over %llu cbs\n",
                     g_gpu_busy_accum * 1000.0,
                     (unsigned long long)g_gpu_busy_cbs);

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -11601,6 +11601,9 @@ decode_again:
         getenv("DS4_SERVER_DISABLE_THINK_TOOL_RECOVERY") == NULL;
     dsml_decode_tracker dsml_tracker;
     dsml_decode_tracker_init(&dsml_tracker);
+    /* Verifier argmax carried over from a speculative iteration; valid for
+     * exactly one loop turn and only for greedy sampling. */
+    int greedy_next = -1;
 
     server_generation_enter(s);
     while (!g_stop_requested && completion < max_tokens &&
@@ -11633,8 +11636,14 @@ decode_again:
         if (in_tool_call && !dsml_decode_state_uses_payload_sampling(dsml_state)) {
             temperature = 0.0f;
         }
-        int token = ds4_session_sample(slot->session, temperature, top_k,
+        int token;
+        if (greedy_next >= 0 && temperature <= 0.0f) {
+            token = greedy_next;
+        } else {
+            token = ds4_session_sample(slot->session, temperature, top_k,
                                        top_p, min_p, &rng);
+        }
+        greedy_next = -1;
         if (ds4_token_is_stop_for_think_mode(s->engine,
                                              token,
                                              j->req.think_mode)) {
@@ -11660,6 +11669,7 @@ decode_again:
                 finish = "error";
                 break;
             }
+            greedy_next = ds4_session_greedy_next(slot->session);
         } else {
             if (server_eval_token(s, slot, token, err, sizeof(err)) != 0) {
                 finish = "error";

--- a/metal/dense.metal
+++ b/metal/dense.metal
@@ -490,8 +490,8 @@ kernel void kernel_mul_mv_q8_0_f32_add2(
 // have independent weight ranges and output extents. Keep the standalone Q8_0
 // lane/block traversal and two-stage reduction verbatim for each bank; only
 // the activation load and threadgroup scheduling are shared.
-[[host_name("kernel_mul_mv_q8_0_f32_pair")]]
-kernel void kernel_mul_mv_q8_0_f32_pair(
+template<short NR0>
+void kernel_mul_mv_q8_0_f32_pair_impl(
         constant ds4_metal_args_mul_mv & args0,
         constant ds4_metal_args_mul_mv & args1,
         device const char * src0_a,
@@ -499,14 +499,13 @@ kernel void kernel_mul_mv_q8_0_f32_pair(
         device const char * src1,
         device       char * dst_a,
         device       char * dst_b,
-        threadgroup  char * shmem [[threadgroup(0)]],
-        uint3  tgpig[[threadgroup_position_in_grid]],
-        ushort tiisg[[thread_index_in_simdgroup]],
-        ushort sgitg[[simdgroup_index_in_threadgroup]]) {
+        threadgroup  char * shmem,
+        uint3  tgpig,
+        ushort tiisg,
+        ushort sgitg) {
     const short NSG = FC_mul_mv_nsg;
     constexpr short NW = N_SIMDWIDTH;
     constexpr short NQ = 8;
-    constexpr short NR0 = N_R0_Q8_0;
 
     const int nb = args0.ne00 / QK8_0;
     const int r0 = tgpig.x * NR0;
@@ -608,6 +607,42 @@ kernel void kernel_mul_mv_q8_0_f32_pair(
             }
         }
     }
+}
+
+[[host_name("kernel_mul_mv_q8_0_f32_pair")]]
+kernel void kernel_mul_mv_q8_0_f32_pair(
+        constant ds4_metal_args_mul_mv & args0,
+        constant ds4_metal_args_mul_mv & args1,
+        device const char * src0_a,
+        device const char * src0_b,
+        device const char * src1,
+        device       char * dst_a,
+        device       char * dst_b,
+        threadgroup  char * shmem [[threadgroup(0)]],
+        uint3  tgpig[[threadgroup_position_in_grid]],
+        ushort tiisg[[thread_index_in_simdgroup]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]]) {
+    kernel_mul_mv_q8_0_f32_pair_impl<N_R0_Q8_0>(
+        args0, args1, src0_a, src0_b, src1, dst_a, dst_b,
+        shmem, tgpig, tiisg, sgitg);
+}
+
+[[host_name("kernel_mul_mv_q8_0_f32_pair_r4")]]
+kernel void kernel_mul_mv_q8_0_f32_pair_r4(
+        constant ds4_metal_args_mul_mv & args0,
+        constant ds4_metal_args_mul_mv & args1,
+        device const char * src0_a,
+        device const char * src0_b,
+        device const char * src1,
+        device       char * dst_a,
+        device       char * dst_b,
+        threadgroup  char * shmem [[threadgroup(0)]],
+        uint3  tgpig[[threadgroup_position_in_grid]],
+        ushort tiisg[[thread_index_in_simdgroup]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]]) {
+    kernel_mul_mv_q8_0_f32_pair_impl<4>(
+        args0, args1, src0_a, src0_b, src1, dst_a, dst_b,
+        shmem, tgpig, tiisg, sgitg);
 }
 
 // Decode shared-expert gate/up projections followed by SwiGLU:

--- a/metal/dense.metal
+++ b/metal/dense.metal
@@ -398,6 +398,94 @@ kernel void kernel_mul_mv_q8_0_f32_rows4_exact(
         args, src0, src1, dst, shmem, tgpig, tiisg, sgitg);
 }
 
+// Laguna shared-expert down projection with the residual fold: writes
+// res_a + res_b + W.x in the matvec epilogue, replacing the separate
+// three-way add dispatch and the intermediate output buffer.  The Q8_0
+// traversal and reduction tree match kernel_mul_mv_q8_0_f32 exactly; the
+// residual sum keeps the standalone add3 kernel's association (a + b) + c.
+[[host_name("kernel_mul_mv_q8_0_f32_add2")]]
+kernel void kernel_mul_mv_q8_0_f32_add2(
+        constant ds4_metal_args_mul_mv & args,
+        device const char * src0,
+        device const char * src1,
+        device const float * res_a,
+        device const float * res_b,
+        device       char * dst,
+        threadgroup  char * shmem [[threadgroup(0)]],
+        uint3  tgpig[[threadgroup_position_in_grid]],
+        ushort tiisg[[thread_index_in_simdgroup]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]]) {
+    const short NSG = FC_mul_mv_nsg;
+    constexpr short NW = N_SIMDWIDTH;
+    constexpr short NQ = 8;
+    constexpr short NR0 = N_R0_Q8_0;
+
+    const int nb = args.ne00/QK8_0;
+    const int r0 = tgpig.x*NR0;
+
+    device const float * y = (device const float *) src1;
+
+    device const block_q8_0 * ax[NR0];
+    FOR_UNROLL (short row = 0; row < NR0; ++row) {
+        const uint64_t offset0 = (r0 + row)*args.nb01;
+        ax[row] = (device const block_q8_0 *) ((device char *) src0 + offset0);
+    }
+
+    float sumf[NR0] = { 0.f };
+
+    const short ix = tiisg/(NW/NQ);
+    const short il = tiisg%(NW/NQ);
+
+    const int ib0 = sgitg*NQ + ix;
+
+    float yl[NQ];
+
+    device const float * yb = y + ib0*QK8_0 + il*NQ;
+
+    for (int ib = ib0; ib < nb; ib += NSG*NQ) {
+        for (short i = 0; i < NQ; ++i) {
+            yl[i] = yb[i];
+        }
+
+        for (short row = 0; row < NR0; row++) {
+            device const int8_t * qs = ax[row][ib].qs + il*NQ;
+
+            float sumq = 0.f;
+            FOR_UNROLL (short i = 0; i < NQ; ++i) {
+                sumq += qs[i] * yl[i];
+            }
+
+            sumf[row] += sumq*ax[row][ib].d;
+        }
+
+        yb += NSG*NQ*QK8_0;
+    }
+
+    device float * dst_f32 = (device float *) dst;
+
+    threadgroup float * shmem_f32[NR0];
+    for (short row = 0; row < NR0; ++row) {
+        shmem_f32[row] = (threadgroup float *) shmem + NW*row;
+        if (sgitg == 0) {
+            shmem_f32[row][tiisg] = 0.0f;
+        }
+        sumf[row] = simd_sum(sumf[row]);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (short row = 0; row < NR0; ++row) {
+        if (tiisg == 0) {
+            shmem_f32[row][sgitg] = sumf[row];
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (short row = 0; row < NR0 && r0 + row < args.ne01; ++row) {
+        float tot = simd_sum(shmem_f32[row][tiisg]);
+        if (tiisg == 0 && sgitg == 0) {
+            dst_f32[r0 + row] = res_a[r0 + row] + res_b[r0 + row] + tot;
+        }
+    }
+}
+
 // Decode Q-A/KV pair. Both projections consume the same activation row but
 // have independent weight ranges and output extents. Keep the standalone Q8_0
 // lane/block traversal and two-stage reduction verbatim for each bank; only

--- a/metal/dflash.metal
+++ b/metal/dflash.metal
@@ -110,6 +110,8 @@ kernel void kernel_dflash_probabilities(
         device const float   *logits,
         device const int32_t *argmax,
         device       float   *probabilities,
+        device       int32_t *top2,
+        device       float   *probabilities2,
         threadgroup float    *scratch [[threadgroup(0)]],
         uint tid [[thread_index_in_threadgroup]],
         uint3 tgpig [[threadgroup_position_in_grid]],
@@ -118,7 +120,11 @@ kernel void kernel_dflash_probabilities(
     if (row >= args.n_rows || args.n_vocab == 0u) return;
     const int32_t top = argmax[row];
     if (top < 0 || (uint32_t)top >= args.n_vocab) {
-        if (tid == 0u) probabilities[row] = 0.0f;
+        if (tid == 0u) {
+            probabilities[row] = 0.0f;
+            top2[row] = -1;
+            probabilities2[row] = 0.0f;
+        }
         return;
     }
 
@@ -126,20 +132,41 @@ kernel void kernel_dflash_probabilities(
         logits + (uint64_t)row * args.n_vocab;
     const float top_logit = row_logits[top];
     float sum = 0.0f;
+    float m2 = -INFINITY;
+    uint i2 = 0xFFFFFFFFu;
     if (isfinite(top_logit)) {
         for (uint col = tid; col < args.n_vocab; col += ntg.x) {
-            const float term = exp(row_logits[col] - top_logit);
+            const float value = row_logits[col];
+            const float term = exp(value - top_logit);
             if (isfinite(term)) sum += term;
+            if (col != (uint32_t)top && value > m2) {
+                m2 = value;
+                i2 = col;
+            }
         }
     }
     scratch[tid] = sum;
+    threadgroup float *max2 = scratch + ntg.x;
+    threadgroup uint *idx2 = (threadgroup uint *)(max2 + ntg.x);
+    max2[tid] = m2;
+    idx2[tid] = i2;
     threadgroup_barrier(mem_flags::mem_threadgroup);
     for (uint step = ntg.x >> 1u; step != 0u; step >>= 1u) {
-        if (tid < step) scratch[tid] += scratch[tid + step];
+        if (tid < step) {
+            scratch[tid] += scratch[tid + step];
+            if (max2[tid + step] > max2[tid]) {
+                max2[tid] = max2[tid + step];
+                idx2[tid] = idx2[tid + step];
+            }
+        }
         threadgroup_barrier(mem_flags::mem_threadgroup);
     }
     if (tid == 0u) {
-        probabilities[row] =
+        const float inv_sum =
             scratch[0] > 0.0f ? 1.0f / scratch[0] : 0.0f;
+        probabilities[row] = inv_sum;
+        top2[row] = idx2[0] == 0xFFFFFFFFu ? -1 : (int32_t)idx2[0];
+        probabilities2[row] = isfinite(max2[0]) ?
+            exp(max2[0] - top_logit) * inv_sum : 0.0f;
     }
 }

--- a/metal/dsv4_misc.metal
+++ b/metal/dsv4_misc.metal
@@ -4576,6 +4576,11 @@ kernel void kernel_glm_attention_indexed_batch_q2_group4(
 
 // GLM-5.2 decode router for one token. Selection uses sigmoid(logit)+bias,
 // while route weights are normalized from the unbiased sigmoid probabilities.
+// The 256-lane bitonic sort keeps (score, index) pairs in registers: the 30
+// stages with stride < 32 exchange partners through simd_shuffle_xor with no
+// barrier at all, and only the 6 stride >= 32 stages round-trip threadgroup
+// memory.  Comparator and renormalization order match the previous
+// shared-memory sort exactly, so selection and weights are unchanged.
 kernel void kernel_glm_router_select_one(
         constant ds4_metal_args_glm_router_select_one & args,
         device const float *logits,
@@ -4586,8 +4591,8 @@ kernel void kernel_glm_router_select_one(
         threadgroup float *scratch [[threadgroup(0)]],
         uint token [[threadgroup_position_in_grid]],
         uint tid [[thread_position_in_threadgroup]]) {
-    threadgroup float *sel_scores = scratch;
-    threadgroup int32_t *idx = (threadgroup int32_t *)(scratch + 256);
+    threadgroup float *s_arr = scratch;
+    threadgroup int32_t *i_arr = (threadgroup int32_t *)(scratch + 256);
     device const float *token_logits = logits + (uint64_t)token * args.n_expert;
     device int32_t *token_selected = selected + (uint64_t)token * args.n_expert_used;
     device float *token_weights = weights + (uint64_t)token * args.n_expert_used;
@@ -4597,42 +4602,53 @@ kernel void kernel_glm_router_select_one(
     const bool active = tid < n_expert;
     const float p = active ? ds4_glm_router_sigmoid(token_logits[tid]) : 0.0f;
     if (active) token_probs[tid] = p;
-    sel_scores[tid] = active ? p + bias[tid] : -INFINITY;
-    idx[tid] = (int32_t)tid;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float s = active ? p + bias[tid] : -INFINITY;
+    int32_t idx = (int32_t)tid;
 
     for (uint k = 2; k <= 256; k <<= 1) {
         for (uint j = k >> 1; j > 0; j >>= 1) {
-            const uint other = tid ^ j;
-            if (other > tid) {
-                const int32_t a = idx[tid];
-                const int32_t b = idx[other];
-                const bool descending = (tid & k) == 0;
-                const bool swap = descending
-                    ? ds4_glm_router_better(sel_scores, b, a)
-                    : ds4_glm_router_better(sel_scores, a, b);
-                if (swap) {
-                    idx[tid] = b;
-                    idx[other] = a;
-                }
+            float os;
+            int32_t oi;
+            if (j < 32) {
+                os = simd_shuffle_xor(s, (ushort)j);
+                oi = simd_shuffle_xor(idx, (ushort)j);
+            } else {
+                s_arr[tid] = s;
+                i_arr[tid] = idx;
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                const uint other = tid ^ j;
+                os = s_arr[other];
+                oi = i_arr[other];
+                threadgroup_barrier(mem_flags::mem_threadgroup);
             }
-            threadgroup_barrier(mem_flags::mem_threadgroup);
+            const bool descending = (tid & k) == 0;
+            const bool keep_better = descending == ((tid & j) == 0);
+            const bool mine_better = s > os || (s == os && idx < oi);
+            if (mine_better != keep_better) {
+                s = os;
+                idx = oi;
+            }
         }
     }
 
+    /* Rank tid now holds the tid-th best (score, expert) pair.  Stage the
+     * per-expert sigmoid and the top-k expert ids in threadgroup memory so
+     * the renormalization reads the same values in the same order as the
+     * previous device round-trip. */
     const uint k_used = min(args.n_expert_used, n_expert);
-    if (tid < k_used) {
-        token_selected[tid] = idx[tid];
-    }
+    s_arr[tid] = p;
+    if (tid < k_used) i_arr[tid] = idx;
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     if (tid < k_used) {
+        token_selected[tid] = idx;
         float sum = 0.0f;
         for (uint i = 0; i < k_used; i++) {
-            sum += token_probs[(uint)token_selected[i]];
+            sum += s_arr[(uint)i_arr[i]];
         }
         sum = max(sum, 6.103515625e-5f);
-        token_weights[tid] = token_probs[(uint)token_selected[tid]] / sum * args.expert_weight_scale;
+        token_weights[tid] = s_arr[(uint)idx] / sum * args.expert_weight_scale;
     }
 }
 

--- a/metal/laguna.metal
+++ b/metal/laguna.metal
@@ -16,7 +16,7 @@ struct ds4_metal_args_laguna_norm_rope {
     float    attn_factor;
     float    beta_fast;
     float    beta_slow;
-    uint32_t pad0;
+    uint32_t cache_row;   /* used only by the fused rope+store variant */
 };
 
 static inline void laguna_head_rms_norm_rope_neox(
@@ -137,6 +137,108 @@ kernel void kernel_laguna_qk_head_rms_norm_rope_neox(
     device const float *weight = is_q ? q_weight : k_weight;
     laguna_head_rms_norm_rope_neox(
         args, row, weight, scratch, tid, ntg_u.x, token);
+}
+
+// Decode-only twin of the Q/K kernel above that also commits the roped K row
+// and the untouched V row to the attention ring as f16, removing the separate
+// store dispatch from the per-token chain.  The norm and rotation arithmetic
+// is identical; the rope section is predicated instead of early-returning so
+// every thread reaches the store barrier.  Q-head threadgroups exit before
+// the store uniformly.
+kernel void kernel_laguna_qk_head_rms_norm_rope_store_neox(
+        constant ds4_metal_args_laguna_norm_rope &args,
+        device float       *q,
+        device float       *k,
+        device const float *q_weight,
+        device const float *k_weight,
+        constant uint      &n_q_head,
+        device const float *v,
+        device half        *key_cache,
+        device half        *value_cache,
+        threadgroup float  *scratch [[threadgroup(0)]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort3 ntg_u [[threads_per_threadgroup]],
+        uint3 tgpig [[threadgroup_position_in_grid]]) {
+    const uint combined_head = tgpig.x;
+    const uint nth = ntg_u.x;
+    if (combined_head >= args.n_head || args.n_tokens != 1u ||
+        n_q_head >= args.n_head || args.head_dim == 0u ||
+        args.n_rot > args.head_dim || (args.n_rot & 1u) != 0u) {
+        return;
+    }
+
+    const bool is_q = combined_head < n_q_head;
+    const uint tensor_head = is_q ? combined_head : combined_head - n_q_head;
+    const uint tensor_n_head = is_q ? n_q_head : args.n_head - n_q_head;
+    device float *row = (is_q ? q : k) +
+        (uint64_t)tensor_head * args.head_dim;
+    device const float *weight = is_q ? q_weight : k_weight;
+
+    float ss = 0.0f;
+    for (uint i = tid; i < args.head_dim; i += nth) {
+        const float value = row[i];
+        ss += value * value;
+    }
+    scratch[tid] = ss;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint step = nth >> 1u; step != 0u; step >>= 1u) {
+        if (tid < step) scratch[tid] += scratch[tid + step];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    const float inv = rsqrt(scratch[0] / (float)args.head_dim + args.eps);
+    for (uint i = tid; i < args.head_dim; i += nth) {
+        row[i] = row[i] * inv * weight[i];
+    }
+    threadgroup_barrier(mem_flags::mem_device);
+
+    const uint half_rot = args.n_rot >> 1u;
+    if (tid < half_rot) {
+        float corr_dims[2] = {0.0f, 0.0f};
+        if (args.ext_factor != 0.0f) {
+            rope_yarn_corr_dims((int)args.n_rot,
+                                (int)args.n_ctx_orig,
+                                args.freq_base,
+                                args.beta_fast,
+                                args.beta_slow,
+                                corr_dims);
+        }
+        const int rel_i0 = (int)(tid * 2u);
+        const float inv_ndims = -1.0f / (float)args.n_rot;
+#ifdef DS4_METAL_ROPE_EXP2_LOG2
+        const float theta = (float)args.pos0 *
+            exp2(inv_ndims * (float)rel_i0 * log2(args.freq_base));
+#else
+        const float theta = (float)args.pos0 *
+            pow(args.freq_base, inv_ndims * (float)rel_i0);
+#endif
+        float cos_theta;
+        float sin_theta;
+        rope_yarn(theta,
+                  args.freq_scale,
+                  corr_dims,
+                  rel_i0,
+                  args.ext_factor,
+                  args.attn_factor,
+                  &cos_theta,
+                  &sin_theta);
+        const float x0 = row[tid];
+        const float x1 = row[tid + half_rot];
+        row[tid] = x0 * cos_theta - x1 * sin_theta;
+        row[tid + half_rot] = x0 * sin_theta + x1 * cos_theta;
+    }
+    if (is_q) return;
+
+    threadgroup_barrier(mem_flags::mem_device);
+    const uint width = tensor_n_head * args.head_dim;
+    const uint64_t dst =
+        (uint64_t)args.cache_row * width +
+        (uint64_t)tensor_head * args.head_dim;
+    device const float *v_row = v + (uint64_t)tensor_head * args.head_dim;
+    for (uint i = tid; i < args.head_dim; i += nth) {
+        key_cache[dst + i] = (half)row[i];
+        value_cache[dst + i] = (half)v_row[i];
+    }
 }
 
 struct ds4_metal_args_laguna_kv_store {

--- a/metal/laguna.metal
+++ b/metal/laguna.metal
@@ -437,7 +437,83 @@ kernel void kernel_laguna_attention_prefill_gqa3_f16(
     float sum0 = 0.0f;
     float sum1 = 0.0f;
     float sum2 = 0.0f;
-    for (uint key_pos = key_start; key_pos <= query_pos; key_pos++) {
+    /* Four keys per pass: one vector simd_sum yields four scores, so the
+     * per-key reduction and exp latency chains overlap.  The softmax result
+     * is unchanged; only the running-max rescale happens per quad. */
+    uint key_pos = key_start;
+    for (; key_pos + 4u <= query_pos + 1u; key_pos += 4u) {
+        uint64_t kb[4];
+        bool cur[4];
+        FOR_UNROLL (short kk = 0; kk < 4; kk++) {
+            const uint kp = key_pos + (uint)kk;
+            cur[kk] = kp >= args.pos0;
+            const uint source_row = cur[kk] ?
+                kp - args.pos0 : kp % args.cache_cap;
+            kb[kk] = (uint64_t)source_row * cache_width +
+                     (uint64_t)kv_head * args.head_dim;
+        }
+
+        float4 p0 = float4(0.0f);
+        float4 p1 = float4(0.0f);
+        float4 p2 = float4(0.0f);
+        for (uint d = lane; d < args.head_dim; d += 32u) {
+            const float q0 = qh0[d];
+            const float q1 = qh1[d];
+            const float q2 = qh2[d];
+            FOR_UNROLL (short kk = 0; kk < 4; kk++) {
+                const float key_value = cur[kk] ?
+                    (float)staged_key[kb[kk] + d] :
+                    (float)key_cache[kb[kk] + d];
+                p0[kk] += q0 * key_value;
+                p1[kk] += q1 * key_value;
+                p2[kk] += q2 * key_value;
+            }
+        }
+        const float4 s0 = simd_sum(p0) * args.scale;
+        const float4 s1 = simd_sum(p1) * args.scale;
+        const float4 s2 = simd_sum(p2) * args.scale;
+
+        const float next_max0 =
+            max(max0, max(max(s0.x, s0.y), max(s0.z, s0.w)));
+        const float next_max1 =
+            max(max1, max(max(s1.x, s1.y), max(s1.z, s1.w)));
+        const float next_max2 =
+            max(max2, max(max(s2.x, s2.y), max(s2.z, s2.w)));
+        const float old_scale0 = max0 == -INFINITY ?
+            0.0f : exp(max0 - next_max0);
+        const float old_scale1 = max1 == -INFINITY ?
+            0.0f : exp(max1 - next_max1);
+        const float old_scale2 = max2 == -INFINITY ?
+            0.0f : exp(max2 - next_max2);
+        const float4 e0 = exp(s0 - next_max0);
+        const float4 e1 = exp(s1 - next_max1);
+        const float4 e2 = exp(s2 - next_max2);
+        sum0 = sum0 * old_scale0 + (e0.x + e0.y) + (e0.z + e0.w);
+        sum1 = sum1 * old_scale1 + (e1.x + e1.y) + (e1.z + e1.w);
+        sum2 = sum2 * old_scale2 + (e2.x + e2.y) + (e2.z + e2.w);
+        acc0 = acc0 * old_scale0;
+        acc1 = acc1 * old_scale1;
+        acc2 = acc2 * old_scale2;
+        const uint d0 = lane;
+        FOR_UNROLL (short kk = 0; kk < 4; kk++) {
+            const float4 value = cur[kk] ?
+                float4((float)staged_value[kb[kk] + d0],
+                       (float)staged_value[kb[kk] + d0 + 32u],
+                       (float)staged_value[kb[kk] + d0 + 64u],
+                       (float)staged_value[kb[kk] + d0 + 96u]) :
+                float4((float)value_cache[kb[kk] + d0],
+                       (float)value_cache[kb[kk] + d0 + 32u],
+                       (float)value_cache[kb[kk] + d0 + 64u],
+                       (float)value_cache[kb[kk] + d0 + 96u]);
+            acc0 += value * e0[kk];
+            acc1 += value * e1[kk];
+            acc2 += value * e2[kk];
+        }
+        max0 = next_max0;
+        max1 = next_max1;
+        max2 = next_max2;
+    }
+    for (; key_pos <= query_pos; key_pos++) {
         const bool current = key_pos >= args.pos0;
         const uint source_row = current ?
             key_pos - args.pos0 : key_pos % args.cache_cap;
@@ -578,7 +654,109 @@ kernel void kernel_laguna_attention_prefill_gqa6_f16(
     float sum3 = 0.0f;
     float sum4 = 0.0f;
     float sum5 = 0.0f;
-    for (uint key_pos = key_start; key_pos <= query_pos; key_pos++) {
+    /* Two keys per pass: vector simd_sums overlap the reduction and exp
+     * chains while keeping the six-head register footprint in bounds. */
+    uint key_pos = key_start;
+    for (; key_pos + 2u <= query_pos + 1u; key_pos += 2u) {
+        uint64_t kb[2];
+        bool cur[2];
+        FOR_UNROLL (short kk = 0; kk < 2; kk++) {
+            const uint kp = key_pos + (uint)kk;
+            cur[kk] = kp >= args.pos0;
+            const uint source_row = cur[kk] ?
+                kp - args.pos0 : kp % args.cache_cap;
+            kb[kk] = (uint64_t)source_row * cache_width +
+                     (uint64_t)kv_head * args.head_dim;
+        }
+
+        float2 p0 = float2(0.0f);
+        float2 p1 = float2(0.0f);
+        float2 p2 = float2(0.0f);
+        float2 p3 = float2(0.0f);
+        float2 p4 = float2(0.0f);
+        float2 p5 = float2(0.0f);
+        for (uint d = lane; d < args.head_dim; d += 32u) {
+            const float2 key_value = float2(
+                cur[0] ? (float)staged_key[kb[0] + d]
+                       : (float)key_cache[kb[0] + d],
+                cur[1] ? (float)staged_key[kb[1] + d]
+                       : (float)key_cache[kb[1] + d]);
+            p0 += qh0[d] * key_value;
+            p1 += qh1[d] * key_value;
+            p2 += qh2[d] * key_value;
+            p3 += qh3[d] * key_value;
+            p4 += qh4[d] * key_value;
+            p5 += qh5[d] * key_value;
+        }
+        const float2 s0 = simd_sum(p0) * args.scale;
+        const float2 s1 = simd_sum(p1) * args.scale;
+        const float2 s2 = simd_sum(p2) * args.scale;
+        const float2 s3 = simd_sum(p3) * args.scale;
+        const float2 s4 = simd_sum(p4) * args.scale;
+        const float2 s5 = simd_sum(p5) * args.scale;
+
+        const float next_max0 = max(max0, max(s0.x, s0.y));
+        const float next_max1 = max(max1, max(s1.x, s1.y));
+        const float next_max2 = max(max2, max(s2.x, s2.y));
+        const float next_max3 = max(max3, max(s3.x, s3.y));
+        const float next_max4 = max(max4, max(s4.x, s4.y));
+        const float next_max5 = max(max5, max(s5.x, s5.y));
+        const float old_scale0 = max0 == -INFINITY ?
+            0.0f : exp(max0 - next_max0);
+        const float old_scale1 = max1 == -INFINITY ?
+            0.0f : exp(max1 - next_max1);
+        const float old_scale2 = max2 == -INFINITY ?
+            0.0f : exp(max2 - next_max2);
+        const float old_scale3 = max3 == -INFINITY ?
+            0.0f : exp(max3 - next_max3);
+        const float old_scale4 = max4 == -INFINITY ?
+            0.0f : exp(max4 - next_max4);
+        const float old_scale5 = max5 == -INFINITY ?
+            0.0f : exp(max5 - next_max5);
+        const float2 e0 = exp(s0 - next_max0);
+        const float2 e1 = exp(s1 - next_max1);
+        const float2 e2 = exp(s2 - next_max2);
+        const float2 e3 = exp(s3 - next_max3);
+        const float2 e4 = exp(s4 - next_max4);
+        const float2 e5 = exp(s5 - next_max5);
+        sum0 = sum0 * old_scale0 + e0.x + e0.y;
+        sum1 = sum1 * old_scale1 + e1.x + e1.y;
+        sum2 = sum2 * old_scale2 + e2.x + e2.y;
+        sum3 = sum3 * old_scale3 + e3.x + e3.y;
+        sum4 = sum4 * old_scale4 + e4.x + e4.y;
+        sum5 = sum5 * old_scale5 + e5.x + e5.y;
+        acc0 = acc0 * old_scale0;
+        acc1 = acc1 * old_scale1;
+        acc2 = acc2 * old_scale2;
+        acc3 = acc3 * old_scale3;
+        acc4 = acc4 * old_scale4;
+        acc5 = acc5 * old_scale5;
+        const uint dv = lane;
+        FOR_UNROLL (short kk = 0; kk < 2; kk++) {
+            const float4 value = cur[kk] ?
+                float4((float)staged_value[kb[kk] + dv],
+                       (float)staged_value[kb[kk] + dv + 32u],
+                       (float)staged_value[kb[kk] + dv + 64u],
+                       (float)staged_value[kb[kk] + dv + 96u]) :
+                float4((float)value_cache[kb[kk] + dv],
+                       (float)value_cache[kb[kk] + dv + 32u],
+                       (float)value_cache[kb[kk] + dv + 64u],
+                       (float)value_cache[kb[kk] + dv + 96u]);
+            acc0 += value * e0[kk];
+            acc1 += value * e1[kk];
+            acc2 += value * e2[kk];
+            acc3 += value * e3[kk];
+            acc4 += value * e4[kk];
+            acc5 += value * e5[kk];
+        }
+        max0 = next_max0;
+        max1 = next_max1;
+        max2 = next_max2;
+        max3 = next_max3;
+        max4 = next_max4;
+        max5 = next_max5;
+    }
+    for (; key_pos <= query_pos; key_pos++) {
         const bool current = key_pos >= args.pos0;
         const uint source_row = current ?
             key_pos - args.pos0 : key_pos % args.cache_cap;

--- a/metal/laguna.metal
+++ b/metal/laguna.metal
@@ -1429,6 +1429,170 @@ kernel void kernel_laguna_attention_decode_rows_gqa3_f16(
     }
 }
 
+// Post-wrap twin of the gqa3 verifier-rows kernel: the block's own keys come
+// from the staging buffer instead of the ring, so storing the block can wait
+// until after attention and never overwrites slots still visible to earlier
+// rows.  Key visit order per row is unchanged (ring segment then staged
+// segment continue one striding sequence), so each row stays bit-identical
+// to the pre-wrap kernel's reduction.
+kernel void kernel_laguna_attention_decode_rows_gqa3_staged_f16(
+        constant ds4_metal_args_laguna_prefill_attention &args,
+        device const float *q,
+        device const float *gate,
+        device const half  *key_cache,
+        device const half  *value_cache,
+        device const half  *staged_key,
+        device const half  *staged_value,
+        device float       *out,
+        threadgroup float  *scratch [[threadgroup(0)]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort simd_group_u [[simdgroup_index_in_threadgroup]],
+        uint3 tgpig [[threadgroup_position_in_grid]]) {
+    constexpr uint nsg = 8u;
+    const uint head0 = tgpig.x * 3u;
+    const uint token = tgpig.y;
+    if (head0 + 2u >= args.n_head || token >= args.n_tokens ||
+        args.n_head_kv == 0u || args.head_dim != 128u) {
+        return;
+    }
+    const uint key_count = min(args.pos0 + token + 1u, args.cache_cap);
+    if (key_count == 0u) return;
+    const uint key_start = args.pos0 + token + 1u - key_count;
+    const uint ring_len = key_count - (token + 1u);
+    const uint simd_group = (uint)simd_group_u;
+    const uint heads_per_kv = args.n_head / args.n_head_kv;
+    const uint kv_head = head0 / heads_per_kv;
+    if ((head0 + 2u) / heads_per_kv != kv_head) return;
+    const uint cache_width = args.n_head_kv * args.head_dim;
+    const uint64_t row0 = (uint64_t)token * args.n_head + head0;
+    device const float *qh0 = q + row0 * args.head_dim;
+    device const float *qh1 = qh0 + args.head_dim;
+    device const float *qh2 = qh1 + args.head_dim;
+
+    float4 acc0 = float4(0.0f);
+    float4 acc1 = float4(0.0f);
+    float4 acc2 = float4(0.0f);
+    float max0 = -INFINITY;
+    float max1 = -INFINITY;
+    float max2 = -INFINITY;
+    float sum0 = 0.0f;
+    float sum1 = 0.0f;
+    float sum2 = 0.0f;
+    for (uint i = simd_group; i < key_count; i += nsg) {
+        device const half *kp;
+        device const half *vp;
+        if (i < ring_len) {
+            const uint cache_row = (key_start + i) % args.cache_cap;
+            const uint64_t kv_base =
+                (uint64_t)cache_row * cache_width +
+                (uint64_t)kv_head * args.head_dim;
+            kp = key_cache + kv_base;
+            vp = value_cache + kv_base;
+        } else {
+            const uint64_t kv_base =
+                (uint64_t)(i - ring_len) * cache_width +
+                (uint64_t)kv_head * args.head_dim;
+            kp = staged_key + kv_base;
+            vp = staged_value + kv_base;
+        }
+        const uint d0 = lane;
+        const float4 key = float4((float)kp[d0],
+                                  (float)kp[d0 + 32u],
+                                  (float)kp[d0 + 64u],
+                                  (float)kp[d0 + 96u]);
+        const float score0 = simd_sum(dot(float4(qh0[d0],
+                                                   qh0[d0 + 32u],
+                                                   qh0[d0 + 64u],
+                                                   qh0[d0 + 96u]), key)) * args.scale;
+        const float score1 = simd_sum(dot(float4(qh1[d0],
+                                                   qh1[d0 + 32u],
+                                                   qh1[d0 + 64u],
+                                                   qh1[d0 + 96u]), key)) * args.scale;
+        const float score2 = simd_sum(dot(float4(qh2[d0],
+                                                   qh2[d0 + 32u],
+                                                   qh2[d0 + 64u],
+                                                   qh2[d0 + 96u]), key)) * args.scale;
+        const float next_max0 = max(max0, score0);
+        const float next_max1 = max(max1, score1);
+        const float next_max2 = max(max2, score2);
+        const float old_scale0 = max0 == -INFINITY ? 0.0f : exp(max0 - next_max0);
+        const float old_scale1 = max1 == -INFINITY ? 0.0f : exp(max1 - next_max1);
+        const float old_scale2 = max2 == -INFINITY ? 0.0f : exp(max2 - next_max2);
+        const float value_scale0 = exp(score0 - next_max0);
+        const float value_scale1 = exp(score1 - next_max1);
+        const float value_scale2 = exp(score2 - next_max2);
+        sum0 = sum0 * old_scale0 + value_scale0;
+        sum1 = sum1 * old_scale1 + value_scale1;
+        sum2 = sum2 * old_scale2 + value_scale2;
+        const float4 value = float4((float)vp[d0],
+                                    (float)vp[d0 + 32u],
+                                    (float)vp[d0 + 64u],
+                                    (float)vp[d0 + 96u]);
+        acc0 = acc0 * old_scale0 + value * value_scale0;
+        acc1 = acc1 * old_scale1 + value * value_scale1;
+        acc2 = acc2 * old_scale2 + value * value_scale2;
+        max0 = next_max0;
+        max1 = next_max1;
+        max2 = next_max2;
+    }
+
+    threadgroup float *partial_max = scratch;
+    threadgroup float *partial_sum = partial_max + 3u * nsg;
+    threadgroup float *partial_value = partial_sum + 3u * nsg;
+    const uint slots[3] = {simd_group,
+                           nsg + simd_group,
+                           2u * nsg + simd_group};
+    const float maxima[3] = {max0, max1, max2};
+    const float sums[3] = {sum0, sum1, sum2};
+    const float4 values[3] = {acc0, acc1, acc2};
+    for (uint h = 0u; h < 3u; h++) {
+        const uint slot = slots[h];
+        if (lane == 0u) {
+            partial_max[slot] = maxima[h];
+            partial_sum[slot] = sums[h];
+        }
+        const uint base = slot * args.head_dim + lane;
+        partial_value[base] = values[h].x;
+        partial_value[base + 32u] = values[h].y;
+        partial_value[base + 64u] = values[h].z;
+        partial_value[base + 96u] = values[h].w;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_group != 0u) return;
+    for (uint h = 0u; h < 3u; h++) {
+        const uint slot_base = h * nsg;
+        float global_max = partial_max[slot_base];
+        for (uint sg = 1u; sg < nsg; sg++) {
+            global_max = max(global_max, partial_max[slot_base + sg]);
+        }
+        float merged_sum = 0.0f;
+        float4 merged = float4(0.0f);
+        for (uint sg = 0u; sg < nsg; sg++) {
+            const uint slot = slot_base + sg;
+            const float weight = partial_sum[slot] > 0.0f ?
+                exp(partial_max[slot] - global_max) : 0.0f;
+            merged_sum += partial_sum[slot] * weight;
+            const uint base = slot * args.head_dim + lane;
+            merged.x += partial_value[base] * weight;
+            merged.y += partial_value[base + 32u] * weight;
+            merged.z += partial_value[base + 64u] * weight;
+            merged.w += partial_value[base + 96u] * weight;
+        }
+
+        const uint64_t row = row0 + h;
+        const float inv_sum = merged_sum > 0.0f ? 1.0f / merged_sum : 0.0f;
+        const float gate_value = gate[row];
+        const float gate_scale = gate_value > 20.0f ?
+            gate_value : log(1.0f + exp(gate_value));
+        device float *oh = out + row * args.head_dim;
+        oh[lane]       = merged.x * inv_sum * gate_scale;
+        oh[lane + 32u] = merged.y * inv_sum * gate_scale;
+        oh[lane + 64u] = merged.z * inv_sum * gate_scale;
+        oh[lane + 96u] = merged.w * inv_sum * gate_scale;
+    }
+}
+
 // Laguna's split-K decode attention consumes the generic FlashAttention
 // partial layout, but every reduced head is immediately multiplied by its
 // learned gate. Apply that epilogue before the final store so decode does not

--- a/metal/laguna.metal
+++ b/metal/laguna.metal
@@ -1417,3 +1417,442 @@ kernel void kernel_laguna_q6_K_matmul_f32(
         }
     }
 }
+
+#ifdef DS4_METAL_HAS_TENSOR
+/*
+ * Register-resident FlashAttention for Laguna prefill on the M5 tensor
+ * units.  The fragment machinery is a compact port of MLX's steel NAX
+ * attention support (Copyright © 2025 Apple Inc., MIT license): 16x16
+ * fragments live in registers, matmuls run through
+ * mpp::tensor_ops::matmul2d<16,32,16> per simdgroup, and the online
+ * softmax reduces rows with two lane shuffles.  No threadgroup memory is
+ * used anywhere.
+ *
+ * Laguna specifics on top of the steel kernel: keys arrive as up to three
+ * linear segments (the full-attention ring is linear, the sliding-window
+ * ring splits at its wrap point, and the current chunk lives in the staging
+ * buffers), masking applies causality plus the 512-token window in absolute
+ * positions, and the learned per-head gate multiplies the normalized output
+ * in the epilogue.
+ */
+
+#define STEEL_CONST static constant constexpr const
+
+namespace ds4nax {
+
+constant constexpr float kNegInf = -3.402823466e38f;
+
+struct Frag {
+    STEEL_CONST short kFragRows = 16;
+    STEEL_CONST short kFragCols = 16;
+    STEEL_CONST short kElemsPerFrag = 8;
+    STEEL_CONST short kElemRows = 2;
+    STEEL_CONST short kElemCols = 4;
+    STEEL_CONST short kElemRowsJump = 8;
+
+    template <typename U>
+    using frag_t = metal::vec<U, kElemsPerFrag>;
+
+    METAL_FUNC static short2 get_coord() {
+        const ushort lane = __metal_get_thread_index_in_simdgroup(ushort());
+        const short qid = lane >> 2;
+        const short fm = ((qid & 4) | ((lane >> 1) & 3));
+        const short fn = ((qid & 2) | (lane & 1)) * 4;
+        return short2{fn, fm};
+    }
+
+    template <typename T, typename U>
+    METAL_FUNC static void load(
+            thread frag_t<T> &dst,
+            device const U *src,
+            const int ld,
+            const int off_x,
+            const int off_y) {
+        const short2 sc = get_coord();
+        src += (sc.y + off_x) * ld + sc.x + off_y;
+        FOR_UNROLL (short i = 0; i < kElemRows; i++) {
+            FOR_UNROLL (short j = 0; j < kElemCols; j++) {
+                dst[i * kElemCols + j] =
+                    static_cast<T>(src[i * kElemRowsJump * ld + j]);
+            }
+        }
+    }
+
+    template <typename T, typename U>
+    METAL_FUNC static void load_rows(
+            thread frag_t<T> &dst,
+            device const U *src,
+            const int ld,
+            const int lim_x,
+            const int off_x,
+            const int off_y) {
+        const short2 sc = get_coord();
+        src += (sc.y + off_x) * ld + sc.x + off_y;
+        const int lx = lim_x - off_x - sc.y;
+        FOR_UNROLL (short i = 0; i < kElemRows; i++) {
+            if (i * kElemRowsJump < lx) {
+                FOR_UNROLL (short j = 0; j < kElemCols; j++) {
+                    dst[i * kElemCols + j] =
+                        static_cast<T>(src[i * kElemRowsJump * ld + j]);
+                }
+            } else {
+                FOR_UNROLL (short j = 0; j < kElemCols; j++) {
+                    dst[i * kElemCols + j] = T(0);
+                }
+            }
+        }
+    }
+
+    template <typename T, typename U>
+    METAL_FUNC static void store_rows(
+            const thread frag_t<T> &src,
+            device U *dst,
+            const int ld,
+            const int lim_x,
+            const int off_x,
+            const int off_y) {
+        const short2 sc = get_coord();
+        dst += (sc.y + off_x) * ld + sc.x + off_y;
+        const int lx = lim_x - off_x - sc.y;
+        FOR_UNROLL (short i = 0; i < kElemRows; i++) {
+            if (i * kElemRowsJump < lx) {
+                FOR_UNROLL (short j = 0; j < kElemCols; j++) {
+                    dst[i * kElemRowsJump * ld + j] =
+                        static_cast<U>(src[i * kElemCols + j]);
+                }
+            }
+        }
+    }
+
+    template <typename Op, typename T>
+    METAL_FUNC static void row_reduce(
+            const thread frag_t<T> &inp,
+            thread T *reduced) {
+        FOR_UNROLL (short i = 0; i < kElemRows; i++) {
+            T tr = Op::apply(
+                Op::apply(inp[i * kElemCols + 0], inp[i * kElemCols + 1]),
+                Op::apply(inp[i * kElemCols + 2], inp[i * kElemCols + 3]));
+            T qr = simd_shuffle_xor(tr, ushort(1));
+            qr = Op::apply(tr, qr);
+            T sr = simd_shuffle_xor(qr, ushort(8));
+            sr = Op::apply(qr, sr);
+            reduced[i] = Op::apply(reduced[i], sr);
+        }
+    }
+
+    template <typename Op, typename T>
+    METAL_FUNC static void row_bin_op(
+            thread frag_t<T> &inp,
+            const thread T *rows) {
+        FOR_UNROLL (short i = 0; i < kElemRows; i++) {
+            FOR_UNROLL (short j = 0; j < kElemCols; j++) {
+                inp[i * kElemCols + j] =
+                    Op::apply(inp[i * kElemCols + j], rows[i]);
+            }
+        }
+    }
+
+    /* C[16x32] += A[16x16] x (B0|B1)[16x32], optionally B transposed. */
+    template <typename CT, typename AT, typename BT, bool tb>
+    METAL_FUNC static void mma(
+            thread frag_t<CT> &c0,
+            thread frag_t<CT> &c1,
+            const thread frag_t<AT> &a,
+            const thread frag_t<BT> &b0,
+            const thread frag_t<BT> &b1,
+            metal::bool_constant<tb>) {
+        constexpr auto desc = mpp::tensor_ops::matmul2d_descriptor(
+            16, 32, 16, false, tb, true,
+            mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate);
+        mpp::tensor_ops::matmul2d<desc, metal::execution_simdgroup> op;
+        auto ca = op.template get_left_input_cooperative_tensor<AT, BT, CT>();
+        auto cb = op.template get_right_input_cooperative_tensor<AT, BT, CT>();
+        auto cc = op.template get_destination_cooperative_tensor<
+            decltype(ca), decltype(cb), CT>();
+        FOR_UNROLL (short i = 0; i < kElemsPerFrag; i++) {
+            ca[i] = a[i];
+        }
+        FOR_UNROLL (short i = 0; i < kElemsPerFrag; i++) {
+            cb[i] = b0[i];
+            cb[kElemsPerFrag + i] = b1[i];
+        }
+        FOR_UNROLL (short i = 0; i < kElemsPerFrag; i++) {
+            cc[i] = c0[i];
+            cc[kElemsPerFrag + i] = c1[i];
+        }
+        op.run(ca, cb, cc);
+        FOR_UNROLL (short i = 0; i < kElemsPerFrag; i++) {
+            c0[i] = cc[i];
+            c1[i] = cc[kElemsPerFrag + i];
+        }
+    }
+};
+
+struct MaxOp {
+    template <typename T>
+    METAL_FUNC static T apply(T x, T y) { return metal::max(x, y); }
+};
+struct SumOp {
+    template <typename T>
+    METAL_FUNC static T apply(T x, T y) { return x + y; }
+};
+struct MulOp {
+    template <typename T>
+    METAL_FUNC static T apply(T x, T y) { return x * y; }
+};
+struct ExpSubOp {
+    template <typename T>
+    METAL_FUNC static T apply(T x, T y) { return metal::fast::exp2(x - y); }
+};
+
+} // namespace ds4nax
+
+/* One threadgroup covers 64 query rows of one head: four simdgroups of 16
+ * rows each, fully warp-autonomous except for two scheduling barriers that
+ * every warp reaches the same number of times (loop bounds derive from the
+ * threadgroup's query range; per-row precision comes from masking). */
+kernel void kernel_laguna_attention_prefill_nax_f16(
+        constant ds4_metal_args_laguna_prefill_attention &args,
+        device const float *q,
+        device const float *gate,
+        device const half  *key_cache,
+        device const half  *value_cache,
+        device const half  *staged_key,
+        device const half  *staged_value,
+        device float       *out,
+        ushort simd_group_id [[simdgroup_index_in_threadgroup]],
+        uint3 tgpig [[threadgroup_position_in_grid]]) {
+    using Frag = ds4nax::Frag;
+    constexpr short BQ = 64;
+    constexpr short BK = 32;
+    constexpr short TD = 8;   /* 128 / 16 head-dim fragments */
+    constexpr short TK = 2;   /* 32 / 16 key fragments per block */
+    using frag_f = Frag::frag_t<float>;
+    using frag_h = Frag::frag_t<half>;
+
+    const uint head = tgpig.y;
+    if (head >= args.n_head || args.head_dim != 128u) return;
+    const uint heads_per_kv = args.n_head / args.n_head_kv;
+    const uint kv_head = head / heads_per_kv;
+    const int kv_ld = (int)(args.n_head_kv * args.head_dim);
+    const int q_ld = (int)(args.n_head * args.head_dim);
+
+    const int tile_row0 = (int)tgpig.x * BQ + 16 * (int)simd_group_id;
+    device const float *Qw = q + (uint64_t)tile_row0 * q_ld +
+                             (uint64_t)head * args.head_dim;
+    const int rows_lim = (int)args.n_tokens - tile_row0;
+    const int q_abs0 = (int)args.pos0 + tile_row0;
+
+    /* Threadgroup-uniform query range for loop bounds. */
+    const int tg_q_lo = (int)args.pos0 + (int)tgpig.x * BQ;
+    const int tg_q_hi = (int)args.pos0 +
+        metal::min((int)tgpig.x * BQ + BQ, (int)args.n_tokens) - 1;
+    const int window = args.cache_cap == 512u ? 512 : 0x40000000;
+
+    const float scale2 = args.scale * 1.44269504089f;
+
+    frag_f Ofrag[TD];
+    FOR_UNROLL (short i = 0; i < TD; i++) {
+        Ofrag[i] = frag_f(0.0f);
+    }
+    float2 max_score = float2(ds4nax::kNegInf);
+    float2 sum_score = float2(0.0f);
+
+    /* Key/value segments in absolute-position order. */
+    device const half *seg_k[3];
+    device const half *seg_v[3];
+    int seg_abs[3];
+    int seg_len[3];
+    short n_segs = 0;
+    if (args.cache_cap != 512u) {
+        /* Full attention: the ring never wraps during prefill. */
+        if (args.pos0 != 0u) {
+            seg_k[n_segs] = key_cache + (uint64_t)kv_head * args.head_dim;
+            seg_v[n_segs] = value_cache + (uint64_t)kv_head * args.head_dim;
+            seg_abs[n_segs] = 0;
+            seg_len[n_segs] = (int)args.pos0;
+            n_segs++;
+        }
+    } else {
+        const int h = metal::min((int)args.pos0, 512);
+        if (h > 0) {
+            const int base_abs = (int)args.pos0 - h;
+            const int slot0 = base_abs % 512;
+            const int part1 = metal::min(h, 512 - slot0);
+            seg_k[n_segs] = key_cache + (uint64_t)slot0 * kv_ld +
+                            (uint64_t)kv_head * args.head_dim;
+            seg_v[n_segs] = value_cache + (uint64_t)slot0 * kv_ld +
+                            (uint64_t)kv_head * args.head_dim;
+            seg_abs[n_segs] = base_abs;
+            seg_len[n_segs] = part1;
+            n_segs++;
+            if (h > part1) {
+                seg_k[n_segs] = key_cache + (uint64_t)kv_head * args.head_dim;
+                seg_v[n_segs] = value_cache + (uint64_t)kv_head * args.head_dim;
+                seg_abs[n_segs] = base_abs + part1;
+                seg_len[n_segs] = h - part1;
+                n_segs++;
+            }
+        }
+    }
+    seg_k[n_segs] = staged_key + (uint64_t)kv_head * args.head_dim;
+    seg_v[n_segs] = staged_value + (uint64_t)kv_head * args.head_dim;
+    seg_abs[n_segs] = (int)args.pos0;
+    seg_len[n_segs] = (int)args.n_tokens;
+    n_segs++;
+
+    const short2 sc = Frag::get_coord();
+    const short sm = sc.y;
+    const short sn = sc.x;
+
+    for (short seg = 0; seg < n_segs; seg++) {
+        const int s_abs = seg_abs[seg];
+        const int s_len = seg_len[seg];
+        /* Block culling against the threadgroup's query range. */
+        int kb_start = 0;
+        if (window != 0x40000000) {
+            kb_start = metal::max(0, (tg_q_lo - window + 1 - s_abs) / BK);
+        }
+        int kb_lim = (tg_q_hi - s_abs) / BK + 1;
+        kb_lim = metal::min(kb_lim, (s_len + BK - 1) / BK);
+        if (kb_lim <= kb_start) continue;
+
+        device const half *Kw = seg_k[seg] + (uint64_t)kb_start * BK * kv_ld;
+        device const half *Vw = seg_v[seg] + (uint64_t)kb_start * BK * kv_ld;
+
+        for (int kb = kb_start; kb < kb_lim; kb++) {
+            const int col_abs0 = s_abs + kb * BK;
+            const int col_in_seg0 = kb * BK;
+            const bool tail_k = col_in_seg0 + BK > s_len;
+
+            /* S = Q @ K^T in the exp2 domain. */
+            frag_f Sfrag[TK];
+            FOR_UNROLL (short ik = 0; ik < TK; ik++) {
+                Sfrag[ik] = frag_f(0.0f);
+            }
+            FOR_UNROLL (short id = 0; id < TD; id++) {
+                frag_h Qf;
+                frag_h K0;
+                frag_h K1;
+                if (rows_lim < 16) {
+                    Frag::load_rows(Qf, Qw, q_ld, rows_lim, 0, id * 16);
+                } else {
+                    Frag::load(Qf, Qw, q_ld, 0, id * 16);
+                }
+                if (tail_k) {
+                    Frag::load_rows(K0, Kw, kv_ld, s_len - col_in_seg0,
+                                    0, id * 16);
+                    Frag::load_rows(K1, Kw, kv_ld, s_len - col_in_seg0,
+                                    16, id * 16);
+                } else {
+                    Frag::load(K0, Kw, kv_ld, 0, id * 16);
+                    Frag::load(K1, Kw, kv_ld, 16, id * 16);
+                }
+                Frag::mma(Sfrag[0], Sfrag[1], Qf, K0, K1,
+                          metal::bool_constant<true>{});
+            }
+            FOR_UNROLL (short ik = 0; ik < TK; ik++) {
+                FOR_UNROLL (short ii = 0; ii < Frag::kElemsPerFrag; ii++) {
+                    Sfrag[ik][ii] *= scale2;
+                }
+            }
+
+            /* Causality, sliding window, and segment tail in one mask. */
+            const bool needs_causal = col_abs0 + BK - 1 > tg_q_lo;
+            const bool needs_window = window != 0x40000000 &&
+                col_abs0 < tg_q_hi - window + 1;
+            if (needs_causal || needs_window || tail_k) {
+                FOR_UNROLL (short ik = 0; ik < TK; ik++) {
+                    FOR_UNROLL (short ii = 0; ii < Frag::kElemRows; ii++) {
+                        const int r = q_abs0 + sm + ii * Frag::kElemRowsJump;
+                        FOR_UNROLL (short jj = 0; jj < Frag::kElemCols; jj++) {
+                            const int c = col_abs0 + ik * 16 + sn + jj;
+                            const int cs = col_in_seg0 + ik * 16 + sn + jj;
+                            const bool valid =
+                                c <= r && r - c < window && cs < s_len;
+                            const short loc = ii * Frag::kElemCols + jj;
+                            Sfrag[ik][loc] =
+                                valid ? Sfrag[ik][loc] : ds4nax::kNegInf;
+                        }
+                    }
+                }
+            }
+
+            /* Online softmax. */
+            float2 new_max = max_score;
+            FOR_UNROLL (short ik = 0; ik < TK; ik++) {
+                Frag::row_reduce<ds4nax::MaxOp>(Sfrag[ik],
+                                                (thread float *)&new_max);
+            }
+            FOR_UNROLL (short ik = 0; ik < TK; ik++) {
+                Frag::row_bin_op<ds4nax::ExpSubOp>(Sfrag[ik],
+                                                   (thread float *)&new_max);
+            }
+            float2 factor;
+            FOR_UNROLL (short i = 0; i < 2; i++) {
+                factor[i] = metal::fast::exp2(max_score[i] - new_max[i]);
+                max_score[i] = new_max[i];
+                sum_score[i] *= factor[i];
+            }
+            FOR_UNROLL (short ik = 0; ik < TK; ik++) {
+                Frag::row_reduce<ds4nax::SumOp>(Sfrag[ik],
+                                                (thread float *)&sum_score);
+            }
+            FOR_UNROLL (short id = 0; id < TD; id++) {
+                Frag::row_bin_op<ds4nax::MulOp>(Ofrag[id],
+                                                (thread float *)&factor);
+            }
+
+            simdgroup_barrier(mem_flags::mem_none);
+
+            /* O += P @ V. */
+            FOR_UNROLL (short id = 0; id < TD; id += 2) {
+                if (id == 4) {
+                    threadgroup_barrier(mem_flags::mem_none);
+                }
+                FOR_UNROLL (short ik = 0; ik < TK; ik++) {
+                    frag_h V0;
+                    frag_h V1;
+                    if (tail_k) {
+                        Frag::load_rows(V0, Vw, kv_ld, s_len - col_in_seg0,
+                                        ik * 16, id * 16);
+                        Frag::load_rows(V1, Vw, kv_ld, s_len - col_in_seg0,
+                                        ik * 16, id * 16 + 16);
+                    } else {
+                        Frag::load(V0, Vw, kv_ld, ik * 16, id * 16);
+                        Frag::load(V1, Vw, kv_ld, ik * 16, id * 16 + 16);
+                    }
+                    Frag::mma(Ofrag[id], Ofrag[id + 1], Sfrag[ik], V0, V1,
+                              metal::bool_constant<false>{});
+                }
+            }
+
+            Kw += BK * kv_ld;
+            Vw += BK * kv_ld;
+        }
+    }
+
+    threadgroup_barrier(mem_flags::mem_none);
+
+    /* Normalize and apply the learned per-head softplus gate. */
+    float2 rcp;
+    FOR_UNROLL (short i = 0; i < 2; i++) {
+        const int t = tile_row0 + sm + i * Frag::kElemRowsJump;
+        float gate_scale = 1.0f;
+        if (t < (int)args.n_tokens) {
+            const float gv = gate[(uint64_t)t * args.n_head + head];
+            gate_scale = gv > 20.0f ? gv : metal::log(1.0f + metal::exp(gv));
+        }
+        rcp[i] = sum_score[i] > 0.0f ? gate_scale / sum_score[i] : 0.0f;
+    }
+    FOR_UNROLL (short id = 0; id < TD; id++) {
+        Frag::row_bin_op<ds4nax::MulOp>(Ofrag[id], (thread float *)&rcp);
+    }
+
+    device float *Ow = out + (uint64_t)tile_row0 * q_ld +
+                       (uint64_t)head * args.head_dim;
+    FOR_UNROLL (short id = 0; id < TD; id++) {
+        Frag::store_rows(Ofrag[id], Ow, q_ld, rows_lim, 0, id * 16);
+    }
+}
+#endif

--- a/metal/laguna.metal
+++ b/metal/laguna.metal
@@ -102,6 +102,61 @@ static inline float4 laguna_head_rms_norm_rope_neox_simd(
     return v;
 }
 
+// One lane-owned float4 slice of a 128-wide head row (dims lane, +32, +64,
+// +96), promoted to float.
+static inline float4 laguna_load_head4(device const half *row, uint d0) {
+    return float4((float)row[d0],
+                  (float)row[d0 + 32u],
+                  (float)row[d0 + 64u],
+                  (float)row[d0 + 96u]);
+}
+
+// One key position's online-softmax update for a three-query-head group.
+// Kept in one place so the two-deep pipelined loops below stay
+// arithmetic-identical to the original single-position bodies.
+static inline void laguna_gqa3_online_step(
+        float4 key,
+        float4 value,
+        float scale,
+        device const float *qh0,
+        device const float *qh1,
+        device const float *qh2,
+        uint d0,
+        thread float4 &acc0, thread float4 &acc1, thread float4 &acc2,
+        thread float &max0, thread float &max1, thread float &max2,
+        thread float &sum0, thread float &sum1, thread float &sum2) {
+    const float score0 = simd_sum(dot(float4(qh0[d0],
+                                               qh0[d0 + 32u],
+                                               qh0[d0 + 64u],
+                                               qh0[d0 + 96u]), key)) * scale;
+    const float score1 = simd_sum(dot(float4(qh1[d0],
+                                               qh1[d0 + 32u],
+                                               qh1[d0 + 64u],
+                                               qh1[d0 + 96u]), key)) * scale;
+    const float score2 = simd_sum(dot(float4(qh2[d0],
+                                               qh2[d0 + 32u],
+                                               qh2[d0 + 64u],
+                                               qh2[d0 + 96u]), key)) * scale;
+    const float next_max0 = max(max0, score0);
+    const float next_max1 = max(max1, score1);
+    const float next_max2 = max(max2, score2);
+    const float old_scale0 = max0 == -INFINITY ? 0.0f : exp(max0 - next_max0);
+    const float old_scale1 = max1 == -INFINITY ? 0.0f : exp(max1 - next_max1);
+    const float old_scale2 = max2 == -INFINITY ? 0.0f : exp(max2 - next_max2);
+    const float value_scale0 = exp(score0 - next_max0);
+    const float value_scale1 = exp(score1 - next_max1);
+    const float value_scale2 = exp(score2 - next_max2);
+    sum0 = sum0 * old_scale0 + value_scale0;
+    sum1 = sum1 * old_scale1 + value_scale1;
+    sum2 = sum2 * old_scale2 + value_scale2;
+    acc0 = acc0 * old_scale0 + value * value_scale0;
+    acc1 = acc1 * old_scale1 + value * value_scale1;
+    acc2 = acc2 * old_scale2 + value * value_scale2;
+    max0 = next_max0;
+    max1 = next_max1;
+    max2 = next_max2;
+}
+
 // Barrier-free variants for the Laguna head geometry (head_dim 128,
 // n_rot 64 or 128): four heads per threadgroup, one simdgroup each.
 kernel void kernel_laguna_head_rms_norm_rope_simd(
@@ -1049,49 +1104,39 @@ kernel void kernel_laguna_attention_decode_gqa3_split_f16(
     float sum2 = 0.0f;
     const uint first = iwg * args.nsg + simd_group;
     const uint stride = args.nwg * args.nsg;
-    for (uint i = first; i < key_count; i += stride) {
+    const uint d0 = lane;
+    /* Two key positions per trip with every K/V load hoisted ahead of the
+     * simd_sum chains, so the second position's device loads are in flight
+     * during the first position's reductions.  Per-position arithmetic and
+     * visit order are unchanged. */
+    uint i = first;
+    for (; i + stride < key_count; i += 2u * stride) {
+        const uint64_t base_a =
+            (uint64_t)i * cache_width +
+            (uint64_t)kv_head * args.head_dim;
+        const uint64_t base_b =
+            (uint64_t)(i + stride) * cache_width +
+            (uint64_t)kv_head * args.head_dim;
+        const float4 ka = laguna_load_head4(key_cache + base_a, d0);
+        const float4 va = laguna_load_head4(value_cache + base_a, d0);
+        const float4 kb = laguna_load_head4(key_cache + base_b, d0);
+        const float4 vb = laguna_load_head4(value_cache + base_b, d0);
+        laguna_gqa3_online_step(ka, va, args.scale, qh0, qh1, qh2, d0,
+                                acc0, acc1, acc2, max0, max1, max2,
+                                sum0, sum1, sum2);
+        laguna_gqa3_online_step(kb, vb, args.scale, qh0, qh1, qh2, d0,
+                                acc0, acc1, acc2, max0, max1, max2,
+                                sum0, sum1, sum2);
+    }
+    for (; i < key_count; i += stride) {
         const uint64_t kv_base =
             (uint64_t)i * cache_width +
             (uint64_t)kv_head * args.head_dim;
-        const uint d0 = lane;
-        const float4 key = float4((float)key_cache[kv_base + d0],
-                                  (float)key_cache[kv_base + d0 + 32u],
-                                  (float)key_cache[kv_base + d0 + 64u],
-                                  (float)key_cache[kv_base + d0 + 96u]);
-        const float score0 = simd_sum(dot(float4(qh0[d0],
-                                                   qh0[d0 + 32u],
-                                                   qh0[d0 + 64u],
-                                                   qh0[d0 + 96u]), key)) * args.scale;
-        const float score1 = simd_sum(dot(float4(qh1[d0],
-                                                   qh1[d0 + 32u],
-                                                   qh1[d0 + 64u],
-                                                   qh1[d0 + 96u]), key)) * args.scale;
-        const float score2 = simd_sum(dot(float4(qh2[d0],
-                                                   qh2[d0 + 32u],
-                                                   qh2[d0 + 64u],
-                                                   qh2[d0 + 96u]), key)) * args.scale;
-        const float next_max0 = max(max0, score0);
-        const float next_max1 = max(max1, score1);
-        const float next_max2 = max(max2, score2);
-        const float old_scale0 = max0 == -INFINITY ? 0.0f : exp(max0 - next_max0);
-        const float old_scale1 = max1 == -INFINITY ? 0.0f : exp(max1 - next_max1);
-        const float old_scale2 = max2 == -INFINITY ? 0.0f : exp(max2 - next_max2);
-        const float value_scale0 = exp(score0 - next_max0);
-        const float value_scale1 = exp(score1 - next_max1);
-        const float value_scale2 = exp(score2 - next_max2);
-        sum0 = sum0 * old_scale0 + value_scale0;
-        sum1 = sum1 * old_scale1 + value_scale1;
-        sum2 = sum2 * old_scale2 + value_scale2;
-        const float4 value = float4((float)value_cache[kv_base + d0],
-                                    (float)value_cache[kv_base + d0 + 32u],
-                                    (float)value_cache[kv_base + d0 + 64u],
-                                    (float)value_cache[kv_base + d0 + 96u]);
-        acc0 = acc0 * old_scale0 + value * value_scale0;
-        acc1 = acc1 * old_scale1 + value * value_scale1;
-        acc2 = acc2 * old_scale2 + value * value_scale2;
-        max0 = next_max0;
-        max1 = next_max1;
-        max2 = next_max2;
+        const float4 key = laguna_load_head4(key_cache + kv_base, d0);
+        const float4 value = laguna_load_head4(value_cache + kv_base, d0);
+        laguna_gqa3_online_step(key, value, args.scale, qh0, qh1, qh2, d0,
+                                acc0, acc1, acc2, max0, max1, max2,
+                                sum0, sum1, sum2);
     }
 
     threadgroup float *partial_max = scratch;
@@ -1430,51 +1475,35 @@ kernel void kernel_laguna_attention_decode_rows_gqa3_f16(
     float sum0 = 0.0f;
     float sum1 = 0.0f;
     float sum2 = 0.0f;
-    for (uint i = simd_group; i < key_count; i += nsg) {
-        const uint key_pos = key_start + i;
-        const uint cache_row = key_pos % args.cache_cap;
-        const uint64_t kv_base =
-            (uint64_t)cache_row * cache_width +
+    const uint d0 = lane;
+    uint i = simd_group;
+    for (; i + nsg < key_count; i += 2u * nsg) {
+        const uint64_t base_a =
+            (uint64_t)((key_start + i) % args.cache_cap) * cache_width +
             (uint64_t)kv_head * args.head_dim;
-        const uint d0 = lane;
-        const float4 key = float4((float)key_cache[kv_base + d0],
-                                  (float)key_cache[kv_base + d0 + 32u],
-                                  (float)key_cache[kv_base + d0 + 64u],
-                                  (float)key_cache[kv_base + d0 + 96u]);
-        const float score0 = simd_sum(dot(float4(qh0[d0],
-                                                   qh0[d0 + 32u],
-                                                   qh0[d0 + 64u],
-                                                   qh0[d0 + 96u]), key)) * args.scale;
-        const float score1 = simd_sum(dot(float4(qh1[d0],
-                                                   qh1[d0 + 32u],
-                                                   qh1[d0 + 64u],
-                                                   qh1[d0 + 96u]), key)) * args.scale;
-        const float score2 = simd_sum(dot(float4(qh2[d0],
-                                                   qh2[d0 + 32u],
-                                                   qh2[d0 + 64u],
-                                                   qh2[d0 + 96u]), key)) * args.scale;
-        const float next_max0 = max(max0, score0);
-        const float next_max1 = max(max1, score1);
-        const float next_max2 = max(max2, score2);
-        const float old_scale0 = max0 == -INFINITY ? 0.0f : exp(max0 - next_max0);
-        const float old_scale1 = max1 == -INFINITY ? 0.0f : exp(max1 - next_max1);
-        const float old_scale2 = max2 == -INFINITY ? 0.0f : exp(max2 - next_max2);
-        const float value_scale0 = exp(score0 - next_max0);
-        const float value_scale1 = exp(score1 - next_max1);
-        const float value_scale2 = exp(score2 - next_max2);
-        sum0 = sum0 * old_scale0 + value_scale0;
-        sum1 = sum1 * old_scale1 + value_scale1;
-        sum2 = sum2 * old_scale2 + value_scale2;
-        const float4 value = float4((float)value_cache[kv_base + d0],
-                                    (float)value_cache[kv_base + d0 + 32u],
-                                    (float)value_cache[kv_base + d0 + 64u],
-                                    (float)value_cache[kv_base + d0 + 96u]);
-        acc0 = acc0 * old_scale0 + value * value_scale0;
-        acc1 = acc1 * old_scale1 + value * value_scale1;
-        acc2 = acc2 * old_scale2 + value * value_scale2;
-        max0 = next_max0;
-        max1 = next_max1;
-        max2 = next_max2;
+        const uint64_t base_b =
+            (uint64_t)((key_start + i + nsg) % args.cache_cap) * cache_width +
+            (uint64_t)kv_head * args.head_dim;
+        const float4 ka = laguna_load_head4(key_cache + base_a, d0);
+        const float4 va = laguna_load_head4(value_cache + base_a, d0);
+        const float4 kb = laguna_load_head4(key_cache + base_b, d0);
+        const float4 vb = laguna_load_head4(value_cache + base_b, d0);
+        laguna_gqa3_online_step(ka, va, args.scale, qh0, qh1, qh2, d0,
+                                acc0, acc1, acc2, max0, max1, max2,
+                                sum0, sum1, sum2);
+        laguna_gqa3_online_step(kb, vb, args.scale, qh0, qh1, qh2, d0,
+                                acc0, acc1, acc2, max0, max1, max2,
+                                sum0, sum1, sum2);
+    }
+    for (; i < key_count; i += nsg) {
+        const uint64_t kv_base =
+            (uint64_t)((key_start + i) % args.cache_cap) * cache_width +
+            (uint64_t)kv_head * args.head_dim;
+        const float4 key = laguna_load_head4(key_cache + kv_base, d0);
+        const float4 value = laguna_load_head4(value_cache + kv_base, d0);
+        laguna_gqa3_online_step(key, value, args.scale, qh0, qh1, qh2, d0,
+                                acc0, acc1, acc2, max0, max1, max2,
+                                sum0, sum1, sum2);
     }
 
     threadgroup float *partial_max = scratch;
@@ -1583,13 +1612,57 @@ kernel void kernel_laguna_attention_decode_rows_gqa3_staged_f16(
     float sum0 = 0.0f;
     float sum1 = 0.0f;
     float sum2 = 0.0f;
-    for (uint i = simd_group; i < key_count; i += nsg) {
+    const uint d0 = lane;
+    uint i = simd_group;
+    for (; i + nsg < key_count; i += 2u * nsg) {
+        device const half *kpa;
+        device const half *vpa;
+        device const half *kpb;
+        device const half *vpb;
+        if (i < ring_len) {
+            const uint64_t kv_base =
+                (uint64_t)((key_start + i) % args.cache_cap) * cache_width +
+                (uint64_t)kv_head * args.head_dim;
+            kpa = key_cache + kv_base;
+            vpa = value_cache + kv_base;
+        } else {
+            const uint64_t kv_base =
+                (uint64_t)(i - ring_len) * cache_width +
+                (uint64_t)kv_head * args.head_dim;
+            kpa = staged_key + kv_base;
+            vpa = staged_value + kv_base;
+        }
+        if (i + nsg < ring_len) {
+            const uint64_t kv_base =
+                (uint64_t)((key_start + i + nsg) % args.cache_cap) *
+                cache_width +
+                (uint64_t)kv_head * args.head_dim;
+            kpb = key_cache + kv_base;
+            vpb = value_cache + kv_base;
+        } else {
+            const uint64_t kv_base =
+                (uint64_t)(i + nsg - ring_len) * cache_width +
+                (uint64_t)kv_head * args.head_dim;
+            kpb = staged_key + kv_base;
+            vpb = staged_value + kv_base;
+        }
+        const float4 ka = laguna_load_head4(kpa, d0);
+        const float4 va = laguna_load_head4(vpa, d0);
+        const float4 kb = laguna_load_head4(kpb, d0);
+        const float4 vb = laguna_load_head4(vpb, d0);
+        laguna_gqa3_online_step(ka, va, args.scale, qh0, qh1, qh2, d0,
+                                acc0, acc1, acc2, max0, max1, max2,
+                                sum0, sum1, sum2);
+        laguna_gqa3_online_step(kb, vb, args.scale, qh0, qh1, qh2, d0,
+                                acc0, acc1, acc2, max0, max1, max2,
+                                sum0, sum1, sum2);
+    }
+    for (; i < key_count; i += nsg) {
         device const half *kp;
         device const half *vp;
         if (i < ring_len) {
-            const uint cache_row = (key_start + i) % args.cache_cap;
             const uint64_t kv_base =
-                (uint64_t)cache_row * cache_width +
+                (uint64_t)((key_start + i) % args.cache_cap) * cache_width +
                 (uint64_t)kv_head * args.head_dim;
             kp = key_cache + kv_base;
             vp = value_cache + kv_base;
@@ -1600,45 +1673,11 @@ kernel void kernel_laguna_attention_decode_rows_gqa3_staged_f16(
             kp = staged_key + kv_base;
             vp = staged_value + kv_base;
         }
-        const uint d0 = lane;
-        const float4 key = float4((float)kp[d0],
-                                  (float)kp[d0 + 32u],
-                                  (float)kp[d0 + 64u],
-                                  (float)kp[d0 + 96u]);
-        const float score0 = simd_sum(dot(float4(qh0[d0],
-                                                   qh0[d0 + 32u],
-                                                   qh0[d0 + 64u],
-                                                   qh0[d0 + 96u]), key)) * args.scale;
-        const float score1 = simd_sum(dot(float4(qh1[d0],
-                                                   qh1[d0 + 32u],
-                                                   qh1[d0 + 64u],
-                                                   qh1[d0 + 96u]), key)) * args.scale;
-        const float score2 = simd_sum(dot(float4(qh2[d0],
-                                                   qh2[d0 + 32u],
-                                                   qh2[d0 + 64u],
-                                                   qh2[d0 + 96u]), key)) * args.scale;
-        const float next_max0 = max(max0, score0);
-        const float next_max1 = max(max1, score1);
-        const float next_max2 = max(max2, score2);
-        const float old_scale0 = max0 == -INFINITY ? 0.0f : exp(max0 - next_max0);
-        const float old_scale1 = max1 == -INFINITY ? 0.0f : exp(max1 - next_max1);
-        const float old_scale2 = max2 == -INFINITY ? 0.0f : exp(max2 - next_max2);
-        const float value_scale0 = exp(score0 - next_max0);
-        const float value_scale1 = exp(score1 - next_max1);
-        const float value_scale2 = exp(score2 - next_max2);
-        sum0 = sum0 * old_scale0 + value_scale0;
-        sum1 = sum1 * old_scale1 + value_scale1;
-        sum2 = sum2 * old_scale2 + value_scale2;
-        const float4 value = float4((float)vp[d0],
-                                    (float)vp[d0 + 32u],
-                                    (float)vp[d0 + 64u],
-                                    (float)vp[d0 + 96u]);
-        acc0 = acc0 * old_scale0 + value * value_scale0;
-        acc1 = acc1 * old_scale1 + value * value_scale1;
-        acc2 = acc2 * old_scale2 + value * value_scale2;
-        max0 = next_max0;
-        max1 = next_max1;
-        max2 = next_max2;
+        const float4 key = laguna_load_head4(kp, d0);
+        const float4 value = laguna_load_head4(vp, d0);
+        laguna_gqa3_online_step(key, value, args.scale, qh0, qh1, qh2, d0,
+                                acc0, acc1, acc2, max0, max1, max2,
+                                sum0, sum1, sum2);
     }
 
     threadgroup float *partial_max = scratch;

--- a/metal/laguna.metal
+++ b/metal/laguna.metal
@@ -198,6 +198,56 @@ kernel void kernel_laguna_qk_head_rms_norm_rope_store_neox(
     value_cache[dst + lane + 96u] = (half)v_row[lane + 96u];
 }
 
+// Rows twin of the fused rope+store kernel: verifier rows occupy
+// consecutive cache slots (the caller guarantees the block does not wrap
+// the sliding ring), so row r lands at cache_row + r.  Norm/RoPE values
+// and the stored K/V bytes are identical to the unfused pair.
+kernel void kernel_laguna_qk_head_rms_norm_rope_store_rows_neox(
+        constant ds4_metal_args_laguna_norm_rope &args,
+        device float       *q,
+        device float       *k,
+        device const float *q_weight,
+        device const float *k_weight,
+        constant uint      &n_q_head,
+        device const float *v,
+        device half        *key_cache,
+        device half        *value_cache,
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]],
+        uint3 tgpig [[threadgroup_position_in_grid]]) {
+    const uint combined_head = tgpig.x * 4u + sgitg;
+    const uint token = tgpig.y;
+    if (combined_head >= args.n_head || token >= args.n_tokens ||
+        n_q_head >= args.n_head || args.head_dim != 128u ||
+        (args.n_rot != 64u && args.n_rot != 128u)) {
+        return;
+    }
+
+    const bool is_q = combined_head < n_q_head;
+    const uint tensor_head = is_q ? combined_head : combined_head - n_q_head;
+    const uint tensor_n_head = is_q ? n_q_head : args.n_head - n_q_head;
+    device float *row = (is_q ? q : k) +
+        ((uint64_t)token * tensor_n_head + tensor_head) * args.head_dim;
+    const float4 roped = laguna_head_rms_norm_rope_neox_simd(
+        args, row, is_q ? q_weight : k_weight, lane, token);
+    if (is_q) return;
+
+    const uint width = tensor_n_head * args.head_dim;
+    const uint64_t dst =
+        (uint64_t)(args.cache_row + token) * width +
+        (uint64_t)tensor_head * args.head_dim;
+    device const float *v_row = v +
+        ((uint64_t)token * tensor_n_head + tensor_head) * args.head_dim;
+    key_cache[dst + lane]       = (half)roped.x;
+    key_cache[dst + lane + 32u] = (half)roped.y;
+    key_cache[dst + lane + 64u] = (half)roped.z;
+    key_cache[dst + lane + 96u] = (half)roped.w;
+    value_cache[dst + lane]       = (half)v_row[lane];
+    value_cache[dst + lane + 32u] = (half)v_row[lane + 32u];
+    value_cache[dst + lane + 64u] = (half)v_row[lane + 64u];
+    value_cache[dst + lane + 96u] = (half)v_row[lane + 96u];
+}
+
 struct ds4_metal_args_laguna_kv_store {
     uint32_t cache_cap;
     uint32_t cache_row;

--- a/metal/laguna.metal
+++ b/metal/laguna.metal
@@ -19,34 +19,26 @@ struct ds4_metal_args_laguna_norm_rope {
     uint32_t cache_row;   /* used only by the fused rope+store variant */
 };
 
-static inline void laguna_head_rms_norm_rope_neox(
+// Simdgroup-resident norm+rope for head_dim 128: each lane owns dims
+// {lane, lane+32, lane+64, lane+96}, so the square sum reduces with one
+// simd_sum (no barrier), every lane recomputes the cheap rsqrt, and both
+// elements of every NeoX rotary pair land in the same lane for both Laguna
+// rotary widths (64 and 128).  The head row is read and written exactly
+// once, in registers, with no threadgroup memory at all.
+static inline float4 laguna_head_rms_norm_rope_neox_simd(
         constant ds4_metal_args_laguna_norm_rope &args,
         device float       *row,
         device const float *weight,
-        threadgroup float  *scratch [[threadgroup(0)]],
-        uint tid,
-        uint nth,
+        ushort lane,
         uint token) {
-    float ss = 0.0f;
-    for (uint i = tid; i < args.head_dim; i += nth) {
-        const float v = row[i];
-        ss += v * v;
-    }
-    scratch[tid] = ss;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint step = nth >> 1u; step != 0u; step >>= 1u) {
-        if (tid < step) scratch[tid] += scratch[tid + step];
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-
-    const float inv = rsqrt(scratch[0] / (float)args.head_dim + args.eps);
-    for (uint i = tid; i < args.head_dim; i += nth) {
-        row[i] = row[i] * inv * weight[i];
-    }
-    threadgroup_barrier(mem_flags::mem_device);
-
-    const uint half_rot = args.n_rot >> 1u;
-    if (tid >= half_rot) return;
+    const uint d0 = lane;
+    const uint d1 = lane + 32u;
+    const uint d2 = lane + 64u;
+    const uint d3 = lane + 96u;
+    float4 v = float4(row[d0], row[d1], row[d2], row[d3]);
+    const float ss = simd_sum(v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w);
+    const float inv = rsqrt(ss / 128.0f + args.eps);
+    v *= inv * float4(weight[d0], weight[d1], weight[d2], weight[d3]);
 
     float corr_dims[2] = {0.0f, 0.0f};
     if (args.ext_factor != 0.0f) {
@@ -57,94 +49,111 @@ static inline void laguna_head_rms_norm_rope_neox(
                             args.beta_slow,
                             corr_dims);
     }
-    const int rel_i0 = (int)(tid * 2u);
     const float inv_ndims = -1.0f / (float)args.n_rot;
+    const float pos = (float)(args.pos0 + token);
 #ifdef DS4_METAL_ROPE_EXP2_LOG2
-    const float theta = (float)(args.pos0 + token) *
-        exp2(inv_ndims * (float)rel_i0 * log2(args.freq_base));
+    const float log2_base = log2(args.freq_base);
+#define DS4_LAGUNA_ROPE_THETA(rel) \
+        (pos * exp2(inv_ndims * (float)(rel) * log2_base))
 #else
-    const float theta = (float)(args.pos0 + token) *
-        pow(args.freq_base, inv_ndims * (float)rel_i0);
+#define DS4_LAGUNA_ROPE_THETA(rel) \
+        (pos * pow(args.freq_base, inv_ndims * (float)(rel)))
 #endif
-    float cos_theta;
-    float sin_theta;
-    rope_yarn(theta,
-              args.freq_scale,
-              corr_dims,
-              rel_i0,
-              args.ext_factor,
-              args.attn_factor,
-              &cos_theta,
-              &sin_theta);
-    const float x0 = row[tid];
-    const float x1 = row[tid + half_rot];
-    row[tid] = x0 * cos_theta - x1 * sin_theta;
-    row[tid + half_rot] = x0 * sin_theta + x1 * cos_theta;
+    if (args.n_rot == 128u) {
+        float cos_theta;
+        float sin_theta;
+        int rel_i0 = (int)(2u * lane);
+        rope_yarn(DS4_LAGUNA_ROPE_THETA(rel_i0),
+                  args.freq_scale, corr_dims, rel_i0,
+                  args.ext_factor, args.attn_factor,
+                  &cos_theta, &sin_theta);
+        const float x0 = v.x;
+        const float x1 = v.z;
+        v.x = x0 * cos_theta - x1 * sin_theta;
+        v.z = x0 * sin_theta + x1 * cos_theta;
+        rel_i0 = (int)(2u * (lane + 32u));
+        rope_yarn(DS4_LAGUNA_ROPE_THETA(rel_i0),
+                  args.freq_scale, corr_dims, rel_i0,
+                  args.ext_factor, args.attn_factor,
+                  &cos_theta, &sin_theta);
+        const float y0 = v.y;
+        const float y1 = v.w;
+        v.y = y0 * cos_theta - y1 * sin_theta;
+        v.w = y0 * sin_theta + y1 * cos_theta;
+    } else {
+        /* n_rot == 64: dims 64..127 stay unrotated. */
+        float cos_theta;
+        float sin_theta;
+        const int rel_i0 = (int)(2u * lane);
+        rope_yarn(DS4_LAGUNA_ROPE_THETA(rel_i0),
+                  args.freq_scale, corr_dims, rel_i0,
+                  args.ext_factor, args.attn_factor,
+                  &cos_theta, &sin_theta);
+        const float x0 = v.x;
+        const float x1 = v.y;
+        v.x = x0 * cos_theta - x1 * sin_theta;
+        v.y = x0 * sin_theta + x1 * cos_theta;
+    }
+#undef DS4_LAGUNA_ROPE_THETA
+    row[d0] = v.x;
+    row[d1] = v.y;
+    row[d2] = v.z;
+    row[d3] = v.w;
+    return v;
 }
 
-// Laguna uses Qwen-style per-head RMSNorm and NeoX rotary pairs. Rotary
-// dimensions occupy the prefix of each head; any remaining dimensions are
-// normalized but left unrotated.
-kernel void kernel_laguna_head_rms_norm_rope_neox(
+// Barrier-free variants for the Laguna head geometry (head_dim 128,
+// n_rot 64 or 128): four heads per threadgroup, one simdgroup each.
+kernel void kernel_laguna_head_rms_norm_rope_simd(
         constant ds4_metal_args_laguna_norm_rope &args,
         device float       *x,
         device const float *weight,
-        threadgroup float  *scratch [[threadgroup(0)]],
-        uint tid [[thread_index_in_threadgroup]],
-        ushort3 ntg_u [[threads_per_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]],
         uint3 tgpig [[threadgroup_position_in_grid]]) {
-    const uint head = tgpig.x;
+    const uint head = tgpig.x * 4u + sgitg;
     const uint token = tgpig.y;
     if (head >= args.n_head || token >= args.n_tokens ||
-        args.head_dim == 0u || args.n_rot > args.head_dim ||
-        (args.n_rot & 1u) != 0u) {
+        args.head_dim != 128u ||
+        (args.n_rot != 64u && args.n_rot != 128u)) {
         return;
     }
-
     device float *row = x +
         ((uint64_t)token * args.n_head + head) * args.head_dim;
-    laguna_head_rms_norm_rope_neox(
-        args, row, weight, scratch, tid, ntg_u.x, token);
+    laguna_head_rms_norm_rope_neox_simd(args, row, weight, lane, token);
 }
 
-// Decode uses the same norm/RoPE arithmetic for Q and K. Keeping both tensors
-// in one grid removes a small Metal dispatch without changing the per-head
-// reduction order.
-kernel void kernel_laguna_qk_head_rms_norm_rope_neox(
+kernel void kernel_laguna_qk_head_rms_norm_rope_simd(
         constant ds4_metal_args_laguna_norm_rope &args,
         device float       *q,
         device float       *k,
         device const float *q_weight,
         device const float *k_weight,
         constant uint      &n_q_head,
-        threadgroup float  *scratch [[threadgroup(0)]],
-        uint tid [[thread_index_in_threadgroup]],
-        ushort3 ntg_u [[threads_per_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]],
         uint3 tgpig [[threadgroup_position_in_grid]]) {
-    const uint combined_head = tgpig.x;
+    const uint combined_head = tgpig.x * 4u + sgitg;
     const uint token = tgpig.y;
     if (combined_head >= args.n_head || token >= args.n_tokens ||
-        n_q_head >= args.n_head || args.head_dim == 0u ||
-        args.n_rot > args.head_dim || (args.n_rot & 1u) != 0u) {
+        n_q_head >= args.n_head || args.head_dim != 128u ||
+        (args.n_rot != 64u && args.n_rot != 128u)) {
         return;
     }
-
     const bool is_q = combined_head < n_q_head;
     const uint tensor_head = is_q ? combined_head : combined_head - n_q_head;
     const uint tensor_n_head = is_q ? n_q_head : args.n_head - n_q_head;
     device float *row = (is_q ? q : k) +
         ((uint64_t)token * tensor_n_head + tensor_head) * args.head_dim;
-    device const float *weight = is_q ? q_weight : k_weight;
-    laguna_head_rms_norm_rope_neox(
-        args, row, weight, scratch, tid, ntg_u.x, token);
+    laguna_head_rms_norm_rope_neox_simd(
+        args, row, is_q ? q_weight : k_weight, lane, token);
 }
 
 // Decode-only twin of the Q/K kernel above that also commits the roped K row
 // and the untouched V row to the attention ring as f16, removing the separate
-// store dispatch from the per-token chain.  The norm and rotation arithmetic
-// is identical; the rope section is predicated instead of early-returning so
-// every thread reaches the store barrier.  Q-head threadgroups exit before
-// the store uniformly.
+// store dispatch from the per-token chain.  Four heads per threadgroup, one
+// barrier-free simdgroup each; K heads convert their freshly roped registers
+// straight to the cache row.
 kernel void kernel_laguna_qk_head_rms_norm_rope_store_neox(
         constant ds4_metal_args_laguna_norm_rope &args,
         device float       *q,
@@ -155,15 +164,13 @@ kernel void kernel_laguna_qk_head_rms_norm_rope_store_neox(
         device const float *v,
         device half        *key_cache,
         device half        *value_cache,
-        threadgroup float  *scratch [[threadgroup(0)]],
-        uint tid [[thread_index_in_threadgroup]],
-        ushort3 ntg_u [[threads_per_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]],
         uint3 tgpig [[threadgroup_position_in_grid]]) {
-    const uint combined_head = tgpig.x;
-    const uint nth = ntg_u.x;
+    const uint combined_head = tgpig.x * 4u + sgitg;
     if (combined_head >= args.n_head || args.n_tokens != 1u ||
-        n_q_head >= args.n_head || args.head_dim == 0u ||
-        args.n_rot > args.head_dim || (args.n_rot & 1u) != 0u) {
+        n_q_head >= args.n_head || args.head_dim != 128u ||
+        (args.n_rot != 64u && args.n_rot != 128u)) {
         return;
     }
 
@@ -172,73 +179,23 @@ kernel void kernel_laguna_qk_head_rms_norm_rope_store_neox(
     const uint tensor_n_head = is_q ? n_q_head : args.n_head - n_q_head;
     device float *row = (is_q ? q : k) +
         (uint64_t)tensor_head * args.head_dim;
-    device const float *weight = is_q ? q_weight : k_weight;
-
-    float ss = 0.0f;
-    for (uint i = tid; i < args.head_dim; i += nth) {
-        const float value = row[i];
-        ss += value * value;
-    }
-    scratch[tid] = ss;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint step = nth >> 1u; step != 0u; step >>= 1u) {
-        if (tid < step) scratch[tid] += scratch[tid + step];
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-
-    const float inv = rsqrt(scratch[0] / (float)args.head_dim + args.eps);
-    for (uint i = tid; i < args.head_dim; i += nth) {
-        row[i] = row[i] * inv * weight[i];
-    }
-    threadgroup_barrier(mem_flags::mem_device);
-
-    const uint half_rot = args.n_rot >> 1u;
-    if (tid < half_rot) {
-        float corr_dims[2] = {0.0f, 0.0f};
-        if (args.ext_factor != 0.0f) {
-            rope_yarn_corr_dims((int)args.n_rot,
-                                (int)args.n_ctx_orig,
-                                args.freq_base,
-                                args.beta_fast,
-                                args.beta_slow,
-                                corr_dims);
-        }
-        const int rel_i0 = (int)(tid * 2u);
-        const float inv_ndims = -1.0f / (float)args.n_rot;
-#ifdef DS4_METAL_ROPE_EXP2_LOG2
-        const float theta = (float)args.pos0 *
-            exp2(inv_ndims * (float)rel_i0 * log2(args.freq_base));
-#else
-        const float theta = (float)args.pos0 *
-            pow(args.freq_base, inv_ndims * (float)rel_i0);
-#endif
-        float cos_theta;
-        float sin_theta;
-        rope_yarn(theta,
-                  args.freq_scale,
-                  corr_dims,
-                  rel_i0,
-                  args.ext_factor,
-                  args.attn_factor,
-                  &cos_theta,
-                  &sin_theta);
-        const float x0 = row[tid];
-        const float x1 = row[tid + half_rot];
-        row[tid] = x0 * cos_theta - x1 * sin_theta;
-        row[tid + half_rot] = x0 * sin_theta + x1 * cos_theta;
-    }
+    const float4 roped = laguna_head_rms_norm_rope_neox_simd(
+        args, row, is_q ? q_weight : k_weight, lane, 0u);
     if (is_q) return;
 
-    threadgroup_barrier(mem_flags::mem_device);
     const uint width = tensor_n_head * args.head_dim;
     const uint64_t dst =
         (uint64_t)args.cache_row * width +
         (uint64_t)tensor_head * args.head_dim;
     device const float *v_row = v + (uint64_t)tensor_head * args.head_dim;
-    for (uint i = tid; i < args.head_dim; i += nth) {
-        key_cache[dst + i] = (half)row[i];
-        value_cache[dst + i] = (half)v_row[i];
-    }
+    key_cache[dst + lane]       = (half)roped.x;
+    key_cache[dst + lane + 32u] = (half)roped.y;
+    key_cache[dst + lane + 64u] = (half)roped.z;
+    key_cache[dst + lane + 96u] = (half)roped.w;
+    value_cache[dst + lane]       = (half)v_row[lane];
+    value_cache[dst + lane + 32u] = (half)v_row[lane + 32u];
+    value_cache[dst + lane + 64u] = (half)v_row[lane + 64u];
+    value_cache[dst + lane + 96u] = (half)v_row[lane + 96u];
 }
 
 struct ds4_metal_args_laguna_kv_store {

--- a/metal/laguna.metal
+++ b/metal/laguna.metal
@@ -248,6 +248,61 @@ kernel void kernel_laguna_qk_head_rms_norm_rope_store_rows_neox(
     value_cache[dst + lane + 96u] = (half)v_row[lane + 96u];
 }
 
+struct ds4_metal_args_laguna_spec_copy {
+    uint32_t pos0;
+    uint32_t first_row;
+    uint32_t n_rows;
+    uint32_t cache_cap;
+    uint32_t row_elems;
+    uint32_t n_layers;
+    uint32_t to_backup;
+    uint32_t pad0;
+};
+
+// One dispatch snapshots (or restores) the speculative rows of every
+// sliding-window layer at once, replacing ~150 host-encoded blits per
+// DFlash cycle.  addrs holds {key_cache, value_cache, key_backup,
+// value_backup} GPU addresses per layer; each threadgroup moves one
+// row of one layer (K and V halves split across the thread range).
+kernel void kernel_laguna_spec_ring_copy_all_f16(
+        constant ds4_metal_args_laguna_spec_copy &args,
+        device const ulong *addrs,
+        uint3 tgpig [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        uint3 ntg [[threads_per_threadgroup]]) {
+    const uint layer = tgpig.x;
+    const uint row = args.first_row + tgpig.y;
+    if (layer >= args.n_layers || row >= args.n_rows ||
+        args.cache_cap == 0u || (args.row_elems & 7u) != 0u) {
+        return;
+    }
+    const uint ring = (args.pos0 + row) % args.cache_cap;
+    const uint vec_count = args.row_elems / 8u;
+    device const ulong *base = addrs + (uint64_t)layer * 4u;
+    device uint4 *key_cache = reinterpret_cast<device uint4 *>(base[0]);
+    device uint4 *value_cache = reinterpret_cast<device uint4 *>(base[1]);
+    device uint4 *key_backup = reinterpret_cast<device uint4 *>(base[2]);
+    device uint4 *value_backup = reinterpret_cast<device uint4 *>(base[3]);
+    const uint64_t cache_off = (uint64_t)ring * vec_count;
+    const uint64_t backup_off = (uint64_t)row * vec_count;
+    for (uint t = tid; t < 2u * vec_count; t += ntg.x) {
+        if (t < vec_count) {
+            if (args.to_backup != 0u) {
+                key_backup[backup_off + t] = key_cache[cache_off + t];
+            } else {
+                key_cache[cache_off + t] = key_backup[backup_off + t];
+            }
+        } else {
+            const uint u = t - vec_count;
+            if (args.to_backup != 0u) {
+                value_backup[backup_off + u] = value_cache[cache_off + u];
+            } else {
+                value_cache[cache_off + u] = value_backup[backup_off + u];
+            }
+        }
+    }
+}
+
 struct ds4_metal_args_laguna_kv_store {
     uint32_t cache_cap;
     uint32_t cache_row;

--- a/metal/laguna.metal
+++ b/metal/laguna.metal
@@ -1280,6 +1280,155 @@ kernel void kernel_laguna_attention_decode_rows_gqa_f16(
     oh[lane + 96u] = merged.w * inv_sum * gate_scale;
 }
 
+// Sliding-window verifier rows evaluated three query heads per threadgroup so
+// each K/V row is loaded once instead of three times (the global-layer gqa3
+// split kernel established this reduction shape).  Eight SIMD groups stripe
+// the key range; their independently normalized partials merge in threadgroup
+// memory exactly like kernel_laguna_attention_decode_rows_gqa_f16.
+kernel void kernel_laguna_attention_decode_rows_gqa3_f16(
+        constant ds4_metal_args_laguna_prefill_attention &args,
+        device const float *q,
+        device const float *gate,
+        device const half  *key_cache,
+        device const half  *value_cache,
+        device float       *out,
+        threadgroup float  *scratch [[threadgroup(0)]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort simd_group_u [[simdgroup_index_in_threadgroup]],
+        uint3 tgpig [[threadgroup_position_in_grid]]) {
+    constexpr uint nsg = 8u;
+    const uint head0 = tgpig.x * 3u;
+    const uint token = tgpig.y;
+    if (head0 + 2u >= args.n_head || token >= args.n_tokens ||
+        args.n_head_kv == 0u || args.head_dim != 128u) {
+        return;
+    }
+    const uint key_count = min(args.pos0 + token + 1u, args.cache_cap);
+    if (key_count == 0u) return;
+    const uint key_start = args.pos0 + token + 1u - key_count;
+    const uint simd_group = (uint)simd_group_u;
+    const uint heads_per_kv = args.n_head / args.n_head_kv;
+    const uint kv_head = head0 / heads_per_kv;
+    if ((head0 + 2u) / heads_per_kv != kv_head) return;
+    const uint cache_width = args.n_head_kv * args.head_dim;
+    const uint64_t row0 = (uint64_t)token * args.n_head + head0;
+    device const float *qh0 = q + row0 * args.head_dim;
+    device const float *qh1 = qh0 + args.head_dim;
+    device const float *qh2 = qh1 + args.head_dim;
+
+    float4 acc0 = float4(0.0f);
+    float4 acc1 = float4(0.0f);
+    float4 acc2 = float4(0.0f);
+    float max0 = -INFINITY;
+    float max1 = -INFINITY;
+    float max2 = -INFINITY;
+    float sum0 = 0.0f;
+    float sum1 = 0.0f;
+    float sum2 = 0.0f;
+    for (uint i = simd_group; i < key_count; i += nsg) {
+        const uint key_pos = key_start + i;
+        const uint cache_row = key_pos % args.cache_cap;
+        const uint64_t kv_base =
+            (uint64_t)cache_row * cache_width +
+            (uint64_t)kv_head * args.head_dim;
+        const uint d0 = lane;
+        const float4 key = float4((float)key_cache[kv_base + d0],
+                                  (float)key_cache[kv_base + d0 + 32u],
+                                  (float)key_cache[kv_base + d0 + 64u],
+                                  (float)key_cache[kv_base + d0 + 96u]);
+        const float score0 = simd_sum(dot(float4(qh0[d0],
+                                                   qh0[d0 + 32u],
+                                                   qh0[d0 + 64u],
+                                                   qh0[d0 + 96u]), key)) * args.scale;
+        const float score1 = simd_sum(dot(float4(qh1[d0],
+                                                   qh1[d0 + 32u],
+                                                   qh1[d0 + 64u],
+                                                   qh1[d0 + 96u]), key)) * args.scale;
+        const float score2 = simd_sum(dot(float4(qh2[d0],
+                                                   qh2[d0 + 32u],
+                                                   qh2[d0 + 64u],
+                                                   qh2[d0 + 96u]), key)) * args.scale;
+        const float next_max0 = max(max0, score0);
+        const float next_max1 = max(max1, score1);
+        const float next_max2 = max(max2, score2);
+        const float old_scale0 = max0 == -INFINITY ? 0.0f : exp(max0 - next_max0);
+        const float old_scale1 = max1 == -INFINITY ? 0.0f : exp(max1 - next_max1);
+        const float old_scale2 = max2 == -INFINITY ? 0.0f : exp(max2 - next_max2);
+        const float value_scale0 = exp(score0 - next_max0);
+        const float value_scale1 = exp(score1 - next_max1);
+        const float value_scale2 = exp(score2 - next_max2);
+        sum0 = sum0 * old_scale0 + value_scale0;
+        sum1 = sum1 * old_scale1 + value_scale1;
+        sum2 = sum2 * old_scale2 + value_scale2;
+        const float4 value = float4((float)value_cache[kv_base + d0],
+                                    (float)value_cache[kv_base + d0 + 32u],
+                                    (float)value_cache[kv_base + d0 + 64u],
+                                    (float)value_cache[kv_base + d0 + 96u]);
+        acc0 = acc0 * old_scale0 + value * value_scale0;
+        acc1 = acc1 * old_scale1 + value * value_scale1;
+        acc2 = acc2 * old_scale2 + value * value_scale2;
+        max0 = next_max0;
+        max1 = next_max1;
+        max2 = next_max2;
+    }
+
+    threadgroup float *partial_max = scratch;
+    threadgroup float *partial_sum = partial_max + 3u * nsg;
+    threadgroup float *partial_value = partial_sum + 3u * nsg;
+    const uint slots[3] = {simd_group,
+                           nsg + simd_group,
+                           2u * nsg + simd_group};
+    const float maxima[3] = {max0, max1, max2};
+    const float sums[3] = {sum0, sum1, sum2};
+    const float4 values[3] = {acc0, acc1, acc2};
+    for (uint h = 0u; h < 3u; h++) {
+        const uint slot = slots[h];
+        if (lane == 0u) {
+            partial_max[slot] = maxima[h];
+            partial_sum[slot] = sums[h];
+        }
+        const uint base = slot * args.head_dim + lane;
+        partial_value[base] = values[h].x;
+        partial_value[base + 32u] = values[h].y;
+        partial_value[base + 64u] = values[h].z;
+        partial_value[base + 96u] = values[h].w;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_group != 0u) return;
+    for (uint h = 0u; h < 3u; h++) {
+        const uint slot_base = h * nsg;
+        float global_max = partial_max[slot_base];
+        for (uint sg = 1u; sg < nsg; sg++) {
+            global_max = max(global_max, partial_max[slot_base + sg]);
+        }
+        float merged_sum = 0.0f;
+        float4 merged = float4(0.0f);
+        for (uint sg = 0u; sg < nsg; sg++) {
+            const uint slot = slot_base + sg;
+            const float weight = partial_sum[slot] > 0.0f ?
+                exp(partial_max[slot] - global_max) : 0.0f;
+            merged_sum += partial_sum[slot] * weight;
+            const uint base = slot * args.head_dim + lane;
+            merged.x += partial_value[base] * weight;
+            merged.y += partial_value[base + 32u] * weight;
+            merged.z += partial_value[base + 64u] * weight;
+            merged.w += partial_value[base + 96u] * weight;
+        }
+
+        const uint64_t row = row0 + h;
+        const float inv_sum = merged_sum > 0.0f ? 1.0f / merged_sum : 0.0f;
+        const float gate_value = gate[row];
+        const float gate_scale = gate_value > 20.0f ?
+            gate_value : log(1.0f + exp(gate_value));
+        device float *oh = out + row * args.head_dim;
+        oh[lane]       = merged.x * inv_sum * gate_scale;
+        oh[lane + 32u] = merged.y * inv_sum * gate_scale;
+        oh[lane + 64u] = merged.z * inv_sum * gate_scale;
+        oh[lane + 96u] = merged.w * inv_sum * gate_scale;
+    }
+}
+
 // Laguna's split-K decode attention consumes the generic FlashAttention
 // partial layout, but every reduced head is immediately multiplied by its
 // learned gate. Apply that epilogue before the final store so decode does not

--- a/metal/moe.metal
+++ b/metal/moe.metal
@@ -8277,6 +8277,184 @@ typedef decltype(kernel_attn_out_low_q8_0_mpp_direct_rhs<64>) attn_out_low_q8_0_
 
 template [[host_name("kernel_attn_out_low_q8_0_mpp_direct_rhs_n64")]] kernel attn_out_low_q8_0_mpp_direct_rhs_n64_t kernel_attn_out_low_q8_0_mpp_direct_rhs<64>;
 
+// TensorOps twin of kernel_mul_mm_id for Q4_K routed experts.  Staging keeps
+// the legacy kernel's precision profile exactly -- expert weights dequantized
+// to half, gathered activations staged as half, float accumulation -- so only
+// the multiply-accumulate order changes.  Both operand tiles are
+// double-buffered: the next k-step's dequant and gather overlap the current
+// cooperative matmul, one threadgroup barrier per step.
+//
+// Threadgroup layout (20736 bytes): A tiles 2x(64x32 half), B tiles
+// 2x(32x32 half), C store 64x32 float, 32 gathered row offsets.
+template<typename T1>
+kernel void kernel_mul_mm_id_q4_K_mpp(
+        constant ds4_metal_args_mul_mm_id & args,
+        device const char * src0,
+        device const char * src1,
+        device const char * htpe,
+        device const char * hids,
+        device       char * dst,
+        threadgroup  char * shmem [[threadgroup(0)]],
+        uint3  tgpig[[threadgroup_position_in_grid]],
+        ushort tiitg[[thread_index_in_threadgroup]],
+        ushort tiisg[[thread_index_in_simdgroup]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]]) {
+    constexpr int NR0 = 64;
+    constexpr int NR1 = 32;
+    constexpr int NK  = 32;
+
+    const int im = tgpig.z;
+    const int r0 = tgpig.y*NR0;
+    const int r1 = tgpig.x*NR1;
+
+    device const uint32_t * tpe_u32 = (device const uint32_t *) (htpe);
+    device const int32_t  * ids_i32 = (device const int32_t  *) (hids);
+
+    const int32_t neh1 = tpe_u32[im];
+    if (r1 >= neh1) {
+        return;
+    }
+
+    const short nr0 = (args.ne0 - r0 < NR0) ? (short)(args.ne0 - r0) : (short)NR0;
+    const short nr1 = (    neh1 - r1 < NR1) ? (short)(    neh1 - r1) : (short)NR1;
+
+    if (!ds4_tp_owns_expert(im, args.ne02, args.tp_rank, args.tp_world)) {
+        for (short j = sgitg; j < nr1; j += 4) {
+            const int idj = ids_i32[im*args.ne21 + r1 + j];
+            const short ide = idj % args.ne20;
+            const int   idt = idj / args.ne20;
+            device float * D = (device float *) dst + r0 + ide*args.ne0 +
+                (uint64_t)idt*args.ne1*args.ne0;
+            for (int i = tiisg; i < nr0; i += 32) {
+                D[i] = 0.0f;
+            }
+        }
+        return;
+    }
+
+    threadgroup half *sa = (threadgroup half *)shmem;
+    threadgroup half *sb = (threadgroup half *)(shmem + 2*NR0*NK*sizeof(half));
+    threadgroup float *sc_out = (threadgroup float *)
+        (shmem + 2*NR0*NK*sizeof(half) + 2*NR1*NK*sizeof(half));
+    threadgroup uint64_t *b_off = (threadgroup uint64_t *)(sc_out + NR0*NR1);
+
+    if (tiitg < NR1) {
+        if ((short)tiitg < nr1) {
+            const int id = ids_i32[im*args.ne21 + r1 + tiitg];
+            const short i11 = (id % args.ne20) % args.ne11;
+            const int   i12 = id / args.ne20;
+            b_off[tiitg] = (uint64_t)args.nb12*i12 + (uint64_t)args.nb11*i11;
+        } else {
+            b_off[tiitg] = (uint64_t)-1;
+        }
+    }
+
+    const uint64_t offset0 = (uint64_t)(im - args.tp_expert_base)*args.nb02;
+
+    auto tA0 = tensor(sa,          dextents<int32_t, 2>(NK, NR0));
+    auto tA1 = tensor(sa + NR0*NK, dextents<int32_t, 2>(NK, NR0));
+    auto tB0 = tensor(sb,          dextents<int32_t, 2>(NK, NR1));
+    auto tB1 = tensor(sb + NR1*NK, dextents<int32_t, 2>(NK, NR1));
+
+    /* Full-precision accumulation: the reduced-precision descriptor drifts
+     * far outside the legacy kernel's envelope on 48-layer MoE stacks. */
+    matmul2d<
+        matmul2d_descriptor(NR1, NR0, NK, false, true, false,
+            matmul2d_descriptor::mode::multiply_accumulate),
+        execution_simdgroups<4>> mm;
+
+    auto cT = mm.template get_destination_cooperative_tensor<decltype(tB0), decltype(tA0), float>();
+
+    #pragma unroll
+    for (uint16_t i = 0; i < cT.get_capacity(); ++i) {
+        if (cT.is_valid_element(i)) {
+            cT[i] = 0.0f;
+        }
+    }
+
+    auto stage_a = [&](const int loop_k, threadgroup half *buf) {
+        const short row = tiitg / 2;
+        const short chunk = tiitg % 2;
+        const int k_pos = loop_k + chunk*16;
+        if (r0 + row < args.ne0) {
+            device const block_q4_K *x =
+                (device const block_q4_K *)(src0 + args.nb01*(r0 + row) + offset0) +
+                k_pos/QK_K;
+            half4x4 temp;
+            dequantize_q4_K(x, (short)((k_pos % QK_K)/16), temp);
+            threadgroup half4 *dst4 = (threadgroup half4 *)(buf + row*NK + chunk*16);
+            dst4[0] = temp[0];
+            dst4[1] = temp[1];
+            dst4[2] = temp[2];
+            dst4[3] = temp[3];
+        } else {
+            threadgroup half4 *dst4 = (threadgroup half4 *)(buf + row*NK + chunk*16);
+            dst4[0] = half4(0.0h);
+            dst4[1] = half4(0.0h);
+            dst4[2] = half4(0.0h);
+            dst4[3] = half4(0.0h);
+        }
+    };
+    auto stage_b = [&](const int loop_k, threadgroup half *buf) {
+        const short row = tiitg / 4;
+        const short seg = tiitg % 4;
+        const uint64_t off = b_off[row];
+        threadgroup half *out8 = buf + row*NK + seg*8;
+        if (off != (uint64_t)-1) {
+            device const T1 *y = (device const T1 *)(src1 + off) + loop_k + seg*8;
+            FOR_UNROLL (short i = 0; i < 8; i++) {
+                out8[i] = (half)y[i];
+            }
+        } else {
+            FOR_UNROLL (short i = 0; i < 8; i++) {
+                out8[i] = (half)0;
+            }
+        }
+    };
+
+    stage_a(0, sa);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    stage_b(0, sb);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    uint buf_sel = 0;
+    for (int loop_k = 0; loop_k < args.ne00; loop_k += NK) {
+        auto mA = (buf_sel ? tA1 : tA0).slice(0, 0);
+        auto mB = (buf_sel ? tB1 : tB0).slice(0, 0);
+        mm.run(mB, mA, cT);
+
+        const int next_k = loop_k + NK;
+        if (next_k < args.ne00) {
+            buf_sel ^= 1u;
+            stage_a(next_k, buf_sel ? sa + NR0*NK : sa);
+            stage_b(next_k, buf_sel ? sb + NR1*NK : sb);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    auto tC = tensor(sc_out, dextents<int32_t, 2>(NR0, NR1));
+    cT.store(tC);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (short j = sgitg; j < nr1; j += 4) {
+        const int idj = ids_i32[im*args.ne21 + r1 + j];
+        const short ide = idj % args.ne20;
+        const int   idt = idj / args.ne20;
+        device float * D = (device float *) dst + r0 + ide*args.ne0 +
+            (uint64_t)idt*args.ne1*args.ne0;
+        threadgroup const float * C = sc_out + j*NR0;
+        for (int i = tiisg; i < nr0; i += 32) {
+            D[i] = C[i];
+        }
+    }
+}
+
+typedef decltype(kernel_mul_mm_id_q4_K_mpp<float>) mul_mm_id_q4_K_mpp_f32_t;
+typedef decltype(kernel_mul_mm_id_q4_K_mpp<half>)  mul_mm_id_q4_K_mpp_f16_t;
+
+template [[host_name("kernel_mul_mm_id_q4_K_f32_mpp")]] kernel mul_mm_id_q4_K_mpp_f32_t kernel_mul_mm_id_q4_K_mpp<float>;
+template [[host_name("kernel_mul_mm_id_q4_K_f16_mpp")]] kernel mul_mm_id_q4_K_mpp_f16_t kernel_mul_mm_id_q4_K_mpp<half>;
+
 #endif
 
 #undef QK_NL

--- a/metal/norm.metal
+++ b/metal/norm.metal
@@ -44,9 +44,16 @@ kernel void kernel_rms_norm_fuse_impl(
 
     float sumf = 0.0f;
 
-    // parallel sum
+    // parallel sum, caching the row in registers so the output pass does
+    // not re-read device memory (bit-exact: same values, same order)
+    constexpr short XCACHE = 4;
+    T xcache[XCACHE];
+    const bool cached = args.ne00_t <= (int)(XCACHE * ntg.x);
+    short nc = 0;
     for (int i00 = tpitg.x; i00 < args.ne00_t; i00 += ntg.x) {
-        sumf += dot(x[i00], x[i00]);
+        const T v = x[i00];
+        if (cached) xcache[nc++] = v;
+        sumf += dot(v, v);
     }
     sumf = simd_sum(sumf);
 
@@ -65,15 +72,17 @@ kernel void kernel_rms_norm_fuse_impl(
     const float scale = 1.0f/sqrt(mean + args.eps);
 
     device T * y = (device T *) (dst + i03*args.nb3 + i02*args.nb2 + i01*args.nb1);
+    nc = 0;
     for (int i00 = tpitg.x; i00 < args.ne00_t; i00 += ntg.x) {
+        const T v = cached ? xcache[nc++] : x[i00];
         if (F == 1) {
-            y[i00] = (x[i00]*scale);
+            y[i00] = (v*scale);
         }
         if (F == 2) {
-            y[i00] = (x[i00]*scale)*f0[i00];
+            y[i00] = (v*scale)*f0[i00];
         }
         if (F == 3) {
-            y[i00] = (x[i00]*scale)*f0[i00] + f1[i00];
+            y[i00] = (v*scale)*f0[i00] + f1[i00];
         }
     }
 }
@@ -114,9 +123,16 @@ kernel void kernel_add_rms_norm_mul_f32_4(
         (norm_dst + i03*args.nb3 + i02*args.nb2 + i01*args.nb1);
 
     float sumf = 0.0f;
+    // Register-cache the freshly computed sums so the output pass does not
+    // re-read them from device memory (sum[] stays a real output).
+    constexpr short XCACHE = 4;
+    float4 xcache[XCACHE];
+    const bool cached = args.ne00_t <= (int)(XCACHE * ntg.x);
+    short nc = 0;
     for (int i00 = tpitg.x; i00 < args.ne00_t; i00 += ntg.x) {
         const float4 v = a[i00] + b[i00];
         sum[i00] = v;
+        if (cached) xcache[nc++] = v;
         sumf += dot(v, v);
     }
     sumf = simd_sum(sumf);
@@ -127,8 +143,10 @@ kernel void kernel_add_rms_norm_mul_f32_4(
 
     const float mean = sumf / args.ne00;
     const float scale = 1.0f / sqrt(mean + args.eps);
+    nc = 0;
     for (int i00 = tpitg.x; i00 < args.ne00_t; i00 += ntg.x) {
-        norm[i00] = (sum[i00] * scale) * w[i00];
+        const float4 v = cached ? xcache[nc++] : sum[i00];
+        norm[i00] = (v * scale) * w[i00];
     }
 }
 


### PR DESCRIPTION
## Laguna S 2.1 performance campaign — mlxfast-challenge ports + DFlash pipeline work

Optimization work on the Laguna S 2.1 path, porting every applicable technique from the mlxfast-challenge Laguna XS 2.1 effort (same architecture family) and then optimizing the DFlash speculative-decoding cycle. Every commit is atomic, measured cold (100-120 s thermal cooldowns, canonical codegen 512-token protocol), and quality-gated (teacher-forced NLL, decode-consistency drift envelope, bit-identical greedy streams wherever the change class allows it).

### Headline results (M5 Max, 614 GB/s)

| Metric | Before | After |
|---|---|---|
| Prefill @16k | 327 t/s | **1152 t/s (3.5x)** |
| Prefill @4k | 496 t/s | **1221 t/s** |
| Decode (no DFlash) | 62.2 t/s | 66.6 t/s (76% of measured memory wall) |
| **CLI generation, DFlash active** | **48.4 t/s** | **87.9 t/s (+81.6%)** |

DFlash output remains bit-identical to plain greedy decode (lossless speculation verified on 512/1024-token streams at every step).

### Main changes

- **NAX FlashAttention prefill**: port of the MLX steel tensor-unit kernel (16x16 register fragments, matmul2d per simdgroup, exp2-domain online softmax) with Laguna-specific K/V segmenting (SWA-512 ring wrap, absolute-position causal+window masking, softplus gate epilogue).
- **Tensor-ops matmuls + Q4_K gather-GEMM twin** for routed experts; non-32-aligned batch split so real prompts hit the tensor path.
- **Shared-K/V GQA attention** (3 query heads per KV group) for decode, sliding-ring decode, and DFlash verifier rows; two-deep software-pipelined K/V loops.
- **DFlash cycle engineering**: graded per-position confidence pruning (0.50/0.55/0.65), all-width verifier pre-encode behind a held-command-buffer stack (serial re-encode now 0.00 ms), verifier argmax reused as the greedy sample, consolidated snapshot/restore via a GPU-address table + residency set, post-wrap batched verifier rows through a staged path.
- **Fusions**: residual-add+RMSNorm (single and rows), fused QK rope + KV store (single and rows), RMSNorm register caching.
- **DFlash training-data harvest tooling** (env-gated diagnostics): per-position aux-feature dump + per-cycle draft/target argmax sidecar, enabling draft-model distillation work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
