### PR TITLE
fix: restore ROCm Q8 prequantized decode kernels

### DIFF
--- a/rocm/ds4_rocm_attention_launch.cuh
+++ b/rocm/ds4_rocm_attention_launch.cuh
@@ -1303,6 +1303,45 @@ extern "C" int ds4_gpu_attention_output_low_q8_tensor(
                 (uint32_t)low_dim);
         return cuda_ok(cudaGetLastError(), "attention_output_low_q8 splitk sum launch");
     }
+    /* Restore the prequantized integer decode path for the attention
+     * output projection (grouped_q8_0_a_preq_warp8_kernel). ef8d923
+     * dropped it together with the matmul_q8_0 preq decode kernels,
+     * leaving the fp32 paths below as the only option.
+     * Quality mode keeps the fp32 path to preserve numeric precision. */
+    if (!g_quality_mode) {
+        const uint64_t x_rows = (uint64_t)n_groups;
+        const uint64_t xq_bytes = x_rows * blocks_a * 32u;
+        const uint64_t scale_offset = (xq_bytes + 15u) & ~15ull;
+        const uint64_t tmp_bytes = scale_offset + x_rows * blocks_a * sizeof(float);
+        void *tmp = cuda_tmp_alloc(tmp_bytes, "attention output low q8 prequant");
+        if (tmp) {
+            int8_t *xq = (int8_t *)tmp;
+            float *xscale = (float *)((char *)tmp + scale_offset);
+            const int use_dp4a = 1;
+            dim3 qgrid((unsigned)blocks_a, (unsigned)x_rows, 1);
+            quantize_q8_0_f32_kernel<<<qgrid, 32>>>(
+                    xq, xscale, (const float *)heads->ptr, group_dim, blocks_a);
+            if (cuda_ok(cudaGetLastError(),
+                        "attention_output_low_q8 prequant launch")) {
+                const uint32_t rows_per_block = g_quality_mode ? 8u : 32u;
+                dim3 grid_a(((unsigned)low_dim + rows_per_block - 1u) / rows_per_block,
+                            1, 1);
+                grouped_q8_0_a_preq_warp8_kernel<<<grid_a, rows_per_block * 32u>>>(
+                        (float *)low->ptr,
+                        out_a,
+                        xq,
+                        xscale,
+                        group_dim,
+                        rank,
+                        n_groups,
+                        1,
+                        blocks_a,
+                        use_dp4a);
+                if (cuda_ok(cudaGetLastError(),
+                            "attention_output_low_q8 launch")) return 1;
+            }
+        }
+    }
     if ((group_dim & 31u) == 0u && group_dim <= 4096u && (rank % 64u) == 0u) {
         const unsigned rows_per_block = 64u;
         grouped_q8_0_a_f32_sharedx_rows_w32_2row_kernel<<<

--- a/rocm/ds4_rocm_matmul.cuh
+++ b/rocm/ds4_rocm_matmul.cuh
@@ -330,6 +330,43 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
     const char *wptr = cuda_model_range_ptr(model_map, weight_offset, weight_bytes, "q8_0");
     if (!wptr) return 0;
     if (n_tok == 1) {
+        /* Prefer the prequantized integer decode path: quantize x to Q8
+         * once, then run Q8xQ8 dot products (dp4a). The fp32 shared-input
+         * path below is kept as a fallback for shapes the integer path
+         * does not cover. ef8d923 (ROCm GLM 5.2 support) dropped this
+         * decode-only fast path, halving DeepSeek decode throughput.
+         * Quality mode keeps the fp32 path to preserve numeric precision,
+         * matching the historical q8_prequant_decode semantics. */
+        if (!g_quality_mode) {
+            const uint64_t xq_bytes = blocks * 32u;
+            const uint64_t scale_offset = (xq_bytes + 15u) & ~15ull;
+            const uint64_t tmp_bytes = scale_offset + blocks * sizeof(float);
+            void *tmp = cuda_tmp_alloc(tmp_bytes, "q8_0 prequant decode");
+            if (tmp) {
+                int8_t *xq = (int8_t *)tmp;
+                float *xscale = (float *)((char *)tmp + scale_offset);
+                dim3 qgrid((unsigned)blocks, 1, 1);
+                quantize_q8_0_f32_kernel<<<qgrid, 32>>>(
+                        xq, xscale, (const float *)x->ptr, in_dim, blocks);
+                if (cuda_ok(cudaGetLastError(), "matmul_q8_0 quantize launch")) {
+                    const uint32_t rows_per_block = g_quality_mode ? 8u : 1u;
+                    matmul_q8_0_preq_rows_w32_kernel<<<
+                            ((unsigned)out_dim + rows_per_block - 1u) / rows_per_block,
+                            rows_per_block * 32u>>>(
+                            (float *)out->ptr,
+                            reinterpret_cast<const unsigned char *>(wptr),
+                            xq,
+                            xscale,
+                            in_dim,
+                            out_dim,
+                            blocks,
+                            rows_per_block,
+                            1);
+                    if (cuda_ok(cudaGetLastError(),
+                                "matmul_q8_0 preq rows launch")) return 1;
+                }
+            }
+        }
         const bool extended_sharedx =
             in_dim > 8192u &&
             in_dim <= 16384u &&
@@ -606,6 +643,43 @@ extern "C" int ds4_gpu_matmul_q8_0_pair_tensor(
     const char *w0 = cuda_model_range_ptr(model_map, weight0_offset, weight0_bytes, "q8_0_pair0");
     const char *w1 = cuda_model_range_ptr(model_map, weight1_offset, weight1_bytes, "q8_0_pair1");
     if (!w0 || !w1) return 0;
+    /* Restore the prequantized integer decode path for paired Q8
+     * projections (matmul_q8_0_pair_preq_warp8_kernel), dropped by
+     * ef8d923 together with the other Q8 preq decode kernels.
+     * Quality mode keeps the fp32 path to preserve numeric precision. */
+    if (!g_quality_mode) {
+        const uint64_t xq_bytes = blocks * 32u;
+        const uint64_t scale_offset = (xq_bytes + 15u) & ~15ull;
+        const uint64_t tmp_bytes = scale_offset + blocks * sizeof(float);
+        void *tmp = cuda_tmp_alloc(tmp_bytes, "q8_0 pair prequant");
+        if (tmp) {
+            int8_t *xq = (int8_t *)tmp;
+            float *xscale = (float *)((char *)tmp + scale_offset);
+            const int use_dp4a = 1;
+            dim3 qgrid((unsigned)blocks, 1, 1);
+            quantize_q8_0_f32_kernel<<<qgrid, 32>>>(
+                    xq, xscale, (const float *)x->ptr, in_dim, blocks);
+            if (cuda_ok(cudaGetLastError(),
+                        "matmul_q8_0 pair quantize launch")) {
+                const uint64_t max_out = out0_dim > out1_dim ? out0_dim : out1_dim;
+                matmul_q8_0_pair_preq_warp8_kernel<<<
+                        ((unsigned)max_out + 7u) / 8u, 256>>>(
+                        (float *)out0->ptr,
+                        (float *)out1->ptr,
+                        reinterpret_cast<const unsigned char *>(w0),
+                        reinterpret_cast<const unsigned char *>(w1),
+                        xq,
+                        xscale,
+                        in_dim,
+                        out0_dim,
+                        out1_dim,
+                        blocks,
+                        use_dp4a);
+                if (cuda_ok(cudaGetLastError(),
+                            "matmul_q8_0 pair preq launch")) return 1;
+            }
+        }
+    }
     const uint64_t max_out = out0_dim > out1_dim ? out0_dim : out1_dim;
     if ((in_dim & 31u) == 0u && in_dim <= 8192u) {
         const unsigned rows_per_block = 32u;
@@ -674,6 +748,48 @@ static int cuda_matmul_q8_0_hc_expand_tensor_labeled(
     }
     const char *wptr = cuda_model_range_ptr(model_map, weight_offset, weight_bytes, label ? label : "q8_0_hc_expand");
     if (!wptr) return 0;
+    /* Restore the prequantized integer decode path for the HC expand
+     * projection (matmul_q8_0_hc_expand_preq_rows_w32_kernel), dropped
+     * by ef8d923 together with the other Q8 preq decode kernels.
+     * Quality mode keeps the fp32 path to preserve numeric precision. */
+    if (!g_quality_mode) {
+        const uint64_t xq_bytes = blocks * 32u;
+        const uint64_t scale_offset = (xq_bytes + 15u) & ~15ull;
+        const uint64_t tmp_bytes = scale_offset + blocks * sizeof(float);
+        void *tmp = cuda_tmp_alloc(tmp_bytes, "q8_0 hc expand prequant");
+        if (tmp) {
+            int8_t *xq = (int8_t *)tmp;
+            float *xscale = (float *)((char *)tmp + scale_offset);
+            const int use_dp4a = 1;
+            quantize_q8_0_f32_kernel<<<(unsigned)blocks, 32>>>(
+                    xq, xscale, (const float *)x->ptr, in_dim, blocks);
+            if (cuda_ok(cudaGetLastError(),
+                        "matmul_q8_0_hc_expand quantize launch")) {
+                const uint32_t rows_per_block = g_quality_mode ? 8u : 16u;
+                matmul_q8_0_hc_expand_preq_rows_w32_kernel<<<
+                        ((unsigned)out_dim + rows_per_block - 1u) / rows_per_block,
+                        rows_per_block * 32u>>>(
+                        (float *)out_hc->ptr,
+                        (float *)block_out->ptr,
+                        block_add ? (const float *)block_add->ptr : (const float *)block_out->ptr,
+                        (const float *)residual_hc->ptr,
+                        (const float *)split->ptr,
+                        reinterpret_cast<const unsigned char *>(wptr),
+                        xq,
+                        xscale,
+                        in_dim,
+                        out_dim,
+                        n_embd,
+                        n_hc,
+                        blocks,
+                        rows_per_block,
+                        block_add ? 1 : 0,
+                        use_dp4a);
+                if (cuda_ok(cudaGetLastError(),
+                            "matmul_q8_0_hc_expand rows launch")) return 1;
+            }
+        }
+    }
     if ((in_dim & 31u) == 0u && in_dim <= 8192u) {
         const unsigned rows_per_block = 32u;
         const unsigned threads = rows_per_block * 32u;


### PR DESCRIPTION
## Summary

Restore the ROCm Q8 prequantized decode kernels that were dropped by `ef8d923` ("Add ROCm GLM 5.2 support"). On DeepSeek-V4-Flash IQ2XXS this regression halves decode throughput: **~15 t/s → 8.4 t/s** on Strix Halo (gfx1151, ROCm 7.14). All four restored kernels already exist in `rocm/ds4_rocm_q8.cuh`; this PR only reconnects their call sites (2 files, +155 lines, pure additions).

## Root cause

`ef8d923` refactored the ROCm matmul/attention code and removed the prequantized integer (Q8xQ8 + dp4a) single-token decode paths, leaving only fp32 dequant matmuls:

```c
// old (15 t/s):
quantize_q8_0_f32_kernel<<<...>>>(xq, xscale, x, ...);       // quantize activation once
matmul_q8_0_preq_rows_w32_kernel<<<...>>>(out, w, xq, xscale, ..., use_dp4a);  // int dp4a dot

// new after ef8d923 (8.4 t/s):
matmul_q8_0_f32_sharedx_warp_rows_w32_kernel<<<...>>>(out, w, (float*)x->ptr, ...);  // fp32 dequant
```

Q8_0 weights cover the every-token decode path of DeepSeek (attention projections, shared experts, output projection — AProjQ8/SExpQ8/OutQ8 in the IQ2XXS layout), while prefill (n_tok>1, batch kernels) is unaffected — matching the observed profile: prefill ~150 t/s unchanged, decode halved.

**Bisect evidence** (same machine, same ROCm 7.14, same model file, only code version changed; `ds4-bench --ctx-start 2048 --ctx-max 2048 --gen-tokens 64-128`):

| commit | date | decode t/s |
|---|---|---|
| 80ebbc3 (baseline) | 6/17 | 14.97 |
| 519c4d8 (#51) | 7/12 | 15.08 |
| **ef8d923 ("Add ROCm GLM 5.2 support")** | **7/18** | **8.43 ← regression** |
| 646db66 (#39) | 7/20 | 8.42 |
| fa8b0b9 (#26) | 7/22 | 8.43 |
| 54b36ed (main) | 7/28 | 8.44 |

(Commits #45–#50 in between fail to compile on the ROCm path — no CI coverage for ROCm — and were skipped per bisect rules; ef8d923 is the first compilable bad commit.)

## Changes

Restored four preq decode call sites, all guarded by `!g_quality_mode` to preserve the historical `q8_prequant_decode = !g_quality_mode` semantics (quality mode keeps the fp32 path for numeric precision):

1. `cuda_matmul_q8_0_tensor_labeled` — `matmul_q8_0_preq_rows_w32_kernel` (rows_per_block: quality 8 / normal 1, matching old `q8_decode_rpb`)
2. `ds4_gpu_matmul_q8_0_pair_tensor` — `matmul_q8_0_pair_preq_warp8_kernel`
3. `cuda_matmul_q8_0_hc_expand_tensor_labeled` — `matmul_q8_0_hc_expand_preq_rows_w32_kernel` (rows_per_block: quality 8 / normal 16, matching old `q8_hc_decode_rpb`)
4. `ds4_gpu_attention_output_low_q8_tensor` — `grouped_q8_0_a_preq_warp8_kernel` (rows_per_block: quality 8 / normal 32, matching old `attn_out_low_decode_rpb`)

Each preq block keeps the existing fp32 path as fallback (tmp alloc or launch failure → falls through to fp32; strictly more robust than the old hard-fail behavior). Prefill/batch paths and GLM paths are untouched.

## Verification

Benchmark: DeepSeek-V4-Flash IQ2XXS (`...-imatrix-0731.gguf`, 80.8GB), ROCm 7.14, gfx1151, ctx=2048, 128 gen tokens, full residency:

| state | decode t/s |
|---|---|
| main (before) | 8.44 |
| + matmul preq | 9.42 |
| + attention preq | 10.78 |
| **+ pair + hc_expand preq (this PR)** | **15.03** |
| old baseline (80ebbc3) | 14.97 |

Real chat smoke test: `ds4 --rocm -m <model> -p "..." -n 32` → **16.63 t/s**, first-token latency 120 ms → 68 ms, output correct, no errors.

Other: `make rocm -j32` clean; `ds4-eval --self-test-extractors` passes. Note: the full `make test` suite requires CUDA tooling (`$(NVCC)`, Makefile:247) and cannot run on a ROCm-only host — pre-existing environment limitation, unrelated to this change.

## Notes for reviewers

- The four kernels themselves are untouched upstream code (`rocm/ds4_rocm_q8.cuh`); only call sites are restored.
- Launch parameters (use_dp4a=1, grid/block shape, 16-byte-aligned tmp layout) match the pre-ef8d923 code.
- Optionally consider re-introducing `q8_decode_rpb` / `attn_out_low_decode_rpb` / `q8_hc_decode_rpb` as runtime config (this PR uses equivalent hardcoded defaults) and adding a ROCm compile check to CI — six commits between 7/12 and 7/18 currently fail to compile on the ROCm path.
