### PR TITLE
Fix spec prefix capture on compressor-less Flash layers

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -19550,6 +19550,9 @@ static bool metal_graph_capture_prefix_attn_state(
         uint32_t       il,
         uint32_t       slot) {
     if (!g->spec_capture_prefixes) return true;
+    /* Leading layers without an attention compressor (ratio 0) carry no
+     * frontier; mirror spec_frontier_snapshot/commit which skip them. */
+    if (ds4_layer_compress_ratio(il) == 0) return true;
     if (slot >= DS4_SPEC_PREFIX_SLOTS ||
         !g->spec_prefix1_attn_state_kv[il] ||
         !g->spec_prefix1_attn_state_score[il]) {
@@ -19569,6 +19572,9 @@ static bool metal_graph_capture_prefix_index_state(
         uint32_t       il,
         uint32_t       slot) {
     if (!g->spec_capture_prefixes) return true;
+    /* Index-compressor frontiers exist only on ratio-4 layers;
+     * mirror spec_frontier_snapshot/commit which skip the rest. */
+    if (ds4_layer_compress_ratio(il) != 4) return true;
     if (slot >= DS4_SPEC_PREFIX_SLOTS ||
         !g->spec_prefix1_index_state_kv[il] ||
         !g->spec_prefix1_index_state_score[il]) {


### PR DESCRIPTION
`metal_graph_capture_prefix_attn_state()` and `metal_graph_capture_prefix_index_state()` return `false` when the layer's `spec_prefix1_*` buffers are NULL.

Those buffers are allocated only for layers that have a compressor: attention state under `ratio != 0`, index state under `ratio == 4` (ds4.c:17059-17139). For the Flash variant, `ds4_expected_layer_compress_ratio()` returns 0 for layers 0 and 1:

```c
case DS4_VARIANT_FLASH:
    if (il < 2) return 0;
```

So on any Flash model the buffers for layer 0 are NULL, and the strict decode2 verifier — which sets `spec_capture_prefixes` and loops every layer with no ratio gating (ds4.c:34495, :34530) — fails at `il=0` and breaks out. The verifier can't run on Flash at all, independently of SSD streaming.

`spec_frontier_snapshot()`, `spec_frontier_restore()` and `spec_frontier_commit_prefix()` already skip these layers with `if (ratio == 0) continue` and gate index work on `if (ratio == 4)`. The two capture functions are the only ones in that path that don't. This mirrors them.

Returning `true` for a skipped layer is safe because the write-gate and the read-gate are the same: the only reader of the prefix1 buffers and `spec_prefix_n_comp` is `spec_frontier_commit_prefix()`, and each of its reads is already behind the matching predicate (:49754, :49763). The rollback path, `spec_frontier_restore()`, reads the main frontier buffers rather than the prefix1 ones. No consumer can observe uninitialised state for the layers now skipped.

Six lines, two functions. Builds clean under `-Wall -Wextra`.

Found while testing MTP on DeepSeek-V4-Flash; the bug is independent of that work.
