### PR TITLE
Think managed kv

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,14 @@ GLM 5.2 on ROCm. In this mode the non-routed model weights stay resident, while
 routed MoE experts are kept in an in-memory cache and loaded from the GGUF file
 on cache misses.
 
+### CUDA long-context KV override
+
+CUDA automatically uses managed memory for very large KV allocations. On a
+single GPU where model weights fit in VRAM but a long-context KV cache prevents
+session creation, `DS4_CUDA_FORCE_MANAGED_KV=1` forces only the KV allocation
+into CUDA managed memory. This is useful for long-context experiments and may
+reduce decode throughput when the KV pages are not resident.
+
 Streaming is not as fast as fitting the full model in RAM. It still needs memory
 for non-routed weights, KV cache, graph scratch, activations, and the routed
 expert cache. It is useful because routed experts dominate model size and modern

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -2494,7 +2494,7 @@ extern "C" int ds4_gpu_should_use_managed_kv_cache(uint64_t kv_cache_bytes, uint
      * long-lived KV allocation to fault through host memory. Keep this opt-in
      * so ordinary CUDA sessions retain device-only KV performance. */
     const char *force_managed = getenv("DS4_CUDA_FORCE_MANAGED_KV");
-    if (force_managed && force_managed[0] && strcmp(force_managed, "0") != 0) {
+    if (force_managed && strcmp(force_managed, "1") == 0) {
         return 1;
     }
 

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -2493,7 +2493,10 @@ extern "C" int ds4_gpu_should_use_managed_kv_cache(uint64_t kv_cache_bytes, uint
     /* Long-context runs can fit model weights in VRAM but still need the
      * long-lived KV allocation to fault through host memory. Keep this opt-in
      * so ordinary CUDA sessions retain device-only KV performance. */
-    if (getenv("DS4_CUDA_FORCE_MANAGED_KV") != NULL) return 1;
+    const char *force_managed = getenv("DS4_CUDA_FORCE_MANAGED_KV");
+    if (force_managed && force_managed[0] && strcmp(force_managed, "0") != 0) {
+        return 1;
+    }
 
     /* Very large KV caches are where device-only cudaMalloc() can make a
      * unified-memory machine unresponsive.  Managed memory restores the old

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <errno.h>
+#include <float.h>
 #include <limits.h>
 #include <math.h>
 #include <fcntl.h>
@@ -2488,6 +2489,11 @@ static uint64_t cuda_managed_kv_reserve_bytes(uint64_t total_bytes) {
 
 extern "C" int ds4_gpu_should_use_managed_kv_cache(uint64_t kv_cache_bytes, uint64_t context_bytes) {
     if (kv_cache_bytes == 0) return 0;
+
+    /* Long-context runs can fit model weights in VRAM but still need the
+     * long-lived KV allocation to fault through host memory. Keep this opt-in
+     * so ordinary CUDA sessions retain device-only KV performance. */
+    if (getenv("DS4_CUDA_FORCE_MANAGED_KV") != NULL) return 1;
 
     /* Very large KV caches are where device-only cudaMalloc() can make a
      * unified-memory machine unresponsive.  Managed memory restores the old

--- a/tests/cuda_long_context_smoke.c
+++ b/tests/cuda_long_context_smoke.c
@@ -19,6 +19,22 @@ static double getenv_seconds(const char *name, double fallback) {
     return end != s && v > 0.0 ? v : fallback;
 }
 
+static int check_managed_kv_override(void) {
+    const uint64_t small = 1ull * 1024ull * 1024ull * 1024ull;
+    unsetenv("DS4_CUDA_FORCE_MANAGED_KV");
+    if (ds4_gpu_should_use_managed_kv_cache(small, small) != 0) return 1;
+    if (setenv("DS4_CUDA_FORCE_MANAGED_KV", "1", 1) != 0 ||
+        ds4_gpu_should_use_managed_kv_cache(small, small) != 1) {
+        return 1;
+    }
+    if (setenv("DS4_CUDA_FORCE_MANAGED_KV", "0", 1) != 0 ||
+        ds4_gpu_should_use_managed_kv_cache(small, small) != 0) {
+        return 1;
+    }
+    unsetenv("DS4_CUDA_FORCE_MANAGED_KV");
+    return 0;
+}
+
 static int check_large_topk(void) {
     const uint32_t n_comp = 32768;
     const uint32_t n_tokens = 32;
@@ -158,7 +174,8 @@ static int check_decode_attention_overflow_path(void) {
 
 int main(void) {
     if (!ds4_gpu_init()) return 1;
-    int rc = check_large_topk();
+    int rc = check_managed_kv_override();
+    if (check_large_topk() != 0) rc = 1;
     if (check_decode_attention_overflow_path() != 0) rc = 1;
     ds4_gpu_cleanup();
     if (rc == 0) puts("cuda long-context regression: OK");

--- a/tests/cuda_long_context_smoke.c
+++ b/tests/cuda_long_context_smoke.c
@@ -31,6 +31,10 @@ static int check_managed_kv_override(void) {
         ds4_gpu_should_use_managed_kv_cache(small, small) != 0) {
         return 1;
     }
+    if (setenv("DS4_CUDA_FORCE_MANAGED_KV", "true", 1) != 0 ||
+        ds4_gpu_should_use_managed_kv_cache(small, small) != 0) {
+        return 1;
+    }
     unsetenv("DS4_CUDA_FORCE_MANAGED_KV");
     return 0;
 }


### PR DESCRIPTION
# Allow managed KV override for CUDA

## Summary

Add the documented `DS4_CUDA_FORCE_MANAGED_KV=1` opt-in for CUDA. It forces
only the long-lived KV allocation into CUDA managed memory, while model and
optional DSpark support weights remain resident in VRAM.

This makes it possible to run long-context experiments where the weights fit
in VRAM but the KV allocation would otherwise prevent session creation.

The change also includes `<float.h>` so the CUDA backend has the standard
`FLT_MAX` definition it already uses.

## Scope

- Opt-in only: ordinary CUDA sessions continue to use device-only KV.
- Only the exact value `DS4_CUDA_FORCE_MANAGED_KV=1` enables the override.
- Does not change Metal, ROCm, SSD streaming, tensor parallelism, or model
  loading behavior.
- Intended for long-context CUDA experiments such as Think Max with DSpark.

## Testing

Builds completed on an NVIDIA RTX PRO 6000 Blackwell (`sm_120`):

- `make cpu`
- `make cuda CUDA_ARCH=sm_120`
- `make cuda-regression CUDA_ARCH=sm_120`
- `git diff --check`

Runtime validation used DeepSeek V4 Flash IQ2 imatrix (80.76 GiB) plus the
DSpark support GGUF (5.58 GiB) at `ctx=393216`:

```sh
DS4_CUDA_Q8_F16_CACHE_MB=0 \
DS4_CUDA_FORCE_MANAGED_KV=1 \
./ds4 --cuda -m ./ds4flash.gguf \
  --mtp ./gguf/DeepSeek-V4-Flash-DSpark-support.gguf \
  --dspark --think-max --ctx 393216 --prefill-chunk 256 \
  --tokens 32 --temp 0 -p "..."
```

The run loaded the main model and DSpark support resident in VRAM, placed the
5.08 GiB KV allocation in managed memory, and completed at 415.66 prefill t/s
and 59.46 generation t/s in the CLI benchmark. A warm server request completed
64 tokens in 1.2667 seconds (about 50.5 end-to-end tokens/s).

The DSpark acceptance fixture was also run with the existing local GGUFs and a
256-token prefill chunk so the resident main and support models fit on the 96 GB
GPU. Managed-KV and device-KV runs produced matching target/DSpark output and
the same proposal statistics. Four cases accepted every proposed draft; the
existing `c_add` proposal-quality guard failed in both modes because confidence
0.9 produced no draft for that case. This is therefore not caused by the
managed-KV override.

The stock `dspark-verify-depth` fixture uses a fixed 4096-token prefill buffer
and cannot create its sessions with both resident GGUFs on this 96 GB GPU.

## Notes

This is an explicit capacity override. Managed memory can reduce throughput if
the KV pages are not resident, so it is not enabled automatically.