### PR TITLE
Fix DSpark greedy-identity break: replay accepted tokens via single-token decode

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -61017,57 +61017,28 @@ static int ds4_session_eval_dspark_speculative_argmax(
         }
     }
 
-    bool final_logits_ok = false;
-    if (ok && commit_drafts == draft_n) {
-        const double read_t0 = stats_enabled ? now_sec() : 0.0;
-        final_logits_ok =
-            metal_graph_read_spec_logits_row(&s->graph,
-                                             (uint32_t)(draft_n - 1),
-                                             row_logits);
-        if (stats_enabled) {
-            s->dspark_stats.verify_read_ms += (now_sec() - read_t0) * 1000.0;
-        }
-    }
-
-    if (ok && commit_drafts == draft_n && final_logits_ok) {
-        if (tp_verify_sent &&
-            !ds4_tp_send_verify_commit(e->tp.ctx, 1, 0)) {
-            snprintf(err, errlen, "tp: verify commit send failed");
-            s->checkpoint_valid = false;
-            spec_frontier_free(&frontier);
-            DS4_DSPARK_STATS_FINISH();
-            return -1;
-        }
-        memcpy(s->logits, row_logits, (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
-        int emitted_drafts = 0;
-        for (int i = 0; i < draft_n && n_accept < accepted_cap; i++) {
-            accepted[n_accept++] = drafts[i];
-            emitted_drafts++;
-            if (drafts[i] == eos_token) break;
-        }
-        s->checkpoint_valid = true;
-        ds4_session_dspark_capture_note_checkpoint(s);
-        if (stats_enabled) {
-            s->dspark_stats.full_accepts++;
-            s->dspark_stats.accepted_draft_tokens += (uint64_t)emitted_drafts;
-            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist,
-                                      (uint32_t)emitted_drafts);
-        }
-        ds4_session_dspark_scheduler_note(
-                s,
-                (uint32_t)emitted_drafts,
-                false,
-                DS4_DSPARK_SCHED_EXTRA_MS());
-        if (spec_log) {
-            fprintf(stderr,
-                    "ds4: DSpark spec accept drafted=%d accepted=%d\n",
-                    draft_n,
-                    n_accept);
-        }
-        spec_frontier_free(&frontier);
-        DS4_DSPARK_STATS_FINISH();
-        return n_accept;
-    }
+    /* Greedy-identity fix: the verify batch's compressor-frontier writes
+     * come from a batched multi-token GEMM (ds4_gpu_matmul_f16_pair_tensor),
+     * which is numerically distinct from ordinary single-token decode's
+     * fused projection+store kernel
+     * (ds4_gpu_matmul_f16_pair_compressor_store_tensor). Previously, a full
+     * accept (commit_drafts == draft_n) took a fast path that committed the
+     * batch-verify's KV/compressor-frontier state directly, so accepted
+     * tokens' state silently diverged from what plain decode would have
+     * produced -- this eventually flips an argmax tie on longer
+     * generations, breaking --temp 0 greedy-identity vs. no-drafter decode.
+     * There is no separate fast-accept branch any more: every accept (full
+     * or partial) falls through to the rollback+replay path below, which
+     * re-derives each accepted token's KV/compressor state one token at a
+     * time through the same single-token decode kernel
+     * (metal_graph_eval_token_raw_swa) plain greedy decode uses, so the
+     * post-accept state -- and the logits read off it -- are bit-identical
+     * to pure decode for the same tokens. This costs one extra fused
+     * single-token kernel launch (plus its surrounding forward pass) per
+     * accepted token per block; on a net-loss drafter workload this makes
+     * DSpark's already-negative throughput case worse, but correctness
+     * comes first. When there is no drafter, draft_n is never reached (the
+     * caller returns earlier), so this path has zero effect. */
 
     if (verifier_may_have_mutated) {
         s->checkpoint.len = start;


### PR DESCRIPTION
## Summary

Fixes #658: DSpark speculative decode did not preserve byte-identical greedy
(`--temp 0`) output vs. non-speculative decode on longer generations.

## Root cause (see linked issue for full detail)

`ds4_session_eval_dspark_speculative_argmax`'s accept-commit logic had a fast
path for full accepts (`commit_drafts == draft_n`) that committed the verify
batch's own batched-GEMM-derived compressor-frontier KV state
(`ds4_gpu_matmul_f16_pair_tensor`) directly. That state is numerically
distinct (standard FP16/BF16 GEMM non-associativity) from what ordinary
single-token decode's fused kernel
(`ds4_gpu_matmul_f16_pair_compressor_store_tensor`) would have produced for
the same token, so it silently drifted from a pure-decode trajectory until it
eventually flipped an argmax tie on longer generations.

The partial-accept path already had the correct mechanism: roll the
KV/compressor-frontier state back to the pre-verify snapshot, then re-decode
each accepted token one at a time through the same single-token kernel plain
decode uses (`metal_graph_eval_token_raw_swa`). It just wasn't used for full
accepts.

## Fix

Minimal diff: removes the full-accept fast path entirely. Every accept (full
or partial) now falls through to the existing rollback+replay path
unconditionally, so post-accept KV state and logits are always re-derived
through the same code path plain greedy decode uses -- bit-identical by
construction, not by numerical luck.

No new code, no new flags, no dialect/quantization changes. Zero effect when
no drafter is configured (`draft_n` is never reached in that case).

```
 ds4.c | 22 +++++++++++++---------  (1 file changed, 22 insertions(+), 51 deletions(-))
```

## Identity-test evidence

Resident IQ2XXS quant of DeepSeek-V4-Flash + a DSpark support GGUF (`--mtp
<support.gguf> --dspark`), `--cuda --temp 0`, drafter-enabled vs no-drafter,
byte-for-byte `diff`, built from this branch (based on current `main`):

| prompt | tokens | result |
|---|---|---|
| "Explain the TCP three-way handshake." | 400 | byte-identical |
| "Write a detailed explanation of how the TCP three-way handshake..." (longer prose prompt) | 800 | byte-identical |

Both prompts were confirmed to diverge on unpatched `main` before this fix
(the second one is the original reproducer from the linked issue, extended
past its divergence point here). No divergence observed post-fix in either
case.

## Overhead (stated plainly)

This fix makes every accepted token -- including full accepts, which
previously skipped the replay -- pay for one extra fused single-token
forward pass. On our hardware/pairing (NVIDIA GB10, resident IQ2XXS +
this drafter), that increases drafter-enabled generation slowdown vs.
no-drafter from about -5% to roughly -14% to -17% across a few prompts
(single runs, not a full statistical sweep). This is the honest cost of
correctness here: the alternative (a narrower fix that re-derives only the
compressor-frontier projection instead of the full forward pass) is possible
in principle but a larger, riskier change, and wasn't attempted in this PR --
happy to discuss as a follow-up if there's interest.

## Testing

`make cuda-spark`: clean rebuild, zero warnings, on this branch (based on
current `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
