### PR TITLE
fix(cuda): include <float.h> for FLT_MAX (build fails on CUDA 12.8 / Blackwell)

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <limits.h>
+#include <float.h>
 #include <math.h>
 #include <fcntl.h>
 #include <stdio.h>


### PR DESCRIPTION
## Problem

Building the CUDA backend with a recent nvcc (tested: **CUDA 12.8**, `nvidia/cuda:12.8.0-devel-ubuntu24.04`, RTX 5090 / `sm_120`) fails:

```
ds4_cuda.cu(23467): error: identifier "FLT_MAX" is undefined
ds4_cuda.cu(23821): error: identifier "FLT_MAX" is undefined
ds4_cuda.cu(24024): error: identifier "FLT_MAX" is undefined
```

`ds4_cuda.cu` uses `FLT_MAX` but only includes `<math.h>` and `<limits.h>`. `FLT_MAX` lives in `<float.h>`, which older CUDA toolchains happened to pull in transitively but 12.8 does not.

## Fix

Add the explicit `#include <float.h>`. One line, no behavior change; still builds on toolchains that had it transitively.

## Repro

```
docker run --rm --gpus all -v $PWD:/ds4 nvidia/cuda:12.8.0-devel-ubuntu24.04 \
  bash -c "apt-get update && apt-get install -y build-essential && cd /ds4 && make cuda CUDA_ARCH=sm_120"
```

Fails before this change, builds clean after (all of `ds4`/`ds4-server`/`ds4-bench`/`ds4-eval`/`ds4-agent`).

---

Minor related note for anyone building in a **GPU-less** environment (CI, `docker build`): `make cuda-generic` sets `CUDA_ARCH=native`, which needs a GPU present to detect — off-GPU it falls back to a default arch and later fails on `__dp4a` etc. Use `make cuda CUDA_ARCH=sm_120` (explicit) there. Happy to send a small containerized-build Dockerfile as a follow-up if useful.

Thanks for ds4 — the SSD-streaming expert cache is excellent work.