### PR TITLE
DSpark: add byte-exact Metal verifier for lossless batching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,15 @@ tests/test_mxfp4_metal: tests/test_mxfp4_metal.o ds4_metal.o
 test-mxfp4-metal: tests/test_mxfp4_metal
 	./tests/test_mxfp4_metal
 
+tests/test_routed_exact_batch_metal.o: tests/test_routed_exact_batch_metal.c ds4_gpu.h
+	$(CC) $(CFLAGS) -I. -c -o $@ tests/test_routed_exact_batch_metal.c
+
+tests/test_routed_exact_batch_metal: tests/test_routed_exact_batch_metal.o ds4_metal.o
+	$(CC) $(CFLAGS) -o $@ $^ $(METAL_LDLIBS)
+
+test-routed-exact-batch-metal: tests/test_routed_exact_batch_metal
+	./tests/test_routed_exact_batch_metal
+
 cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_eval_cpu.o ds4_agent_cpu.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS)
 	$(CC) $(CFLAGS) -o ds4 ds4_cli_cpu.o ds4_help.o linenoise.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-server ds4_server_cpu.o ds4_help.o ds4_kvstore.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
@@ -461,4 +470,4 @@ mxfp4-dot-test: tests/test_mxfp4_dot.c
 	./tests/test_mxfp4_dot
 
 clean:
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_routed_exact_batch_metal tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o

--- a/ds4.c
+++ b/ds4.c
@@ -29384,6 +29384,7 @@ static bool metal_graph_encode_layer_ffn_batch(
                                                metal_graph_batch_ffn_norm(g),
                                                il,
                                                n_tokens,
+                                               false,
                                                &g->batch_routed_mid_is_f16,
                                                false) != 0;
     }
@@ -34805,6 +34806,663 @@ static bool metal_graph_verify_decode2_exact(
         ds4_gpu_tensor_free(next0_by_tier[t]);
         ds4_gpu_tensor_free(cur1_by_tier[t]);
         ds4_gpu_tensor_free(cur0_by_tier[t]);
+    }
+    return ok;
+}
+
+typedef struct {
+    int tier;
+    uint32_t row;
+    bool prepared;
+    bool active;
+    ds4_gpu_tensor *hc_split;
+    ds4_gpu_tensor *hc_pre;
+    ds4_gpu_tensor *hc_post;
+    ds4_gpu_tensor *hc_comb;
+    ds4_gpu_tensor *after_attn_hc;
+    ds4_gpu_tensor *ffn_norm;
+    ds4_gpu_tensor *routed_out;
+    ds4_gpu_tensor *router_selected;
+    ds4_gpu_tensor *router_weights;
+    ds4_gpu_tensor *saved_hc_split;
+    ds4_gpu_tensor *saved_hc_pre;
+    ds4_gpu_tensor *saved_hc_post;
+    ds4_gpu_tensor *saved_hc_comb;
+    ds4_gpu_tensor *saved_after_attn_hc;
+    ds4_gpu_tensor *saved_ffn_norm;
+    ds4_gpu_tensor *saved_routed_out;
+    ds4_gpu_tensor *saved_router_selected;
+    ds4_gpu_tensor *saved_router_weights;
+} metal_graph_exact_routed_row_alias;
+
+/* Keep every row's FFN state in the existing batch workspace while the
+ * ordinary decode tail is split around routed MoE.  These are backend-owned
+ * views (not stack wrappers), because Metal tensors are Objective-C objects. */
+static bool metal_graph_bind_exact_routed_row(
+        ds4_gpu_graph                         *g,
+        uint32_t                               row,
+        uint64_t                               hc_dim,
+        uint64_t                               mix_hc,
+        metal_graph_exact_routed_row_alias    *alias) {
+    if (!g || !alias || g->active_tier < 0 ||
+        g->active_tier >= DS4_MAX_GPUS) {
+        return false;
+    }
+    if (!alias->prepared) {
+        memset(alias, 0, sizeof(*alias));
+        alias->tier = g->active_tier;
+        alias->row = row;
+        alias->hc_split = metal_graph_tensor_row_view(
+                metal_graph_batch_hc_split(g), row, mix_hc);
+        alias->hc_pre = alias->hc_split ?
+            ds4_gpu_tensor_view(alias->hc_split,
+                                0,
+                                (uint64_t)DS4_N_HC * sizeof(float)) : NULL;
+        alias->hc_post = alias->hc_split ?
+            ds4_gpu_tensor_view(alias->hc_split,
+                                (uint64_t)DS4_N_HC * sizeof(float),
+                                (uint64_t)DS4_N_HC * sizeof(float)) : NULL;
+        alias->hc_comb = alias->hc_split ?
+            ds4_gpu_tensor_view(alias->hc_split,
+                                2ull * DS4_N_HC * sizeof(float),
+                                (uint64_t)DS4_N_HC * DS4_N_HC *
+                                    sizeof(float)) : NULL;
+        alias->after_attn_hc = metal_graph_tensor_row_view(
+                metal_graph_batch_after_attn_hc(g), row, hc_dim);
+        alias->ffn_norm = metal_graph_tensor_row_view(
+                metal_graph_batch_ffn_norm(g), row, DS4_N_EMBD);
+        alias->routed_out = metal_graph_tensor_row_view(
+                metal_graph_batch_routed_out(g), row, DS4_N_EMBD);
+        alias->router_selected = metal_graph_tensor_row_view(
+                metal_graph_batch_router_selected(g),
+                row,
+                DS4_N_EXPERT_USED);
+        alias->router_weights = metal_graph_tensor_row_view(
+                metal_graph_batch_router_weights(g),
+                row,
+                DS4_N_EXPERT_USED);
+        if (!alias->hc_split || !alias->hc_pre || !alias->hc_post ||
+            !alias->hc_comb || !alias->after_attn_hc ||
+            !alias->ffn_norm || !alias->routed_out ||
+            !alias->router_selected || !alias->router_weights) {
+            ds4_gpu_tensor_free(alias->router_weights);
+            ds4_gpu_tensor_free(alias->router_selected);
+            ds4_gpu_tensor_free(alias->routed_out);
+            ds4_gpu_tensor_free(alias->ffn_norm);
+            ds4_gpu_tensor_free(alias->after_attn_hc);
+            ds4_gpu_tensor_free(alias->hc_comb);
+            ds4_gpu_tensor_free(alias->hc_post);
+            ds4_gpu_tensor_free(alias->hc_pre);
+            ds4_gpu_tensor_free(alias->hc_split);
+            memset(alias, 0, sizeof(*alias));
+            return false;
+        }
+        alias->prepared = true;
+    } else if (alias->active || alias->tier != g->active_tier ||
+               alias->row != row) {
+        return false;
+    }
+
+    const int tier = alias->tier;
+    alias->saved_hc_split = g->hc_split_by_tier[tier];
+    alias->saved_hc_pre = g->hc_pre_by_tier[tier];
+    alias->saved_hc_post = g->hc_post_by_tier[tier];
+    alias->saved_hc_comb = g->hc_comb_by_tier[tier];
+    alias->saved_after_attn_hc = g->after_attn_hc_by_tier[tier];
+    alias->saved_ffn_norm = g->ffn_norm_by_tier[tier];
+    alias->saved_routed_out = g->routed_out_by_tier[tier];
+    alias->saved_router_selected = g->router_selected_by_tier[tier];
+    alias->saved_router_weights = g->router_weights_by_tier[tier];
+    g->hc_split_by_tier[tier] = alias->hc_split;
+    g->hc_pre_by_tier[tier] = alias->hc_pre;
+    g->hc_post_by_tier[tier] = alias->hc_post;
+    g->hc_comb_by_tier[tier] = alias->hc_comb;
+    g->after_attn_hc_by_tier[tier] = alias->after_attn_hc;
+    g->ffn_norm_by_tier[tier] = alias->ffn_norm;
+    g->routed_out_by_tier[tier] = alias->routed_out;
+    g->router_selected_by_tier[tier] = alias->router_selected;
+    g->router_weights_by_tier[tier] = alias->router_weights;
+    alias->active = true;
+    return true;
+}
+
+static void metal_graph_unbind_exact_routed_row(
+        ds4_gpu_graph                         *g,
+        metal_graph_exact_routed_row_alias    *alias) {
+    if (!alias) return;
+    if (g && alias->active) {
+        const int tier = alias->tier;
+        g->hc_split_by_tier[tier] = alias->saved_hc_split;
+        g->hc_pre_by_tier[tier] = alias->saved_hc_pre;
+        g->hc_post_by_tier[tier] = alias->saved_hc_post;
+        g->hc_comb_by_tier[tier] = alias->saved_hc_comb;
+        g->after_attn_hc_by_tier[tier] = alias->saved_after_attn_hc;
+        g->ffn_norm_by_tier[tier] = alias->saved_ffn_norm;
+        g->routed_out_by_tier[tier] = alias->saved_routed_out;
+        g->router_selected_by_tier[tier] =
+            alias->saved_router_selected;
+        g->router_weights_by_tier[tier] = alias->saved_router_weights;
+    }
+    alias->active = false;
+}
+
+static void metal_graph_release_exact_routed_row(
+        ds4_gpu_graph                         *g,
+        metal_graph_exact_routed_row_alias    *alias) {
+    if (!alias) return;
+    metal_graph_unbind_exact_routed_row(g, alias);
+    ds4_gpu_tensor_free(alias->router_weights);
+    ds4_gpu_tensor_free(alias->router_selected);
+    ds4_gpu_tensor_free(alias->routed_out);
+    ds4_gpu_tensor_free(alias->ffn_norm);
+    ds4_gpu_tensor_free(alias->after_attn_hc);
+    ds4_gpu_tensor_free(alias->hc_comb);
+    ds4_gpu_tensor_free(alias->hc_post);
+    ds4_gpu_tensor_free(alias->hc_pre);
+    ds4_gpu_tensor_free(alias->hc_split);
+    memset(alias, 0, sizeof(*alias));
+}
+
+static bool metal_graph_dspark_capture_verified_exact_layer(
+        ds4_gpu_graph        *g,
+        uint32_t              il,
+        uint32_t              start,
+        uint32_t              n_tokens,
+        ds4_gpu_tensor *const *hidden_rows) {
+    if (!g) return false;
+    const int slot = metal_graph_dspark_target_slot(g, il);
+    if (slot < 0) return true;
+    if (!hidden_rows || !g->dspark_target_hidden_batch ||
+        !g->dspark_target_hidden || !g->dspark_hc_mean_weights ||
+        start == 0 || n_tokens == 0 ||
+        n_tokens + 1u < n_tokens ||
+        n_tokens + 1u > g->prefill_cap) {
+        return false;
+    }
+
+    const uint64_t embd_bytes = (uint64_t)DS4_N_EMBD * sizeof(float);
+    ds4_gpu_tensor *batch_dst =
+        ds4_gpu_tensor_view(g->dspark_target_hidden_batch,
+                            (((uint64_t)(uint32_t)slot * g->prefill_cap +
+                              1u) * DS4_N_EMBD) * sizeof(float),
+                            (uint64_t)n_tokens * embd_bytes);
+    bool ok = batch_dst != NULL;
+    for (uint32_t row = 0; ok && row < n_tokens; row++) {
+        ds4_gpu_tensor *dst_row =
+            ds4_gpu_tensor_view(batch_dst,
+                                (uint64_t)row * embd_bytes,
+                                embd_bytes);
+        ok = dst_row && hidden_rows[row] &&
+             ds4_gpu_hc_weighted_sum_tensor(
+                     dst_row,
+                     hidden_rows[row],
+                     g->dspark_hc_mean_weights,
+                     DS4_N_EMBD,
+                     DS4_N_HC) != 0;
+        ds4_gpu_tensor_free(dst_row);
+    }
+
+    ds4_gpu_tensor *last_src = ok ?
+        ds4_gpu_tensor_view(batch_dst,
+                            (uint64_t)(n_tokens - 1u) * embd_bytes,
+                            embd_bytes) : NULL;
+    ds4_gpu_tensor *last_dst = ok ?
+        ds4_gpu_tensor_view(g->dspark_target_hidden,
+                            (uint64_t)(uint32_t)slot * embd_bytes,
+                            embd_bytes) : NULL;
+    ok = ok && last_src && last_dst &&
+         ds4_gpu_tensor_copy(last_dst, 0, last_src, 0, embd_bytes) != 0;
+    ds4_gpu_tensor_free(last_dst);
+    ds4_gpu_tensor_free(last_src);
+    ds4_gpu_tensor_free(batch_dst);
+    if (ok) {
+        metal_graph_dspark_capture_note_slot(g, (uint32_t)slot);
+        ok = metal_graph_dspark_capture_batch_note_slot(
+                g, (uint32_t)slot, start - 1u, n_tokens + 1u);
+    }
+    return ok;
+}
+
+/* Decode-order exact verifier for an arbitrary tiny candidate block.
+ *
+ * This is deliberately a correctness scaffold: every candidate row uses the
+ * ordinary single-token kernels and the canonical causal cache-update order.
+ * The outer loop is layer-major so independently exact stages can later share
+ * model-weight visits without changing the target token stream. */
+static bool metal_graph_verify_decode_block_exact(
+        ds4_gpu_graph       *g,
+        const ds4_model     *model,
+        const ds4_weights   *weights,
+        const int           *tokens,
+        uint32_t             n_tokens,
+        uint32_t             start,
+        int                 *row_tops,
+        float               *last_logits) {
+    if (!g || !model || !weights || !tokens || !last_logits ||
+        n_tokens < 2u || n_tokens > DS4_DSPARK_MAX_BLOCK_SIZE ||
+        !row_tops || g->raw_cap == 0) {
+        return false;
+    }
+
+    const uint64_t hc_dim = (uint64_t)DS4_N_HC * DS4_N_EMBD;
+    const uint64_t mix_hc =
+        2ull * DS4_N_HC + (uint64_t)DS4_N_HC * DS4_N_HC;
+    const uint64_t hc_bytes = hc_dim * sizeof(float);
+    ds4_gpu_tensor
+        *cur_by_tier[DS4_MAX_GPUS][DS4_DSPARK_MAX_BLOCK_SIZE] = {{0}};
+    ds4_gpu_tensor
+        *next_by_tier[DS4_MAX_GPUS][DS4_DSPARK_MAX_BLOCK_SIZE] = {{0}};
+    ds4_gpu_tensor *saved_cur_by_tier[DS4_MAX_GPUS] = {0};
+    ds4_gpu_tensor *saved_after_by_tier[DS4_MAX_GPUS] = {0};
+    metal_graph_exact_routed_row_alias
+        routed_rows[DS4_DSPARK_MAX_BLOCK_SIZE] = {{0}};
+    const int saved_active_tier = g->active_tier;
+    const bool saved_capture = g->spec_capture_prefixes;
+    const bool exact_routed_requested =
+        metal_graph_tp_env_flag(
+                "DS4_DSPARK_EXACT_ROUTED_BATCH", false);
+    int failure_stage = 0;
+    uint32_t failure_layer = UINT32_MAX;
+    uint32_t failure_row = UINT32_MAX;
+
+    bool ok = true;
+    for (int tier = 0; tier < DS4_MAX_GPUS; tier++) {
+        saved_cur_by_tier[tier] = g->cur_hc_by_tier[tier];
+        saved_after_by_tier[tier] = g->after_ffn_hc_by_tier[tier];
+        if (!g->batch_cur_hc_by_tier[tier] &&
+            !g->batch_next_hc_by_tier[tier]) {
+            continue;
+        }
+        if (!g->batch_cur_hc_by_tier[tier] ||
+            !g->batch_next_hc_by_tier[tier]) {
+            ok = false;
+            break;
+        }
+        for (uint32_t row = 0; row < n_tokens; row++) {
+            cur_by_tier[tier][row] =
+                metal_graph_tensor_row_view(g->batch_cur_hc_by_tier[tier],
+                                            row, hc_dim);
+            next_by_tier[tier][row] =
+                metal_graph_tensor_row_view(g->batch_next_hc_by_tier[tier],
+                                            row, hc_dim);
+            if (!cur_by_tier[tier][row] ||
+                !next_by_tier[tier][row]) {
+                ok = false;
+                break;
+            }
+        }
+        if (!ok) break;
+    }
+
+    int cur_tier = g->emb_tier;
+    if (cur_tier < 0 || cur_tier >= DS4_MAX_GPUS) ok = false;
+    for (uint32_t row = 0; ok && row < n_tokens; row++) {
+        if (!cur_by_tier[cur_tier][row]) {
+            ok = false;
+            break;
+        }
+    }
+    if (ok) ok = metal_graph_set_active_tier_no_copy(g, cur_tier);
+    for (uint32_t row = 0; ok && row < n_tokens; row++) {
+        failure_stage = 1;
+        failure_row = row;
+        ok = ds4_gpu_embed_token_hc_tensor(
+                     cur_by_tier[cur_tier][row],
+                     model->map,
+                     model->size,
+                     weights->token_embd->abs_offset,
+                     (uint32_t)weights->token_embd->dim[1],
+                     (uint32_t)tokens[row],
+                     DS4_N_EMBD,
+                     DS4_N_HC) != 0;
+    }
+
+    g->spec_capture_prefixes = true;
+    bool dspark_capture_active =
+        ok && g->dspark_capture_enabled &&
+        metal_graph_dspark_capture_verified_suffix_begin(
+                g, start, n_tokens, false);
+    failure_stage = 2;
+    if (ok) ok = ds4_gpu_begin_commands() != 0;
+    uint32_t encoded_rows = 0;
+    const uint32_t total_rows = DS4_N_LAYER * n_tokens;
+    for (uint32_t il = 0; ok && il < DS4_N_LAYER; il++) {
+        const int this_tier = g->placement ? g->placement[il + 1u] : cur_tier;
+        failure_layer = il;
+        if (this_tier < 0 || this_tier >= DS4_MAX_GPUS) {
+            ok = false;
+            break;
+        }
+        for (uint32_t row = 0; row < n_tokens; row++) {
+            if (!cur_by_tier[this_tier][row] ||
+                !next_by_tier[this_tier][row]) {
+                ok = false;
+                break;
+            }
+        }
+        if (!ok) break;
+        if (this_tier != cur_tier) {
+            for (uint32_t row = 0; ok && row < n_tokens; row++) {
+                ok = ds4_gpu_tensor_copy_xdev(
+                             cur_by_tier[this_tier][row],
+                             cur_by_tier[cur_tier][row],
+                             hc_bytes) != 0;
+            }
+            if (!ok) break;
+            cur_tier = this_tier;
+        }
+        ok = metal_graph_set_active_tier_no_copy(g, this_tier);
+        if (!ok) break;
+
+        const ds4_layer_weights *layer = &weights->layer[il];
+        const uint32_t ratio = ds4_layer_compress_ratio(il);
+        const bool exact_routed_types =
+            layer->ffn_gate_exps && layer->ffn_up_exps &&
+            layer->ffn_down_exps &&
+            layer->ffn_gate_exps->type == layer->ffn_up_exps->type &&
+            ((layer->ffn_gate_exps->type == DS4_TENSOR_IQ2_XXS &&
+              layer->ffn_down_exps->type == DS4_TENSOR_Q2_K) ||
+             (layer->ffn_gate_exps->type == DS4_TENSOR_Q4_K &&
+              layer->ffn_down_exps->type == DS4_TENSOR_Q4_K) ||
+             (layer->ffn_gate_exps->type == DS4_TENSOR_MXFP4 &&
+              layer->ffn_down_exps->type == DS4_TENSOR_MXFP4));
+        const bool exact_routed =
+            exact_routed_requested &&
+            n_tokens <= 5u &&
+            !g->placement && g->tp_world < 2 && !g->ssd_streaming &&
+            !g->materialize_ffn_out &&
+            !metal_graph_directional_steering_attn_enabled(g) &&
+            !metal_graph_directional_steering_ffn_enabled(g) &&
+            exact_routed_types && DS4_N_EXPERT_USED == 6u &&
+            metal_graph_batch_hc_split(g) &&
+            metal_graph_batch_after_attn_hc(g) &&
+            metal_graph_batch_ffn_norm(g) &&
+            metal_graph_batch_router_selected(g) &&
+            metal_graph_batch_router_weights(g) &&
+            metal_graph_batch_routed_gate(g) &&
+            metal_graph_batch_routed_up(g) &&
+            metal_graph_batch_routed_mid(g) &&
+            metal_graph_batch_routed_down(g) &&
+            metal_graph_batch_routed_out(g);
+
+        if (exact_routed) {
+            for (uint32_t row = 0; ok && row < n_tokens; row++) {
+                failure_stage = 10;
+                failure_row = row;
+                const uint32_t pos = start + row;
+                ok = metal_graph_bind_exact_routed_row(
+                        g, row, hc_dim, mix_hc, &routed_rows[row]);
+                if (ok) {
+                    g->cur_hc_by_tier[this_tier] =
+                        cur_by_tier[this_tier][row];
+                    g->after_ffn_hc_by_tier[this_tier] =
+                        next_by_tier[this_tier][row];
+                    ok = metal_graph_encode_decode_layer_phase(
+                             g,
+                             model,
+                             layer,
+                             il,
+                             pos,
+                             g->layer_raw_cache[il],
+                             g->raw_cap,
+                             pos % g->raw_cap,
+                             metal_graph_raw_span_for_batch(g, pos, 1),
+                             tokens[row],
+                             METAL_DECODE_LAYER_TO_ROUTER);
+                }
+                metal_graph_unbind_exact_routed_row(
+                        g, &routed_rows[row]);
+                if (!ok) break;
+
+                if (row + 1u < n_tokens &&
+                    row < DS4_SPEC_PREFIX_SLOTS) {
+                    failure_stage = 11;
+                    if (ratio != 0) {
+                        ok = metal_graph_capture_prefix_attn_state(
+                                g, il, row);
+                    }
+                    if (ok && ratio == 4u) {
+                        ok = metal_graph_capture_prefix_index_state(
+                                g, il, row);
+                    }
+                }
+            }
+
+            if (ok) {
+                const uint64_t expert_in_dim =
+                    layer->ffn_gate_exps->dim[0];
+                const uint64_t expert_mid_dim =
+                    layer->ffn_gate_exps->dim[1];
+                const uint64_t down_in_dim =
+                    layer->ffn_down_exps->dim[0];
+                const uint64_t routed_out_dim =
+                    layer->ffn_down_exps->dim[1];
+                const uint64_t gate_row_bytes =
+                    routed_expert_row_bytes(layer->ffn_gate_exps);
+                const uint64_t gate_expert_bytes =
+                    expert_mid_dim * gate_row_bytes;
+                const uint64_t down_row_bytes =
+                    routed_expert_row_bytes(layer->ffn_down_exps);
+                const uint64_t down_expert_bytes =
+                    routed_out_dim * down_row_bytes;
+                failure_stage = 14;
+                g->batch_routed_mid_is_f16 = false;
+                ok = ds4_gpu_routed_moe_batch_tensor(
+                         metal_graph_batch_routed_out(g),
+                         metal_graph_batch_routed_gate(g),
+                         metal_graph_batch_routed_up(g),
+                         metal_graph_batch_routed_mid(g),
+                         metal_graph_batch_routed_down(g),
+                         model->map,
+                         model->size,
+                         layer->ffn_gate_exps->abs_offset,
+                         layer->ffn_up_exps->abs_offset,
+                         layer->ffn_down_exps->abs_offset,
+                         layer->ffn_gate_exps->type,
+                         layer->ffn_down_exps->type,
+                         gate_expert_bytes,
+                         gate_row_bytes,
+                         down_expert_bytes,
+                         down_row_bytes,
+                         (uint32_t)expert_in_dim,
+                         (uint32_t)down_in_dim,
+                         (uint32_t)routed_out_dim,
+                         metal_graph_batch_router_selected(g),
+                         metal_graph_batch_router_weights(g),
+                         DS4_N_EXPERT,
+                         DS4_N_EXPERT_USED,
+                         DS4_SWIGLU_CLAMP_EXP,
+                         metal_graph_batch_ffn_norm(g),
+                         il,
+                         n_tokens,
+                         true,
+                         &g->batch_routed_mid_is_f16,
+                         false) != 0 &&
+                     !g->batch_routed_mid_is_f16;
+            }
+
+            for (uint32_t row = 0; ok && row < n_tokens; row++) {
+                failure_stage = 15;
+                failure_row = row;
+                const uint32_t pos = start + row;
+                ok = metal_graph_bind_exact_routed_row(
+                        g, row, hc_dim, mix_hc, &routed_rows[row]);
+                if (ok) {
+                    g->cur_hc_by_tier[this_tier] =
+                        cur_by_tier[this_tier][row];
+                    g->after_ffn_hc_by_tier[this_tier] =
+                        next_by_tier[this_tier][row];
+                    ok = metal_graph_encode_decode_layer_phase(
+                             g,
+                             model,
+                             layer,
+                             il,
+                             pos,
+                             g->layer_raw_cache[il],
+                             g->raw_cap,
+                             pos % g->raw_cap,
+                             metal_graph_raw_span_for_batch(g, pos, 1),
+                             tokens[row],
+                             METAL_DECODE_LAYER_FROM_ROUTER);
+                }
+                metal_graph_unbind_exact_routed_row(
+                        g, &routed_rows[row]);
+                if (!ok) break;
+
+                encoded_rows++;
+                if (encoded_rows < total_rows &&
+                    (encoded_rows % 8u) == 0u &&
+                    ds4_gpu_commands_active()) {
+                    failure_stage = 12;
+                    ok = ds4_gpu_flush_commands() != 0;
+                }
+            }
+        } else {
+            for (uint32_t row = 0; ok && row < n_tokens; row++) {
+                failure_stage = 10;
+                failure_row = row;
+                const uint32_t pos = start + row;
+                g->cur_hc_by_tier[this_tier] =
+                    cur_by_tier[this_tier][row];
+                g->after_ffn_hc_by_tier[this_tier] =
+                    next_by_tier[this_tier][row];
+                ok = metal_graph_encode_decode_layer(
+                         g,
+                         model,
+                         layer,
+                         il,
+                         pos,
+                         g->layer_raw_cache[il],
+                         g->raw_cap,
+                         pos % g->raw_cap,
+                         metal_graph_raw_span_for_batch(g, pos, 1),
+                         tokens[row]);
+                if (!ok) break;
+
+                if (row + 1u < n_tokens &&
+                    row < DS4_SPEC_PREFIX_SLOTS) {
+                    failure_stage = 11;
+                    if (ratio != 0) {
+                        ok = metal_graph_capture_prefix_attn_state(
+                                g, il, row);
+                    }
+                    if (ok && ratio == 4u) {
+                        ok = metal_graph_capture_prefix_index_state(
+                                g, il, row);
+                    }
+                    if (!ok) break;
+                }
+
+                encoded_rows++;
+                if (encoded_rows < total_rows &&
+                    (encoded_rows % 8u) == 0u &&
+                    ds4_gpu_commands_active()) {
+                    failure_stage = 12;
+                    ok = ds4_gpu_flush_commands() != 0;
+                }
+            }
+        }
+        for (uint32_t row = 0; ok && row < n_tokens; row++) {
+            ds4_gpu_tensor *tmp = cur_by_tier[this_tier][row];
+            cur_by_tier[this_tier][row] =
+                next_by_tier[this_tier][row];
+            next_by_tier[this_tier][row] = tmp;
+        }
+        if (ok && dspark_capture_active) {
+            failure_stage = 13;
+            ok = metal_graph_dspark_capture_verified_exact_layer(
+                    g,
+                    il,
+                    start,
+                    n_tokens,
+                    cur_by_tier[this_tier]);
+        }
+    }
+    if (ok) {
+        failure_stage = 20;
+        failure_layer = UINT32_MAX;
+        failure_row = UINT32_MAX;
+        if (ds4_gpu_commands_active()) {
+            ok = ds4_gpu_end_commands() != 0;
+        }
+    } else {
+        (void)ds4_gpu_synchronize();
+    }
+    g->spec_capture_prefixes = saved_capture;
+
+    for (uint32_t row = 0; ok && row < n_tokens; row++) {
+        failure_stage = 30;
+        failure_row = row;
+        ok = metal_graph_set_active_tier_no_copy(g, cur_tier);
+        if (!ok) break;
+        g->cur_hc_by_tier[cur_tier] = cur_by_tier[cur_tier][row];
+        ok = ds4_gpu_begin_commands() != 0;
+        if (ok) {
+            ok = metal_graph_encode_output_head(
+                     g, model, weights, weights->output->dim[1]);
+        }
+        const uint64_t logits_bytes =
+            (uint64_t)DS4_N_VOCAB * sizeof(float);
+        if (ok && g->spec_logits) {
+            ok = ds4_gpu_tensor_copy(g->spec_logits,
+                                     (uint64_t)row * logits_bytes,
+                                     metal_graph_logits(g),
+                                     0,
+                                     logits_bytes) != 0;
+        }
+        if (ok && row + 1u < n_tokens) {
+            ok = ds4_gpu_argmax_tensor(metal_graph_comp_selected(g),
+                                       metal_graph_logits(g),
+                                       DS4_N_VOCAB) != 0;
+        }
+        if (ok) ok = ds4_gpu_end_commands() != 0;
+        else (void)ds4_gpu_synchronize();
+        if (!ok) break;
+
+        if (row + 1u < n_tokens) {
+            ok = ds4_gpu_tensor_read(metal_graph_comp_selected(g),
+                                     0,
+                                     &row_tops[row],
+                                     sizeof(row_tops[row])) != 0;
+        } else {
+            ok = ds4_gpu_tensor_read(
+                     metal_graph_logits(g),
+                     0,
+                     last_logits,
+                     (uint64_t)DS4_N_VOCAB *
+                         sizeof(last_logits[0])) != 0;
+        }
+    }
+
+    g->spec_capture_prefixes = saved_capture;
+    for (uint32_t row = 0; row < n_tokens; row++) {
+        metal_graph_release_exact_routed_row(g, &routed_rows[row]);
+    }
+    for (int tier = 0; tier < DS4_MAX_GPUS; tier++) {
+        g->cur_hc_by_tier[tier] = saved_cur_by_tier[tier];
+        g->after_ffn_hc_by_tier[tier] = saved_after_by_tier[tier];
+    }
+    if (g->placement) {
+        if (saved_active_tier >= 0) {
+            (void)metal_graph_set_active_tier_no_copy(g, saved_active_tier);
+        } else {
+            g->active_tier = saved_active_tier;
+        }
+    }
+    for (int tier = 0; tier < DS4_MAX_GPUS; tier++) {
+        for (uint32_t row = 0; row < n_tokens; row++) {
+            ds4_gpu_tensor_free(next_by_tier[tier][row]);
+            ds4_gpu_tensor_free(cur_by_tier[tier][row]);
+        }
+    }
+    if (!ok) {
+        if (dspark_capture_active) {
+            metal_graph_dspark_capture_invalidate(g);
+        }
+        fprintf(stderr,
+                "ds4: exact block verifier failed stage=%d layer=%u "
+                "row=%u n=%u\n",
+                failure_stage, failure_layer, failure_row, n_tokens);
     }
     return ok;
 }
@@ -40283,6 +40941,7 @@ static int glm_graph_routed_moe_batch_dispatch(
                                                x,
                                                il,
                                                n_tokens,
+                                               false,
                                                &g->batch_routed_mid_is_f16,
                                                force_resident);
     }
@@ -61495,6 +62154,11 @@ static int ds4_session_eval_dspark_speculative_argmax(
     int *row_tops = draft_n > 1 ? row_tops_buf : NULL;
     float *row_logits = s->spec_row_logits;
     const int start = s->checkpoint.len;
+    const bool exact_verify =
+        draft_n > 1 &&
+        e->backend == DS4_BACKEND_METAL &&
+        !e->tp.active &&
+        metal_graph_tp_env_flag("DS4_DSPARK_EXACT_VERIFY", false);
     const double snapshot_t0 = stats_enabled ? now_sec() : 0.0;
     bool have_frontier = spec_frontier_snapshot(&frontier, s);
     if (stats_enabled) {
@@ -61519,20 +62183,45 @@ static int ds4_session_eval_dspark_speculative_argmax(
         for (int i = 0; i < draft_n; i++) token_vec_push(&s->checkpoint, drafts[i]);
         verifier_may_have_mutated = true;
         ds4_verify_suffix_timing verify_timing;
+        memset(&verify_timing, 0, sizeof(verify_timing));
         const double verify_t0 = stats_enabled ? now_sec() : 0.0;
-        ok = metal_graph_verify_suffix_tops(&s->graph,
-                                            &e->model,
-                                            &e->weights,
-                                            &s->checkpoint,
-                                            (uint32_t)start,
-                                            (uint32_t)draft_n,
-                                            draft_n > 1 &&
-                                                draft_n <=
-                                                    (int)DS4_SPEC_PREFIX_SLOTS + 1,
-                                            true,
-                                            row_tops,
-                                            NULL,
-                                            stats_enabled ? &verify_timing : NULL);
+        if (exact_verify) {
+            static bool announced = false;
+            if (!announced) {
+                fprintf(stderr,
+                        "ds4: DSpark exact decode-order block verifier "
+                        "enabled\n");
+                announced = true;
+            }
+            const double layer_t0 = stats_enabled ? now_sec() : 0.0;
+            ok = metal_graph_verify_decode_block_exact(
+                    &s->graph,
+                    &e->model,
+                    &e->weights,
+                    drafts,
+                    (uint32_t)draft_n,
+                    (uint32_t)start,
+                    row_tops,
+                    row_logits);
+            if (stats_enabled) {
+                verify_timing.layer_ms =
+                    (now_sec() - layer_t0) * 1000.0;
+            }
+        } else {
+            ok = metal_graph_verify_suffix_tops(
+                    &s->graph,
+                    &e->model,
+                    &e->weights,
+                    &s->checkpoint,
+                    (uint32_t)start,
+                    (uint32_t)draft_n,
+                    draft_n > 1 &&
+                        draft_n <= (int)DS4_SPEC_PREFIX_SLOTS + 1,
+                    true,
+                    row_tops,
+                    NULL,
+                    stats_enabled ? &verify_timing : NULL);
+        }
         if (stats_enabled) {
             s->dspark_stats.verify_ms += (now_sec() - verify_t0) * 1000.0;
             s->dspark_stats.verify_upload_ms += verify_timing.upload_ms;

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -25395,8 +25395,9 @@ extern "C" int ds4_gpu_routed_moe_one_tensor(ds4_gpu_tensor *out, ds4_gpu_tensor
                              selected, weights, n_total_expert, n_expert, clamp, x,
                              layer_index, 1, force_resident ? 0 : 1, 0);
 }
-extern "C" int ds4_gpu_routed_moe_batch_tensor(ds4_gpu_tensor *out, ds4_gpu_tensor *gate, ds4_gpu_tensor *up, ds4_gpu_tensor *mid, ds4_gpu_tensor *down, const void *model_map, uint64_t model_size, uint64_t gate_offset, uint64_t up_offset, uint64_t down_offset, uint32_t gate_type, uint32_t down_type, uint64_t gate_expert_bytes, uint64_t gate_row_bytes, uint64_t down_expert_bytes, uint64_t down_row_bytes, uint32_t expert_in_dim, uint32_t expert_mid_dim, uint32_t out_dim, const ds4_gpu_tensor *selected, const ds4_gpu_tensor *weights, uint32_t n_total_expert, uint32_t n_expert, float clamp, const ds4_gpu_tensor *x, uint32_t layer_index, uint32_t n_tokens, bool *mid_is_f16, bool force_resident) {
+extern "C" int ds4_gpu_routed_moe_batch_tensor(ds4_gpu_tensor *out, ds4_gpu_tensor *gate, ds4_gpu_tensor *up, ds4_gpu_tensor *mid, ds4_gpu_tensor *down, const void *model_map, uint64_t model_size, uint64_t gate_offset, uint64_t up_offset, uint64_t down_offset, uint32_t gate_type, uint32_t down_type, uint64_t gate_expert_bytes, uint64_t gate_row_bytes, uint64_t down_expert_bytes, uint64_t down_row_bytes, uint32_t expert_in_dim, uint32_t expert_mid_dim, uint32_t out_dim, const ds4_gpu_tensor *selected, const ds4_gpu_tensor *weights, uint32_t n_total_expert, uint32_t n_expert, float clamp, const ds4_gpu_tensor *x, uint32_t layer_index, uint32_t n_tokens, bool exact_rows, bool *mid_is_f16, bool force_resident) {
     (void)force_resident;
+    (void)exact_rows;
     if (mid_is_f16) *mid_is_f16 = false;
     return routed_moe_launch(out, gate, up, mid, down, model_map, model_size,
                              gate_offset, up_offset, down_offset,

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -2390,6 +2390,8 @@ int ds4_gpu_routed_moe_batch_tensor(
         const ds4_gpu_tensor *x,
         uint32_t                layer_index,
         uint32_t                n_tokens,
+        /* Preserve the serial F32 row arithmetic on supported Metal paths. */
+        bool                    exact_rows,
         bool                   *mid_is_f16,
         bool                    force_resident);
 

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -37516,10 +37516,11 @@ int ds4_gpu_routed_moe_batch_tensor(
         const ds4_gpu_tensor *x,
         uint32_t                layer_index,
         uint32_t                n_tokens,
+        bool                    exact_rows,
         bool                   *mid_is_f16,
         bool                    force_resident) {
-    (void)force_resident;
     if (!g_initialized && !ds4_gpu_init()) return 0;
+    (void)force_resident;
     /* TP sharding (see ds4_gpu_routed_moe_one_tensor): bind from the owned
      * expert range and rebase ids in the kernels. */
     uint32_t first_expert = 0;
@@ -37855,6 +37856,7 @@ int ds4_gpu_routed_moe_batch_tensor(
          * write/read. --quality keeps the older F32 intermediate.
          */
         const bool request_mid_f16 =
+            !exact_rows &&
             !g_quality_mode &&
             !use_q4_batch_expert_table &&
             !use_iq2_batch_selected_addr;
@@ -38168,7 +38170,7 @@ int ds4_gpu_routed_moe_batch_tensor(
             !use_q4_batch_expert_table &&
             !use_mm_id &&
             n_expert == 6 &&
-            n_tokens <= 4u &&
+            (n_tokens <= 4u || (exact_rows && n_tokens <= 5u)) &&
             down_sum6_pipeline != nil;
         int ok = 0;
         if (use_iq2_batch_selected_addr) {

--- a/tests/test_mxfp4_metal.c
+++ b/tests/test_mxfp4_metal.c
@@ -307,7 +307,7 @@ int main(void) {
         expert_bytes, row_bytes, DIM, DIM, DIM,
         selected_batch_tensor, weights_batch_tensor,
         N_TOTAL_EXPERT, N_EXPERT, 7.0f, x_batch_tensor,
-        0u, BATCH_TOKENS, &mid_is_f16, true);
+        0u, BATCH_TOKENS, false, &mid_is_f16, true);
     ok = ok && mid_is_f16;
     ok = ok && ds4_gpu_tensor_read(
         mid_batch_tensor, 0, mid_batch_storage,

--- a/tests/test_routed_exact_batch_metal.c
+++ b/tests/test_routed_exact_batch_metal.c
@@ -1,0 +1,465 @@
+#define _DARWIN_C_SOURCE
+
+#include "ds4_gpu.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define ROWS 5u
+#define SLOTS 6u
+#define N_TOTAL_EXPERT 8u
+#define IN_DIM 4096u
+#define MID_DIM 2048u
+#define OUT_DIM 4096u
+
+typedef struct {
+    const char *name;
+    uint32_t gate_type;
+    uint32_t down_type;
+    uint32_t gate_block_width;
+    uint32_t gate_block_bytes;
+    uint32_t down_block_width;
+    uint32_t down_block_bytes;
+    uint32_t gate_scale_bytes;
+    uint32_t down_scale_bytes;
+} quant_case;
+
+static const quant_case quant_cases[] = {
+    { "MXFP4/MXFP4",  39u, 39u, 32u, 17u, 32u, 17u, 1u, 1u },
+    { "Q4_K/Q4_K",    12u, 12u, 256u, 144u, 256u, 144u, 4u, 4u },
+};
+
+bool ds4_log_is_tty(FILE *fp) {
+    (void)fp;
+    return false;
+}
+
+static uint64_t align_up(uint64_t value, uint64_t alignment) {
+    return (value + alignment - 1u) / alignment * alignment;
+}
+
+static uint64_t quant_row_bytes(uint32_t dim,
+                                uint32_t block_width,
+                                uint32_t block_bytes) {
+    return (dim / block_width) * (uint64_t)block_bytes;
+}
+
+static void fill_quant_tensor(void *base,
+                              uint32_t matrix_rows,
+                              uint64_t row_bytes,
+                              uint32_t block_bytes,
+                              uint32_t scale_bytes,
+                              bool mxfp4,
+                              uint32_t salt) {
+    uint8_t *bytes = base;
+    for (uint32_t expert = 0; expert < N_TOTAL_EXPERT; expert++) {
+        for (uint32_t row = 0; row < matrix_rows; row++) {
+            uint8_t *row_ptr = bytes +
+                ((uint64_t)expert * matrix_rows + row) * row_bytes;
+            for (uint64_t block = 0;
+                 block < row_bytes / block_bytes;
+                 block++) {
+                uint8_t *dst = row_ptr + block * block_bytes;
+                const uint32_t seed = salt + expert * 29u + row * 17u +
+                    (uint32_t)block * 13u;
+                if (mxfp4) {
+                    dst[0] = (uint8_t)(120u + (seed & 3u));
+                } else {
+                    const _Float16 d = (_Float16)(1.0f / 2048.0f);
+                    const uint32_t scale_offset =
+                        block_bytes == 84u ? block_bytes - 4u : 0u;
+                    memcpy(dst + scale_offset, &d, sizeof(d));
+                    if (scale_bytes == 4u) {
+                        const _Float16 dmin =
+                            (_Float16)(1.0f / 4096.0f);
+                        memcpy(dst + scale_offset + sizeof(d),
+                               &dmin,
+                               sizeof(dmin));
+                    }
+                }
+                for (uint32_t i = 0; i < block_bytes; i++) {
+                    const uint32_t scale_offset =
+                        block_bytes == 84u ? block_bytes - 4u : 0u;
+                    if (i >= scale_offset &&
+                        i < scale_offset + scale_bytes) {
+                        continue;
+                    }
+                    dst[i] = (uint8_t)(seed + i * 7u);
+                }
+            }
+        }
+    }
+}
+
+static int clear_tensor(ds4_gpu_tensor *tensor, uint64_t bytes) {
+    void *zero = calloc(1, (size_t)bytes);
+    if (!zero) return 0;
+    const int ok = ds4_gpu_tensor_write(tensor, 0, zero, bytes);
+    free(zero);
+    return ok;
+}
+
+static int compare_bits(const char *case_name,
+                        const char *tensor_name,
+                        const float *actual,
+                        const float *expected,
+                        uint64_t count) {
+    for (uint64_t i = 0; i < count; i++) {
+        if (memcmp(actual + i, expected + i, sizeof(float)) != 0) {
+            uint32_t a = 0;
+            uint32_t e = 0;
+            memcpy(&a, actual + i, sizeof(a));
+            memcpy(&e, expected + i, sizeof(e));
+            fprintf(stderr,
+                    "exact routed batch %s %s mismatch at %llu: "
+                    "0x%08x vs 0x%08x\n",
+                    case_name,
+                    tensor_name,
+                    (unsigned long long)i,
+                    a,
+                    e);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int execute_serial_rows(
+        ds4_gpu_tensor *out,
+        ds4_gpu_tensor *gate,
+        ds4_gpu_tensor *up,
+        ds4_gpu_tensor *mid,
+        ds4_gpu_tensor *experts,
+        ds4_gpu_tensor *selected,
+        ds4_gpu_tensor *weights,
+        ds4_gpu_tensor *x,
+        const void *model,
+        uint64_t model_size,
+        uint64_t gate_offset,
+        uint64_t up_offset,
+        uint64_t down_offset,
+        const quant_case *quant,
+        uint64_t gate_expert_bytes,
+        uint64_t gate_row_bytes,
+        uint64_t down_expert_bytes,
+        uint64_t down_row_bytes) {
+    const uint64_t pair_row_bytes =
+        (uint64_t)SLOTS * MID_DIM * sizeof(float);
+    const uint64_t down_row_values = (uint64_t)SLOTS * OUT_DIM;
+    const uint64_t down_row_values_bytes =
+        down_row_values * sizeof(float);
+    const uint64_t out_row_bytes = (uint64_t)OUT_DIM * sizeof(float);
+    int ok = ds4_gpu_begin_commands();
+    for (uint32_t row = 0; ok && row < ROWS; row++) {
+        ds4_gpu_tensor *out_row = ds4_gpu_tensor_view(
+                out, (uint64_t)row * out_row_bytes, out_row_bytes);
+        ds4_gpu_tensor *gate_row = ds4_gpu_tensor_view(
+                gate, (uint64_t)row * pair_row_bytes, pair_row_bytes);
+        ds4_gpu_tensor *up_row = ds4_gpu_tensor_view(
+                up, (uint64_t)row * pair_row_bytes, pair_row_bytes);
+        ds4_gpu_tensor *mid_row = ds4_gpu_tensor_view(
+                mid, (uint64_t)row * pair_row_bytes, pair_row_bytes);
+        ds4_gpu_tensor *experts_row = ds4_gpu_tensor_view(
+                experts,
+                (uint64_t)row * down_row_values_bytes,
+                down_row_values_bytes);
+        ds4_gpu_tensor *selected_row = ds4_gpu_tensor_view(
+                selected,
+                (uint64_t)row * SLOTS * sizeof(int32_t),
+                SLOTS * sizeof(int32_t));
+        ds4_gpu_tensor *weights_row = ds4_gpu_tensor_view(
+                weights,
+                (uint64_t)row * SLOTS * sizeof(float),
+                SLOTS * sizeof(float));
+        ds4_gpu_tensor *x_row = ds4_gpu_tensor_view(
+                x,
+                (uint64_t)row * IN_DIM * sizeof(float),
+                IN_DIM * sizeof(float));
+        ok = out_row && gate_row && up_row && mid_row && experts_row &&
+             selected_row && weights_row && x_row &&
+             ds4_gpu_routed_moe_one_tensor(
+                     out_row,
+                     gate_row,
+                     up_row,
+                     mid_row,
+                     experts_row,
+                     model,
+                     model_size,
+                     gate_offset,
+                     up_offset,
+                     down_offset,
+                     quant->gate_type,
+                     quant->down_type,
+                     gate_expert_bytes,
+                     gate_row_bytes,
+                     down_expert_bytes,
+                     down_row_bytes,
+                     IN_DIM,
+                     MID_DIM,
+                     OUT_DIM,
+                     selected_row,
+                     weights_row,
+                     N_TOTAL_EXPERT,
+                     SLOTS,
+                     7.0f,
+                     x_row,
+                     NULL,
+                     0u,
+                     false);
+        ds4_gpu_tensor_free(x_row);
+        ds4_gpu_tensor_free(weights_row);
+        ds4_gpu_tensor_free(selected_row);
+        ds4_gpu_tensor_free(experts_row);
+        ds4_gpu_tensor_free(mid_row);
+        ds4_gpu_tensor_free(up_row);
+        ds4_gpu_tensor_free(gate_row);
+        ds4_gpu_tensor_free(out_row);
+    }
+    return ds4_gpu_end_commands() && ok;
+}
+
+static int execute_exact_batch(
+        ds4_gpu_tensor *out,
+        ds4_gpu_tensor *gate,
+        ds4_gpu_tensor *up,
+        ds4_gpu_tensor *mid,
+        ds4_gpu_tensor *experts,
+        ds4_gpu_tensor *selected,
+        ds4_gpu_tensor *weights,
+        ds4_gpu_tensor *x,
+        const void *model,
+        uint64_t model_size,
+        uint64_t gate_offset,
+        uint64_t up_offset,
+        uint64_t down_offset,
+        const quant_case *quant,
+        uint64_t gate_expert_bytes,
+        uint64_t gate_row_bytes,
+        uint64_t down_expert_bytes,
+        uint64_t down_row_bytes) {
+    bool mid_is_f16 = true;
+    int ok = ds4_gpu_begin_commands();
+    ok = ok && ds4_gpu_routed_moe_batch_tensor(
+            out,
+            gate,
+            up,
+            mid,
+            experts,
+            model,
+            model_size,
+            gate_offset,
+            up_offset,
+            down_offset,
+            quant->gate_type,
+            quant->down_type,
+            gate_expert_bytes,
+            gate_row_bytes,
+            down_expert_bytes,
+            down_row_bytes,
+            IN_DIM,
+            MID_DIM,
+            OUT_DIM,
+            selected,
+            weights,
+            N_TOTAL_EXPERT,
+            SLOTS,
+            7.0f,
+            x,
+            0u,
+            ROWS,
+            true,
+            &mid_is_f16,
+            false);
+    ok = ds4_gpu_end_commands() && ok && !mid_is_f16;
+    return ok;
+}
+
+static int run_case(const quant_case *quant, void **model_keepalive) {
+    const uint64_t page = (uint64_t)getpagesize();
+    const uint64_t gate_row_bytes = quant_row_bytes(
+            IN_DIM, quant->gate_block_width, quant->gate_block_bytes);
+    const uint64_t down_row_bytes = quant_row_bytes(
+            MID_DIM, quant->down_block_width, quant->down_block_bytes);
+    const uint64_t gate_expert_bytes = MID_DIM * gate_row_bytes;
+    const uint64_t down_expert_bytes = OUT_DIM * down_row_bytes;
+    const uint64_t gate_tensor_bytes =
+        N_TOTAL_EXPERT * gate_expert_bytes;
+    const uint64_t down_tensor_bytes =
+        N_TOTAL_EXPERT * down_expert_bytes;
+    const uint64_t gate_offset = 0;
+    const uint64_t up_offset = align_up(gate_tensor_bytes, page);
+    const uint64_t down_offset =
+        align_up(up_offset + gate_tensor_bytes, page);
+    const uint64_t model_size =
+        align_up(down_offset + down_tensor_bytes, page);
+    void *model = NULL;
+    if (posix_memalign(&model, (size_t)page, (size_t)model_size) != 0) {
+        return 0;
+    }
+    *model_keepalive = model;
+    memset(model, 0, (size_t)model_size);
+    fill_quant_tensor((uint8_t *)model + gate_offset,
+                      MID_DIM,
+                      gate_row_bytes,
+                      quant->gate_block_bytes,
+                      quant->gate_scale_bytes,
+                      quant->gate_type == 39u,
+                      3u);
+    fill_quant_tensor((uint8_t *)model + up_offset,
+                      MID_DIM,
+                      gate_row_bytes,
+                      quant->gate_block_bytes,
+                      quant->gate_scale_bytes,
+                      quant->gate_type == 39u,
+                      71u);
+    fill_quant_tensor((uint8_t *)model + down_offset,
+                      OUT_DIM,
+                      down_row_bytes,
+                      quant->down_block_bytes,
+                      quant->down_scale_bytes,
+                      quant->down_type == 39u,
+                      139u);
+    if (!ds4_gpu_set_model_map(model, model_size)) return 0;
+
+    const uint64_t pair_elems = (uint64_t)ROWS * SLOTS * MID_DIM;
+    const uint64_t pair_bytes = pair_elems * sizeof(float);
+    const uint64_t down_elems = (uint64_t)ROWS * SLOTS * OUT_DIM;
+    const uint64_t down_bytes = down_elems * sizeof(float);
+    const uint64_t out_elems = (uint64_t)ROWS * OUT_DIM;
+    const uint64_t out_bytes = out_elems * sizeof(float);
+    float x[ROWS * IN_DIM];
+    int32_t selected[ROWS * SLOTS];
+    float weights[ROWS * SLOTS];
+    static const int32_t ids[ROWS][SLOTS] = {
+        { 0, 1, 2, 3, 4, 5 },
+        { 0, 2, 3, 4, 5, 6 },
+        { 0, 1, 3, 5, 6, 7 },
+        { 1, 2, 3, 4, 6, 7 },
+        { 0, 2, 4, 5, 6, 7 },
+    };
+    for (uint32_t row = 0; row < ROWS; row++) {
+        for (uint32_t i = 0; i < IN_DIM; i++) {
+            x[row * IN_DIM + i] =
+                (float)((int32_t)((i * 13u + row * 19u) % 61u) - 30) /
+                (256.0f + 16.0f * row);
+        }
+        for (uint32_t slot = 0; slot < SLOTS; slot++) {
+            selected[row * SLOTS + slot] = ids[row][slot];
+            weights[row * SLOTS + slot] =
+                (float)(slot + 1u + row) / 43.0f;
+        }
+    }
+
+    ds4_gpu_tensor *x_tensor = ds4_gpu_tensor_alloc(sizeof(x));
+    ds4_gpu_tensor *selected_tensor = ds4_gpu_tensor_alloc(sizeof(selected));
+    ds4_gpu_tensor *weights_tensor = ds4_gpu_tensor_alloc(sizeof(weights));
+    ds4_gpu_tensor *gate_tensor = ds4_gpu_tensor_alloc(pair_bytes);
+    ds4_gpu_tensor *up_tensor = ds4_gpu_tensor_alloc(pair_bytes);
+    ds4_gpu_tensor *mid_tensor = ds4_gpu_tensor_alloc(pair_bytes);
+    ds4_gpu_tensor *experts_tensor = ds4_gpu_tensor_alloc(down_bytes);
+    ds4_gpu_tensor *out_tensor = ds4_gpu_tensor_alloc(out_bytes);
+    float *gate_ref = malloc((size_t)pair_bytes);
+    float *up_ref = malloc((size_t)pair_bytes);
+    float *mid_ref = malloc((size_t)pair_bytes);
+    float *out_ref = malloc((size_t)out_bytes);
+    float *gate_batch = malloc((size_t)pair_bytes);
+    float *up_batch = malloc((size_t)pair_bytes);
+    float *mid_batch = malloc((size_t)pair_bytes);
+    float *out_batch = malloc((size_t)out_bytes);
+    int ok = x_tensor && selected_tensor && weights_tensor && gate_tensor &&
+        up_tensor && mid_tensor && experts_tensor && out_tensor &&
+        gate_ref && up_ref && mid_ref && out_ref &&
+        gate_batch && up_batch && mid_batch && out_batch;
+    ok = ok && ds4_gpu_tensor_write(x_tensor, 0, x, sizeof(x)) &&
+        ds4_gpu_tensor_write(
+                selected_tensor, 0, selected, sizeof(selected)) &&
+        ds4_gpu_tensor_write(
+                weights_tensor, 0, weights, sizeof(weights));
+
+    ok = ok && clear_tensor(gate_tensor, pair_bytes) &&
+        clear_tensor(up_tensor, pair_bytes) &&
+        clear_tensor(mid_tensor, pair_bytes) &&
+        clear_tensor(experts_tensor, down_bytes) &&
+        clear_tensor(out_tensor, out_bytes) &&
+        execute_serial_rows(
+                out_tensor, gate_tensor, up_tensor, mid_tensor,
+                experts_tensor, selected_tensor, weights_tensor, x_tensor,
+                model, model_size, gate_offset, up_offset, down_offset,
+                quant, gate_expert_bytes, gate_row_bytes,
+                down_expert_bytes, down_row_bytes) &&
+        ds4_gpu_tensor_read(gate_tensor, 0, gate_ref, pair_bytes) &&
+        ds4_gpu_tensor_read(up_tensor, 0, up_ref, pair_bytes) &&
+        ds4_gpu_tensor_read(mid_tensor, 0, mid_ref, pair_bytes) &&
+        ds4_gpu_tensor_read(out_tensor, 0, out_ref, out_bytes);
+
+    ok = ok && clear_tensor(gate_tensor, pair_bytes) &&
+        clear_tensor(up_tensor, pair_bytes) &&
+        clear_tensor(mid_tensor, pair_bytes) &&
+        clear_tensor(experts_tensor, down_bytes) &&
+        clear_tensor(out_tensor, out_bytes) &&
+        execute_exact_batch(
+                out_tensor, gate_tensor, up_tensor, mid_tensor,
+                experts_tensor, selected_tensor, weights_tensor, x_tensor,
+                model, model_size, gate_offset, up_offset, down_offset,
+                quant, gate_expert_bytes, gate_row_bytes,
+                down_expert_bytes, down_row_bytes) &&
+        ds4_gpu_tensor_read(gate_tensor, 0, gate_batch, pair_bytes) &&
+        ds4_gpu_tensor_read(up_tensor, 0, up_batch, pair_bytes) &&
+        ds4_gpu_tensor_read(mid_tensor, 0, mid_batch, pair_bytes) &&
+        ds4_gpu_tensor_read(out_tensor, 0, out_batch, out_bytes);
+
+    ok = ok && compare_bits(
+            quant->name, "gate", gate_batch, gate_ref, pair_elems) &&
+        compare_bits(quant->name, "up", up_batch, up_ref, pair_elems) &&
+        compare_bits(quant->name, "mid", mid_batch, mid_ref, pair_elems) &&
+        compare_bits(quant->name, "out", out_batch, out_ref, out_elems);
+    fprintf(stderr, "exact routed batch %-14s: %s\n",
+            quant->name, ok ? "PASS" : "FAIL");
+
+    free(out_batch);
+    free(mid_batch);
+    free(up_batch);
+    free(gate_batch);
+    free(out_ref);
+    free(mid_ref);
+    free(up_ref);
+    free(gate_ref);
+    ds4_gpu_tensor_free(out_tensor);
+    ds4_gpu_tensor_free(experts_tensor);
+    ds4_gpu_tensor_free(mid_tensor);
+    ds4_gpu_tensor_free(up_tensor);
+    ds4_gpu_tensor_free(gate_tensor);
+    ds4_gpu_tensor_free(weights_tensor);
+    ds4_gpu_tensor_free(selected_tensor);
+    ds4_gpu_tensor_free(x_tensor);
+    return ok;
+}
+
+int main(void) {
+    unsetenv("DS4_METAL_FORCE_TINY_MOE_MM_ID");
+    unsetenv("DS4_METAL_MOE_WRITE_CLAMPED_ACT");
+    int ok = ds4_gpu_init();
+    ds4_gpu_set_quality(false);
+    ds4_gpu_set_ssd_streaming(false);
+
+    void *models[sizeof(quant_cases) / sizeof(quant_cases[0])] = { NULL };
+    for (uint32_t i = 0;
+         ok && i < sizeof(quant_cases) / sizeof(quant_cases[0]);
+         i++) {
+        ok = run_case(&quant_cases[i], &models[i]);
+    }
+
+    ds4_gpu_cleanup();
+    for (uint32_t i = 0;
+         i < sizeof(models) / sizeof(models[0]);
+         i++) {
+        free(models[i]);
+    }
+    fprintf(stderr, "Metal exact routed batch: %s\n",
+            ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
> **TL;DR:** Byte-identical DSpark verification with zero impact on the default path; the first routed-batching prototype is exact but currently **11.2% slower end-to-end**.

## Scope caveat: this is not the IQ3 quality target

The full-model A/B below uses a 91 GB mixed Q2/Q4 fixture because current upstream `main` can load it and it exercises the routed types covered by this patch. It is **not evidence of IQ3_XXS quality** and should not be read as the final model for the original performance goal.

I also tried both local IQ3 candidates against this clean branch. The merged Unsloth `UD-IQ3_XXS` file is rejected because `deepseek4.vocab_size` is absent, while the ds4-adjusted copy reaches an unsupported routed tensor (`iq2_xs`, type 17). Supporting that community mixed-quant dialect requires separate loader/kernel compatibility work and is intentionally not folded into this verifier PR. The routed numbers here are therefore kernel-fixture results only.

## What

This draft adds an opt-in, decode-order-exact DSpark verifier for Metal:

- `DS4_DSPARK_EXACT_VERIFY=1` verifies an arbitrary tiny draft block with the
  ordinary one-token kernels and canonical causal cache-update order.
- It retains per-row hidden states in the existing prefill workspace, captures
  the intermediate compressor/indexer frontiers needed by partial accepts, and
  produces the row top-1 values plus the final continuation logits.
- `DS4_DSPARK_EXACT_ROUTED_BATCH=1` additionally experiments with batching the
  routed MoE section for blocks of at most five rows. It is limited to the
  resident single-GPU Metal paths exercised here: IQ2_XXS/Q2_K, Q4_K/Q4_K, and
  MXFP4/MXFP4.
- The Metal routed batch API gets an `exact_rows` mode. It keeps the routed
  intermediate in F32 and permits the direct six-expert reduction for five
  rows. Existing callers pass `false`; CUDA accepts and ignores the new flag.
- A real-shape Metal regression test compares five serial rows with the exact
  batch bit-for-bit for MXFP4 and Q4_K.

Both modes are off by default. The normal verifier and normal decode paths are
unchanged unless the environment flags are set.

## Why

The normal layer-major DSpark verifier intentionally uses batch kernels. Their
arithmetic can differ from ordinary one-token decode, which is enough to change
a near-tie and leave the accepted KV/frontier state on a different trajectory.
The exact verifier is a correctness reference and a place to develop
lossless verifier batching against canonical one-token output.

The routed experiment tests one such stage. Its kernel output is exact, but the
current split-around-router schedule is not yet a speedup; see the measured
negative result below. I am opening this as a draft so that correctness and API
structure can be reviewed before trying to remove that scheduling cost.

This overlaps conceptually with #590 and #659, but takes a different route:
make verification itself decode-order exact instead of repairing accepted
state by replay alone. It may conflict textually with ongoing DSpark changes.

## Correctness and performance

Machine: Apple M5 Max, 128 GB, macOS 26.5.2, Metal, high-power mode.

Model: `DeepSeek-V4-Flash-Layers37-42Q4KExperts-OtherExpertLayersIQ2XXSGateUp-Q2KDown-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix-fixed-0731.gguf`
with the official DSpark support GGUF. The real-project prompt contains 11,442
runtime tokens; context 16,384, prefill chunk 2,048, greedy, 64 generated
tokens, DSpark block 5, confidence 0.

All five outputs (plain target, two exact controls, and two exact+routed runs)
had the same SHA-256:

```
c9a88b8bb05a80a18539b5df79fb2b14c19a6c7afc7110449d10455dc9fba243
```

The DSpark acceptance trace was also identical in every exact A/B arm: 20
cycles, 100 proposed, 35 accepted, 35.00% acceptance.

| path | generation tok/s | verifier time |
|---|---:|---:|
| plain target | 32.93 | n/a |
| exact control A | 18.75 | 2369.9 ms |
| exact control B | 19.20 | 2316.6 ms |
| exact+routed A | 16.81 | 2713.7 ms |
| exact+routed B | 16.89 | 2678.5 ms |

The routed experiment averages 16.85 tok/s versus 18.98 tok/s for the exact
control: **11.2% slower end-to-end** (and about 15.1% more verifier time).
The per-layer split/resume schedule currently costs more than the routed
microbatch saves. This PR therefore makes no speedup claim and does not enable
the path by default.

## Checks

```sh
make clean && make -j8
make -j8 tests/test_routed_exact_batch_metal
./tests/test_routed_exact_batch_metal
./ds4_test --metal-kernels
./ds4-eval --self-test-extractors
./ds4_agent_test
./tests/test_layer_pack
./tests/test_engine_mgpu_placement
./tests/test_gpu_args
./tests/test_gpu_args_cli.sh
make cpu -j8
```

Results:

- Clean Metal and CPU builds, with no new warnings.
- Exact routed regression: PASS for MXFP4/MXFP4 and Q4_K/Q4_K.
- Metal kernel suite: OK.
- Model-independent evaluator, agent, layer-pack, placement, and GPU-argument
  tests: PASS.
- Full `make test` reached `./ds4_test` and stopped because the default
  `ds4flash.gguf` fixture is not present in the worktree. The model-independent
  parts above were then run explicitly. The full-model exactness/performance
  bracket used the explicit model path and serialized every process.
- CUDA hardware was not available. The CUDA backend only receives the API
  parameter and ignores it; the new verifier is gated to single-GPU Metal.

## Review focus

1. Is an opt-in exact verifier useful as a correctness/reference mode, or
   should it live only in a test harness until its throughput improves?
2. Should the routed experiment be split into a follow-up after the verifier
   structure is accepted?
3. The next performance step is to avoid splitting every row around the router
   (or batch a larger exact tail), not to enable the current routed path.
