### PR TITLE
server: route unterminated reasoning to reasoning_content, not content

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -4780,6 +4780,30 @@ static void split_reasoning_content(const char *text, size_t n, char **content_o
     free(s);
 }
 
+/* LOCAL PATCH (not upstream): unterminated reasoning is not an answer.
+ *
+ * When generation hits the token cap before </think> arrives, the old behaviour
+ * routed the whole unterminated buffer into content, so a truncated reasoning
+ * chain reached clients looking exactly like a finished reply.  split_reasoning_
+ * content() cannot tell that case apart from a legitimate non-thinking answer
+ * (neither carries a </think>, and the buffer does not retain the opening tag),
+ * so the discrimination has to happen here, where require_thinking_closed
+ * already tells us thinking was expected.
+ *
+ * Routing the buffer to reasoning_content and emptying content makes truncation
+ * self-describing on the wire for every consumer, not just ones that check
+ * finish_reason.  content is set to "" rather than NULL deliberately: the JSON
+ * writer guards NULL, but not every path in this file has been audited for it,
+ * and an empty answer is already unmistakably not an answer. */
+static void ds4_local_unterminated_reasoning(const char *text,
+                                             char **content_out,
+                                             char **reasoning_out) {
+    const char *body = text ? text : "";
+    if (!strncmp(body, "<think>", 7)) body += 7;
+    *reasoning_out = xstrdup(body);
+    *content_out = xstrdup("");
+}
+
 static bool parse_deepseek_generated_message_ex(const char *text,
                                                 bool require_thinking_closed,
                                                 char **content_out,
@@ -4800,7 +4824,7 @@ static bool parse_deepseek_generated_message_ex(const char *text,
         if (!think_end) {
             /* Model did not close thinking, ignore any DSML in reasoning */
             fprintf(stderr, "ds4-server: thinking not closed, ignoring DSML in reasoning\n");
-            split_reasoning_content(text, strlen(text), content_out, reasoning_out);
+            ds4_local_unterminated_reasoning(text, content_out, reasoning_out);
             return true;
         }
         tool_search = think_end + 8;
@@ -4985,7 +5009,7 @@ static bool parse_glm_generated_message_ex(const char *text,
         const char *think_end = find_last_substr(text, "</think>");
         if (!think_end) {
             fprintf(stderr, "ds4-server: thinking not closed, ignoring GLM tool calls in reasoning\n");
-            split_reasoning_content(text, strlen(text), content_out, reasoning_out);
+            ds4_local_unterminated_reasoning(text, content_out, reasoning_out);
             return true;
         }
         tool_search = think_end + 8;


### PR DESCRIPTION
## Problem

When generation hits the token cap before `</think>` arrives, the unterminated reasoning buffer is emitted as `content`. A truncated chain-of-thought therefore reaches clients looking exactly like a finished answer.

The server already detects the condition and logs it:

```
ds4-server: thinking not closed, ignoring DSML in reasoning
```

…but the message it then builds is indistinguishable from a normal reply. Observed on `DeepSeek-V4-Flash-0731`:

| response | `finish_reason` | `content` | `reasoning_content` |
|---|---|---|---|
| completed | `stop` | 2,491 B (the answer) | 27,631 B |
| **truncated** | `length` | **40,786 B of raw reasoning** | **0 B** |

Any client that does not inspect `finish_reason` will treat 40 KB of abandoned deliberation as the assistant's answer. That matters most for agent loops, where a delegate may consume the result without a human ever seeing it.

## Why not fix `split_reasoning_content()`

It cannot make the distinction on its own. An unterminated reasoning buffer and a legitimate non-thinking answer both lack `</think>`, and the stored text does not retain the opening `<think>` either — so there is no discriminator in the text. It also has other call sites where the current behaviour is correct; changing it there would route ordinary non-thinking answers into `reasoning_content`.

The information exists only at the call sites that already know thinking was expected, via `require_thinking_closed`. That is where this patch acts.

## Change

A small helper, used at the two `require_thinking_closed && !think_end` sites — one in `parse_deepseek_generated_message_ex`, one in `parse_glm_generated_message_ex`, so the two parsers stay symmetric:

```c
static void ds4_local_unterminated_reasoning(const char *text,
                                             char **content_out,
                                             char **reasoning_out) {
    const char *body = text ? text : "";
    if (!strncmp(body, "<think>", 7)) body += 7;
    *reasoning_out = xstrdup(body);
    *content_out = xstrdup("");
}
```

Truncation becomes self-describing on the wire for every consumer, rather than only for those that check `finish_reason`.

### On `""` vs `NULL`

`content` is set to `""` rather than `NULL` deliberately. `json_escape()` dereferences its argument without a NULL check; the response writer guards with `text ? text : ""`, but I did not audit every consumer. An empty answer is already unmistakably not an answer, and `finish_reason` plus a populated `reasoning_content` carry the rest of the signal. Happy to switch to a literal JSON `null` if you would prefer that — it is one further line in the response writer.

The helper name carries a `ds4_local_` prefix because it began as a local patch; rename as you see fit.

## Verification

Apple M4 Max, Metal, `DeepSeek-V4-Flash-0731` q2-q4-imatrix:

| case | `finish` | `content` | `reasoning_content` |
|---|---|---|---|
| truncated thinking | `length` | `""` | 333 B |
| completed thinking | `stop` | `"12 x 12 = 144."` | 186 B |
| non-thinking | `stop` | `"12 x 12 = 144."` | `""` |

The latter two are unchanged from before the patch — including the non-thinking case, which is the one that would break if `split_reasoning_content()` were changed directly.

`ds4_test` (which `#include`s `ds4_server.c`, so it compiles the change) reports an **identical set of assertion failures with and without this patch** on my machine — a `diff` of the sorted failure lists is empty. Those failures appear to be pre-existing in my environment rather than related to this change. `test_q4k_dot` (4/4), `ds4_agent_test`, and `ds4-eval --self-test-extractors` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
