### PR TITLE
Render chat markdown in the ds4 CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /ds4_agent_test
 /ds4_server_test
 /ds4_test
+/ds4-render-test
 /ds4flash.gguf
 /TODO.md
 /gguf/

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,8 @@ help:
 	@echo "  make mtp-verify-depth  Run legacy MTP speculative verification smoke if MTP GGUF is present"
 	@echo "  make clean        Remove build outputs"
 
-ds4: ds4_cli.o ds4_help.o linenoise.o ds4_gpu_args.o $(CORE_OBJS)
-	$(CC) $(CFLAGS) -o $@ ds4_cli.o ds4_help.o linenoise.o ds4_gpu_args.o $(CORE_OBJS) $(METAL_LDLIBS)
+ds4: ds4_cli.o ds4_help.o ds4_render.o linenoise.o ds4_gpu_args.o $(CORE_OBJS)
+	$(CC) $(CFLAGS) -o $@ ds4_cli.o ds4_help.o ds4_render.o linenoise.o ds4_gpu_args.o $(CORE_OBJS) $(METAL_LDLIBS)
 
 ds4-server: ds4_server.o ds4_help.o ds4_kvstore.o rax.o ds4_gpu_args.o $(CORE_OBJS)
 	$(CC) $(CFLAGS) -o $@ ds4_server.o ds4_help.o ds4_kvstore.o rax.o ds4_gpu_args.o $(CORE_OBJS) $(METAL_LDLIBS)
@@ -137,8 +137,8 @@ check-mxfp4-half-lut:
 test-mxfp4-metal: check-mxfp4-half-lut tests/test_mxfp4_metal
 	./tests/test_mxfp4_metal
 
-cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_eval_cpu.o ds4_agent_cpu.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS)
-	$(CC) $(CFLAGS) -o ds4 ds4_cli_cpu.o ds4_help.o linenoise.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
+cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_eval_cpu.o ds4_agent_cpu.o ds4_help.o ds4_render.o ds4_web.o ds4_kvstore.o linenoise.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS)
+	$(CC) $(CFLAGS) -o ds4 ds4_cli_cpu.o ds4_help.o ds4_render.o linenoise.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-server ds4_server_cpu.o ds4_help.o ds4_kvstore.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-bench ds4_bench_cpu.o ds4_help.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-eval ds4_eval_cpu.o ds4_help.o $(CPU_CORE_OBJS) $(LDLIBS)
@@ -185,7 +185,7 @@ strix-halo:
 
 rocm: strix-halo
 
-ds4: ds4_cli.o ds4_help.o linenoise.o ds4_gpu_args.o $(CORE_OBJS)
+ds4: ds4_cli.o ds4_help.o ds4_render.o linenoise.o ds4_gpu_args.o $(CORE_OBJS)
 	$(DS4_LINK) -o $@ $^ $(DS4_LINK_LIBS)
 
 ds4-server: ds4_server.o ds4_help.o ds4_kvstore.o rax.o ds4_gpu_args.o $(CORE_OBJS)
@@ -206,8 +206,8 @@ gguf-tools/quality-testing/score_official.o: gguf-tools/quality-testing/score_of
 gguf-tools/quality-testing/score_official: gguf-tools/quality-testing/score_official.o $(CORE_OBJS) rax.o ds4_gpu_args.o
 	$(DS4_LINK) -o $@ $^ $(DS4_LINK_LIBS)
 
-cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_eval_cpu.o ds4_agent_cpu.o ds4_help.o ds4_web.o ds4_kvstore.o linenoise.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS)
-	$(CC) $(CFLAGS) -o ds4 ds4_cli_cpu.o ds4_help.o linenoise.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
+cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_eval_cpu.o ds4_agent_cpu.o ds4_help.o ds4_render.o ds4_web.o ds4_kvstore.o linenoise.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS)
+	$(CC) $(CFLAGS) -o ds4 ds4_cli_cpu.o ds4_help.o ds4_render.o linenoise.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-server ds4_server_cpu.o ds4_help.o ds4_kvstore.o rax.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-bench ds4_bench_cpu.o ds4_help.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-eval ds4_eval_cpu.o ds4_help.o $(CPU_CORE_OBJS) $(LDLIBS)
@@ -229,8 +229,11 @@ ds4.o: ds4.c ds4.h ds4_ssd.h ds4_distributed.h ds4_gpu.h
 ds4_ssd.o: ds4_ssd.c ds4_ssd.h
 	$(CC) $(CFLAGS) -c -o $@ ds4_ssd.c
 
-ds4_cli.o: ds4_cli.c ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h linenoise.h
+ds4_cli.o: ds4_cli.c ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h ds4_render.h linenoise.h
 	$(CC) $(CFLAGS) -c -o $@ ds4_cli.c
+
+ds4_render.o: ds4_render.c ds4_render.h
+	$(CC) $(CFLAGS) -c -o $@ ds4_render.c
 
 ds4_distributed.o: ds4_distributed.c ds4_distributed.h ds4.h ds4_ssd.h
 	$(CC) $(CFLAGS) -c -o $@ ds4_distributed.c
@@ -271,6 +274,12 @@ ds4_agent_test.o: tests/ds4_agent_test.c ds4_agent.c ds4.h ds4_ssd.h ds4_distrib
 tests/cuda_long_context_smoke.o: tests/cuda_long_context_smoke.c ds4_gpu.h
 	$(CC) $(CFLAGS) -I. -c -o $@ tests/cuda_long_context_smoke.c
 
+tests/ds4_render_test.o: tests/ds4_render_test.c ds4_render.h
+	$(CC) $(CFLAGS) -I. -c -o $@ $<
+
+ds4-render-test: tests/ds4_render_test.o ds4_render.o
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
+
 rax.o: rax.c rax.h rax_malloc.h
 	$(CC) $(CFLAGS) -c -o $@ rax.c
 
@@ -280,7 +289,7 @@ linenoise.o: linenoise.c linenoise.h
 ds4_cpu.o: ds4.c ds4.h ds4_ssd.h ds4_distributed.h ds4_gpu.h
 	$(CC) $(CFLAGS) -Wno-unused-function -DDS4_NO_GPU -c -o $@ ds4.c
 
-ds4_cli_cpu.o: ds4_cli.c ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h linenoise.h
+ds4_cli_cpu.o: ds4_cli.c ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h ds4_render.h linenoise.h
 	$(CC) $(CFLAGS) -DDS4_NO_GPU -c -o $@ ds4_cli.c
 
 ds4_gpu_args_cpu.o: ds4_gpu_args.c ds4_gpu_args.h ds4_gpu_mgpu.h
@@ -442,8 +451,9 @@ endif
 
 test: ds4_test ds4_agent_test ds4-eval q4k-dot-test mxfp4-dot-test \
 	tests/test_layer_pack tests/test_engine_mgpu_placement tests/test_gpu_args \
-	$(SAMPLING_TEST) ds4 ds4-server ds4-bench ds4-agent
+	ds4-render-test $(SAMPLING_TEST) ds4 ds4-server ds4-bench ds4-agent
 	./ds4-eval --self-test-extractors
+	./ds4-render-test
 	./ds4_agent_test
 	./ds4_test
 	./tests/test_layer_pack
@@ -488,4 +498,4 @@ mxfp4-dot-test: tests/test_mxfp4_dot.c
 	./tests/test_mxfp4_dot
 
 clean:
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4-render-test ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o

--- a/README.md
+++ b/README.md
@@ -979,8 +979,23 @@ ds4>
 The interactive CLI is a real multi-turn chat. It keeps the rendered chat
 transcript and the live graph KV checkpoint, so each turn extends the previous
 conversation. Useful commands are `/help`, `/think`, `/think-max`, `/nothink`,
-`/ctx N`, `/read FILE`, and `/quit`. Ctrl+C interrupts the current generation
-and returns to `ds4>`.
+`/ctx N`, `/markdown MODE`, `/read FILE`, and `/quit`. Ctrl+C interrupts the
+current generation and returns to `ds4>`.
+
+Replies are rendered as markdown when stdout is a terminal. Bold, italic, and
+inline code become terminal attributes, fenced code blocks are syntax
+highlighted, headings, lists, quotes, and rules are styled, and pipe tables are
+drawn as aligned boxes using character widths that count CJK text correctly.
+Thinking runs through the same renderer in a muted grey palette, so reasoning
+keeps its structure without competing with the answer. `--markdown MODE` selects
+how much of this runs: `full` is the default and does everything, `basic` keeps
+the inline and block styling but streams table rows as ordinary text instead of
+buffering a table until it ends, and `off` prints the raw model text. `--plain`
+is an alias for `--markdown off`, and `--think-plain` keeps thinking flat grey
+while the answer still renders. In the interactive prompt, `/markdown
+[off|basic|full]` switches the mode for the following turns and prints the
+current mode when called without an argument. Redirected or piped output is
+always raw, whatever the mode.
 
 The CLI defaults to thinking mode. Use `/nothink` or `--nothink` for direct
 answers. `--mtp MTP.gguf --mtp-draft 2` enables the optional MTP speculative

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -3,6 +3,7 @@
 #include "ds4_gpu_args.h"
 #include "ds4_tp.h"
 #include "ds4_help.h"
+#include "ds4_render.h"
 #include "linenoise.h"
 
 /* ds4 CLI.
@@ -95,6 +96,7 @@ typedef struct {
     cli_generation_options gen;
     char *prompt_owned;
     bool inspect;
+    bool plain_output;      /* --plain: no markdown rendering on a terminal */
     /* CLI flag wiring: raw argv values for --gpu-vram and --gpu-devices.
      * Resolved post-parse via parse_gpu_vram_arg(). */
     const char *gpu_vram_arg;
@@ -373,119 +375,47 @@ static bool is_rendered_chat_prompt(const char *prompt) {
     return false;
 }
 
+/* Chat output funnels through one renderer.  Markdown formatting only happens
+ * on a terminal and when --plain was not given; redirected output stays a byte
+ * for byte copy of the model text minus the <think> markers. */
 typedef struct {
     ds4_engine *engine;
     FILE *fp;
-    bool format_thinking;
-    bool in_think;
-    bool color_open;
-    bool use_color;
-    bool last_output_newline;
-    char pending[16];
-    size_t pending_len;
+    ds4r render;
 } token_printer;
 
-static bool bytes_has_prefix(const char *p, size_t n, const char *prefix) {
-    size_t plen = strlen(prefix);
-    return n >= plen && memcmp(p, prefix, plen) == 0;
+static void token_printer_init(token_printer *p,
+                               ds4_engine     *engine,
+                               FILE           *fp,
+                               bool            format_thinking,
+                               bool            plain) {
+    memset(p, 0, sizeof(*p));
+    p->engine = engine;
+    p->fp = fp;
+    ds4r_init(&p->render, fp, isatty(fileno(fp)) != 0, format_thinking);
+    if (plain) ds4r_set_markdown(&p->render, false);
+    /* Thinking models start their reply inside the reasoning block, without
+     * emitting the opening tag. */
+    if (format_thinking) ds4r_set_in_think(&p->render, true);
 }
 
-static bool bytes_is_partial_prefix(const char *p, size_t n, const char *prefix) {
-    size_t plen = strlen(prefix);
-    return n < plen && memcmp(prefix, p, n) == 0;
-}
-
-static void token_printer_set_grey(token_printer *p) {
-    if (p->use_color && !p->color_open) {
-        fputs("\x1b[90m", p->fp);
-        p->color_open = true;
-    }
-}
-
-static void token_printer_reset_color(token_printer *p) {
-    if (p->use_color && p->color_open) {
-        fputs("\x1b[0m", p->fp);
-        p->color_open = false;
-    }
-}
-
-static void token_printer_write_char(token_printer *p, char c) {
-    if (p->in_think) token_printer_set_grey(p);
-    fputc((unsigned char)c, p->fp);
-    p->last_output_newline = c == '\n';
-}
-
-static void token_printer_process(token_printer *p, const char *text, size_t len, bool finish) {
-    const char *think_open = "<think>";
-    const char *think_close = "</think>";
-    size_t total = p->pending_len + len;
-    char *buf = malloc(total ? total : 1);
-    if (!buf) return;
-    if (p->pending_len) memcpy(buf, p->pending, p->pending_len);
-    if (len) memcpy(buf + p->pending_len, text, len);
-    p->pending_len = 0;
-
-    size_t i = 0;
-    while (i < total) {
-        const char *cur = buf + i;
-        const size_t rem = total - i;
-        if (bytes_has_prefix(cur, rem, think_open)) {
-            p->in_think = true;
-            i += strlen(think_open);
-            continue;
-        }
-        if (bytes_has_prefix(cur, rem, think_close)) {
-            p->in_think = false;
-            token_printer_reset_color(p);
-            if (!p->last_output_newline) {
-                fputc('\n', p->fp);
-                p->last_output_newline = true;
-            }
-            i += strlen(think_close);
-            continue;
-        }
-        if (!finish && cur[0] == '<' &&
-            (bytes_is_partial_prefix(cur, rem, think_open) ||
-             bytes_is_partial_prefix(cur, rem, think_close)))
-        {
-            if (rem < sizeof(p->pending)) {
-                memcpy(p->pending, cur, rem);
-                p->pending_len = rem;
-            }
-            break;
-        }
-        token_printer_write_char(p, cur[0]);
-        i++;
-    }
-
-    free(buf);
+static void token_printer_release(token_printer *p) {
+    ds4r_free(&p->render);
 }
 
 static void token_printer_finish(token_printer *p) {
-    if (p->format_thinking) {
-        token_printer_process(p, NULL, 0, true);
-        token_printer_reset_color(p);
-    }
-    fflush(p->fp);
+    ds4r_finish(&p->render);
 }
 
 static void generation_done(void *ud) {
     token_printer *p = ud;
     token_printer_finish(p);
-    if (!p->last_output_newline) {
-        fputc('\n', p->fp);
-        p->last_output_newline = true;
-    }
+    if (!ds4r_at_line_start(&p->render)) ds4r_newline(&p->render);
     fflush(p->fp);
 }
 
 static void token_printer_write_text(token_printer *p, const char *text, size_t len) {
-    if (p->format_thinking) {
-        token_printer_process(p, text, len, false);
-    } else if (len) {
-        fwrite(text, 1, len, p->fp);
-        p->last_output_newline = text[len - 1] == '\n';
-    }
+    ds4r_write(&p->render, text, len);
 }
 
 static void print_generated_token(void *ud, int token) {
@@ -534,14 +464,9 @@ static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, con
 
     char err[160];
     ds4_think_mode think_mode = cli_effective_think_mode(&cfg->gen);
-    token_printer printer = {
-        .engine = engine,
-        .fp = stdout,
-        .format_thinking = ds4_think_mode_enabled(think_mode),
-        .in_think = ds4_think_mode_enabled(think_mode),
-        .use_color = isatty(fileno(stdout)) != 0,
-        .last_output_newline = true,
-    };
+    token_printer printer;
+    token_printer_init(&printer, engine, stdout,
+                       ds4_think_mode_enabled(think_mode), cfg->plain_output);
     cli_prefill_progress progress = {
         .base_tokens = 0,
         .input_tokens = prompt->len,
@@ -560,6 +485,7 @@ static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, con
         ds4_session_set_progress(session, NULL, NULL);
         ds4_session_set_display_progress(session, NULL, NULL);
         fprintf(stderr, "ds4: prompt processing failed: %s\n", err);
+        token_printer_release(&printer);
         ds4_session_free(session);
         return 1;
     }
@@ -611,6 +537,7 @@ static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, con
             cli_dist_busy_set(cfg, false);
             if (ntok < 0) {
                 fprintf(stderr, "ds4: decode failed: %s\n", err);
+                token_printer_release(&printer);
                 ds4_session_free(session);
                 return 1;
             }
@@ -630,6 +557,7 @@ static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, con
             cli_dist_busy_set(cfg, false);
             if (eval_rc != 0) {
                 fprintf(stderr, "ds4: decode failed: %s\n", err);
+                token_printer_release(&printer);
                 ds4_session_free(session);
                 return 1;
             }
@@ -654,6 +582,7 @@ static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, con
     }
     const double t_decode1 = cli_now_sec();
     generation_done(&printer);
+    token_printer_release(&printer);
     if (cli_interrupt_requested()) cli_interrupt_clear();
 
     const double prefill_s = t_prefill1 - t_prefill0;
@@ -1232,14 +1161,10 @@ static int run_generation(ds4_engine *engine, const cli_config *cfg) {
              * compares like with like. */
             rc = run_sampled_generation(engine, cfg, &prompt);
         } else {
-            token_printer printer = {
-                .engine = engine,
-                .fp = stdout,
-                .format_thinking = ds4_think_mode_enabled(cli_effective_think_mode(&cfg->gen)),
-                .in_think = ds4_think_mode_enabled(cli_effective_think_mode(&cfg->gen)),
-                .use_color = isatty(fileno(stdout)) != 0,
-                .last_output_newline = true,
-            };
+            token_printer printer;
+            token_printer_init(&printer, engine, stdout,
+                               ds4_think_mode_enabled(cli_effective_think_mode(&cfg->gen)),
+                               cfg->plain_output);
             cli_prefill_progress progress = {
                 .base_tokens = 0,
                 .input_tokens = prompt.len,
@@ -1252,6 +1177,7 @@ static int run_generation(ds4_engine *engine, const cli_config *cfg) {
                                             &printer,
                                             cli_prefill_progress_cb,
                                             &progress);
+            token_printer_release(&printer);
         }
     }
 
@@ -1462,14 +1388,9 @@ static int run_chat_turn(ds4_engine *engine, cli_config *cfg, repl_chat *chat, c
     ds4_session_set_display_progress(chat->session, NULL, NULL);
     const double t_prefill1 = cli_now_sec();
 
-    token_printer printer = {
-        .engine = engine,
-        .fp = stdout,
-        .format_thinking = ds4_think_mode_enabled(think_mode),
-        .in_think = ds4_think_mode_enabled(think_mode),
-        .use_color = isatty(fileno(stdout)) != 0,
-        .last_output_newline = true,
-    };
+    token_printer printer;
+    token_printer_init(&printer, engine, stdout,
+                       ds4_think_mode_enabled(think_mode), cfg->plain_output);
 
     int max_tokens = cfg->gen.n_predict;
     int room = ds4_session_ctx(chat->session) - ds4_session_pos(chat->session);
@@ -1519,6 +1440,7 @@ static int run_chat_turn(ds4_engine *engine, cli_config *cfg, repl_chat *chat, c
             cli_dist_busy_set(cfg, false);
             if (ntok < 0) {
                 fprintf(stderr, "ds4: decode failed: %s\n", err);
+                token_printer_release(&printer);
                 return 1;
             }
         } else {
@@ -1535,6 +1457,7 @@ static int run_chat_turn(ds4_engine *engine, cli_config *cfg, repl_chat *chat, c
             cli_dist_busy_set(cfg, false);
             if (eval_rc != 0) {
                 fprintf(stderr, "ds4: decode failed: %s\n", err);
+                token_printer_release(&printer);
                 ds4_session_invalidate(chat->session);
                 return 1;
             }
@@ -1561,6 +1484,7 @@ static int run_chat_turn(ds4_engine *engine, cli_config *cfg, repl_chat *chat, c
     }
     const double t_decode1 = cli_now_sec();
     generation_done(&printer);
+    token_printer_release(&printer);
 
     const bool interrupted = cli_interrupt_requested();
     if (interrupted && generated == 0) {
@@ -1835,6 +1759,8 @@ static cli_config parse_options(int argc, char **argv) {
             c.gen.system = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--raw") || !strcmp(arg, "--raw-prompt")) {
             c.gen.raw_prompt = true;
+        } else if (!strcmp(arg, "--plain") || !strcmp(arg, "--no-markdown")) {
+            c.plain_output = true;
         } else if (!strcmp(arg, "-m") || !strcmp(arg, "--model")) {
             c.engine.model_path = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--mtp")) {

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -90,13 +90,30 @@ typedef struct {
     bool metal_graph_prompt_test;
 } cli_generation_options;
 
+/* How much of the markdown pipeline runs on a terminal.  BASIC leaves table
+ * rows as ordinary text so nothing is ever buffered while streaming. */
+typedef enum {
+    CLI_MARKDOWN_OFF = 0,
+    CLI_MARKDOWN_BASIC,
+    CLI_MARKDOWN_FULL,
+} cli_markdown_mode;
+
+static const char *cli_markdown_mode_name(cli_markdown_mode mode) {
+    switch (mode) {
+    case CLI_MARKDOWN_OFF: return "off";
+    case CLI_MARKDOWN_BASIC: return "basic";
+    default: return "full";
+    }
+}
+
 typedef struct {
     ds4_engine_options engine;
     ds4_dist_options *dist;
     cli_generation_options gen;
     char *prompt_owned;
     bool inspect;
-    bool plain_output;      /* --plain: no markdown rendering on a terminal */
+    cli_markdown_mode markdown;
+    bool think_plain;       /* --think-plain: reasoning stays flat grey */
     /* CLI flag wiring: raw argv values for --gpu-vram and --gpu-devices.
      * Resolved post-parse via parse_gpu_vram_arg(). */
     const char *gpu_vram_arg;
@@ -214,6 +231,15 @@ static float parse_float_range(const char *s, const char *opt, float min, float 
         exit(2);
     }
     return v;
+}
+
+static cli_markdown_mode parse_markdown_mode(const char *s) {
+    if (!strcmp(s, "off")) return CLI_MARKDOWN_OFF;
+    if (!strcmp(s, "basic")) return CLI_MARKDOWN_BASIC;
+    if (!strcmp(s, "full")) return CLI_MARKDOWN_FULL;
+    fprintf(stderr, "ds4: invalid value for --markdown: %s\n", s);
+    fprintf(stderr, "ds4: valid markdown modes are: off, basic, full\n");
+    exit(2);
 }
 
 static ds4_backend parse_backend(const char *s) {
@@ -384,16 +410,20 @@ typedef struct {
     ds4r render;
 } token_printer;
 
-static void token_printer_init(token_printer *p,
-                               ds4_engine     *engine,
-                               FILE           *fp,
-                               bool            format_thinking,
-                               bool            plain) {
+static void token_printer_init(token_printer  *p,
+                               ds4_engine      *engine,
+                               FILE            *fp,
+                               bool             format_thinking,
+                               const cli_config *cfg) {
     memset(p, 0, sizeof(*p));
     p->engine = engine;
     p->fp = fp;
     ds4r_init(&p->render, fp, isatty(fileno(fp)) != 0, format_thinking);
-    if (plain) ds4r_set_markdown(&p->render, false);
+    if (cfg->markdown == CLI_MARKDOWN_OFF)
+        ds4r_set_markdown(&p->render, false);
+    if (cfg->markdown != CLI_MARKDOWN_FULL)
+        ds4r_set_tables(&p->render, false);
+    if (cfg->think_plain) ds4r_set_think_markdown(&p->render, false);
     /* Thinking models start their reply inside the reasoning block, without
      * emitting the opening tag. */
     if (format_thinking) ds4r_set_in_think(&p->render, true);
@@ -466,7 +496,7 @@ static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, con
     ds4_think_mode think_mode = cli_effective_think_mode(&cfg->gen);
     token_printer printer;
     token_printer_init(&printer, engine, stdout,
-                       ds4_think_mode_enabled(think_mode), cfg->plain_output);
+                       ds4_think_mode_enabled(think_mode), cfg);
     cli_prefill_progress progress = {
         .base_tokens = 0,
         .input_tokens = prompt->len,
@@ -1164,7 +1194,7 @@ static int run_generation(ds4_engine *engine, const cli_config *cfg) {
             token_printer printer;
             token_printer_init(&printer, engine, stdout,
                                ds4_think_mode_enabled(cli_effective_think_mode(&cfg->gen)),
-                               cfg->plain_output);
+                               cfg);
             cli_prefill_progress progress = {
                 .base_tokens = 0,
                 .input_tokens = prompt.len,
@@ -1200,6 +1230,7 @@ static void print_repl_help(void) {
     puts("  /think-max     Use Think Max only when context is at least 393216 tokens.");
     puts("  /nothink       Disable thinking mode.");
     puts("  /ctx N         Set context size for following prompts.");
+    puts("  /markdown MODE Set output rendering: off, basic, or full.");
     puts("  /power N       Set GPU duty cycle percentage, 1..100.");
     puts("  /read FILE     Read a prompt from FILE and run it.");
     puts("  /quit, /exit   Leave the prompt.");
@@ -1390,7 +1421,7 @@ static int run_chat_turn(ds4_engine *engine, cli_config *cfg, repl_chat *chat, c
 
     token_printer printer;
     token_printer_init(&printer, engine, stdout,
-                       ds4_think_mode_enabled(think_mode), cfg->plain_output);
+                       ds4_think_mode_enabled(think_mode), cfg);
 
     int max_tokens = cfg->gen.n_predict;
     int room = ds4_session_ctx(chat->session) - ds4_session_pos(chat->session);
@@ -1561,6 +1592,23 @@ static int run_repl(ds4_engine *engine, cli_config *cfg) {
             cfg->gen.think_mode = DS4_THINK_NONE;
             repl_chat_apply_think_prefix(engine, &chat, DS4_THINK_NONE);
             puts("Thinking mode: none.");
+        } else if (!strncmp(cmd, "/markdown", 9) &&
+                   (cmd[9] == '\0' || isspace((unsigned char)cmd[9]))) {
+            char *arg = trim_inplace(cmd + 9);
+            if (!arg[0]) {
+                printf("Markdown: %s.\n", cli_markdown_mode_name(cfg->markdown));
+            } else if (!strcmp(arg, "off")) {
+                cfg->markdown = CLI_MARKDOWN_OFF;
+                puts("Markdown: off.");
+            } else if (!strcmp(arg, "basic")) {
+                cfg->markdown = CLI_MARKDOWN_BASIC;
+                puts("Markdown: basic.");
+            } else if (!strcmp(arg, "full")) {
+                cfg->markdown = CLI_MARKDOWN_FULL;
+                puts("Markdown: full.");
+            } else {
+                fprintf(stderr, "ds4: /markdown takes off, basic, or full\n");
+            }
         } else if (!strncmp(cmd, "/power", 6) && (cmd[6] == '\0' || isspace((unsigned char)cmd[6]))) {
             char *arg = trim_inplace(cmd + 6);
             if (!arg[0]) {
@@ -1686,6 +1734,7 @@ static cli_config parse_options(int argc, char **argv) {
             .mtp_draft_tokens = 1,
             .mtp_margin = 3.0f,
         },
+        .markdown = CLI_MARKDOWN_FULL,
         .gen = {
             .prompt = NULL,
             .system = "You are a helpful assistant",
@@ -1759,8 +1808,12 @@ static cli_config parse_options(int argc, char **argv) {
             c.gen.system = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--raw") || !strcmp(arg, "--raw-prompt")) {
             c.gen.raw_prompt = true;
-        } else if (!strcmp(arg, "--plain") || !strcmp(arg, "--no-markdown")) {
-            c.plain_output = true;
+        } else if (!strcmp(arg, "--markdown")) {
+            c.markdown = parse_markdown_mode(need_arg(&i, argc, argv, arg));
+        } else if (!strcmp(arg, "--plain")) {
+            c.markdown = CLI_MARKDOWN_OFF;
+        } else if (!strcmp(arg, "--think-plain")) {
+            c.think_plain = true;
         } else if (!strcmp(arg, "-m") || !strcmp(arg, "--model")) {
             c.engine.model_path = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--mtp")) {

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -259,7 +259,9 @@ static void print_cli_specific(FILE *fp, const help_colors *c, bool full) {
     opt(fp, c, "ds4", "Start the interactive prompt.");
     opt(fp, c, "ds4 -p TEXT", "Run one prompt and exit.");
     opt(fp, c, "ds4 --prompt-file FILE", "Run a long prompt from a file and exit.");
-    opt(fp, c, "--plain, --no-markdown", "Print raw model text instead of rendered markdown.");
+    opt(fp, c, "--markdown MODE", "Terminal rendering: off, basic, or full. Default: full");
+    opt(fp, c, "--plain", "Alias for --markdown off.");
+    opt(fp, c, "--think-plain", "Keep thinking text flat grey instead of rendering it.");
     fputc('\n', fp);
     if (full) {
         print_cli_diagnostics(fp, c);
@@ -293,6 +295,7 @@ static void print_cli_commands(FILE *fp, const help_colors *c) {
     opt(fp, c, "/help", "Show interactive commands.");
     opt(fp, c, "/think, /think-max, /nothink", "Switch thinking mode.");
     opt(fp, c, "/ctx N", "Restart the interactive session with a new context size.");
+    opt(fp, c, "/markdown MODE", "Switch terminal rendering: off, basic, or full.");
     opt(fp, c, "/power N", "Set GPU duty cycle percentage, 1..100.");
     opt(fp, c, "/read FILE", "Read FILE and submit it as the next user message.");
     opt(fp, c, "/quit, /exit", "Leave the prompt.");

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -259,6 +259,7 @@ static void print_cli_specific(FILE *fp, const help_colors *c, bool full) {
     opt(fp, c, "ds4", "Start the interactive prompt.");
     opt(fp, c, "ds4 -p TEXT", "Run one prompt and exit.");
     opt(fp, c, "ds4 --prompt-file FILE", "Run a long prompt from a file and exit.");
+    opt(fp, c, "--plain, --no-markdown", "Print raw model text instead of rendered markdown.");
     fputc('\n', fp);
     if (full) {
         print_cli_diagnostics(fp, c);

--- a/ds4_render.c
+++ b/ds4_render.c
@@ -38,6 +38,7 @@
 #define DS4R_THINK      "\x1b[90m"
 #define DS4R_THINK_DIM  "\x1b[2;90m"
 
+static bool ds4r_markdown_active(const ds4r *r);
 static void ds4r_render_byte(ds4r *r, char c);
 static void ds4r_md_feed(ds4r *r, char c);
 static void ds4r_scan_byte(ds4r *r, char c);
@@ -1485,7 +1486,7 @@ static void ds4r_table_byte(ds4r *r, char c) {
  * ============================================================================ */
 
 static void ds4r_line_begin(ds4r *r) {
-    if (!r->format_markdown || r->md_code_block) {
+    if (!ds4r_markdown_active(r) || r->md_code_block) {
         r->line_mode = DS4R_LINE_OFF;
         return;
     }
@@ -1551,7 +1552,7 @@ static void ds4r_scan_byte(ds4r *r, char c) {
             }
             break;
         }
-        if (c == '|') {
+        if (c == '|' && r->format_tables) {
             r->line_mode = DS4R_LINE_TABLE;
             r->tbl_scan = false;
             ds4r_table_append(r, r->line_buf, r->line_len);
@@ -1678,8 +1679,12 @@ static void ds4r_scan_byte(ds4r *r, char c) {
     ds4r_render_byte(r, c);
 }
 
+static bool ds4r_markdown_active(const ds4r *r) {
+    return r->format_markdown && (!r->in_think || r->think_markdown);
+}
+
 static void ds4r_render_byte(ds4r *r, char c) {
-    if (!r->format_markdown) {
+    if (!ds4r_markdown_active(r)) {
         ds4r_md_emit_mark_literals(r);
         ds4r_write_char_raw(r, c);
         return;
@@ -1801,6 +1806,8 @@ void ds4r_init(ds4r *r, FILE *fp, bool color, bool format_thinking) {
     r->fp = fp;
     r->use_color = color;
     r->format_markdown = color;
+    r->format_tables = color;
+    r->think_markdown = color;
     r->format_thinking = format_thinking;
     r->last_output_newline = true;
     ds4r_line_begin(r);
@@ -1808,6 +1815,15 @@ void ds4r_init(ds4r *r, FILE *fp, bool color, bool format_thinking) {
 
 void ds4r_set_markdown(ds4r *r, bool enabled) {
     r->format_markdown = enabled && r->use_color;
+    ds4r_line_begin(r);
+}
+
+void ds4r_set_tables(ds4r *r, bool enabled) {
+    r->format_tables = enabled;
+}
+
+void ds4r_set_think_markdown(ds4r *r, bool enabled) {
+    r->think_markdown = enabled;
     ds4r_line_begin(r);
 }
 

--- a/ds4_render.c
+++ b/ds4_render.c
@@ -1,0 +1,979 @@
+/* Streaming Markdown renderer for terminal chat output.  See ds4_render.h.
+ *
+ * ds4r_write() strips the <think> markers and feeds the rest to
+ * ds4r_md_feed(), which handles the inline constructs: bold, italic, inline
+ * code, and fenced code blocks.  Bytes that cannot be classified yet are held
+ * back: marker runs and partial UTF-8 sequences.
+ *
+ * The inline machine, the UTF-8 accumulator, and the fenced-block highlighter
+ * follow the agent renderer in ds4_agent.c. */
+
+#include "ds4_render.h"
+
+#include <ctype.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#define DS4R_RESET "\x1b[0m"
+
+static void ds4r_render_byte(ds4r *r, char c);
+static void ds4r_md_feed(ds4r *r, char c);
+
+static size_t ds4r_utf8_need(unsigned char c) {
+    if (c < 0x80) return 1;
+    if (c >= 0xc2 && c <= 0xdf) return 2;
+    if (c >= 0xe0 && c <= 0xef) return 3;
+    if (c >= 0xf0 && c <= 0xf4) return 4;
+    return 1;
+}
+
+/* ============================================================================
+ * Growable buffers
+ * ============================================================================ */
+
+typedef struct {
+    char *p;
+    size_t len;
+    size_t cap;
+    bool oom;
+} ds4r_str;
+
+static void ds4r_str_add(ds4r_str *s, const char *b, size_t n) {
+    if (s->oom || !n) return;
+    if (s->len + n + 1 > s->cap) {
+        size_t cap = s->cap ? s->cap * 2 : 256;
+        while (cap < s->len + n + 1) cap *= 2;
+        char *np = realloc(s->p, cap);
+        if (!np) {
+            s->oom = true;
+            return;
+        }
+        s->p = np;
+        s->cap = cap;
+    }
+    memcpy(s->p + s->len, b, n);
+    s->len += n;
+    s->p[s->len] = '\0';
+}
+
+static void ds4r_str_addz(ds4r_str *s, const char *z) {
+    ds4r_str_add(s, z, strlen(z));
+}
+
+static void ds4r_str_free(ds4r_str *s) {
+    free(s->p);
+    memset(s, 0, sizeof(*s));
+}
+
+static bool ds4r_bytes_append(char **buf, size_t *len, size_t *cap,
+                              const char *s, size_t n) {
+    if (!n) return true;
+    if (*len + n + 1 > *cap) {
+        size_t want = *cap ? *cap * 2 : 1024;
+        while (want < *len + n + 1) want *= 2;
+        char *np = realloc(*buf, want);
+        if (!np) return false;
+        *buf = np;
+        *cap = want;
+    }
+    memcpy(*buf + *len, s, n);
+    *len += n;
+    (*buf)[*len] = '\0';
+    return true;
+}
+
+/* ============================================================================
+ * Raw output and terminal attributes
+ * ============================================================================ */
+
+static void ds4r_out(ds4r *r, const char *s, size_t n) {
+    if (!n) return;
+    fwrite(s, 1, n, r->fp);
+    r->last_output_newline = s[n - 1] == '\n';
+}
+
+static void ds4r_seq(ds4r *r, const char *s) {
+    if (r->use_color) ds4r_out(r, s, strlen(s));
+}
+
+static void ds4r_reset_color(ds4r *r) {
+    if (r->use_color && r->color_open) ds4r_out(r, DS4R_RESET, 4);
+    r->color_open = false;
+    r->attr_key = 0;
+}
+
+/* One bit per active attribute, so an attribute change in the middle of a line
+ * repaints instead of silently keeping the previous escape. */
+static unsigned ds4r_attr_key(const ds4r *r) {
+    unsigned k = 0;
+    if (r->in_think) k |= 1u;
+    if (r->md_code_block) k |= 2u;
+    if (r->md_inline_code) k |= 4u;
+    if (r->md_bold) k |= 8u;
+    if (r->md_italic) k |= 16u;
+    return k;
+}
+
+static void ds4r_set_attrs(ds4r *r) {
+    if (r->in_think) {
+        ds4r_seq(r, "\x1b[90m");
+        return;
+    }
+    if (r->md_code_block) {
+        ds4r_seq(r, "\x1b[38;5;75m");
+        return;
+    }
+    if (r->md_inline_code) ds4r_seq(r, "\x1b[36m");
+    if (r->md_bold) ds4r_seq(r, "\x1b[1m");
+    if (r->md_italic) ds4r_seq(r, "\x1b[3m");
+}
+
+/* Emit one complete character with the attributes it must be shown in. */
+static void ds4r_put(ds4r *r, const char *s, size_t n) {
+    unsigned key = r->use_color ? ds4r_attr_key(r) : 0;
+    if (key != r->attr_key) {
+        ds4r_reset_color(r);
+        if (key) {
+            ds4r_set_attrs(r);
+            r->color_open = true;
+            r->attr_key = key;
+        }
+    }
+    ds4r_out(r, s, n);
+}
+
+static void ds4r_flush_utf8(ds4r *r) {
+    if (!r->utf8_pending_len) return;
+    char buf[4];
+    size_t n = r->utf8_pending_len;
+    memcpy(buf, r->utf8_pending, n);
+    r->utf8_pending_len = 0;
+    r->utf8_pending_need = 0;
+    ds4r_put(r, buf, n);
+}
+
+/* Hold incomplete UTF-8 sequences so an attribute change can never be written
+ * between the bytes of one character. */
+static void ds4r_write_char_raw(ds4r *r, char c) {
+    if (!r->format_markdown) {
+        ds4r_put(r, &c, 1);
+        return;
+    }
+    unsigned char uc = (unsigned char)c;
+    if (r->utf8_pending_len) {
+        if ((uc & 0xc0) == 0x80 &&
+            r->utf8_pending_len < sizeof(r->utf8_pending)) {
+            r->utf8_pending[r->utf8_pending_len++] = c;
+            if (r->utf8_pending_len == r->utf8_pending_need) ds4r_flush_utf8(r);
+            return;
+        }
+        ds4r_flush_utf8(r);
+    }
+    size_t need = ds4r_utf8_need(uc);
+    if (need == 1) {
+        ds4r_put(r, &c, 1);
+        return;
+    }
+    r->utf8_pending[0] = c;
+    r->utf8_pending_len = 1;
+    r->utf8_pending_need = need;
+}
+
+/* Fence markers are shown without markdown attributes. */
+static void ds4r_put_plain(ds4r *r, char c) {
+    ds4r_flush_utf8(r);
+    ds4r_reset_color(r);
+    ds4r_out(r, &c, 1);
+}
+
+/* ============================================================================
+ * Fenced code block highlighting
+ * ============================================================================
+ *
+ * Poor man's code highlighter inspired by antirez/kilo: a tiny language table
+ * plus one line-oriented tokenizer for comments, strings, numbers, and
+ * separator-bounded keywords.  Ported from the agent renderer. */
+
+#define DS4R_HL_NORMAL   0
+#define DS4R_HL_COMMENT  1
+#define DS4R_HL_KEYWORD1 2
+#define DS4R_HL_KEYWORD2 3
+#define DS4R_HL_STRING   4
+#define DS4R_HL_NUMBER   5
+
+#define DS4R_SYNTAX_NUMBERS          (1u << 0)
+#define DS4R_SYNTAX_STRINGS          (1u << 1)
+#define DS4R_SYNTAX_BACKTICK_STRINGS (1u << 2)
+#define DS4R_SYNTAX_CASE_INSENSITIVE (1u << 3)
+
+struct ds4r_syntax {
+    const char *name;
+    const char *aliases;
+    const char **keywords;
+    const char *singleline_comments[3];
+    const char *multiline_start;
+    const char *multiline_end;
+    unsigned flags;
+};
+
+static const char *ds4r_kw_generic[] = {
+    "if","else","for","while","do","switch","case","default","break",
+    "continue","return","try","catch","finally","throw","throws","class",
+    "struct","enum","interface","trait","impl","fn","func","function",
+    "def","lambda","let","var","const","static","public","private",
+    "protected","import","include","from","export","package","module",
+    "namespace","new","delete","async","await","yield","match","type",
+    "true|","false|","null|","nil|","none|","None|","NULL|","void|",
+    "int|","long|","float|","double|","char|","bool|","string|",
+    "String|","usize|","isize|","u8|","u16|","u32|","u64|","i8|",
+    "i16|","i32|","i64|",NULL
+};
+
+static const char *ds4r_kw_c[] = {
+    "auto","break","case","continue","default","do","else","enum",
+    "extern","for","goto","if","register","return","sizeof","static",
+    "struct","switch","typedef","union","volatile","while",
+    "alignas","alignof","and","and_eq","asm","bitand","bitor","class",
+    "compl","constexpr","const_cast","decltype","delete","dynamic_cast",
+    "explicit","export","false","friend","inline","mutable","namespace",
+    "new","noexcept","not","not_eq","nullptr","operator","or","or_eq",
+    "private","protected","public","reinterpret_cast","static_assert",
+    "static_cast","template","this","thread_local","throw","true","try",
+    "typeid","typename","virtual","xor","xor_eq",
+    "NULL|","bool|","char|","const|","double|","float|","int|","long|",
+    "short|","signed|","size_t|","ssize_t|","uint8_t|","uint16_t|",
+    "uint32_t|","uint64_t|","unsigned|","void|",NULL
+};
+
+static const char *ds4r_kw_python[] = {
+    "and","as","assert","async","await","break","case","class","continue",
+    "def","del","elif","else","except","finally","for","from","global",
+    "if","import","in","is","lambda","match","nonlocal","not","or","pass",
+    "raise","return","try","while","with","yield",
+    "False|","None|","True|","bool|","bytes|","dict|","float|","int|",
+    "list|","object|","set|","str|","tuple|",NULL
+};
+
+static const char *ds4r_kw_js[] = {
+    "async","await","break","case","catch","class","const","continue",
+    "debugger","default","delete","do","else","export","extends",
+    "finally","for","from","function","get","if","import","in",
+    "instanceof","let","new","of","return","set","static","super",
+    "switch","this","throw","try","typeof","var","void","while","with",
+    "yield","abstract","as","declare","enum","implements","interface",
+    "keyof","namespace","private","protected","public","readonly","type",
+    "any|","boolean|","false|","never|","null|","number|","string|",
+    "symbol|","true|","undefined|","unknown|","void|",NULL
+};
+
+static const char *ds4r_kw_java[] = {
+    "abstract","assert","break","case","catch","class","const","continue",
+    "default","do","else","enum","extends","final","finally","for","goto",
+    "if","implements","import","instanceof","interface","native","new",
+    "package","private","protected","public","return","static","strictfp",
+    "super","switch","synchronized","this","throw","throws","transient",
+    "try","volatile","while",
+    "boolean|","byte|","char|","double|","false|","float|","int|","long|",
+    "null|","short|","true|","void|",NULL
+};
+
+static const char *ds4r_kw_go[] = {
+    "break","case","chan","const","continue","default","defer","else",
+    "fallthrough","for","func","go","goto","if","import","interface",
+    "map","package","range","return","select","struct","switch","type",
+    "var","bool|","byte|","complex64|","complex128|","error|","false|",
+    "float32|","float64|","int|","int8|","int16|","int32|","int64|",
+    "nil|","rune|","string|","true|","uint|","uint8|","uint16|",
+    "uint32|","uint64|","uintptr|",NULL
+};
+
+static const char *ds4r_kw_rust[] = {
+    "as","async","await","break","const","continue","crate","dyn","else",
+    "enum","extern","fn","for","if","impl","in","let","loop","match",
+    "mod","move","mut","pub","ref","return","self","Self","static",
+    "struct","super","trait","type","unsafe","use","where","while",
+    "bool|","char|","false|","f32|","f64|","i8|","i16|","i32|","i64|",
+    "i128|","isize|","str|","String|","true|","u8|","u16|","u32|",
+    "u64|","u128|","usize|",NULL
+};
+
+static const char *ds4r_kw_shell[] = {
+    "case","do","done","elif","else","esac","fi","for","function","if",
+    "in","select","then","time","until","while","break","continue",
+    "return","export","local","readonly","source","test","true|","false|",
+    "echo|","printf|","cd|","pwd|","read|","set|","unset|","shift|",NULL
+};
+
+static const char *ds4r_kw_sql[] = {
+    "add","alter","and","as","asc","between","by","case","check","column",
+    "constraint","create","delete","desc","distinct","drop","else","end",
+    "exists","foreign","from","group","having","in","index","insert",
+    "into","is","join","key","left","like","limit","not","null","on",
+    "or","order","outer","primary","references","right","select","set",
+    "table","then","union","unique","update","values","view","where",
+    "bigint|","boolean|","date|","decimal|","false|","int|","integer|",
+    "numeric|","real|","text|","timestamp|","true|","varchar|",NULL
+};
+
+static const char *ds4r_kw_ruby[] = {
+    "BEGIN","END","alias","and","begin","break","case","class","def",
+    "defined?","do","else","elsif","end","ensure","for","if","in",
+    "module","next","not","or","redo","rescue","retry","return","self",
+    "super","then","undef","unless","until","when","while","yield",
+    "false|","nil|","true|",NULL
+};
+
+static const char *ds4r_kw_swift[] = {
+    "actor","as","associatedtype","async","await","break","case","catch",
+    "class","continue","default","defer","do","else","enum","extension",
+    "fallthrough","for","func","guard","if","import","in","init","inout",
+    "is","let","nonisolated","operator","private","protocol","public",
+    "repeat","return","self","Self","static","struct","subscript","super",
+    "switch","throw","throws","try","typealias","var","where","while",
+    "Any|","Bool|","Double|","false|","Float|","Int|","nil|","String|",
+    "true|","Void|",NULL
+};
+
+static const char *ds4r_kw_kotlin[] = {
+    "as","break","class","continue","do","else","false","for","fun","if",
+    "in","interface","is","null","object","package","return","super",
+    "this","throw","true","try","typealias","typeof","val","var","when",
+    "while","actual","annotation","by","catch","companion","const",
+    "constructor","crossinline","data","enum","expect","external","final",
+    "finally","import","infix","init","inline","inner","internal","lateinit",
+    "noinline","open","operator","out","override","private","protected",
+    "public","reified","sealed","suspend","tailrec","vararg",
+    "Any|","Boolean|","Byte|","Char|","Double|","Float|","Int|","Long|",
+    "Short|","String|","Unit|",NULL
+};
+
+static const char *ds4r_kw_lua[] = {
+    "and","break","do","else","elseif","end","false","for","function",
+    "goto","if","in","local","nil","not","or","repeat","return","then",
+    "true","until","while",NULL
+};
+
+static const char *ds4r_kw_html[] = {
+    "a","body","button","div","doctype","form","h1","h2","h3","head",
+    "html","input","label","li","link","main","meta","ol","option","p",
+    "script","section","select","span","style","table","tbody","td","th",
+    "thead","title","tr","ul","class|","href|","id|","name|","rel|",
+    "src|","type|","value|",NULL
+};
+
+static const char *ds4r_kw_css[] = {
+    "align-items","background","border","bottom","color","display","flex",
+    "font","font-size","gap","grid","height","justify-content","left",
+    "margin","max-width","min-width","padding","position","right","top",
+    "transform","width","z-index","absolute|","auto|","block|","flex|",
+    "grid|","hidden|","inline|","none|","relative|","solid|",NULL
+};
+
+static const ds4r_syntax ds4r_syntaxes[] = {
+    {"generic", "", ds4r_kw_generic, {"//","#",NULL}, "/*", "*/",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS | DS4R_SYNTAX_BACKTICK_STRINGS},
+    {"c", " c h cpp c++ cc cxx hpp hxx objc objective-c", ds4r_kw_c,
+        {"//",NULL,NULL}, "/*", "*/",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {"python", " py python py3", ds4r_kw_python, {"#",NULL,NULL}, NULL, NULL,
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {"javascript", " js jsx javascript typescript ts tsx node mjs cjs",
+        ds4r_kw_js, {"//",NULL,NULL}, "/*", "*/",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS | DS4R_SYNTAX_BACKTICK_STRINGS},
+    {"java", " java", ds4r_kw_java, {"//",NULL,NULL}, "/*", "*/",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {"go", " go golang", ds4r_kw_go, {"//",NULL,NULL}, "/*", "*/",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS | DS4R_SYNTAX_BACKTICK_STRINGS},
+    {"rust", " rs rust", ds4r_kw_rust, {"//",NULL,NULL}, "/*", "*/",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {"shell", " sh bash zsh shell fish ksh", ds4r_kw_shell, {"#",NULL,NULL},
+        NULL, NULL,
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS | DS4R_SYNTAX_BACKTICK_STRINGS},
+    {"sql", " sql postgres mysql sqlite", ds4r_kw_sql, {"--",NULL,NULL},
+        "/*", "*/",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS | DS4R_SYNTAX_CASE_INSENSITIVE},
+    {"ruby", " rb ruby", ds4r_kw_ruby, {"#",NULL,NULL}, NULL, NULL,
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {"swift", " swift", ds4r_kw_swift, {"//",NULL,NULL}, "/*", "*/",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {"kotlin", " kt kts kotlin", ds4r_kw_kotlin, {"//",NULL,NULL}, "/*", "*/",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {"lua", " lua", ds4r_kw_lua, {"--",NULL,NULL}, NULL, NULL,
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {"html", " html htm xml svg", ds4r_kw_html, {NULL,NULL,NULL}, "<!--", "-->",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {"css", " css scss sass", ds4r_kw_css, {NULL,NULL,NULL}, "/*", "*/",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {"json", " json jsonc", NULL, {"//",NULL,NULL}, "/*", "*/",
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {"yaml", " yaml yml toml ini", NULL, {"#",NULL,NULL}, NULL, NULL,
+        DS4R_SYNTAX_NUMBERS | DS4R_SYNTAX_STRINGS},
+    {NULL, NULL, NULL, {NULL,NULL,NULL}, NULL, NULL, 0}
+};
+
+static bool ds4r_syntax_alias_match(const char *aliases, const char *lang) {
+    if (!aliases || !lang || !lang[0]) return false;
+    size_t llen = strlen(lang);
+    const char *p = aliases;
+    while (*p) {
+        while (*p == ' ') p++;
+        const char *start = p;
+        while (*p && *p != ' ') p++;
+        if ((size_t)(p - start) == llen && !strncasecmp(start, lang, llen))
+            return true;
+    }
+    return false;
+}
+
+/* An empty or explicitly plain info string disables highlighting: those fences
+ * usually carry ASCII diagrams or command output that must stay untouched. */
+static const ds4r_syntax *ds4r_syntax_for_lang(const char *lang) {
+    static const char *plain[] = {"text","txt","plain","none","ascii",
+                                  "diagram","output","log",NULL};
+    if (!lang || !lang[0]) return NULL;
+    for (int i = 0; plain[i]; i++)
+        if (!strcasecmp(plain[i], lang)) return NULL;
+    for (const ds4r_syntax *s = ds4r_syntaxes; s->name; s++) {
+        if (!strcasecmp(s->name, lang) ||
+            ds4r_syntax_alias_match(s->aliases, lang))
+            return s;
+    }
+    return &ds4r_syntaxes[0];
+}
+
+static bool ds4r_syntax_separator(char c) {
+    unsigned char uc = (unsigned char)c;
+    return c == '\0' || isspace(uc) ||
+           strchr(",.()+-/*=~%[]{}<>:;!&|^?", c) != NULL;
+}
+
+static bool ds4r_syntax_line_comment(const ds4r_syntax *syn, const char *p,
+                                     const char *end) {
+    for (int i = 0; i < 3 && syn->singleline_comments[i]; i++) {
+        const char *m = syn->singleline_comments[i];
+        size_t mlen = strlen(m);
+        if (mlen && (size_t)(end - p) >= mlen && !strncmp(p, m, mlen))
+            return true;
+    }
+    return false;
+}
+
+static int ds4r_syntax_color(int hl) {
+    switch (hl) {
+    case DS4R_HL_COMMENT: return 244;
+    case DS4R_HL_KEYWORD1: return 214;
+    case DS4R_HL_KEYWORD2: return 81;
+    case DS4R_HL_STRING: return 150;
+    case DS4R_HL_NUMBER: return 203;
+    default: return 252;
+    }
+}
+
+/* cur tracks the color already set, so a run of same-class tokens costs one
+ * escape instead of one per character. */
+static void ds4r_syntax_out(ds4r *r, ds4r_str *out, int *cur, int hl,
+                            const char *s, size_t n) {
+    if (!n) return;
+    if (r->use_color && hl != *cur) {
+        char seq[32];
+        snprintf(seq, sizeof(seq), "\x1b[38;5;%dm", ds4r_syntax_color(hl));
+        ds4r_str_addz(out, seq);
+        *cur = hl;
+    }
+    ds4r_str_add(out, s, n);
+}
+
+static size_t ds4r_syntax_keyword_len(const char *kw, bool *secondary) {
+    size_t len = strlen(kw);
+    *secondary = len && kw[len - 1] == '|';
+    return *secondary ? len - 1 : len;
+}
+
+static bool ds4r_syntax_match_keyword(const ds4r_syntax *syn, const char *p,
+                                      const char *line_end, size_t *out_len,
+                                      int *out_hl) {
+    if (!syn->keywords) return false;
+    for (int i = 0; syn->keywords[i]; i++) {
+        bool secondary = false;
+        size_t klen = ds4r_syntax_keyword_len(syn->keywords[i], &secondary);
+        if ((size_t)(line_end - p) < klen) continue;
+        bool match = (syn->flags & DS4R_SYNTAX_CASE_INSENSITIVE) ?
+            !strncasecmp(p, syn->keywords[i], klen) :
+            !strncmp(p, syn->keywords[i], klen);
+        if (!match) continue;
+        if (!ds4r_syntax_separator(p[klen])) continue;
+        *out_len = klen;
+        *out_hl = secondary ? DS4R_HL_KEYWORD2 : DS4R_HL_KEYWORD1;
+        return true;
+    }
+    return false;
+}
+
+static bool ds4r_syntax_number_start(const char *p, const char *line,
+                                     bool prev_sep, int prev_hl) {
+    unsigned char c = (unsigned char)*p;
+    if (isdigit(c) && (prev_sep || prev_hl == DS4R_HL_NUMBER)) return true;
+    if (*p == '.' && p > line && prev_hl == DS4R_HL_NUMBER) return true;
+    return false;
+}
+
+static size_t ds4r_syntax_number_len(const char *p, const char *line_end) {
+    const char *q = p;
+    while (q < line_end) {
+        unsigned char c = (unsigned char)*q;
+        if (isalnum(c) || *q == '_' || *q == '.' || *q == '+' || *q == '-') q++;
+        else break;
+    }
+    return (size_t)(q - p);
+}
+
+/* The caller guarantees line[len] == '\0', so keyword lookahead may read the
+ * terminator when a keyword ends the line. */
+static void ds4r_syntax_emit_line(ds4r *r, ds4r_str *out,
+                                  const char *line, size_t len) {
+    const ds4r_syntax *syn = r->md_syntax;
+    const char *p = line;
+    const char *end = line + len;
+    bool prev_sep = true;
+    int prev_hl = DS4R_HL_NORMAL;
+    int cur = -1;
+
+    while (p < end) {
+        if (r->md_code_in_ml_comment) {
+            const char *mce = syn->multiline_end;
+            if (mce && *mce) {
+                size_t mlen = strlen(mce);
+                const char *q = p;
+                while (q < end && ((size_t)(end - q) < mlen ||
+                       strncmp(q, mce, mlen))) q++;
+                if (q < end) {
+                    q += mlen;
+                    ds4r_syntax_out(r, out, &cur, DS4R_HL_COMMENT, p, (size_t)(q - p));
+                    p = q;
+                    r->md_code_in_ml_comment = false;
+                    prev_sep = true;
+                    prev_hl = DS4R_HL_COMMENT;
+                    continue;
+                }
+            }
+            ds4r_syntax_out(r, out, &cur, DS4R_HL_COMMENT, p, (size_t)(end - p));
+            break;
+        }
+
+        if (ds4r_syntax_line_comment(syn, p, end)) {
+            ds4r_syntax_out(r, out, &cur, DS4R_HL_COMMENT, p, (size_t)(end - p));
+            break;
+        }
+
+        if (syn->multiline_start && syn->multiline_end &&
+            (size_t)(end - p) >= strlen(syn->multiline_start) &&
+            !strncmp(p, syn->multiline_start, strlen(syn->multiline_start))) {
+            size_t mlen = strlen(syn->multiline_start);
+            const char *q = p + mlen;
+            size_t elen = strlen(syn->multiline_end);
+            while (q < end && ((size_t)(end - q) < elen ||
+                   strncmp(q, syn->multiline_end, elen))) q++;
+            if (q < end) q += elen;
+            else r->md_code_in_ml_comment = true;
+            ds4r_syntax_out(r, out, &cur, DS4R_HL_COMMENT, p, (size_t)(q - p));
+            p = q;
+            prev_sep = false;
+            prev_hl = DS4R_HL_COMMENT;
+            continue;
+        }
+
+        if ((syn->flags & DS4R_SYNTAX_STRINGS) &&
+            (*p == '"' || *p == '\'' ||
+             ((syn->flags & DS4R_SYNTAX_BACKTICK_STRINGS) && *p == '`'))) {
+            int quote = *p;
+            const char *q = p + 1;
+            while (q < end) {
+                if (*q == '\\' && q + 1 < end) {
+                    q += 2;
+                    continue;
+                }
+                q++;
+                if (q[-1] == quote) break;
+            }
+            ds4r_syntax_out(r, out, &cur, DS4R_HL_STRING, p, (size_t)(q - p));
+            p = q;
+            prev_sep = false;
+            prev_hl = DS4R_HL_STRING;
+            continue;
+        }
+
+        if ((syn->flags & DS4R_SYNTAX_NUMBERS) &&
+            ds4r_syntax_number_start(p, line, prev_sep, prev_hl)) {
+            size_t nlen = ds4r_syntax_number_len(p, end);
+            ds4r_syntax_out(r, out, &cur, DS4R_HL_NUMBER, p, nlen);
+            p += nlen;
+            prev_sep = false;
+            prev_hl = DS4R_HL_NUMBER;
+            continue;
+        }
+
+        if (prev_sep) {
+            size_t klen = 0;
+            int khl = DS4R_HL_NORMAL;
+            if (ds4r_syntax_match_keyword(syn, p, end, &klen, &khl)) {
+                ds4r_syntax_out(r, out, &cur, khl, p, klen);
+                p += klen;
+                prev_sep = false;
+                prev_hl = khl;
+                continue;
+            }
+        }
+
+        ds4r_syntax_out(r, out, &cur, DS4R_HL_NORMAL, p, 1);
+        prev_sep = ds4r_syntax_separator(*p);
+        prev_hl = DS4R_HL_NORMAL;
+        p++;
+    }
+    if (r->use_color && cur >= 0) ds4r_str_addz(out, DS4R_RESET);
+}
+
+/* ============================================================================
+ * Code blocks
+ * ============================================================================ */
+
+static void ds4r_code_line_append(ds4r *r, char c) {
+    if (!ds4r_bytes_append(&r->code_line, &r->code_line_len,
+                           &r->code_line_cap, &c, 1))
+        ds4r_put(r, &c, 1);      /* out of memory: stream the byte instead */
+}
+
+/* Code lines are held until their newline arrives so the highlighter sees a
+ * whole line.  Nothing is rewritten afterwards, so the terminal never gets a
+ * repaint and fence content stays byte exact apart from color. */
+static void ds4r_code_emit_line(ds4r *r, bool with_newline) {
+    ds4r_flush_utf8(r);
+    ds4r_reset_color(r);
+    if (r->code_line_len) {
+        if (r->md_syntax) {
+            ds4r_str out = {0};
+            ds4r_syntax_emit_line(r, &out, r->code_line, r->code_line_len);
+            if (!out.oom && out.p) ds4r_out(r, out.p, out.len);
+            else ds4r_out(r, r->code_line, r->code_line_len);
+            ds4r_str_free(&out);
+        } else {
+            ds4r_seq(r, "\x1b[38;5;75m");
+            ds4r_out(r, r->code_line, r->code_line_len);
+            ds4r_seq(r, DS4R_RESET);
+        }
+    }
+    r->code_line_len = 0;
+    if (r->code_line) r->code_line[0] = '\0';
+    if (with_newline) {
+        ds4r_out(r, "\n", 1);
+        r->md_code_line_start = true;
+    }
+}
+
+static void ds4r_code_byte(ds4r *r, char c) {
+    if (c == '\n') {
+        ds4r_code_emit_line(r, true);
+        return;
+    }
+    ds4r_code_line_append(r, c);
+    if (c != ' ' && c != '\t' && c != '\r') r->md_code_line_start = false;
+}
+
+static void ds4r_code_begin(ds4r *r) {
+    ds4r_flush_utf8(r);
+    ds4r_reset_color(r);
+    r->md_code_block = true;
+    r->md_inline_code = false;
+    r->md_fence_info = true;
+    r->md_code_line_start = true;
+    r->md_code_in_ml_comment = false;
+    r->md_syntax = NULL;
+    r->md_fence_lang_len = 0;
+    r->md_fence_lang[0] = '\0';
+    r->code_line_len = 0;
+}
+
+static void ds4r_code_end(ds4r *r) {
+    bool only_space = true;
+    for (size_t i = 0; i < r->code_line_len; i++) {
+        if (r->code_line[i] != ' ' && r->code_line[i] != '\t' &&
+            r->code_line[i] != '\r') {
+            only_space = false;
+            break;
+        }
+    }
+    if (r->code_line_len && !only_space) ds4r_code_emit_line(r, false);
+    else r->code_line_len = 0;
+    r->md_code_block = false;
+    r->md_inline_code = false;
+    r->md_fence_info = false;
+    r->md_code_line_start = true;
+    r->md_code_in_ml_comment = false;
+    r->md_syntax = NULL;
+    r->md_fence_lang_len = 0;
+    r->md_fence_lang[0] = '\0';
+}
+
+/* ============================================================================
+ * Inline markdown
+ * ============================================================================ */
+
+static void ds4r_md_clear_mark(ds4r *r) {
+    r->md_mark = DS4R_MARK_NONE;
+    r->md_mark_len = 0;
+}
+
+static void ds4r_md_emit_mark_literals(ds4r *r) {
+    char c;
+    if (r->md_mark == DS4R_MARK_STAR) c = '*';
+    else if (r->md_mark == DS4R_MARK_BACKTICK) c = '`';
+    else return;
+    size_t count = r->md_mark_len;
+    ds4r_md_clear_mark(r);
+    for (size_t i = 0; i < count; i++) {
+        if (r->md_code_block) ds4r_code_byte(r, c);
+        else ds4r_write_char_raw(r, c);
+    }
+}
+
+static void ds4r_md_commit_backticks(ds4r *r) {
+    size_t count = r->md_mark_len;
+    ds4r_md_clear_mark(r);
+    if (count >= 3) {
+        bool was_code = r->md_code_block;
+        /* Flush the partial code line before the closing fence is printed,
+         * otherwise its buffered indentation would follow the marker. */
+        if (was_code) ds4r_code_end(r);
+        for (size_t i = 0; i < count; i++) ds4r_put_plain(r, '`');
+        if (!was_code) ds4r_code_begin(r);
+        return;
+    }
+    if (r->md_code_block) {
+        for (size_t i = 0; i < count; i++) ds4r_code_byte(r, '`');
+        return;
+    }
+    /* Support both `code` and ``code``. */
+    r->md_inline_code = !r->md_inline_code;
+}
+
+static bool ds4r_space_byte(char c) {
+    return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+/* Consume one byte of markdown-aware output.  Backticks and stars are held
+ * until the parser knows whether they form a marker; ordinary text goes to the
+ * raw writer with the current attributes. */
+static void ds4r_md_feed(ds4r *r, char c) {
+    if (r->md_fence_info) {
+        if (c == '\n') {
+            r->md_fence_lang[r->md_fence_lang_len] = '\0';
+            r->md_syntax = ds4r_syntax_for_lang(r->md_fence_lang);
+            ds4r_put_plain(r, '\n');
+            r->md_fence_info = false;
+            r->md_code_line_start = true;
+        } else {
+            unsigned char uc = (unsigned char)c;
+            if (r->md_fence_lang_len + 1 < sizeof(r->md_fence_lang) &&
+                (isalnum(uc) || c == '_' || c == '-' || c == '+' || c == '#'))
+                r->md_fence_lang[r->md_fence_lang_len++] = c;
+            ds4r_put_plain(r, c);
+        }
+        return;
+    }
+
+    if (r->md_mark == DS4R_MARK_BACKTICK) {
+        if (c == '`') {
+            r->md_mark_len++;
+            return;
+        }
+        ds4r_md_commit_backticks(r);
+        ds4r_md_feed(r, c);
+        return;
+    }
+
+    if (r->md_mark == DS4R_MARK_STAR) {
+        ds4r_md_clear_mark(r);
+        if (!r->md_inline_code && !r->md_code_block && c == '*') {
+            r->md_bold = !r->md_bold;
+            return;
+        }
+        /* "a * b" keeps its literal star: opening emphasis may not be followed
+         * by whitespace. */
+        if (!r->md_inline_code && !r->md_code_block &&
+            (r->md_italic || !ds4r_space_byte(c))) {
+            r->md_italic = !r->md_italic;
+            ds4r_md_feed(r, c);
+            return;
+        }
+        ds4r_write_char_raw(r, '*');
+        ds4r_md_feed(r, c);
+        return;
+    }
+
+    if (c == '`' && (!r->md_code_block || r->md_code_line_start)) {
+        r->md_mark = DS4R_MARK_BACKTICK;
+        r->md_mark_len = 1;
+        return;
+    }
+    if (r->md_code_block) {
+        ds4r_code_byte(r, c);
+        return;
+    }
+    if (!r->md_inline_code && c == '*') {
+        r->md_mark = DS4R_MARK_STAR;
+        r->md_mark_len = 1;
+        return;
+    }
+    ds4r_write_char_raw(r, c);
+}
+
+static void ds4r_render_byte(ds4r *r, char c) {
+    if (!r->format_markdown || r->in_think) {
+        ds4r_md_emit_mark_literals(r);
+        ds4r_write_char_raw(r, c);
+        return;
+    }
+    ds4r_md_feed(r, c);
+}
+
+/* ============================================================================
+ * <think> filtering and public entry points
+ * ============================================================================ */
+
+static bool ds4r_has_prefix(const char *p, size_t n, const char *prefix) {
+    size_t plen = strlen(prefix);
+    return n >= plen && memcmp(p, prefix, plen) == 0;
+}
+
+static bool ds4r_is_partial_prefix(const char *p, size_t n, const char *prefix) {
+    size_t plen = strlen(prefix);
+    return n < plen && memcmp(prefix, p, n) == 0;
+}
+
+/* Hide the think markers, grey the thinking text, and never emit a control tag
+ * that is still split across model tokens. */
+static void ds4r_think_process(ds4r *r, const char *text, size_t len,
+                               bool finish) {
+    const char *think_open = "<think>";
+    const char *think_close = "</think>";
+    size_t total = r->pending_len + len;
+    char *buf = malloc(total ? total : 1);
+    if (!buf) return;
+    if (r->pending_len) memcpy(buf, r->pending, r->pending_len);
+    if (len) memcpy(buf + r->pending_len, text, len);
+    r->pending_len = 0;
+
+    size_t i = 0;
+    while (i < total) {
+        const char *cur = buf + i;
+        const size_t rem = total - i;
+        if (ds4r_has_prefix(cur, rem, think_open)) {
+            ds4r_flush_utf8(r);
+            r->in_think = true;
+            i += strlen(think_open);
+            continue;
+        }
+        if (ds4r_has_prefix(cur, rem, think_close)) {
+            ds4r_flush_utf8(r);
+            r->in_think = false;
+            ds4r_reset_color(r);
+            if (!r->last_output_newline) ds4r_out(r, "\n", 1);
+            i += strlen(think_close);
+            continue;
+        }
+        if (!finish && cur[0] == '<' &&
+            (ds4r_is_partial_prefix(cur, rem, think_open) ||
+             ds4r_is_partial_prefix(cur, rem, think_close)))
+        {
+            if (rem < sizeof(r->pending)) {
+                memcpy(r->pending, cur, rem);
+                r->pending_len = rem;
+            }
+            break;
+        }
+        ds4r_render_byte(r, cur[0]);
+        i++;
+    }
+
+    free(buf);
+}
+
+void ds4r_init(ds4r *r, FILE *fp, bool color, bool format_thinking) {
+    memset(r, 0, sizeof(*r));
+    r->fp = fp;
+    r->use_color = color;
+    r->format_markdown = color;
+    r->format_thinking = format_thinking;
+    r->last_output_newline = true;
+}
+
+void ds4r_set_markdown(ds4r *r, bool enabled) {
+    r->format_markdown = enabled && r->use_color;
+}
+
+void ds4r_set_in_think(ds4r *r, bool in_think) {
+    r->in_think = in_think;
+}
+
+bool ds4r_at_line_start(const ds4r *r) {
+    return r->last_output_newline;
+}
+
+void ds4r_newline(ds4r *r) {
+    ds4r_flush_utf8(r);
+    ds4r_reset_color(r);
+    ds4r_out(r, "\n", 1);
+}
+
+void ds4r_write(ds4r *r, const char *text, size_t len) {
+    if (r->format_thinking) {
+        ds4r_think_process(r, text, len, false);
+        return;
+    }
+    if (!r->format_markdown) {
+        if (len) {
+            fwrite(text, 1, len, r->fp);
+            r->last_output_newline = text[len - 1] == '\n';
+        }
+        return;
+    }
+    for (size_t i = 0; i < len; i++) ds4r_render_byte(r, text[i]);
+}
+
+void ds4r_finish(ds4r *r) {
+    if (r->format_thinking) ds4r_think_process(r, NULL, 0, true);
+    if (r->format_markdown) {
+        /* A closing fence can be the last thing the model emits, with no
+         * following byte to push the pending backticks through. */
+        if (r->md_mark == DS4R_MARK_BACKTICK && r->md_mark_len >= 3)
+            ds4r_md_commit_backticks(r);
+        else
+            ds4r_md_emit_mark_literals(r);
+        if (r->md_code_block && r->code_line_len) ds4r_code_emit_line(r, false);
+        ds4r_flush_utf8(r);
+        r->md_bold = false;
+        r->md_italic = false;
+        r->md_inline_code = false;
+        r->md_code_block = false;
+        r->md_fence_info = false;
+        r->md_code_line_start = false;
+        r->md_code_in_ml_comment = false;
+        r->md_syntax = NULL;
+        r->md_fence_lang_len = 0;
+        r->md_fence_lang[0] = '\0';
+        ds4r_md_clear_mark(r);
+    }
+    ds4r_flush_utf8(r);
+    ds4r_reset_color(r);
+    fflush(r->fp);
+}
+
+void ds4r_free(ds4r *r) {
+    free(r->code_line);
+    r->code_line = NULL;
+    r->code_line_len = 0;
+    r->code_line_cap = 0;
+}

--- a/ds4_render.c
+++ b/ds4_render.c
@@ -9,7 +9,10 @@
  *
  * The inline machine, the UTF-8 accumulator, and the fenced-block highlighter
  * follow the agent renderer in ds4_agent.c; the line-start dispatch and the
- * table layout are new. */
+ * table layout are new.
+ *
+ * <think> blocks run through the same pipeline with a muted palette, so
+ * reasoning keeps its structure without ever using hue. */
 
 #include "ds4_render.h"
 
@@ -27,6 +30,13 @@
 
 #define DS4R_GREY  "\x1b[38;5;244m"
 #define DS4R_RESET "\x1b[0m"
+
+/* Thinking text is rendered with the same markdown pipeline as the answer, but
+ * every style maps to a grey variant: reasoning must stay in the background and
+ * never compete with the answer for attention.  No hue is ever emitted inside a
+ * think block, only SGR 90 plus bold/italic/underline/dim. */
+#define DS4R_THINK      "\x1b[90m"
+#define DS4R_THINK_DIM  "\x1b[2;90m"
 
 static void ds4r_render_byte(ds4r *r, char c);
 static void ds4r_md_feed(ds4r *r, char c);
@@ -269,9 +279,42 @@ static unsigned ds4r_attr_key(const ds4r *r) {
     return k;
 }
 
+/* Decorations the renderer draws itself: bullets, quote bars, rules, and table
+ * frames. */
+static const char *ds4r_deco_color(const ds4r *r) {
+    return r->in_think ? DS4R_THINK_DIM : DS4R_GREY;
+}
+
 static void ds4r_set_attrs(ds4r *r) {
     if (r->in_think) {
-        ds4r_seq(r, "\x1b[90m");
+        /* One combined sequence so the grey base survives every attribute. */
+        char seq[16];
+        size_t n = 0;
+        seq[n++] = '\x1b';
+        seq[n++] = '[';
+        if (!r->md_code_block) {
+            if (r->md_bold || r->md_heading) {
+                seq[n++] = '1';
+                seq[n++] = ';';
+            }
+            if (r->md_italic) {
+                seq[n++] = '3';
+                seq[n++] = ';';
+            }
+            if (r->md_heading_underline) {
+                seq[n++] = '4';
+                seq[n++] = ';';
+            }
+            if (r->md_inline_code) {
+                seq[n++] = '2';
+                seq[n++] = ';';
+            }
+        }
+        seq[n++] = '9';
+        seq[n++] = '0';
+        seq[n++] = 'm';
+        seq[n] = '\0';
+        ds4r_seq(r, seq);
         return;
     }
     if (r->md_code_block) {
@@ -345,11 +388,31 @@ static void ds4r_emit_styled(ds4r *r, const char *color, const char *text) {
     if (color) ds4r_seq(r, DS4R_RESET);
 }
 
-/* Fence markers are shown without markdown attributes. */
+/* Fence markers are shown without markdown attributes.  Inside a think block
+ * they still carry the muted base color, so the fence does not flash at answer
+ * brightness in the middle of dim text. */
 static void ds4r_put_plain(ds4r *r, char c) {
+    bool bold = r->md_bold;
+    bool italic = r->md_italic;
+    bool code = r->md_inline_code;
+    bool block = r->md_code_block;
+    bool heading = r->md_heading;
+    bool underline = r->md_heading_underline;
+
     ds4r_flush_utf8(r);
-    ds4r_reset_color(r);
-    ds4r_out(r, &c, 1);
+    r->md_bold = false;
+    r->md_italic = false;
+    r->md_inline_code = false;
+    r->md_code_block = false;
+    r->md_heading = false;
+    r->md_heading_underline = false;
+    ds4r_put(r, &c, 1);
+    r->md_bold = bold;
+    r->md_italic = italic;
+    r->md_inline_code = code;
+    r->md_code_block = block;
+    r->md_heading = heading;
+    r->md_heading_underline = underline;
 }
 
 static int ds4r_columns(const ds4r *r) {
@@ -824,14 +887,14 @@ static void ds4r_code_emit_line(ds4r *r, bool with_newline) {
     ds4r_flush_utf8(r);
     ds4r_reset_color(r);
     if (r->code_line_len) {
-        if (r->md_syntax) {
+        if (r->md_syntax && !r->in_think) {
             ds4r_str out = {0};
             ds4r_syntax_emit_line(r, &out, r->code_line, r->code_line_len);
             if (!out.oom && out.p) ds4r_out(r, out.p, out.len);
             else ds4r_out(r, r->code_line, r->code_line_len);
             ds4r_str_free(&out);
         } else {
-            ds4r_seq(r, "\x1b[38;5;75m");
+            ds4r_seq(r, r->in_think ? DS4R_THINK : "\x1b[38;5;75m");
             ds4r_out(r, r->code_line, r->code_line_len);
             ds4r_seq(r, DS4R_RESET);
         }
@@ -949,7 +1012,8 @@ static void ds4r_md_feed(ds4r *r, char c) {
     if (r->md_fence_info) {
         if (c == '\n') {
             r->md_fence_lang[r->md_fence_lang_len] = '\0';
-            r->md_syntax = ds4r_syntax_for_lang(r->md_fence_lang);
+            r->md_syntax = r->in_think ? NULL :
+                ds4r_syntax_for_lang(r->md_fence_lang);
             ds4r_put_plain(r, '\n');
             r->md_fence_info = false;
             r->md_code_line_start = true;
@@ -1107,7 +1171,8 @@ static bool ds4r_is_align_cell(const char *s, ds4r_align *out) {
  * With out == NULL the function only measures.  bold_init keeps a header cell
  * bold across nested **markers**. */
 static int ds4r_cell_scan(const char *s, int limit, bool ellipsis,
-                          bool bold_init, bool color, ds4r_str *out) {
+                          bool bold_init, bool color, bool muted,
+                          ds4r_str *out) {
     bool bold = bold_init;
     bool italic = false;
     bool code = false;
@@ -1120,7 +1185,9 @@ static int ds4r_cell_scan(const char *s, int limit, bool ellipsis,
     while (i < len) {
         if (s[i] == '`') {
             code = !code;
-            if (out && color) ds4r_str_addz(out, code ? "\x1b[36m" : "\x1b[39m");
+            if (out && color)
+                ds4r_str_addz(out, muted ? (code ? "\x1b[2m" : "\x1b[22m") :
+                                           (code ? "\x1b[36m" : "\x1b[39m"));
             i++;
             continue;
         }
@@ -1152,7 +1219,7 @@ static int ds4r_cell_scan(const char *s, int limit, bool ellipsis,
         i += n;
     }
     if (out && color) {
-        if (code) ds4r_str_addz(out, "\x1b[39m");
+        if (code) ds4r_str_addz(out, muted ? "\x1b[22m" : "\x1b[39m");
         if (italic) ds4r_str_addz(out, "\x1b[23m");
         if (bold) ds4r_str_addz(out, "\x1b[22m");
     }
@@ -1166,7 +1233,7 @@ static int ds4r_cell_scan(const char *s, int limit, bool ellipsis,
 static void ds4r_table_border(ds4r *r, ds4r_str *out, const int *colw,
                               int ncols, int pad, const char *left,
                               const char *mid, const char *right) {
-    if (r->use_color) ds4r_str_addz(out, DS4R_GREY);
+    if (r->use_color) ds4r_str_addz(out, ds4r_deco_color(r));
     ds4r_str_addz(out, left);
     for (int c = 0; c < ncols; c++) {
         ds4r_str_repeat(out, "\xe2\x94\x80", colw[c] + 2 * pad);
@@ -1177,7 +1244,7 @@ static void ds4r_table_border(ds4r *r, ds4r_str *out, const int *colw,
 }
 
 static void ds4r_table_bar(ds4r *r, ds4r_str *out) {
-    if (r->use_color) ds4r_str_addz(out, DS4R_GREY);
+    if (r->use_color) ds4r_str_addz(out, ds4r_deco_color(r));
     ds4r_str_addz(out, "\xe2\x94\x82");
     if (r->use_color) ds4r_str_addz(out, DS4R_RESET);
 }
@@ -1188,10 +1255,14 @@ static void ds4r_table_row(ds4r *r, ds4r_str *out, char **cells, int ncells,
     for (int c = 0; c < ncols; c++) {
         const char *text = (c < ncells && cells[c]) ? cells[c] : "";
         ds4r_str cell = {0};
-        int want = ds4r_cell_scan(text, INT_MAX, false, header, false, NULL);
+        bool muted = r->in_think;
+        int want = ds4r_cell_scan(text, INT_MAX, false, header, false, muted,
+                                  NULL);
         int w = want <= colw[c] ?
-            ds4r_cell_scan(text, INT_MAX, false, header, r->use_color, &cell) :
-            ds4r_cell_scan(text, colw[c] - 1, true, header, r->use_color, &cell);
+            ds4r_cell_scan(text, INT_MAX, false, header, r->use_color, muted,
+                           &cell) :
+            ds4r_cell_scan(text, colw[c] - 1, true, header, r->use_color, muted,
+                           &cell);
         int slack = colw[c] - w;
         if (slack < 0) slack = 0;
         int before = align[c] == DS4R_ALIGN_RIGHT ? slack :
@@ -1199,7 +1270,9 @@ static void ds4r_table_row(ds4r *r, ds4r_str *out, char **cells, int ncells,
 
         ds4r_table_bar(r, out);
         ds4r_str_pad(out, pad + before);
+        if (muted && r->use_color) ds4r_str_addz(out, DS4R_THINK);
         if (cell.p) ds4r_str_add(out, cell.p, cell.len);
+        if (muted && r->use_color) ds4r_str_addz(out, DS4R_RESET);
         ds4r_str_pad(out, slack - before + pad);
         ds4r_str_free(&cell);
     }
@@ -1277,7 +1350,8 @@ static bool ds4r_table_render(ds4r *r) {
         for (int c = 0; c < ncols; c++) {
             const char *text = cells[i * (size_t)ncols + (size_t)c];
             if (!text) continue;
-            int w = ds4r_cell_scan(text, INT_MAX, false, false, false, NULL);
+            int w = ds4r_cell_scan(text, INT_MAX, false, false, false, false,
+                                   NULL);
             if (w > colw[c]) colw[c] = w;
         }
     }
@@ -1411,7 +1485,7 @@ static void ds4r_table_byte(ds4r *r, char c) {
  * ============================================================================ */
 
 static void ds4r_line_begin(ds4r *r) {
-    if (!r->format_markdown || r->in_think || r->md_code_block) {
+    if (!r->format_markdown || r->md_code_block) {
         r->line_mode = DS4R_LINE_OFF;
         return;
     }
@@ -1462,7 +1536,7 @@ static void ds4r_scan_rule(ds4r *r) {
     if (cols < 4) cols = 4;
     ds4r_str out = {0};
     ds4r_str_repeat(&out, "\xe2\x94\x80", cols);
-    if (!out.oom && out.p) ds4r_emit_styled(r, DS4R_GREY, out.p);
+    if (!out.oom && out.p) ds4r_emit_styled(r, ds4r_deco_color(r), out.p);
     ds4r_str_free(&out);
 }
 
@@ -1499,7 +1573,7 @@ static void ds4r_scan_byte(ds4r *r, char c) {
         }
         if (c == '>') {
             ds4r_scan_emit_indent(r);
-            ds4r_emit_styled(r, DS4R_GREY, "\xe2\x94\x82 ");
+            ds4r_emit_styled(r, ds4r_deco_color(r), "\xe2\x94\x82 ");
             r->line_len = 0;
             r->indent_len = 0;
             r->scan = DS4R_SCAN_QUOTE;
@@ -1534,7 +1608,7 @@ static void ds4r_scan_byte(ds4r *r, char c) {
         if (c == ' ' || c == '\t') {
             if (r->marker_run == 1 && r->marker_ch != '_') {
                 ds4r_scan_emit_indent(r);
-                ds4r_emit_styled(r, DS4R_GREY, "\xe2\x80\xa2");
+                ds4r_emit_styled(r, ds4r_deco_color(r), "\xe2\x80\xa2");
                 ds4r_out(r, " ", 1);
                 ds4r_scan_done(r);
                 return;
@@ -1586,7 +1660,7 @@ static void ds4r_scan_byte(ds4r *r, char c) {
             memcpy(marker, r->line_buf + r->indent_len, n);
             marker[n] = '\0';
             ds4r_scan_emit_indent(r);
-            ds4r_emit_styled(r, DS4R_GREY, marker);
+            ds4r_emit_styled(r, ds4r_deco_color(r), marker);
             ds4r_out(r, " ", 1);
             ds4r_scan_done(r);
             return;
@@ -1605,7 +1679,7 @@ static void ds4r_scan_byte(ds4r *r, char c) {
 }
 
 static void ds4r_render_byte(ds4r *r, char c) {
-    if (!r->format_markdown || r->in_think) {
+    if (!r->format_markdown) {
         ds4r_md_emit_mark_literals(r);
         ds4r_write_char_raw(r, c);
         return;
@@ -1635,9 +1709,35 @@ static bool ds4r_is_partial_prefix(const char *p, size_t n, const char *prefix) 
     return n < plen && memcmp(prefix, p, n) == 0;
 }
 
-static void ds4r_drop_line_state(ds4r *r) {
-    if (r->line_mode == DS4R_LINE_TABLE) ds4r_table_flush(r);
+/* Close every construct that is still open and print what was held back.  Used
+ * at both think boundaries and at the end of a reply, so no table, fence, or
+ * attribute can leak from thinking into the answer or the other way round. */
+static void ds4r_md_flush_state(ds4r *r) {
+    if (!r->format_markdown) return;
     if (r->line_mode == DS4R_LINE_SCAN) ds4r_scan_flush(r);
+    if (r->line_mode == DS4R_LINE_TABLE) ds4r_table_flush(r);
+    /* A closing fence can be the last thing the model emits, with no following
+     * byte to push the pending backticks through. */
+    if (r->md_mark == DS4R_MARK_BACKTICK && r->md_mark_len >= 3)
+        ds4r_md_commit_backticks(r);
+    else
+        ds4r_md_emit_mark_literals(r);
+    if (r->md_code_block && r->code_line_len) ds4r_code_emit_line(r, false);
+    ds4r_flush_utf8(r);
+    r->md_bold = false;
+    r->md_italic = false;
+    r->md_inline_code = false;
+    r->md_heading = false;
+    r->md_heading_underline = false;
+    r->md_code_block = false;
+    r->md_fence_info = false;
+    r->md_code_line_start = false;
+    r->md_code_in_ml_comment = false;
+    r->md_syntax = NULL;
+    r->md_fence_lang_len = 0;
+    r->md_fence_lang[0] = '\0';
+    ds4r_md_clear_mark(r);
+    ds4r_table_reset(r);
     r->line_mode = DS4R_LINE_OFF;
 }
 
@@ -1659,13 +1759,18 @@ static void ds4r_think_process(ds4r *r, const char *text, size_t len,
         const char *cur = buf + i;
         const size_t rem = total - i;
         if (ds4r_has_prefix(cur, rem, think_open)) {
-            ds4r_drop_line_state(r);
+            ds4r_md_flush_state(r);
             ds4r_flush_utf8(r);
+            ds4r_reset_color(r);
             r->in_think = true;
+            ds4r_line_begin(r);
             i += strlen(think_open);
             continue;
         }
         if (ds4r_has_prefix(cur, rem, think_close)) {
+            /* Flush while still inside the block so anything held back is
+             * printed with the muted palette, then start the answer clean. */
+            ds4r_md_flush_state(r);
             ds4r_flush_utf8(r);
             r->in_think = false;
             ds4r_reset_color(r);
@@ -1743,33 +1848,7 @@ void ds4r_write(ds4r *r, const char *text, size_t len) {
 
 void ds4r_finish(ds4r *r) {
     if (r->format_thinking) ds4r_think_process(r, NULL, 0, true);
-    if (r->format_markdown) {
-        if (r->line_mode == DS4R_LINE_SCAN) ds4r_scan_flush(r);
-        if (r->line_mode == DS4R_LINE_TABLE) ds4r_table_flush(r);
-        /* A closing fence can be the last thing the model emits, with no
-         * following byte to push the pending backticks through. */
-        if (r->md_mark == DS4R_MARK_BACKTICK && r->md_mark_len >= 3)
-            ds4r_md_commit_backticks(r);
-        else
-            ds4r_md_emit_mark_literals(r);
-        if (r->md_code_block && r->code_line_len) ds4r_code_emit_line(r, false);
-        ds4r_flush_utf8(r);
-        r->md_bold = false;
-        r->md_italic = false;
-        r->md_inline_code = false;
-        r->md_heading = false;
-        r->md_heading_underline = false;
-        r->md_code_block = false;
-        r->md_fence_info = false;
-        r->md_code_line_start = false;
-        r->md_code_in_ml_comment = false;
-        r->md_syntax = NULL;
-        r->md_fence_lang_len = 0;
-        r->md_fence_lang[0] = '\0';
-        ds4r_md_clear_mark(r);
-        ds4r_table_reset(r);
-        r->line_mode = DS4R_LINE_OFF;
-    }
+    ds4r_md_flush_state(r);
     ds4r_flush_utf8(r);
     ds4r_reset_color(r);
     fflush(r->fp);

--- a/ds4_render.c
+++ b/ds4_render.c
@@ -1,12 +1,14 @@
 /* Streaming Markdown renderer for terminal chat output.  See ds4_render.h.
  *
- * ds4r_write() strips the <think> markers and feeds the rest to
- * ds4r_md_feed(), which handles the inline constructs: bold, italic, inline
- * code, and fenced code blocks.  Bytes that cannot be classified yet are held
- * back: marker runs and partial UTF-8 sequences.
+ * The parser is a byte pump with three layers.  ds4r_write() strips <think>
+ * markers, ds4r_render_byte() classifies logical line starts (headings, lists,
+ * quotes, rules), and ds4r_md_feed() handles the inline constructs (bold,
+ * italic, inline code, fenced blocks).  Everything that cannot be decided from
+ * the bytes seen so far is held in a small buffer: marker runs and partial
+ * UTF-8 sequences.
  *
  * The inline machine, the UTF-8 accumulator, and the fenced-block highlighter
- * follow the agent renderer in ds4_agent.c. */
+ * follow the agent renderer in ds4_agent.c; the line-start dispatch is new. */
 
 #include "ds4_render.h"
 
@@ -18,10 +20,14 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 
+#define DS4R_GREY  "\x1b[38;5;244m"
 #define DS4R_RESET "\x1b[0m"
 
 static void ds4r_render_byte(ds4r *r, char c);
 static void ds4r_md_feed(ds4r *r, char c);
+static void ds4r_scan_byte(ds4r *r, char c);
+static void ds4r_scan_flush(ds4r *r);
+static void ds4r_line_begin(ds4r *r);
 
 static size_t ds4r_utf8_need(unsigned char c) {
     if (c < 0x80) return 1;
@@ -62,6 +68,10 @@ static void ds4r_str_add(ds4r_str *s, const char *b, size_t n) {
 
 static void ds4r_str_addz(ds4r_str *s, const char *z) {
     ds4r_str_add(s, z, strlen(z));
+}
+
+static void ds4r_str_repeat(ds4r_str *s, const char *unit, int times) {
+    for (int i = 0; i < times; i++) ds4r_str_addz(s, unit);
 }
 
 static void ds4r_str_free(ds4r_str *s) {
@@ -113,8 +123,9 @@ static unsigned ds4r_attr_key(const ds4r *r) {
     if (r->in_think) k |= 1u;
     if (r->md_code_block) k |= 2u;
     if (r->md_inline_code) k |= 4u;
-    if (r->md_bold) k |= 8u;
+    if (r->md_bold || r->md_heading) k |= 8u;
     if (r->md_italic) k |= 16u;
+    if (r->md_heading_underline) k |= 32u;
     return k;
 }
 
@@ -128,8 +139,9 @@ static void ds4r_set_attrs(ds4r *r) {
         return;
     }
     if (r->md_inline_code) ds4r_seq(r, "\x1b[36m");
-    if (r->md_bold) ds4r_seq(r, "\x1b[1m");
+    if (r->md_bold || r->md_heading) ds4r_seq(r, "\x1b[1m");
     if (r->md_italic) ds4r_seq(r, "\x1b[3m");
+    if (r->md_heading_underline) ds4r_seq(r, "\x1b[4m");
 }
 
 /* Emit one complete character with the attributes it must be shown in. */
@@ -183,11 +195,30 @@ static void ds4r_write_char_raw(ds4r *r, char c) {
     r->utf8_pending_need = need;
 }
 
+/* Bytes the renderer generates itself (rules, bullets, quote bars) carry their
+ * own color, so any streaming attribute is closed first. */
+static void ds4r_emit_styled(ds4r *r, const char *color, const char *text) {
+    ds4r_flush_utf8(r);
+    ds4r_reset_color(r);
+    if (color) ds4r_seq(r, color);
+    ds4r_out(r, text, strlen(text));
+    if (color) ds4r_seq(r, DS4R_RESET);
+}
+
 /* Fence markers are shown without markdown attributes. */
 static void ds4r_put_plain(ds4r *r, char c) {
     ds4r_flush_utf8(r);
     ds4r_reset_color(r);
     ds4r_out(r, &c, 1);
+}
+
+static int ds4r_columns(const ds4r *r) {
+    if (r->cols_override > 0) return r->cols_override;
+    struct winsize ws;
+    int fd = r->fp ? fileno(r->fp) : -1;
+    if (fd >= 0 && ioctl(fd, TIOCGWINSZ, &ws) == 0 && ws.ws_col > 0)
+        return ws.ws_col;
+    return 80;
 }
 
 /* ============================================================================
@@ -763,6 +794,14 @@ static bool ds4r_space_byte(char c) {
     return c == ' ' || c == '\t' || c == '\r' || c == '\n';
 }
 
+static void ds4r_md_end_line(ds4r *r) {
+    r->md_heading = false;
+    r->md_heading_underline = false;
+    ds4r_write_char_raw(r, '\n');
+    ds4r_flush_utf8(r);
+    ds4r_line_begin(r);
+}
+
 /* Consume one byte of markdown-aware output.  Backticks and stars are held
  * until the parser knows whether they form a marker; ordinary text goes to the
  * raw writer with the current attributes. */
@@ -827,13 +866,210 @@ static void ds4r_md_feed(ds4r *r, char c) {
         r->md_mark_len = 1;
         return;
     }
+    if (c == '\n') {
+        ds4r_md_end_line(r);
+        return;
+    }
     ds4r_write_char_raw(r, c);
+}
+
+/* ============================================================================
+ * Line-start dispatch
+ * ============================================================================ */
+
+static void ds4r_line_begin(ds4r *r) {
+    if (!r->format_markdown || r->in_think || r->md_code_block) {
+        r->line_mode = DS4R_LINE_OFF;
+        return;
+    }
+    r->line_mode = DS4R_LINE_SCAN;
+    r->scan = DS4R_SCAN_INDENT;
+    r->line_len = 0;
+    r->indent_len = 0;
+    r->marker_run = 0;
+}
+
+/* Give up on the classification: replay everything the scanner held back. */
+static void ds4r_scan_flush(ds4r *r) {
+    char head[DS4R_LINE_BUF];
+    char tail[DS4R_LINE_BUF];
+    size_t hn = r->indent_len;
+    size_t tn = r->line_len - r->indent_len;
+    size_t run = r->marker_run;
+    char mc = r->marker_ch;
+
+    memcpy(head, r->line_buf, hn);
+    memcpy(tail, r->line_buf + hn, tn);
+    r->line_mode = DS4R_LINE_OFF;
+    r->line_len = 0;
+    r->indent_len = 0;
+    r->marker_run = 0;
+
+    for (size_t i = 0; i < hn; i++) ds4r_render_byte(r, head[i]);
+    for (size_t i = 0; i < run; i++) ds4r_render_byte(r, mc);
+    for (size_t i = 0; i < tn; i++) ds4r_render_byte(r, tail[i]);
+}
+
+/* Emit the indentation of a line whose marker the renderer replaces. */
+static void ds4r_scan_emit_indent(ds4r *r) {
+    for (size_t i = 0; i < r->indent_len; i++)
+        ds4r_write_char_raw(r, r->line_buf[i]);
+}
+
+static void ds4r_scan_done(ds4r *r) {
+    r->line_mode = DS4R_LINE_OFF;
+    r->line_len = 0;
+    r->indent_len = 0;
+    r->marker_run = 0;
+}
+
+static void ds4r_scan_rule(ds4r *r) {
+    int cols = ds4r_columns(r);
+    if (cols > 80) cols = 80;
+    if (cols < 4) cols = 4;
+    ds4r_str out = {0};
+    ds4r_str_repeat(&out, "\xe2\x94\x80", cols);
+    if (!out.oom && out.p) ds4r_emit_styled(r, DS4R_GREY, out.p);
+    ds4r_str_free(&out);
+}
+
+static void ds4r_scan_byte(ds4r *r, char c) {
+    switch (r->scan) {
+    case DS4R_SCAN_INDENT:
+        if (c == ' ' || c == '\t') {
+            if (r->line_len + 16 < DS4R_LINE_BUF) {
+                r->line_buf[r->line_len++] = c;
+                r->indent_len = r->line_len;
+                return;
+            }
+            break;
+        }
+        if (c == '#') {
+            r->scan = DS4R_SCAN_HASH;
+            r->line_buf[r->line_len++] = c;
+            return;
+        }
+        if (c == '-' || c == '*' || c == '+' || c == '_') {
+            r->scan = DS4R_SCAN_MARKER;
+            r->marker_ch = c;
+            r->marker_run = 1;
+            return;
+        }
+        if (c == '>') {
+            ds4r_scan_emit_indent(r);
+            ds4r_emit_styled(r, DS4R_GREY, "\xe2\x94\x82 ");
+            r->line_len = 0;
+            r->indent_len = 0;
+            r->scan = DS4R_SCAN_QUOTE;
+            return;
+        }
+        if (c >= '0' && c <= '9') {
+            r->scan = DS4R_SCAN_NUMBER;
+            r->line_buf[r->line_len++] = c;
+            return;
+        }
+        break;
+
+    case DS4R_SCAN_HASH:
+        if (c == '#' && r->line_len - r->indent_len < 6) {
+            r->line_buf[r->line_len++] = c;
+            return;
+        }
+        if (c == ' ') {
+            ds4r_scan_emit_indent(r);
+            r->md_heading = true;
+            r->md_heading_underline = r->line_len - r->indent_len <= 2;
+            ds4r_scan_done(r);
+            return;
+        }
+        break;
+
+    case DS4R_SCAN_MARKER:
+        if (c == r->marker_ch) {
+            r->marker_run++;
+            return;
+        }
+        if (c == ' ' || c == '\t') {
+            if (r->marker_run == 1 && r->marker_ch != '_') {
+                ds4r_scan_emit_indent(r);
+                ds4r_emit_styled(r, DS4R_GREY, "\xe2\x80\xa2");
+                ds4r_out(r, " ", 1);
+                ds4r_scan_done(r);
+                return;
+            }
+            if (r->marker_run >= 3 && r->line_len + 4 < DS4R_LINE_BUF) {
+                r->scan = DS4R_SCAN_MARKER_TAIL;
+                r->line_buf[r->line_len++] = c;
+                return;
+            }
+            break;
+        }
+        if (c == '\n' && r->marker_run >= 3) {
+            ds4r_scan_rule(r);
+            ds4r_scan_done(r);
+            ds4r_render_byte(r, '\n');
+            return;
+        }
+        break;
+
+    case DS4R_SCAN_MARKER_TAIL:
+        if ((c == ' ' || c == '\t') && r->line_len + 4 < DS4R_LINE_BUF) {
+            r->line_buf[r->line_len++] = c;
+            return;
+        }
+        if (c == '\n') {
+            ds4r_scan_rule(r);
+            ds4r_scan_done(r);
+            ds4r_render_byte(r, '\n');
+            return;
+        }
+        break;
+
+    case DS4R_SCAN_NUMBER:
+        if (c >= '0' && c <= '9' && r->line_len + 6 < DS4R_LINE_BUF) {
+            r->line_buf[r->line_len++] = c;
+            return;
+        }
+        if (c == '.' || c == ')') {
+            r->scan = DS4R_SCAN_NUMBER_DOT;
+            r->line_buf[r->line_len++] = c;
+            return;
+        }
+        break;
+
+    case DS4R_SCAN_NUMBER_DOT:
+        if (c == ' ') {
+            char marker[DS4R_LINE_BUF];
+            size_t n = r->line_len - r->indent_len;
+            memcpy(marker, r->line_buf + r->indent_len, n);
+            marker[n] = '\0';
+            ds4r_scan_emit_indent(r);
+            ds4r_emit_styled(r, DS4R_GREY, marker);
+            ds4r_out(r, " ", 1);
+            ds4r_scan_done(r);
+            return;
+        }
+        break;
+
+    case DS4R_SCAN_QUOTE:
+        r->scan = DS4R_SCAN_INDENT;
+        if (c == ' ') return;    /* the space after '>' belongs to the marker */
+        ds4r_scan_byte(r, c);
+        return;
+    }
+
+    ds4r_scan_flush(r);
+    ds4r_render_byte(r, c);
 }
 
 static void ds4r_render_byte(ds4r *r, char c) {
     if (!r->format_markdown || r->in_think) {
         ds4r_md_emit_mark_literals(r);
         ds4r_write_char_raw(r, c);
+        return;
+    }
+    if (r->line_mode == DS4R_LINE_SCAN) {
+        ds4r_scan_byte(r, c);
         return;
     }
     ds4r_md_feed(r, c);
@@ -851,6 +1087,11 @@ static bool ds4r_has_prefix(const char *p, size_t n, const char *prefix) {
 static bool ds4r_is_partial_prefix(const char *p, size_t n, const char *prefix) {
     size_t plen = strlen(prefix);
     return n < plen && memcmp(prefix, p, n) == 0;
+}
+
+static void ds4r_drop_line_state(ds4r *r) {
+    if (r->line_mode == DS4R_LINE_SCAN) ds4r_scan_flush(r);
+    r->line_mode = DS4R_LINE_OFF;
 }
 
 /* Hide the think markers, grey the thinking text, and never emit a control tag
@@ -871,6 +1112,7 @@ static void ds4r_think_process(ds4r *r, const char *text, size_t len,
         const char *cur = buf + i;
         const size_t rem = total - i;
         if (ds4r_has_prefix(cur, rem, think_open)) {
+            ds4r_drop_line_state(r);
             ds4r_flush_utf8(r);
             r->in_think = true;
             i += strlen(think_open);
@@ -881,6 +1123,7 @@ static void ds4r_think_process(ds4r *r, const char *text, size_t len,
             r->in_think = false;
             ds4r_reset_color(r);
             if (!r->last_output_newline) ds4r_out(r, "\n", 1);
+            ds4r_line_begin(r);
             i += strlen(think_close);
             continue;
         }
@@ -908,14 +1151,21 @@ void ds4r_init(ds4r *r, FILE *fp, bool color, bool format_thinking) {
     r->format_markdown = color;
     r->format_thinking = format_thinking;
     r->last_output_newline = true;
+    ds4r_line_begin(r);
 }
 
 void ds4r_set_markdown(ds4r *r, bool enabled) {
     r->format_markdown = enabled && r->use_color;
+    ds4r_line_begin(r);
 }
 
 void ds4r_set_in_think(ds4r *r, bool in_think) {
     r->in_think = in_think;
+    ds4r_line_begin(r);
+}
+
+void ds4r_set_columns(ds4r *r, int cols) {
+    r->cols_override = cols;
 }
 
 bool ds4r_at_line_start(const ds4r *r) {
@@ -926,6 +1176,7 @@ void ds4r_newline(ds4r *r) {
     ds4r_flush_utf8(r);
     ds4r_reset_color(r);
     ds4r_out(r, "\n", 1);
+    ds4r_line_begin(r);
 }
 
 void ds4r_write(ds4r *r, const char *text, size_t len) {
@@ -946,6 +1197,7 @@ void ds4r_write(ds4r *r, const char *text, size_t len) {
 void ds4r_finish(ds4r *r) {
     if (r->format_thinking) ds4r_think_process(r, NULL, 0, true);
     if (r->format_markdown) {
+        if (r->line_mode == DS4R_LINE_SCAN) ds4r_scan_flush(r);
         /* A closing fence can be the last thing the model emits, with no
          * following byte to push the pending backticks through. */
         if (r->md_mark == DS4R_MARK_BACKTICK && r->md_mark_len >= 3)
@@ -957,6 +1209,8 @@ void ds4r_finish(ds4r *r) {
         r->md_bold = false;
         r->md_italic = false;
         r->md_inline_code = false;
+        r->md_heading = false;
+        r->md_heading_underline = false;
         r->md_code_block = false;
         r->md_fence_info = false;
         r->md_code_line_start = false;
@@ -965,6 +1219,7 @@ void ds4r_finish(ds4r *r) {
         r->md_fence_lang_len = 0;
         r->md_fence_lang[0] = '\0';
         ds4r_md_clear_mark(r);
+        r->line_mode = DS4R_LINE_OFF;
     }
     ds4r_flush_utf8(r);
     ds4r_reset_color(r);

--- a/ds4_render.c
+++ b/ds4_render.c
@@ -2,13 +2,14 @@
  *
  * The parser is a byte pump with three layers.  ds4r_write() strips <think>
  * markers, ds4r_render_byte() classifies logical line starts (headings, lists,
- * quotes, rules), and ds4r_md_feed() handles the inline constructs (bold,
- * italic, inline code, fenced blocks).  Everything that cannot be decided from
- * the bytes seen so far is held in a small buffer: marker runs and partial
- * UTF-8 sequences.
+ * quotes, rules, tables), and ds4r_md_feed() handles the inline constructs
+ * (bold, italic, inline code, fenced blocks).  Everything that cannot be
+ * decided from the bytes seen so far is held in a small buffer: marker runs,
+ * partial UTF-8 sequences, and whole table rows.
  *
  * The inline machine, the UTF-8 accumulator, and the fenced-block highlighter
- * follow the agent renderer in ds4_agent.c; the line-start dispatch is new. */
+ * follow the agent renderer in ds4_agent.c; the line-start dispatch and the
+ * table layout are new. */
 
 #include "ds4_render.h"
 
@@ -20,6 +21,10 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 
+#define DS4R_TBL_MAX_BYTES (64u * 1024u)
+#define DS4R_TBL_MAX_LINES 512u
+#define DS4R_TBL_MAX_COLS  64
+
 #define DS4R_GREY  "\x1b[38;5;244m"
 #define DS4R_RESET "\x1b[0m"
 
@@ -27,7 +32,88 @@ static void ds4r_render_byte(ds4r *r, char c);
 static void ds4r_md_feed(ds4r *r, char c);
 static void ds4r_scan_byte(ds4r *r, char c);
 static void ds4r_scan_flush(ds4r *r);
+static void ds4r_table_byte(ds4r *r, char c);
+static void ds4r_table_flush(ds4r *r);
 static void ds4r_line_begin(ds4r *r);
+
+/* ============================================================================
+ * Character metrics
+ * ============================================================================ */
+
+typedef struct {
+    uint32_t lo;
+    uint32_t hi;
+} ds4r_range;
+
+/* Combining marks and other zero-advance codepoints.  The table is a compact
+ * subset: it covers what shows up in model output rather than the full Unicode
+ * combining property. */
+static const ds4r_range ds4r_zero_ranges[] = {
+    {0x0300, 0x036F}, {0x0483, 0x0489}, {0x0591, 0x05BD}, {0x05BF, 0x05BF},
+    {0x05C1, 0x05C2}, {0x05C4, 0x05C5}, {0x05C7, 0x05C7}, {0x0610, 0x061A},
+    {0x064B, 0x065F}, {0x0670, 0x0670}, {0x06D6, 0x06DC}, {0x06DF, 0x06E4},
+    {0x06E7, 0x06E8}, {0x06EA, 0x06ED}, {0x0711, 0x0711}, {0x0730, 0x074A},
+    {0x07A6, 0x07B0}, {0x07EB, 0x07F3}, {0x0816, 0x0819}, {0x081B, 0x0823},
+    {0x0825, 0x0827}, {0x0829, 0x082D}, {0x0900, 0x0902}, {0x093A, 0x093A},
+    {0x093C, 0x093C}, {0x0941, 0x0948}, {0x094D, 0x094D}, {0x0951, 0x0957},
+    {0x0E31, 0x0E31}, {0x0E34, 0x0E3A}, {0x0E47, 0x0E4E}, {0x1AB0, 0x1AFF},
+    {0x1DC0, 0x1DFF}, {0x200B, 0x200F}, {0x2060, 0x2064}, {0x20D0, 0x20F0},
+    {0xFE00, 0xFE0F}, {0xFE20, 0xFE2F}, {0xFEFF, 0xFEFF}, {0xE0100, 0xE01EF},
+};
+
+/* East Asian Wide and Fullwidth blocks, plus the emoji ranges that terminals
+ * render double width. */
+static const ds4r_range ds4r_wide_ranges[] = {
+    {0x1100, 0x115F}, {0x231A, 0x231B}, {0x2329, 0x232A}, {0x23E9, 0x23EC},
+    {0x23F0, 0x23F0}, {0x23F3, 0x23F3}, {0x25FD, 0x25FE}, {0x2614, 0x2615},
+    {0x2648, 0x2653}, {0x267F, 0x267F}, {0x2693, 0x2693}, {0x26A1, 0x26A1},
+    {0x26AA, 0x26AB}, {0x26BD, 0x26BE}, {0x26C4, 0x26C5}, {0x26CE, 0x26CE},
+    {0x26D4, 0x26D4}, {0x26EA, 0x26EA}, {0x26F2, 0x26F3}, {0x26F5, 0x26F5},
+    {0x26FA, 0x26FA}, {0x26FD, 0x26FD}, {0x2705, 0x2705}, {0x270A, 0x270B},
+    {0x2728, 0x2728}, {0x274C, 0x274C}, {0x274E, 0x274E}, {0x2753, 0x2755},
+    {0x2757, 0x2757}, {0x2795, 0x2797}, {0x27B0, 0x27B0}, {0x27BF, 0x27BF},
+    {0x2B1B, 0x2B1C}, {0x2B50, 0x2B50}, {0x2B55, 0x2B55}, {0x2E80, 0x303E},
+    {0x3041, 0x33FF}, {0x3400, 0x4DBF}, {0x4E00, 0x9FFF}, {0xA000, 0xA4CF},
+    {0xA960, 0xA97F}, {0xAC00, 0xD7A3}, {0xF900, 0xFAFF}, {0xFE10, 0xFE19},
+    {0xFE30, 0xFE52}, {0xFE54, 0xFE66}, {0xFE68, 0xFE6B}, {0xFF00, 0xFF60},
+    {0xFFE0, 0xFFE6}, {0x16FE0, 0x16FE4}, {0x17000, 0x18AFF},
+    {0x1B000, 0x1B2FF}, {0x1F004, 0x1F004}, {0x1F0CF, 0x1F0CF},
+    {0x1F18E, 0x1F18E}, {0x1F191, 0x1F19A}, {0x1F200, 0x1F320},
+    {0x1F32D, 0x1F335}, {0x1F337, 0x1F37C}, {0x1F37E, 0x1F393},
+    {0x1F3A0, 0x1F3CA}, {0x1F3CF, 0x1F3D3}, {0x1F3E0, 0x1F3F0},
+    {0x1F3F4, 0x1F3F4}, {0x1F3F8, 0x1F43E}, {0x1F440, 0x1F440},
+    {0x1F442, 0x1F4FC}, {0x1F4FF, 0x1F53D}, {0x1F54B, 0x1F54E},
+    {0x1F550, 0x1F567}, {0x1F57A, 0x1F57A}, {0x1F595, 0x1F596},
+    {0x1F5A4, 0x1F5A4}, {0x1F5FB, 0x1F64F}, {0x1F680, 0x1F6C5},
+    {0x1F6CC, 0x1F6CC}, {0x1F6D0, 0x1F6D2}, {0x1F6EB, 0x1F6EC},
+    {0x1F6F4, 0x1F6FC}, {0x1F7E0, 0x1F7EB}, {0x1F90C, 0x1F9FF},
+    {0x1FA70, 0x1FAFF}, {0x20000, 0x2FFFD}, {0x30000, 0x3FFFD},
+};
+
+static bool ds4r_in_ranges(const ds4r_range *t, size_t n, uint32_t cp) {
+    size_t lo = 0, hi = n;
+    while (lo < hi) {
+        size_t mid = lo + (hi - lo) / 2;
+        if (cp < t[mid].lo) hi = mid;
+        else if (cp > t[mid].hi) lo = mid + 1;
+        else return true;
+    }
+    return false;
+}
+
+int ds4r_wcwidth(uint32_t cp) {
+    if (cp == 0) return 0;
+    if (cp < 0x20 || (cp >= 0x7f && cp < 0xa0)) return 0;
+    if (ds4r_in_ranges(ds4r_zero_ranges,
+                       sizeof(ds4r_zero_ranges) / sizeof(ds4r_zero_ranges[0]),
+                       cp))
+        return 0;
+    if (ds4r_in_ranges(ds4r_wide_ranges,
+                       sizeof(ds4r_wide_ranges) / sizeof(ds4r_wide_ranges[0]),
+                       cp))
+        return 2;
+    return 1;
+}
 
 static size_t ds4r_utf8_need(unsigned char c) {
     if (c < 0x80) return 1;
@@ -35,6 +121,52 @@ static size_t ds4r_utf8_need(unsigned char c) {
     if (c >= 0xe0 && c <= 0xef) return 3;
     if (c >= 0xf0 && c <= 0xf4) return 4;
     return 1;
+}
+
+/* Decode one codepoint and report the bytes it used.  Malformed input is
+ * consumed one byte at a time and reported as U+FFFD. */
+static size_t ds4r_utf8_decode(const char *s, size_t len, uint32_t *out) {
+    unsigned char c = (unsigned char)s[0];
+    size_t need = ds4r_utf8_need(c);
+    if (need == 1 || need > len) {
+        *out = c < 0x80 ? c : 0xFFFD;
+        return 1;
+    }
+    uint32_t cp = (uint32_t)(c & (0xff >> (need + 1)));
+    for (size_t i = 1; i < need; i++) {
+        unsigned char cc = (unsigned char)s[i];
+        if ((cc & 0xc0) != 0x80) {
+            *out = 0xFFFD;
+            return 1;
+        }
+        cp = (cp << 6) | (cc & 0x3f);
+    }
+    *out = cp;
+    return need;
+}
+
+int ds4r_visible_width(const char *s, size_t len) {
+    int w = 0;
+    size_t i = 0;
+    while (i < len) {
+        if (s[i] == 0x1b) {
+            size_t j = i + 1;
+            if (j < len && s[j] == '[') {
+                j++;
+                while (j < len && (unsigned char)s[j] >= 0x20 &&
+                       (unsigned char)s[j] <= 0x3f) j++;
+                if (j < len) j++;
+            } else if (j < len) {
+                j++;
+            }
+            i = j;
+            continue;
+        }
+        uint32_t cp = 0;
+        i += ds4r_utf8_decode(s + i, len - i, &cp);
+        w += ds4r_wcwidth(cp);
+    }
+    return w;
 }
 
 /* ============================================================================
@@ -68,6 +200,14 @@ static void ds4r_str_add(ds4r_str *s, const char *b, size_t n) {
 
 static void ds4r_str_addz(ds4r_str *s, const char *z) {
     ds4r_str_add(s, z, strlen(z));
+}
+
+static void ds4r_str_addc(ds4r_str *s, char c) {
+    ds4r_str_add(s, &c, 1);
+}
+
+static void ds4r_str_pad(ds4r_str *s, int n) {
+    for (int i = 0; i < n; i++) ds4r_str_addc(s, ' ');
 }
 
 static void ds4r_str_repeat(ds4r_str *s, const char *unit, int times) {
@@ -874,6 +1014,399 @@ static void ds4r_md_feed(ds4r *r, char c) {
 }
 
 /* ============================================================================
+ * Tables
+ * ============================================================================ */
+
+typedef enum {
+    DS4R_ALIGN_LEFT = 0,
+    DS4R_ALIGN_CENTER,
+    DS4R_ALIGN_RIGHT,
+} ds4r_align;
+
+/* Split one buffered row into trimmed cells.  Returns the cell count and, when
+ * out is not NULL, stores freshly allocated unescaped strings. */
+static int ds4r_row_cells(const char *line, size_t len, char **out, int max) {
+    const char *p = line;
+    const char *end = line + len;
+    while (end > p && (end[-1] == '\n' || end[-1] == '\r' ||
+                       end[-1] == ' ' || end[-1] == '\t')) end--;
+    while (p < end && (*p == ' ' || *p == '\t')) p++;
+    if (p < end && *p == '|') p++;
+    if (end > p && end[-1] == '|') {
+        int backslashes = 0;
+        const char *q = end - 1;
+        while (q > p && q[-1] == '\\') {
+            backslashes++;
+            q--;
+        }
+        if ((backslashes % 2) == 0) end--;      /* unescaped closing pipe */
+    }
+
+    int n = 0;
+    const char *cell = p;
+    bool escaped = false;
+    for (const char *q = p; q <= end; q++) {
+        bool split = q == end;
+        if (!split) {
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (*q == '\\') {
+                escaped = true;
+                continue;
+            }
+            split = *q == '|';
+        }
+        if (!split) continue;
+        if (n >= max) return -1;
+        if (out) {
+            const char *cs = cell;
+            const char *ce = q;
+            while (cs < ce && (*cs == ' ' || *cs == '\t')) cs++;
+            while (ce > cs && (ce[-1] == ' ' || ce[-1] == '\t')) ce--;
+            char *dst = malloc((size_t)(ce - cs) + 1);
+            if (!dst) return -1;
+            size_t k = 0;
+            for (const char *s = cs; s < ce; s++) {
+                if (*s == '\\' && s + 1 < ce && s[1] == '|') s++;
+                dst[k++] = *s;
+            }
+            dst[k] = '\0';
+            out[n] = dst;
+        }
+        n++;
+        cell = q + 1;
+    }
+    return n;
+}
+
+static bool ds4r_is_align_cell(const char *s, ds4r_align *out) {
+    const char *p = s;
+    bool left = false, right = false;
+    int dashes = 0;
+    if (*p == ':') {
+        left = true;
+        p++;
+    }
+    while (*p == '-') {
+        dashes++;
+        p++;
+    }
+    if (*p == ':') {
+        right = true;
+        p++;
+    }
+    if (*p != '\0' || dashes < 1) return false;
+    *out = left && right ? DS4R_ALIGN_CENTER :
+           right ? DS4R_ALIGN_RIGHT : DS4R_ALIGN_LEFT;
+    return true;
+}
+
+/* Render one cell with inline markdown, stopping after limit visible columns.
+ * With out == NULL the function only measures.  bold_init keeps a header cell
+ * bold across nested **markers**. */
+static int ds4r_cell_scan(const char *s, int limit, bool ellipsis,
+                          bool bold_init, bool color, ds4r_str *out) {
+    bool bold = bold_init;
+    bool italic = false;
+    bool code = false;
+    bool cut = false;
+    int w = 0;
+    size_t len = strlen(s);
+    size_t i = 0;
+
+    if (out && color && bold) ds4r_str_addz(out, "\x1b[1m");
+    while (i < len) {
+        if (s[i] == '`') {
+            code = !code;
+            if (out && color) ds4r_str_addz(out, code ? "\x1b[36m" : "\x1b[39m");
+            i++;
+            continue;
+        }
+        if (s[i] == '*' && !code) {
+            if (i + 1 < len && s[i + 1] == '*') {
+                bold = !bold;
+                if (out && color)
+                    ds4r_str_addz(out, bold ? "\x1b[1m" : "\x1b[22m");
+                i += 2;
+                continue;
+            }
+            italic = !italic;
+            if (out && color)
+                ds4r_str_addz(out, italic ? "\x1b[3m" : "\x1b[23m");
+            i++;
+            continue;
+        }
+        if (s[i] == '\\' && i + 1 < len && !isalnum((unsigned char)s[i + 1]))
+            i++;
+        uint32_t cp = 0;
+        size_t n = ds4r_utf8_decode(s + i, len - i, &cp);
+        int cw = ds4r_wcwidth(cp);
+        if (w + cw > limit) {
+            cut = true;
+            break;
+        }
+        if (out) ds4r_str_add(out, s + i, n);
+        w += cw;
+        i += n;
+    }
+    if (out && color) {
+        if (code) ds4r_str_addz(out, "\x1b[39m");
+        if (italic) ds4r_str_addz(out, "\x1b[23m");
+        if (bold) ds4r_str_addz(out, "\x1b[22m");
+    }
+    if (cut && ellipsis) {
+        if (out) ds4r_str_addz(out, "\xe2\x80\xa6");
+        w += 1;
+    }
+    return w;
+}
+
+static void ds4r_table_border(ds4r *r, ds4r_str *out, const int *colw,
+                              int ncols, int pad, const char *left,
+                              const char *mid, const char *right) {
+    if (r->use_color) ds4r_str_addz(out, DS4R_GREY);
+    ds4r_str_addz(out, left);
+    for (int c = 0; c < ncols; c++) {
+        ds4r_str_repeat(out, "\xe2\x94\x80", colw[c] + 2 * pad);
+        ds4r_str_addz(out, c + 1 == ncols ? right : mid);
+    }
+    if (r->use_color) ds4r_str_addz(out, DS4R_RESET);
+    ds4r_str_addc(out, '\n');
+}
+
+static void ds4r_table_bar(ds4r *r, ds4r_str *out) {
+    if (r->use_color) ds4r_str_addz(out, DS4R_GREY);
+    ds4r_str_addz(out, "\xe2\x94\x82");
+    if (r->use_color) ds4r_str_addz(out, DS4R_RESET);
+}
+
+static void ds4r_table_row(ds4r *r, ds4r_str *out, char **cells, int ncells,
+                           const int *colw, const ds4r_align *align, int ncols,
+                           int pad, bool header) {
+    for (int c = 0; c < ncols; c++) {
+        const char *text = (c < ncells && cells[c]) ? cells[c] : "";
+        ds4r_str cell = {0};
+        int want = ds4r_cell_scan(text, INT_MAX, false, header, false, NULL);
+        int w = want <= colw[c] ?
+            ds4r_cell_scan(text, INT_MAX, false, header, r->use_color, &cell) :
+            ds4r_cell_scan(text, colw[c] - 1, true, header, r->use_color, &cell);
+        int slack = colw[c] - w;
+        if (slack < 0) slack = 0;
+        int before = align[c] == DS4R_ALIGN_RIGHT ? slack :
+                     align[c] == DS4R_ALIGN_CENTER ? slack / 2 : 0;
+
+        ds4r_table_bar(r, out);
+        ds4r_str_pad(out, pad + before);
+        if (cell.p) ds4r_str_add(out, cell.p, cell.len);
+        ds4r_str_pad(out, slack - before + pad);
+        ds4r_str_free(&cell);
+    }
+    ds4r_table_bar(r, out);
+    ds4r_str_addc(out, '\n');
+}
+
+/* Lay out and print the buffered rows.  Returns false when the buffer is not a
+ * usable table, in which case the caller prints the original text. */
+static bool ds4r_table_render(ds4r *r) {
+    const char *buf = r->tbl;
+    size_t len = r->tbl_len;
+    bool ok = false;
+    size_t nrows = 0;
+    size_t *line_off = NULL;
+    size_t *line_len = NULL;
+    int *rowcells = NULL;
+    char **cells = NULL;
+    int *colw = NULL;
+    ds4r_align *align = NULL;
+    int ncols = 0;
+
+    for (size_t i = 0; i < len; i++)
+        if (buf[i] == '\n') nrows++;
+    if (len && buf[len - 1] != '\n') nrows++;
+    if (nrows < 2) return false;
+
+    line_off = malloc(nrows * sizeof(*line_off));
+    line_len = malloc(nrows * sizeof(*line_len));
+    rowcells = malloc(nrows * sizeof(*rowcells));
+    if (!line_off || !line_len || !rowcells) goto done;
+
+    size_t row = 0;
+    size_t start = 0;
+    for (size_t i = 0; i <= len; i++) {
+        if (i == len || buf[i] == '\n') {
+            if (i == len && i == start) break;
+            line_off[row] = start;
+            line_len[row] = i - start;
+            row++;
+            start = i + 1;
+            if (row == nrows) break;
+        }
+    }
+    nrows = row;
+    if (nrows < 2) goto done;
+
+    for (size_t i = 0; i < nrows; i++) {
+        rowcells[i] = ds4r_row_cells(buf + line_off[i], line_len[i], NULL,
+                                     DS4R_TBL_MAX_COLS);
+        if (rowcells[i] < 1) goto done;
+        if (rowcells[i] > ncols) ncols = rowcells[i];
+    }
+
+    cells = calloc(nrows * (size_t)ncols, sizeof(*cells));
+    colw = calloc((size_t)ncols, sizeof(*colw));
+    align = calloc((size_t)ncols, sizeof(*align));
+    if (!cells || !colw || !align) goto done;
+    for (size_t i = 0; i < nrows; i++) {
+        if (ds4r_row_cells(buf + line_off[i], line_len[i],
+                           cells + i * (size_t)ncols, ncols) < 1)
+            goto done;
+    }
+
+    /* The second row must be the alignment row, as GitHub Markdown requires. */
+    for (int c = 0; c < rowcells[1]; c++) {
+        ds4r_align a = DS4R_ALIGN_LEFT;
+        if (!ds4r_is_align_cell(cells[(size_t)ncols + (size_t)c], &a))
+            goto done;
+        if (c < ncols) align[c] = a;
+    }
+
+    for (size_t i = 0; i < nrows; i++) {
+        if (i == 1) continue;
+        for (int c = 0; c < ncols; c++) {
+            const char *text = cells[i * (size_t)ncols + (size_t)c];
+            if (!text) continue;
+            int w = ds4r_cell_scan(text, INT_MAX, false, false, false, NULL);
+            if (w > colw[c]) colw[c] = w;
+        }
+    }
+    for (int c = 0; c < ncols; c++)
+        if (colw[c] < 1) colw[c] = 1;
+
+    /* Shrink to the terminal: first the cell padding, then the widest column. */
+    int cols = ds4r_columns(r);
+    int pad = 1;
+    for (;;) {
+        int total = ncols + 1;
+        for (int c = 0; c < ncols; c++) total += colw[c] + 2 * pad;
+        if (total <= cols) break;
+        if (pad > 0) {
+            pad = 0;
+            continue;
+        }
+        int widest = 0;
+        for (int c = 1; c < ncols; c++)
+            if (colw[c] > colw[widest]) widest = c;
+        if (colw[widest] <= 1) goto done;   /* cannot fit: print the source */
+        colw[widest]--;
+    }
+
+    ds4r_str out = {0};
+    ds4r_table_border(r, &out, colw, ncols, pad,
+                      "\xe2\x94\x8c", "\xe2\x94\xac", "\xe2\x94\x90");
+    ds4r_table_row(r, &out, cells, rowcells[0], colw, align, ncols, pad, true);
+    ds4r_table_border(r, &out, colw, ncols, pad,
+                      "\xe2\x94\x9c", "\xe2\x94\xbc", "\xe2\x94\xa4");
+    for (size_t i = 2; i < nrows; i++)
+        ds4r_table_row(r, &out, cells + i * (size_t)ncols, rowcells[i],
+                       colw, align, ncols, pad, false);
+    ds4r_table_border(r, &out, colw, ncols, pad,
+                      "\xe2\x94\x94", "\xe2\x94\xb4", "\xe2\x94\x98");
+    if (!out.oom && out.p) {
+        ds4r_flush_utf8(r);
+        ds4r_reset_color(r);
+        ds4r_out(r, out.p, out.len);
+        ok = true;
+    }
+    ds4r_str_free(&out);
+
+done:
+    if (cells) {
+        for (size_t i = 0; i < nrows * (size_t)ncols; i++) free(cells[i]);
+        free(cells);
+    }
+    free(line_off);
+    free(line_len);
+    free(rowcells);
+    free(colw);
+    free(align);
+    return ok;
+}
+
+static void ds4r_table_reset(ds4r *r) {
+    r->tbl_len = 0;
+    r->tbl_lines = 0;
+    r->tbl_scan = false;
+    r->tbl_raw = false;
+    if (r->tbl) r->tbl[0] = '\0';
+}
+
+static void ds4r_table_flush(ds4r *r) {
+    if (!r->tbl_raw && r->tbl_len && !ds4r_table_render(r)) {
+        ds4r_flush_utf8(r);
+        ds4r_reset_color(r);
+        ds4r_out(r, r->tbl, r->tbl_len);
+    }
+    ds4r_table_reset(r);
+    r->line_mode = DS4R_LINE_OFF;
+    r->line_len = 0;
+    r->indent_len = 0;
+    r->marker_run = 0;
+    ds4r_line_begin(r);
+}
+
+static void ds4r_table_append(ds4r *r, const char *s, size_t n) {
+    if (r->tbl_raw) {
+        ds4r_out(r, s, n);
+        return;
+    }
+    if (r->tbl_len + n > DS4R_TBL_MAX_BYTES ||
+        r->tbl_lines >= DS4R_TBL_MAX_LINES ||
+        !ds4r_bytes_append(&r->tbl, &r->tbl_len, &r->tbl_cap, s, n)) {
+        /* Too large to lay out: print what was buffered and pass the rest of
+         * the table through unchanged. */
+        ds4r_flush_utf8(r);
+        ds4r_reset_color(r);
+        if (r->tbl_len) ds4r_out(r, r->tbl, r->tbl_len);
+        r->tbl_len = 0;
+        r->tbl_raw = true;
+        ds4r_out(r, s, n);
+    }
+}
+
+/* Buffer consecutive rows.  The mode ends on the first line that does not
+ * start with a pipe, which is then re-fed through the normal path. */
+static void ds4r_table_byte(ds4r *r, char c) {
+    if (r->tbl_scan) {
+        if ((c == ' ' || c == '\t') && r->line_len + 1 < DS4R_LINE_BUF) {
+            r->line_buf[r->line_len++] = c;
+            return;
+        }
+        if (c == '|') {
+            r->tbl_scan = false;
+            ds4r_table_append(r, r->line_buf, r->line_len);
+            r->line_len = 0;
+            ds4r_table_append(r, "|", 1);
+            return;
+        }
+        char held[DS4R_LINE_BUF];
+        size_t n = r->line_len;
+        memcpy(held, r->line_buf, n);
+        ds4r_table_flush(r);
+        for (size_t i = 0; i < n; i++) ds4r_render_byte(r, held[i]);
+        ds4r_render_byte(r, c);
+        return;
+    }
+    ds4r_table_append(r, &c, 1);
+    if (c == '\n') {
+        r->tbl_lines++;
+        r->tbl_scan = true;
+        r->line_len = 0;
+    }
+}
+
+/* ============================================================================
  * Line-start dispatch
  * ============================================================================ */
 
@@ -943,6 +1476,15 @@ static void ds4r_scan_byte(ds4r *r, char c) {
                 return;
             }
             break;
+        }
+        if (c == '|') {
+            r->line_mode = DS4R_LINE_TABLE;
+            r->tbl_scan = false;
+            ds4r_table_append(r, r->line_buf, r->line_len);
+            r->line_len = 0;
+            r->indent_len = 0;
+            ds4r_table_append(r, "|", 1);
+            return;
         }
         if (c == '#') {
             r->scan = DS4R_SCAN_HASH;
@@ -1068,6 +1610,10 @@ static void ds4r_render_byte(ds4r *r, char c) {
         ds4r_write_char_raw(r, c);
         return;
     }
+    if (r->line_mode == DS4R_LINE_TABLE) {
+        ds4r_table_byte(r, c);
+        return;
+    }
     if (r->line_mode == DS4R_LINE_SCAN) {
         ds4r_scan_byte(r, c);
         return;
@@ -1090,6 +1636,7 @@ static bool ds4r_is_partial_prefix(const char *p, size_t n, const char *prefix) 
 }
 
 static void ds4r_drop_line_state(ds4r *r) {
+    if (r->line_mode == DS4R_LINE_TABLE) ds4r_table_flush(r);
     if (r->line_mode == DS4R_LINE_SCAN) ds4r_scan_flush(r);
     r->line_mode = DS4R_LINE_OFF;
 }
@@ -1198,6 +1745,7 @@ void ds4r_finish(ds4r *r) {
     if (r->format_thinking) ds4r_think_process(r, NULL, 0, true);
     if (r->format_markdown) {
         if (r->line_mode == DS4R_LINE_SCAN) ds4r_scan_flush(r);
+        if (r->line_mode == DS4R_LINE_TABLE) ds4r_table_flush(r);
         /* A closing fence can be the last thing the model emits, with no
          * following byte to push the pending backticks through. */
         if (r->md_mark == DS4R_MARK_BACKTICK && r->md_mark_len >= 3)
@@ -1219,6 +1767,7 @@ void ds4r_finish(ds4r *r) {
         r->md_fence_lang_len = 0;
         r->md_fence_lang[0] = '\0';
         ds4r_md_clear_mark(r);
+        ds4r_table_reset(r);
         r->line_mode = DS4R_LINE_OFF;
     }
     ds4r_flush_utf8(r);
@@ -1231,4 +1780,8 @@ void ds4r_free(ds4r *r) {
     r->code_line = NULL;
     r->code_line_len = 0;
     r->code_line_cap = 0;
+    free(r->tbl);
+    r->tbl = NULL;
+    r->tbl_len = 0;
+    r->tbl_cap = 0;
 }

--- a/ds4_render.h
+++ b/ds4_render.h
@@ -1,0 +1,79 @@
+/* Streaming Markdown renderer for terminal chat output.
+ *
+ * The renderer consumes model output one chunk at a time and writes terminal
+ * text to a FILE*.  It is a streaming parser: ambiguous bytes (marker runs,
+ * incomplete UTF-8 sequences, table rows) are buffered only for as long as the
+ * parser needs them to decide what they are.
+ *
+ * With color disabled the renderer is a byte-for-byte passthrough except for
+ * the <think> handling, which keeps the historical CLI semantics: the tags are
+ * removed and a newline is forced after the closing tag. */
+
+#ifndef DS4_RENDER_H
+#define DS4_RENDER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#define DS4R_FENCE_LANG 32
+
+typedef struct ds4r_syntax ds4r_syntax;
+
+typedef enum {
+    DS4R_MARK_NONE = 0,
+    DS4R_MARK_STAR,
+    DS4R_MARK_BACKTICK,
+} ds4r_mark;
+
+typedef struct {
+    FILE *fp;
+    bool use_color;         /* ANSI attributes may be emitted */
+    bool format_markdown;   /* markdown constructs are rendered */
+    bool format_thinking;   /* <think> blocks are filtered */
+    bool in_think;
+    bool color_open;        /* a non-default attribute is currently set */
+    bool last_output_newline;
+    unsigned attr_key;      /* attribute set the open escape stands for */
+
+    /* <think> marker reassembly across writes. */
+    char pending[16];
+    size_t pending_len;
+
+    /* UTF-8 accumulation, so escapes never land inside a codepoint. */
+    char utf8_pending[4];
+    size_t utf8_pending_len;
+    size_t utf8_pending_need;
+
+    /* Inline markdown. */
+    ds4r_mark md_mark;
+    size_t md_mark_len;
+    bool md_bold;
+    bool md_italic;
+    bool md_inline_code;
+
+    /* Fenced code blocks. */
+    bool md_code_block;
+    bool md_fence_info;
+    bool md_code_line_start;
+    bool md_code_in_ml_comment;
+    const ds4r_syntax *md_syntax;
+    char md_fence_lang[DS4R_FENCE_LANG];
+    size_t md_fence_lang_len;
+    char *code_line;
+    size_t code_line_len;
+    size_t code_line_cap;
+} ds4r;
+
+/* color enables both ANSI attributes and markdown rendering; use
+ * ds4r_set_markdown() to keep colors but print markdown source verbatim. */
+void ds4r_init(ds4r *r, FILE *fp, bool color, bool format_thinking);
+void ds4r_set_markdown(ds4r *r, bool enabled);
+void ds4r_set_in_think(ds4r *r, bool in_think);
+void ds4r_write(ds4r *r, const char *text, size_t len);
+void ds4r_finish(ds4r *r);
+void ds4r_free(ds4r *r);
+void ds4r_newline(ds4r *r);
+bool ds4r_at_line_start(const ds4r *r);
+
+#endif /* DS4_RENDER_H */

--- a/ds4_render.h
+++ b/ds4_render.h
@@ -16,6 +16,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
+#define DS4R_LINE_BUF   96      /* line-start scratch: indent plus markers */
 #define DS4R_FENCE_LANG 32
 
 typedef struct ds4r_syntax ds4r_syntax;
@@ -26,6 +27,21 @@ typedef enum {
     DS4R_MARK_BACKTICK,
 } ds4r_mark;
 
+typedef enum {
+    DS4R_LINE_OFF = 0,      /* mid line: bytes go to the inline parser */
+    DS4R_LINE_SCAN,         /* classifying the start of a logical line */
+} ds4r_line_mode;
+
+typedef enum {
+    DS4R_SCAN_INDENT = 0,
+    DS4R_SCAN_HASH,
+    DS4R_SCAN_MARKER,       /* run of '-', '*', '_' or '+' */
+    DS4R_SCAN_MARKER_TAIL,  /* spaces after a rule-length marker run */
+    DS4R_SCAN_NUMBER,
+    DS4R_SCAN_NUMBER_DOT,
+    DS4R_SCAN_QUOTE,        /* just emitted a '>' prefix */
+} ds4r_scan_state;
+
 typedef struct {
     FILE *fp;
     bool use_color;         /* ANSI attributes may be emitted */
@@ -35,6 +51,7 @@ typedef struct {
     bool color_open;        /* a non-default attribute is currently set */
     bool last_output_newline;
     unsigned attr_key;      /* attribute set the open escape stands for */
+    int cols_override;      /* 0: ask the terminal */
 
     /* <think> marker reassembly across writes. */
     char pending[16];
@@ -51,6 +68,8 @@ typedef struct {
     bool md_bold;
     bool md_italic;
     bool md_inline_code;
+    bool md_heading;
+    bool md_heading_underline;
 
     /* Fenced code blocks. */
     bool md_code_block;
@@ -63,6 +82,15 @@ typedef struct {
     char *code_line;
     size_t code_line_len;
     size_t code_line_cap;
+
+    /* Line-start classification. */
+    ds4r_line_mode line_mode;
+    ds4r_scan_state scan;
+    char line_buf[DS4R_LINE_BUF];
+    size_t line_len;
+    size_t indent_len;      /* bytes of line_buf that precede the marker run */
+    size_t marker_run;
+    char marker_ch;
 } ds4r;
 
 /* color enables both ANSI attributes and markdown rendering; use
@@ -70,6 +98,7 @@ typedef struct {
 void ds4r_init(ds4r *r, FILE *fp, bool color, bool format_thinking);
 void ds4r_set_markdown(ds4r *r, bool enabled);
 void ds4r_set_in_think(ds4r *r, bool in_think);
+void ds4r_set_columns(ds4r *r, int cols);   /* 0 restores terminal detection */
 void ds4r_write(ds4r *r, const char *text, size_t len);
 void ds4r_finish(ds4r *r);
 void ds4r_free(ds4r *r);

--- a/ds4_render.h
+++ b/ds4_render.h
@@ -14,6 +14,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #define DS4R_LINE_BUF   96      /* line-start scratch: indent plus markers */
@@ -30,6 +31,7 @@ typedef enum {
 typedef enum {
     DS4R_LINE_OFF = 0,      /* mid line: bytes go to the inline parser */
     DS4R_LINE_SCAN,         /* classifying the start of a logical line */
+    DS4R_LINE_TABLE,        /* buffering consecutive table rows */
 } ds4r_line_mode;
 
 typedef enum {
@@ -91,6 +93,14 @@ typedef struct {
     size_t indent_len;      /* bytes of line_buf that precede the marker run */
     size_t marker_run;
     char marker_ch;
+
+    /* Table buffering. */
+    char *tbl;
+    size_t tbl_len;
+    size_t tbl_cap;
+    size_t tbl_lines;
+    bool tbl_scan;          /* between rows, deciding whether the table goes on */
+    bool tbl_raw;           /* buffer cap hit: pass the rest of the table through */
 } ds4r;
 
 /* color enables both ANSI attributes and markdown rendering; use
@@ -104,5 +114,9 @@ void ds4r_finish(ds4r *r);
 void ds4r_free(ds4r *r);
 void ds4r_newline(ds4r *r);
 bool ds4r_at_line_start(const ds4r *r);
+
+/* Locale independent character metrics, also used by the table layout. */
+int ds4r_wcwidth(uint32_t cp);
+int ds4r_visible_width(const char *s, size_t len);
 
 #endif /* DS4_RENDER_H */

--- a/ds4_render.h
+++ b/ds4_render.h
@@ -48,6 +48,8 @@ typedef struct {
     FILE *fp;
     bool use_color;         /* ANSI attributes may be emitted */
     bool format_markdown;   /* markdown constructs are rendered */
+    bool format_tables;     /* pipe tables are laid out as boxes */
+    bool think_markdown;    /* thinking uses the muted markdown palette */
     bool format_thinking;   /* <think> blocks are filtered */
     bool in_think;
     bool color_open;        /* a non-default attribute is currently set */
@@ -103,10 +105,15 @@ typedef struct {
     bool tbl_raw;           /* buffer cap hit: pass the rest of the table through */
 } ds4r;
 
-/* color enables both ANSI attributes and markdown rendering; use
- * ds4r_set_markdown() to keep colors but print markdown source verbatim. */
+/* color enables ANSI attributes, markdown rendering, table layout, and the
+ * muted thinking palette; the setters below narrow that down.
+ * ds4r_set_markdown(false) keeps colors but prints markdown source verbatim,
+ * ds4r_set_tables(false) lets table lines flow through as ordinary text, and
+ * ds4r_set_think_markdown(false) restores plain single-grey thinking. */
 void ds4r_init(ds4r *r, FILE *fp, bool color, bool format_thinking);
 void ds4r_set_markdown(ds4r *r, bool enabled);
+void ds4r_set_tables(ds4r *r, bool enabled);
+void ds4r_set_think_markdown(ds4r *r, bool enabled);
 void ds4r_set_in_think(ds4r *r, bool in_think);
 void ds4r_set_columns(ds4r *r, int cols);   /* 0 restores terminal detection */
 void ds4r_write(ds4r *r, const char *text, size_t len);

--- a/tests/ds4_render_test.c
+++ b/tests/ds4_render_test.c
@@ -45,7 +45,7 @@ static void fail(const char *what, const char *got, const char *want) {
 }
 
 static char *render_once(const char *in, size_t len, bool color, bool thinking,
-                         bool in_think, bool bytewise) {
+                         bool in_think, int cols, bool bytewise) {
     char *buf = NULL;
     size_t n = 0;
     FILE *fp = open_memstream(&buf, &n);
@@ -57,6 +57,7 @@ static char *render_once(const char *in, size_t len, bool color, bool thinking,
     ds4r r;
     ds4r_init(&r, fp, color, thinking);
     if (in_think) ds4r_set_in_think(&r, true);
+    if (cols) ds4r_set_columns(&r, cols);
     if (bytewise) {
         for (size_t i = 0; i < len; i++) ds4r_write(&r, in + i, 1);
     } else {
@@ -70,10 +71,10 @@ static char *render_once(const char *in, size_t len, bool color, bool thinking,
 
 /* Render in both chunkings and return the whole-string result. */
 static char *render_opt(const char *in, bool color, bool thinking,
-                        bool in_think) {
+                        bool in_think, int cols) {
     size_t len = strlen(in);
-    char *whole = render_once(in, len, color, thinking, in_think, false);
-    char *split = render_once(in, len, color, thinking, in_think, true);
+    char *whole = render_once(in, len, color, thinking, in_think, cols, false);
+    char *split = render_once(in, len, color, thinking, in_think, cols, true);
     if (whole && split && strcmp(whole, split) != 0)
         fail("chunking is not stable", split, whole);
     free(split);
@@ -81,7 +82,7 @@ static char *render_opt(const char *in, bool color, bool thinking,
 }
 
 static char *render(const char *in) {
-    return render_opt(in, true, false, false);
+    return render_opt(in, true, false, false, 0);
 }
 
 static void expect(const char *what, char *got, const char *want) {
@@ -137,18 +138,50 @@ static void test_utf8(void) {
 
 static void test_think(void) {
     expect("think block",
-           render_opt("<think>hidden</think>visible\n", true, true, false),
+           render_opt("<think>hidden</think>visible\n", true, true, false, 0),
            "\x1b[90mhidden\x1b[0m\nvisible\n");
     /* The CLI starts inside the think block when thinking is enabled. */
     expect("implicit think open",
-           render_opt("reasoning</think>answer\n", true, true, true),
+           render_opt("reasoning</think>answer\n", true, true, true, 0),
            "\x1b[90mreasoning\x1b[0m\nanswer\n");
     expect("think without color",
-           render_opt("<think>hidden</think>visible\n", false, true, false),
+           render_opt("<think>hidden</think>visible\n", false, true, false, 0),
            "hidden\nvisible\n");
     expect("markdown is inert inside think",
-           render_opt("<think>**not bold**</think>ok\n", true, true, false),
+           render_opt("<think>**not bold**</think>ok\n", true, true, false, 0),
            "\x1b[90m**not bold**\x1b[0m\nok\n");
+}
+
+static void test_headings_lists(void) {
+    expect("h1", render("# Title\n"), "\x1b[1m\x1b[4mTitle\x1b[0m\n");
+    expect("h3", render("### Sub\n"), "\x1b[1mSub\x1b[0m\n");
+    expect("not a heading", render("#tag\n"), "#tag\n");
+    expect("bullet", render("- item\n"),
+           "\x1b[38;5;244m\xe2\x80\xa2\x1b[0m item\n");
+    expect("indented bullet", render("  * item\n"),
+           "  \x1b[38;5;244m\xe2\x80\xa2\x1b[0m item\n");
+    expect("ordered", render("1. one\n"),
+           "\x1b[38;5;244m1.\x1b[0m one\n");
+    expect("bold at line start", render("**b** x\n"),
+           "\x1b[1mb\x1b[0m x\n");
+    expect("quote", render("> hi\n"),
+           "\x1b[38;5;244m\xe2\x94\x82 \x1b[0mhi\n");
+    expect("nested quote", render(">> hi\n"),
+           "\x1b[38;5;244m\xe2\x94\x82 \x1b[0m\x1b[38;5;244m\xe2\x94\x82 \x1b[0mhi\n");
+    expect("dash text is not a rule", render("- - x\n"),
+           "\x1b[38;5;244m\xe2\x80\xa2\x1b[0m - x\n");
+
+    char *rule = render_opt("---\n", true, false, false, 20);
+    expect("horizontal rule", rule,
+           "\x1b[38;5;244m"
+           "\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80"
+           "\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80"
+           "\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80"
+           "\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80"
+           "\x1b[0m\n");
+    expect("star rule is a rule", render_opt("***\n", true, false, false, 6),
+           "\x1b[38;5;244m\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80"
+           "\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\x1b[0m\n");
 }
 
 static void test_fences(void) {
@@ -189,7 +222,7 @@ static void test_plain_passthrough(void) {
         "| 1 | 2 |\n"
         "```c\nint main(void) { return 0; }\n```\n"
         "中文 mixed 内容 🚀\n";
-    char *got = render_opt(corpus, false, false, false);
+    char *got = render_opt(corpus, false, false, false, 0);
     if (got && strcmp(got, corpus) != 0)
         fail("color=false passthrough", got, corpus);
     free(got);
@@ -217,6 +250,7 @@ int main(void) {
     test_inline();
     test_utf8();
     test_think();
+    test_headings_lists();
     test_fences();
     test_plain_passthrough();
     test_plain_mode();

--- a/tests/ds4_render_test.c
+++ b/tests/ds4_render_test.c
@@ -97,6 +97,20 @@ static void expect_contains(const char *what, char *got, const char *needle) {
     free(got);
 }
 
+/* Visible width of one output line, escapes excluded. */
+static int line_width(const char *s, int index) {
+    int line = 0;
+    const char *start = s;
+    for (const char *p = s;; p++) {
+        if (*p == '\n' || *p == '\0') {
+            if (line == index) return ds4r_visible_width(start, (size_t)(p - start));
+            if (*p == '\0') return -1;
+            line++;
+            start = p + 1;
+        }
+    }
+}
+
 /* No escape sequence may be written between the bytes of one UTF-8
  * character. */
 static void check_utf8_integrity(const char *what, const char *s) {
@@ -204,9 +218,111 @@ static void test_fences(void) {
     expect("fence closing at finish",
            render("```\nabc\n```"),
            "```\n\x1b[38;5;75mabc\x1b[0m\n```");
+    /* Table pipes inside a fence must not start table buffering. */
     expect("pipes inside a fence stay literal",
            render("```\n| a | b |\n```\n"),
            "```\n\x1b[38;5;75m| a | b |\x1b[0m\n```\n");
+}
+
+static void test_tables(void) {
+    static const char simple[] =
+        "| a | bb |\n"
+        "| --- | --- |\n"
+        "| 1 | 2 |\n";
+    expect("simple table", render(simple),
+           "\x1b[38;5;244m\xe2\x94\x8c\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80"
+           "\xe2\x94\xac\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80"
+           "\xe2\x94\x90\x1b[0m\n"
+           "\x1b[38;5;244m\xe2\x94\x82\x1b[0m \x1b[1ma\x1b[22m "
+           "\x1b[38;5;244m\xe2\x94\x82\x1b[0m \x1b[1mbb\x1b[22m "
+           "\x1b[38;5;244m\xe2\x94\x82\x1b[0m\n"
+           "\x1b[38;5;244m\xe2\x94\x9c\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80"
+           "\xe2\x94\xbc\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80"
+           "\xe2\x94\xa4\x1b[0m\n"
+           "\x1b[38;5;244m\xe2\x94\x82\x1b[0m 1 "
+           "\x1b[38;5;244m\xe2\x94\x82\x1b[0m 2  "
+           "\x1b[38;5;244m\xe2\x94\x82\x1b[0m\n"
+           "\x1b[38;5;244m\xe2\x94\x94\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80"
+           "\xe2\x94\xb4\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80"
+           "\xe2\x94\x98\x1b[0m\n");
+
+    /* Mixed CJK and ASCII: every rendered row must occupy the same columns. */
+    static const char cjk[] =
+        "| Name | 描述 |\n"
+        "| --- | --- |\n"
+        "| alpha | 中文说明 |\n"
+        "| b | x |\n";
+    char *t = render(cjk);
+    if (t) {
+        int w0 = line_width(t, 0);
+        for (int i = 1; i < 6; i++) {
+            int w = line_width(t, i);
+            if (w != w0) {
+                char msg[64];
+                snprintf(msg, sizeof(msg), "cjk row %d width %d != %d",
+                         i, w, w0);
+                fail(msg, t, "equal visible widths");
+                break;
+            }
+        }
+        free(t);
+    }
+
+    /* Alignment row: left, center, right. */
+    static const char aligned[] =
+        "| a | b | c |\n"
+        "| :--- | :---: | ---: |\n"
+        "| xxxx | yyyy | zzzz |\n"
+        "| 1 | 2 | 3 |\n";
+    expect_contains("left alignment", render(aligned),
+                    "\x1b[0m 1    \x1b[38;5;244m");
+    expect_contains("center alignment", render(aligned),
+                    "\x1b[0m  2   \x1b[38;5;244m");
+    expect_contains("right alignment", render(aligned),
+                    "\x1b[0m    3 \x1b[38;5;244m");
+
+    expect_contains("bold inside a cell",
+                    render("| a |\n| --- |\n| **x** |\n"),
+                    "\x1b[1mx\x1b[22m");
+
+    /* Narrow terminal: padding goes first, then the widest column is cut. */
+    static const char wide[] =
+        "| name | description |\n"
+        "| --- | --- |\n"
+        "| a | 0123456789 |\n";
+    expect_contains("narrow table truncates", render_opt(wide, true, false, false, 16),
+                    "\xe2\x80\xa6");
+    /* A column that cannot fit at all falls back to the source text. */
+    expect("hopeless table falls back to raw",
+           render_opt(wide, true, false, false, 4), wide);
+
+    expect("missing separator row falls back to raw",
+           render("| a | b |\n| c | d |\n"),
+           "| a | b |\n| c | d |\n");
+
+    expect_contains("unterminated table renders at finish",
+                    render("| a |\n| --- |\n| 1 |"),
+                    "\xe2\x94\x94");
+
+    /* Text after the table returns to the normal path. */
+    expect_contains("text after a table", render("| a |\n| --- |\n| 1 |\nafter\n"),
+                    "\nafter\n");
+}
+
+static void test_table_buffer_cap(void) {
+    size_t rows = 600;
+    char *in = malloc(rows * 4 + 1);
+    size_t k = 0;
+    for (size_t i = 0; i < rows; i++) {
+        memcpy(in + k, "|a|\n", 4);
+        k += 4;
+    }
+    in[k] = '\0';
+    char *got = render(in);
+    if (got && strcmp(got, in) != 0)
+        fail("table buffer cap passes rows through raw", got, in);
+    free(got);
+    free(in);
 }
 
 static void test_plain_passthrough(void) {
@@ -228,6 +344,53 @@ static void test_plain_passthrough(void) {
     free(got);
 }
 
+static const char g_corpus[] =
+    "# Heading 标题\n"
+    "Text with **bold**, *italic*, `code`, and a * b.\n"
+    "- bullet 中文\n"
+    "1. ordered\n"
+    "> quote\n"
+    "---\n"
+    "| a | 描述 |\n"
+    "| --- | ---: |\n"
+    "| 1 | 中文 |\n"
+    "after\n"
+    "```c\nint x = 1; /* c */\n```\n"
+    "```\n+--+\n| ok |\n+--+\n```\n"
+    "tail 🚀\n";
+
+/* Chunk boundaries must not change the result, whatever the tokenizer emits. */
+static void test_chunk_sweep(void) {
+    size_t len = strlen(g_corpus);
+    char *want = render_once(g_corpus, len, true, false, false, 40, false);
+    if (!want) return;
+    check_utf8_integrity("corpus utf8 integrity", want);
+    for (size_t step = 1; step <= 7; step++) {
+        char *buf = NULL;
+        size_t n = 0;
+        FILE *fp = open_memstream(&buf, &n);
+        ds4r r;
+        ds4r_init(&r, fp, true, false);
+        ds4r_set_columns(&r, 40);
+        for (size_t i = 0; i < len; i += step) {
+            size_t k = len - i < step ? len - i : step;
+            ds4r_write(&r, g_corpus + i, k);
+        }
+        ds4r_finish(&r);
+        ds4r_free(&r);
+        fclose(fp);
+        if (strcmp(buf, want) != 0) {
+            char msg[64];
+            snprintf(msg, sizeof(msg), "chunk size %zu differs", step);
+            fail(msg, buf, want);
+            free(buf);
+            break;
+        }
+        free(buf);
+    }
+    free(want);
+}
+
 /* --plain keeps the terminal colors for thinking but prints markdown source. */
 static void test_plain_mode(void) {
     static const char in[] = "<think>x</think># H\n**b** | a |\n";
@@ -246,14 +409,30 @@ static void test_plain_mode(void) {
     free(buf);
 }
 
+static void test_widths(void) {
+    if (ds4r_wcwidth('a') != 1) fail("wcwidth ascii", "x", "1");
+    if (ds4r_wcwidth(0x4E2D) != 2) fail("wcwidth han", "x", "2");
+    if (ds4r_wcwidth(0xFF21) != 2) fail("wcwidth fullwidth", "x", "2");
+    if (ds4r_wcwidth(0x1F680) != 2) fail("wcwidth emoji", "x", "2");
+    if (ds4r_wcwidth(0x0301) != 0) fail("wcwidth combining", "x", "0");
+    if (ds4r_visible_width("\x1b[1mab\x1b[0m", strlen("\x1b[1mab\x1b[0m")) != 2)
+        fail("visible width skips escapes", "x", "2");
+    if (ds4r_visible_width("中a", 4) != 3)
+        fail("visible width mixes scripts", "x", "3");
+}
+
 int main(void) {
     test_inline();
     test_utf8();
     test_think();
     test_headings_lists();
     test_fences();
+    test_tables();
+    test_table_buffer_cap();
     test_plain_passthrough();
+    test_chunk_sweep();
     test_plain_mode();
+    test_widths();
     if (g_failures) {
         printf("ds4-render-test: %d failure(s)\n", g_failures);
         return 1;

--- a/tests/ds4_render_test.c
+++ b/tests/ds4_render_test.c
@@ -44,8 +44,23 @@ static void fail(const char *what, const char *got, const char *want) {
     g_failures++;
 }
 
-static char *render_once(const char *in, size_t len, bool color, bool thinking,
-                         bool in_think, int cols, bool bytewise) {
+/* Mirrors the CLI option matrix: markdown mode plus the thinking override. */
+typedef struct {
+    bool color;
+    bool thinking;
+    bool in_think;
+    bool markdown;      /* false: --markdown off */
+    bool tables;        /* false: --markdown basic */
+    bool think_markdown;/* false: --think-plain */
+    int cols;
+} ropt;
+
+static ropt ropt_full(void) {
+    ropt o = {true, false, false, true, true, true, 0};
+    return o;
+}
+
+static char *render_once(const char *in, size_t len, ropt o, bool bytewise) {
     char *buf = NULL;
     size_t n = 0;
     FILE *fp = open_memstream(&buf, &n);
@@ -55,9 +70,12 @@ static char *render_once(const char *in, size_t len, bool color, bool thinking,
         return NULL;
     }
     ds4r r;
-    ds4r_init(&r, fp, color, thinking);
-    if (in_think) ds4r_set_in_think(&r, true);
-    if (cols) ds4r_set_columns(&r, cols);
+    ds4r_init(&r, fp, o.color, o.thinking);
+    if (o.in_think) ds4r_set_in_think(&r, true);
+    if (!o.markdown) ds4r_set_markdown(&r, false);
+    if (!o.tables) ds4r_set_tables(&r, false);
+    if (!o.think_markdown) ds4r_set_think_markdown(&r, false);
+    if (o.cols) ds4r_set_columns(&r, o.cols);
     if (bytewise) {
         for (size_t i = 0; i < len; i++) ds4r_write(&r, in + i, 1);
     } else {
@@ -70,19 +88,35 @@ static char *render_once(const char *in, size_t len, bool color, bool thinking,
 }
 
 /* Render in both chunkings and return the whole-string result. */
-static char *render_opt(const char *in, bool color, bool thinking,
-                        bool in_think, int cols) {
+static char *render_ropt(const char *in, ropt o) {
     size_t len = strlen(in);
-    char *whole = render_once(in, len, color, thinking, in_think, cols, false);
-    char *split = render_once(in, len, color, thinking, in_think, cols, true);
+    char *whole = render_once(in, len, o, false);
+    char *split = render_once(in, len, o, true);
     if (whole && split && strcmp(whole, split) != 0)
         fail("chunking is not stable", split, whole);
     free(split);
     return whole;
 }
 
+static char *render_opt(const char *in, bool color, bool thinking,
+                        bool in_think, int cols) {
+    ropt o = ropt_full();
+    o.color = color;
+    o.thinking = thinking;
+    o.in_think = in_think;
+    o.cols = cols;
+    return render_ropt(in, o);
+}
+
 static char *render(const char *in) {
     return render_opt(in, true, false, false, 0);
+}
+
+/* --markdown basic: everything but table layout. */
+static char *render_basic(const char *in) {
+    ropt o = ropt_full();
+    o.tables = false;
+    return render_ropt(in, o);
 }
 
 static void expect(const char *what, char *got, const char *want) {
@@ -478,7 +512,9 @@ static const char g_corpus[] =
 /* Chunk boundaries must not change the result, whatever the tokenizer emits. */
 static void test_chunk_sweep(void) {
     size_t len = strlen(g_corpus);
-    char *want = render_once(g_corpus, len, true, false, false, 40, false);
+    ropt sweep = ropt_full();
+    sweep.cols = 40;
+    char *want = render_once(g_corpus, len, sweep, false);
     if (!want) return;
     check_utf8_integrity("corpus utf8 integrity", want);
     for (size_t step = 1; step <= 7; step++) {
@@ -525,6 +561,71 @@ static void test_plain_mode(void) {
     free(buf);
 }
 
+/* --markdown basic streams table rows as ordinary text: no buffering, no box,
+ * but the inline pass still applies inside the row. */
+static void test_basic_mode(void) {
+    expect("basic mode leaves table rows unboxed",
+           render_basic("| a | **b** |\n| --- | --- |\n| 1 | 2 |\n"),
+           "| a | \x1b[1mb\x1b[0m |\n| --- | --- |\n| 1 | 2 |\n");
+    expect("basic mode still renders headings",
+           render_basic("## H\n"), "\x1b[1m\x1b[4mH\x1b[0m\n");
+    expect("basic mode still renders bullets",
+           render_basic("- x\n"),
+           "\x1b[38;5;244m\xe2\x80\xa2\x1b[0m x\n");
+    expect_contains("basic mode still highlights fenced code",
+                    render_basic("```c\nreturn 0;\n```\n"),
+                    "\x1b[38;5;214mreturn");
+    /* Thinking follows the same rule: muted inline, no boxes. */
+    ropt o = ropt_full();
+    o.tables = false;
+    o.thinking = true;
+    o.in_think = true;
+    expect("basic mode thinking table stays text",
+           render_ropt("| a | **b** |\n", o),
+           "\x1b[90m| a | \x1b[0m\x1b[1;90mb\x1b[0m\x1b[90m |\n\x1b[0m");
+}
+
+/* --think-plain: reasoning falls back to the legacy single-grey passthrough
+ * while the answer keeps its rendering. */
+static void test_think_plain(void) {
+    ropt o = ropt_full();
+    o.thinking = true;
+    o.think_markdown = false;
+    expect("think-plain keeps reasoning flat",
+           render_ropt("<think># H\n**x** | a |</think>**y**\n", o),
+           "\x1b[90m# H\n**x** | a |\x1b[0m\n\x1b[1my\x1b[0m\n");
+    o.in_think = true;
+    expect("think-plain from the first byte",
+           render_ropt("**x**\n", o), "\x1b[90m**x**\n\x1b[0m");
+}
+
+/* --markdown off is the pre-feature behavior: raw text, grey thinking. */
+static void test_off_mode(void) {
+    static const char corpus[] =
+        "# Heading\n"
+        "Text with **bold**, *italic*, `code`, and a * b.\n"
+        "- bullet\n"
+        "1. ordered\n"
+        "> quote\n"
+        "---\n"
+        "| a | 描述 |\n"
+        "| --- | ---: |\n"
+        "| 1 | 中文 |\n"
+        "```c\nint x = 1;\n```\n"
+        "tail 🚀\n";
+    ropt o = ropt_full();
+    o.markdown = false;
+    char *got = render_ropt(corpus, o);
+    if (got && strcmp(got, corpus) != 0)
+        fail("markdown off passthrough", got, corpus);
+    free(got);
+
+    o.thinking = true;
+    o.in_think = true;
+    expect("markdown off keeps thinking grey",
+           render_ropt("**x**\n", o), "\x1b[90m**x**\n\x1b[0m");
+}
+
 static void test_widths(void) {
     if (ds4r_wcwidth('a') != 1) fail("wcwidth ascii", "x", "1");
     if (ds4r_wcwidth(0x4E2D) != 2) fail("wcwidth han", "x", "2");
@@ -550,6 +651,9 @@ int main(void) {
     test_plain_passthrough();
     test_chunk_sweep();
     test_plain_mode();
+    test_basic_mode();
+    test_think_plain();
+    test_off_mode();
     test_widths();
     if (g_failures) {
         printf("ds4-render-test: %d failure(s)\n", g_failures);

--- a/tests/ds4_render_test.c
+++ b/tests/ds4_render_test.c
@@ -1,0 +1,229 @@
+/* Unit tests for the streaming markdown renderer.
+ *
+ * Every corpus is rendered twice, once as a single write and once byte at a
+ * time, and both runs must produce the same bytes: the renderer has to reach
+ * the same state no matter how the model chunks its tokens. */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "ds4_render.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int g_failures;
+
+/* Show escapes and newlines so a mismatch is readable in the test log. */
+static char *show(const char *s) {
+    size_t n = strlen(s);
+    char *out = malloc(n * 4 + 1);
+    size_t k = 0;
+    for (size_t i = 0; i < n; i++) {
+        unsigned char c = (unsigned char)s[i];
+        if (c == 0x1b) {
+            memcpy(out + k, "\\e", 2);
+            k += 2;
+        } else if (c == '\n') {
+            memcpy(out + k, "\\n", 2);
+            k += 2;
+        } else {
+            out[k++] = (char)c;
+        }
+    }
+    out[k] = '\0';
+    return out;
+}
+
+static void fail(const char *what, const char *got, const char *want) {
+    char *g = show(got);
+    char *w = show(want);
+    printf("FAIL %s\n  got:  %s\n  want: %s\n", what, g, w);
+    free(g);
+    free(w);
+    g_failures++;
+}
+
+static char *render_once(const char *in, size_t len, bool color, bool thinking,
+                         bool in_think, bool bytewise) {
+    char *buf = NULL;
+    size_t n = 0;
+    FILE *fp = open_memstream(&buf, &n);
+    if (!fp) {
+        printf("FAIL open_memstream\n");
+        g_failures++;
+        return NULL;
+    }
+    ds4r r;
+    ds4r_init(&r, fp, color, thinking);
+    if (in_think) ds4r_set_in_think(&r, true);
+    if (bytewise) {
+        for (size_t i = 0; i < len; i++) ds4r_write(&r, in + i, 1);
+    } else {
+        ds4r_write(&r, in, len);
+    }
+    ds4r_finish(&r);
+    ds4r_free(&r);
+    fclose(fp);
+    return buf;
+}
+
+/* Render in both chunkings and return the whole-string result. */
+static char *render_opt(const char *in, bool color, bool thinking,
+                        bool in_think) {
+    size_t len = strlen(in);
+    char *whole = render_once(in, len, color, thinking, in_think, false);
+    char *split = render_once(in, len, color, thinking, in_think, true);
+    if (whole && split && strcmp(whole, split) != 0)
+        fail("chunking is not stable", split, whole);
+    free(split);
+    return whole;
+}
+
+static char *render(const char *in) {
+    return render_opt(in, true, false, false);
+}
+
+static void expect(const char *what, char *got, const char *want) {
+    if (!got) return;
+    if (strcmp(got, want) != 0) fail(what, got, want);
+    free(got);
+}
+
+static void expect_contains(const char *what, char *got, const char *needle) {
+    if (!got) return;
+    if (!strstr(got, needle)) fail(what, got, needle);
+    free(got);
+}
+
+/* No escape sequence may be written between the bytes of one UTF-8
+ * character. */
+static void check_utf8_integrity(const char *what, const char *s) {
+    size_t n = strlen(s);
+    for (size_t i = 0; i < n;) {
+        unsigned char c = (unsigned char)s[i];
+        size_t need = 1;
+        if (c >= 0xc2 && c <= 0xdf) need = 2;
+        else if (c >= 0xe0 && c <= 0xef) need = 3;
+        else if (c >= 0xf0 && c <= 0xf4) need = 4;
+        for (size_t k = 1; k < need; k++) {
+            if (i + k >= n || ((unsigned char)s[i + k] & 0xc0) != 0x80) {
+                fail(what, s, "unbroken utf-8 sequences");
+                return;
+            }
+        }
+        i += need;
+    }
+}
+
+static void test_inline(void) {
+    expect("bold", render("**bold**\n"), "\x1b[1mbold\x1b[0m\n");
+    expect("italic", render("*it*\n"), "\x1b[3mit\x1b[0m\n");
+    expect("inline code", render("`code`\n"), "\x1b[36mcode\x1b[0m\n");
+    expect("literal star", render("a * b\n"), "a * b\n");
+    expect("bold inside text",
+           render("say **hi** now\n"),
+           "say \x1b[1mhi\x1b[0m now\n");
+    /* A star run that opens nothing must survive as text. */
+    expect("trailing star", render("2 * 3 = 6\n"), "2 * 3 = 6\n");
+}
+
+static void test_utf8(void) {
+    char *got = render("**中文**测试\n");
+    if (got) check_utf8_integrity("utf8 integrity", got);
+    expect("cjk bold", got, "\x1b[1m中文\x1b[0m测试\n");
+    expect("emoji passthrough", render("ok 🚀 done\n"), "ok 🚀 done\n");
+}
+
+static void test_think(void) {
+    expect("think block",
+           render_opt("<think>hidden</think>visible\n", true, true, false),
+           "\x1b[90mhidden\x1b[0m\nvisible\n");
+    /* The CLI starts inside the think block when thinking is enabled. */
+    expect("implicit think open",
+           render_opt("reasoning</think>answer\n", true, true, true),
+           "\x1b[90mreasoning\x1b[0m\nanswer\n");
+    expect("think without color",
+           render_opt("<think>hidden</think>visible\n", false, true, false),
+           "hidden\nvisible\n");
+    expect("markdown is inert inside think",
+           render_opt("<think>**not bold**</think>ok\n", true, true, false),
+           "\x1b[90m**not bold**\x1b[0m\nok\n");
+}
+
+static void test_fences(void) {
+    expect("plain fence keeps content verbatim",
+           render("```\n+--+\n|ab|\n+--+\n```\n"),
+           "```\n"
+           "\x1b[38;5;75m+--+\x1b[0m\n"
+           "\x1b[38;5;75m|ab|\x1b[0m\n"
+           "\x1b[38;5;75m+--+\x1b[0m\n"
+           "```\n");
+    expect("text fence is not highlighted",
+           render("```text\n1 + 1\n```\n"),
+           "```text\n\x1b[38;5;75m1 + 1\x1b[0m\n```\n");
+    expect_contains("language capture highlights keywords",
+                    render("```c\nreturn 0;\n```\n"),
+                    "\x1b[38;5;214mreturn");
+    expect("unterminated fence flushes at finish",
+           render("```\nabc"),
+           "```\n\x1b[38;5;75mabc\x1b[0m");
+    expect("fence closing at finish",
+           render("```\nabc\n```"),
+           "```\n\x1b[38;5;75mabc\x1b[0m\n```");
+    expect("pipes inside a fence stay literal",
+           render("```\n| a | b |\n```\n"),
+           "```\n\x1b[38;5;75m| a | b |\x1b[0m\n```\n");
+}
+
+static void test_plain_passthrough(void) {
+    static const char corpus[] =
+        "# Heading\n"
+        "Some **bold**, *italic*, `code`, a * b.\n"
+        "- bullet\n"
+        "1. ordered\n"
+        "> quote\n"
+        "---\n"
+        "| a | b |\n"
+        "| --- | --- |\n"
+        "| 1 | 2 |\n"
+        "```c\nint main(void) { return 0; }\n```\n"
+        "中文 mixed 内容 🚀\n";
+    char *got = render_opt(corpus, false, false, false);
+    if (got && strcmp(got, corpus) != 0)
+        fail("color=false passthrough", got, corpus);
+    free(got);
+}
+
+/* --plain keeps the terminal colors for thinking but prints markdown source. */
+static void test_plain_mode(void) {
+    static const char in[] = "<think>x</think># H\n**b** | a |\n";
+    char *buf = NULL;
+    size_t n = 0;
+    FILE *fp = open_memstream(&buf, &n);
+    ds4r r;
+    ds4r_init(&r, fp, true, true);
+    ds4r_set_markdown(&r, false);
+    ds4r_write(&r, in, strlen(in));
+    ds4r_finish(&r);
+    ds4r_free(&r);
+    fclose(fp);
+    if (strcmp(buf, "\x1b[90mx\x1b[0m\n# H\n**b** | a |\n") != 0)
+        fail("plain mode", buf, "\\e[90mx\\e[0m\\n# H\\n**b** | a |\\n");
+    free(buf);
+}
+
+int main(void) {
+    test_inline();
+    test_utf8();
+    test_think();
+    test_fences();
+    test_plain_passthrough();
+    test_plain_mode();
+    if (g_failures) {
+        printf("ds4-render-test: %d failure(s)\n", g_failures);
+        return 1;
+    }
+    printf("ds4-render-test: all tests passed\n");
+    return 0;
+}

--- a/tests/ds4_render_test.c
+++ b/tests/ds4_render_test.c
@@ -161,9 +161,125 @@ static void test_think(void) {
     expect("think without color",
            render_opt("<think>hidden</think>visible\n", false, true, false, 0),
            "hidden\nvisible\n");
-    expect("markdown is inert inside think",
+    expect("thinking renders bold in grey",
            render_opt("<think>**not bold**</think>ok\n", true, true, false, 0),
-           "\x1b[90m**not bold**\x1b[0m\nok\n");
+           "\x1b[1;90mnot bold\x1b[0m\nok\n");
+}
+
+/* Everything a think block emits must be greyscale: SGR 90 plus the plain
+ * attributes.  Any hue (30-37, 91-97, or an extended 38;5;N color) means the
+ * answer palette leaked into the reasoning. */
+static void check_muted(const char *what, const char *s) {
+    for (const char *p = strchr(s, 0x1b); p; p = strchr(p, 0x1b)) {
+        p++;
+        if (*p != '[') continue;
+        p++;
+        for (;;) {
+            int v = 0;
+            bool digits = false;
+            while (*p >= '0' && *p <= '9') {
+                v = v * 10 + (*p - '0');
+                digits = true;
+                p++;
+            }
+            if (digits && v != 0 && v != 1 && v != 2 && v != 3 && v != 4 &&
+                v != 22 && v != 23 && v != 24 && v != 90) {
+                char msg[80];
+                snprintf(msg, sizeof(msg), "%s: SGR %d is not muted", what, v);
+                fail(msg, s, "only 0/1/2/3/4/22/23/24/90");
+                return;
+            }
+            if (*p == ';') {
+                p++;
+                continue;
+            }
+            break;
+        }
+        if (*p) p++;
+    }
+}
+
+/* Render a corpus that stays inside the think block from the first byte, the
+ * way a thinking model streams before it closes the tag. */
+static char *render_thinking(const char *in, int cols) {
+    return render_opt(in, true, true, true, cols);
+}
+
+static void test_think_markdown(void) {
+    expect("thinking bold", render_thinking("**x**\n", 0),
+           "\x1b[1;90mx\x1b[0m\x1b[90m\n\x1b[0m");
+    expect("thinking italic", render_thinking("*x*\n", 0),
+           "\x1b[3;90mx\x1b[0m\x1b[90m\n\x1b[0m");
+    expect("thinking inline code", render_thinking("`x`\n", 0),
+           "\x1b[2;90mx\x1b[0m\x1b[90m\n\x1b[0m");
+    expect("thinking heading", render_thinking("# T\n", 0),
+           "\x1b[1;4;90mT\x1b[0m\x1b[90m\n\x1b[0m");
+    expect("thinking bullet", render_thinking("- x\n", 0),
+           "\x1b[2;90m\xe2\x80\xa2\x1b[0m \x1b[90mx\n\x1b[0m");
+    expect("thinking quote", render_thinking("> x\n", 0),
+           "\x1b[2;90m\xe2\x94\x82 \x1b[0m\x1b[90mx\n\x1b[0m");
+    /* Fenced code keeps its markers but drops syntax colors while thinking. */
+    expect("thinking fence is not highlighted",
+           render_thinking("```c\nreturn 0;\n```\n", 0),
+           "\x1b[90m```\x1b[0m\x1b[90mc\n\x1b[0m"
+           "\x1b[90mreturn 0;\x1b[0m\n\x1b[90m```\n\x1b[0m");
+
+    static const char corpus[] =
+        "# 标题\n"
+        "**bold** *it* `code`\n"
+        "- bullet\n"
+        "1. ordered\n"
+        "> quote\n"
+        "---\n"
+        "| a | 描述 |\n"
+        "| --- | ---: |\n"
+        "| 1 | 中文 |\n"
+        "```c\nint x = 1;\n```\n";
+    char *got = render_thinking(corpus, 40);
+    if (got) {
+        check_muted("think corpus", got);
+        check_utf8_integrity("think corpus utf8", got);
+        if (!strstr(got, "\xe2\x94\x8c"))
+            fail("thinking table is drawn", got, "box drawing");
+        /* The table body must still line up under the muted palette. */
+        const char *box = strstr(got, "\xe2\x94\x8c");
+        if (box) {
+            int w0 = line_width(box, 0);
+            for (int i = 1; i < 5; i++) {
+                if (line_width(box, i) != w0) {
+                    fail("thinking table alignment", got, "equal widths");
+                    break;
+                }
+            }
+        }
+        free(got);
+    }
+}
+
+/* Neither side of the boundary may inherit the other's state. */
+static void test_think_boundary(void) {
+    expect("open bold in think does not reach the answer",
+           render_opt("<think>**bold</think>plain\n", true, true, false, 0),
+           "\x1b[1;90mbold\x1b[0m\nplain\n");
+    expect("open bold in the answer does not reach think",
+           render_opt("a **b<think>c</think>d\n", true, true, false, 0),
+           "a \x1b[1mb\x1b[0m\x1b[90mc\x1b[0m\nd\n");
+    expect_contains("unterminated table flushes at </think>",
+                    render_opt("<think>| a |\n| --- |\n| 1 |</think>after\n",
+                               true, true, false, 0),
+                    "\xe2\x94\x94");
+    expect_contains("text after the flushed table is answer text",
+                    render_opt("<think>| a |\n| --- |\n| 1 |</think>after\n",
+                               true, true, false, 0),
+                    "after\n");
+    expect("open fence in think does not reach the answer",
+           render_opt("<think>```\ncode</think>text\n", true, true, false, 0),
+           "\x1b[90m```\x1b[0m\x1b[90m\n\x1b[0m"
+           "\x1b[90mcode\x1b[0m\ntext\n");
+    /* Interrupting inside a think table still prints what arrived. */
+    expect_contains("unterminated think table flushes at finish",
+                    render_thinking("| a |\n| --- |\n| 1 |", 0),
+                    "\xe2\x94\x94");
 }
 
 static void test_headings_lists(void) {
@@ -425,6 +541,8 @@ int main(void) {
     test_inline();
     test_utf8();
     test_think();
+    test_think_markdown();
+    test_think_boundary();
     test_headings_lists();
     test_fences();
     test_tables();


### PR DESCRIPTION
The interactive `ds4` chat prints model output raw, but DeepSeek V4 Flash answers arrive full of markdown — tables, bold, fenced code. This PR renders that markdown in the terminal, in the style of modern coding-agent TUIs, while keeping every non-interactive path byte-identical.

## What it does

- Inline formatting: **bold**, *italic*, `inline code`; `a * b` stays literal (space-guarded, same rule as the ds4-agent renderer).
- Fenced code blocks with the per-language syntax highlighting already proven in ds4-agent; unlabeled and `text`/`ascii`-style fences stay uncolored so ASCII diagrams pass through verbatim.
- Markdown tables drawn as aligned boxes with box-drawing characters: column alignment honored (`:---:`), cell contents rendered, and widths computed with an embedded locale-independent wcwidth so CJK/emoji cells align correctly. Tables are buffered until complete and degrade gracefully: padding shrink, then `…` truncation, then raw passthrough (also on missing separator row, buffer cap, or interruption).
- Headings, bullet/ordered lists, blockquotes, and horizontal rules get light styling.
- Thinking (`<think>`) content is rendered through the same pipeline but mapped to a muted grey-only palette (no hue colors, no syntax highlighting) so reasoning stays visually de-emphasized while long thinking streams remain readable.

## Modes and compatibility

- `--markdown off|basic|full` (default `full`). `basic` disables only table boxing — the one construct that buffers output — everything else still renders. `--plain` is an alias for `off`; `--think-plain` keeps thinking as flat grey regardless of mode. `/markdown` switches the mode at runtime in the REPL.
- Rendering activates only on a TTY. Piped or redirected output is byte-identical to the current behavior in every mode, verified by tests.
- `ds4_agent.c` is untouched (`git diff` against main is empty for it).

## Implementation

New self-contained `ds4_render.c/.h` (linked into the `ds4` binary only). The inline/fence/syntax/UTF-8 machinery is ported from the static renderer inside `ds4_agent.c`; tables, headings/lists, wcwidth, the muted thinking palette, and the mode knobs are new. Porting rather than extracting keeps this diff zero-risk for the working agent binary; unifying `ds4_agent.c` onto the shared TU would be a natural follow-up PR if you want it. Tables are buffered-then-drawn instead of repainted in place because cursor-up repaint is unreliable in cooked mode with autowrap across wrapped lines and scrollback.

## Tests

`tests/ds4_render_test.c` (wired into `make test`, no model weights needed): every corpus is fed whole-string, byte-at-a-time, and in 1..7-byte chunks with identical output required; markers and UTF-8 sequences split across token boundaries; ANSI never lands mid-codepoint; CJK table alignment asserted by per-row visible width; think/answer boundary state isolation (an unclosed `**` in thinking cannot leak bold into the answer); non-TTY passthrough identity for the full corpus. Metal and cpu builds are warning-free for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwY5tNVR2wBxBBQrxRy4cy
