### PR TITLE
Serve token_embd.weight from the host mapping under DS4_EMBD_MMAP (default OFF)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -2923,6 +2923,19 @@ static bool accelerator_prepare_model_tensor_spans(const ds4_model *m,
         if (ds4_gpu_model_range_replaced(m->map, t->abs_offset, t->bytes)) {
             continue;
         }
+        /* DS4_EMBD_MMAP=1 (default OFF): leave the token embedding table out
+         * of the resident device spans; the CUDA embed path serves the rows
+         * from the read-only host mapping instead (see cuda_model_range_ptr).
+         * Saves ~1 GiB of residency on DeepSeek V4 Flash Q8_0. */
+        if (getenv("DS4_EMBD_MMAP") != NULL &&
+            t->name.len == strlen("token_embd.weight") &&
+            memcmp(t->name.ptr, "token_embd.weight", t->name.len) == 0) {
+            fprintf(stderr,
+                    "ds4: DS4_EMBD_MMAP=1: token_embd.weight (%.2f MiB) left "
+                    "unprepared, served from the host model mapping\n",
+                    (double)t->bytes / 1048576.0);
+            continue;
+        }
 #endif
         spans[nspan++] = (accelerator_tensor_span){
             .off = t->abs_offset,

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -711,6 +711,30 @@ static const char *cuda_model_range_ptr(const void *model_map, uint64_t offset, 
     const char *direct_env = getenv("DS4_CUDA_DIRECT_MODEL");
     if (direct_env && direct_env[0]) return cuda_model_ptr(model_map, offset);
 
+    /* DS4_EMBD_MMAP=1 (default OFF): serve token-embedding row lookups
+     * straight from the read-only host mapping of the GGUF region instead
+     * of promoting the ~1 GiB table to a resident device copy. Per-token
+     * decode touches one row (n_embd x element bytes); on unified-memory
+     * targets (GB10/Grace) the GPU reaches the file-backed pages via
+     * ATS/HMM, and hot rows stay in page cache. The startup span
+     * preparation in ds4.c skips the tensor under the same env, so this
+     * is the only resolution path for it. */
+    static int embd_mmap_mode = -1;
+    if (embd_mmap_mode < 0) {
+        embd_mmap_mode = getenv("DS4_EMBD_MMAP") != NULL ? 1 : 0;
+    }
+    if (embd_mmap_mode && what && strstr(what, "token_embd") != NULL) {
+        static int logged = 0;
+        if (!logged) {
+            logged = 1;
+            fprintf(stderr,
+                    "ds4: DS4_EMBD_MMAP=1: serving %s (%.2f MiB) from the "
+                    "host model mapping (no resident copy)\n",
+                    what, (double)bytes / 1048576.0);
+        }
+        return cuda_model_ptr(model_map, offset);
+    }
+
     const uint64_t end = offset + bytes;
     auto exact = g_model_range_by_offset.find(offset);
     if (exact != g_model_range_by_offset.end()) {


### PR DESCRIPTION
Addresses #688.

`token_embd.weight` is accessed one row (~8-16 KB) per decoded token but held fully resident (~1 GiB on DeepSeek V4 Flash Q8_0). With `DS4_EMBD_MMAP=1` (**default OFF**):

- ds4.c: startup span preparation leaves `token_embd.weight` out of the resident device spans (logged).
- ds4_cuda.cu: `cuda_model_range_ptr` resolves the `token_embd` label to the read-only host model mapping instead of a resident copy, so row lookups are served at page-cache speed.

Measured on GB10 (DeepSeek V4 Flash Q8_0, streaming, ctx 131072): **-1010 MiB resident**, warm decode within run-to-run noise (4.25/4.28/4.36 vs 4.19/4.23/4.33 t/s), no cold-prefill cost, worst case a one-time ~2.5 s first-token transient after a full page-cache drop, recovered by the next request. Full numbers in #688.

**Caveat, stated plainly**: this relies on unified-memory ATS/HMM pageable access (GB10/Grace class) -- the GPU reads the file-backed host pages directly. Discrete-GPU targets would need the `cudaHostRegister`'d-mapping path that `cuda_model_range_ptr` already has for the same idea; that is honest future work, and the env gate defaults OFF precisely so non-unified targets are unaffected.

Build: `make cpu` clean (x86_64), `ds4_cuda.o` + `ds4.o` compile clean with nvcc (arm64 GB10). Companion observability work: #687 / its PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
