### PR TITLE
Add numbered paste placeholders and true multi-row input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 /tests/test_cuda_session_batch
 /tests/cuda_long_context_smoke
 /tests/test_layer_pack
+/tests/test_linenoise_paste
 /tests/test_metal_session_batch
 /tests/test_mxfp4_cuda
 /tests/test_mxfp4_dot

--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,14 @@ tests/test_layer_pack.o: tests/test_layer_pack.c ds4_layer_pack.h
 tests/test_layer_pack: tests/test_layer_pack.o ds4_layer_pack.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
+tests/test_linenoise_paste.o: tests/test_linenoise_paste.c linenoise.c linenoise.h
+	$(CC) $(CFLAGS) -I. -c -o $@ $<
+
+# No linenoise.o here: the test includes the implementation to reach the
+# rendering internals.
+tests/test_linenoise_paste: tests/test_linenoise_paste.o
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
+
 tests/test_gpu_args.o: tests/test_gpu_args.c ds4_gpu_args.h ds4_gpu_mgpu.h
 	$(CC) $(CFLAGS) -I. -DDS4_NO_GPU -c -o $@ $<
 
@@ -442,11 +450,13 @@ endif
 
 test: ds4_test ds4_agent_test ds4-eval q4k-dot-test mxfp4-dot-test \
 	tests/test_layer_pack tests/test_engine_mgpu_placement tests/test_gpu_args \
+	tests/test_linenoise_paste \
 	$(SAMPLING_TEST) ds4 ds4-server ds4-bench ds4-agent
 	./ds4-eval --self-test-extractors
 	./ds4_agent_test
 	./ds4_test
 	./tests/test_layer_pack
+	./tests/test_linenoise_paste
 	./tests/test_engine_mgpu_placement
 	./tests/test_gpu_args
 	./tests/test_gpu_args_cli.sh
@@ -488,4 +498,4 @@ mxfp4-dot-test: tests/test_mxfp4_dot.c
 	./tests/test_mxfp4_dot
 
 clean:
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/test_linenoise_paste tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o

--- a/QA_BEFORE_RELEASES.md
+++ b/QA_BEFORE_RELEASES.md
@@ -586,6 +586,15 @@ The agent is the most stateful component.  Test it manually, not only by build.
   test multiline prompt editing, history navigation, queued prompt display,
   status bar fill to terminal width, syntax highlighting in Markdown/code blocks,
   and SSH/remote terminal flicker.
+- Paste, in both `ds4` and `ds4-agent`:
+  a short snippet of a few lines must appear inline with newlines shown as `↵`;
+  a long or many line paste must collapse to `[Pasted text #1 +N lines]` with the
+  `(paste again to expand)` hint, which must disappear as soon as anything else
+  is typed.  Pasting the same text again must expand that placeholder in place,
+  without duplicating the text, and pasting a file too tall for the terminal
+  twice must beep and keep the placeholder instead of flooding the prompt.
+  Seventeen consecutive pastes must all still be there on submit, and history
+  recall of a folded prompt must submit the real text.
 
 ## 14. Download Script And Model Files
 

--- a/QA_BEFORE_RELEASES.md
+++ b/QA_BEFORE_RELEASES.md
@@ -586,8 +586,14 @@ The agent is the most stateful component.  Test it manually, not only by build.
   test multiline prompt editing, history navigation, queued prompt display,
   status bar fill to terminal width, syntax highlighting in Markdown/code blocks,
   and SSH/remote terminal flicker.
+- Multi row input, in both `ds4` and `ds4-agent`:
+  Ctrl+J must insert a real line break and keep typing on the next row.  Arrows,
+  Home/End, backspace and Ctrl+W must cross the break with the cursor landing
+  where it looks like it should, and deleting the break must fold the rows back
+  into one without leaving a stale row on screen.  Repeat with a row long enough
+  to wrap, and with the terminal resized while the input spans several rows.
 - Paste, in both `ds4` and `ds4-agent`:
-  a short snippet of a few lines must appear inline with newlines shown as `↵`;
+  a short snippet of a few lines must appear inline as real rows;
   a long or many line paste must collapse to `[Pasted text #1 +N lines]` with the
   `(paste again to expand)` hint, which must disappear as soon as anything else
   is typed.  Pasting the same text again must expand that placeholder in place,

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -10410,6 +10410,7 @@ static void runtime_help(void) {
     puts("  Ctrl+X       Edit the first queued prompt.");
     puts("  ESC          Interrupt and send queued prompt immediately.");
     puts("  Ctrl+D       Exit from an empty prompt.");
+    puts("  Paste twice  Paste the same text again to expand its placeholder.");
 }
 
 static void agent_format_ctx_size(int ctx_size, char *buf, size_t len) {

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -10410,6 +10410,7 @@ static void runtime_help(void) {
     puts("  Ctrl+X       Edit the first queued prompt.");
     puts("  ESC          Interrupt and send queued prompt immediately.");
     puts("  Ctrl+D       Exit from an empty prompt.");
+    puts("  Ctrl+J       Insert a newline.");
     puts("  Paste twice  Paste the same text again to expand its placeholder.");
 }
 

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -1278,6 +1278,7 @@ static void print_repl_help(void) {
     puts("  /read FILE     Read a prompt from FILE and run it.");
     puts("  /quit, /exit   Leave the prompt.");
     puts("  Ctrl+C         Stop generation and return to the prompt.");
+    puts("  Ctrl+J         Insert a newline.");
     puts("  Paste twice    Paste the same text again to expand its placeholder.");
 }
 

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -1278,6 +1278,7 @@ static void print_repl_help(void) {
     puts("  /read FILE     Read a prompt from FILE and run it.");
     puts("  /quit, /exit   Leave the prompt.");
     puts("  Ctrl+C         Stop generation and return to the prompt.");
+    puts("  Paste twice    Paste the same text again to expand its placeholder.");
 }
 
 static bool parse_power_percent(const char *arg, int *out) {

--- a/linenoise.c
+++ b/linenoise.c
@@ -721,6 +721,21 @@ failed:
     return 80;
 }
 
+/* Try to get the number of rows in the current terminal, or assume 24 if it
+ * fails. Unlike getColumns() there is no escape sequence fallback: the only
+ * user is the guard refusing to expand a paste that would not fit, and a
+ * conservative guess there simply keeps the placeholder folded. */
+static int getRows(void) {
+    struct winsize ws;
+
+    /* Test mode: use LINENOISE_ROWS env var for fixed height. */
+    char *rows_env = getenv("LINENOISE_ROWS");
+    if (rows_env) return atoi(rows_env);
+
+    if (ioctl(1, TIOCGWINSZ, &ws) == -1 || ws.ws_row == 0) return 24;
+    return ws.ws_row;
+}
+
 /* Clear the screen. Used to handle ctrl+l */
 void linenoiseClearScreen(void) {
     if (write(STDOUT_FILENO,"\x1b[H\x1b[2J",7) <= 0) {
@@ -1321,10 +1336,16 @@ static int linenoiseRangeOverlapsFold(struct linenoiseState *l, size_t pos, size
 }
 
 /* Adjust fold ranges after an insertion. If insertion somehow lands inside a
- * fold, remove that fold because it no longer maps to an unchanged range. */
+ * fold, remove that fold because it no longer maps to an unchanged range.
+ *
+ * This is also where the inline "paste again" hint dies: it is an aid shown
+ * right after a paste, and every path that changes the buffer content passes
+ * through here, through linenoiseAdjustFoldsAfterDelete() or through
+ * linenoiseFoldClear(). Moving the cursor around leaves it alone. */
 static void linenoiseAdjustFoldsAfterInsert(struct linenoiseState *l, size_t pos, size_t len) {
     int j = 0;
 
+    l->fold_hint_id = 0;
     while (j < l->fold_count) {
         if (pos <= l->fold_start[j]) {
             l->fold_start[j] += len;
@@ -1344,6 +1365,7 @@ static void linenoiseAdjustFoldsAfterDelete(struct linenoiseState *l, size_t pos
     size_t end = pos + len;
     int j = 0;
 
+    l->fold_hint_id = 0;
     while (j < l->fold_count) {
         if (end <= l->fold_start[j]) {
             l->fold_start[j] -= len;
@@ -1355,6 +1377,55 @@ static void linenoiseAdjustFoldsAfterDelete(struct linenoiseState *l, size_t pos
             linenoiseFoldRemove(l,j);
         }
     }
+}
+
+/* Number of terminal rows the prompt currently needs, mirroring the row math
+ * of refreshMultiLine() plus the status footer. Return -1 if the buffer can't
+ * be rendered. */
+static int linenoiseRenderRows(struct linenoiseState *l) {
+    char *render = NULL;
+    size_t render_len, render_pos, cols = l->cols ? l->cols : 80;
+    size_t width;
+
+    if (linenoiseRenderBuffer(l,&render,&render_len,&render_pos) == -1) return -1;
+    width = utf8StrWidth(l->prompt,l->plen) + utf8StrWidth(render,render_len);
+    free(render);
+    return (int)((width+cols-1)/cols) + linenoiseStatusRows(l);
+}
+
+/* Return the index of the fold hiding exactly the given text, or -1. A fold is
+ * never partially edited: the cursor jumps over it and any overlapping edit
+ * drops the whole entry, so an exact byte compare is enough. When more than
+ * one fold matches, the most recently created one wins. */
+static int linenoiseFoldMatch(struct linenoiseState *l, const char *buf, size_t len) {
+    int j, best = -1;
+
+    for (j = 0; j < l->fold_count; j++) {
+        if (l->fold_end[j]-l->fold_start[j] != len) continue;
+        if (memcmp(l->buf+l->fold_start[j],buf,len) != 0) continue;
+        if (best == -1 || l->fold_id[j] > l->fold_id[best]) best = j;
+    }
+    return best;
+}
+
+/* Reveal the text hidden by fold j. The expanded text is shown as one long
+ * logical line, so refuse when it would not fit on screen: a file pasted twice
+ * by mistake must not blow the prompt past the terminal. Two rows are kept
+ * free so the prompt still has room to grow. Return 1 on success, or 0 with
+ * the fold left untouched. */
+static int linenoiseFoldExpand(struct linenoiseState *l, int j) {
+    size_t start = l->fold_start[j], end = l->fold_end[j];
+    int id = l->fold_id[j];
+    int rows;
+
+    linenoiseFoldRemove(l,j);
+    rows = linenoiseRenderRows(l);
+    if (rows < 0 || rows > getRows()-2) {
+        linenoiseFoldInsert(l,start,end,id);
+        return 0;
+    }
+    if (l->fold_hint_id == id) l->fold_hint_id = 0;
+    return 1;
 }
 
 /* Helper of refreshSingleLine() and refreshMultiLine() to show hints
@@ -2192,6 +2263,22 @@ static void linenoiseEditPaste(struct linenoiseState *l) {
         len = w;
     }
 
+    /* Pasting the very same text again expands its placeholder instead of
+     * inserting a second copy: this is how the user sees what is hidden.
+     * The cursor is already at the end of the revealed range, exactly where
+     * an ordinary paste of the same text would have left it. */
+    if (!maskmode) {
+        int j = linenoiseFoldMatch(l,buf,len);
+        if (j != -1) {
+            if (linenoiseFoldExpand(l,j))
+                refreshLine(l);
+            else
+                linenoiseBeep();
+            free(buf);
+            return;
+        }
+    }
+
     if (!maskmode && shouldFoldText(buf,len)) {
         size_t start = l->pos;
         if (linenoiseEditInsertNoRefresh(l,buf,len) == -1) {
@@ -2199,7 +2286,9 @@ static void linenoiseEditPaste(struct linenoiseState *l) {
             linenoiseBeep();
             return;
         }
-        linenoiseFoldAdd(l,start,start+len);
+        /* Point the inline hint at the fold just created, so the newest
+         * placeholder is the one advertising how to expand it. */
+        l->fold_hint_id = linenoiseFoldAdd(l,start,start+len);
         refreshLine(l);
     } else {
         linenoiseEditInsert(l,buf,len);
@@ -2254,10 +2343,14 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
     }
 
     switch(c) {
-    case ENTER:    /* enter */
+    case ENTER: {  /* enter */
+        int hinted = l->fold_hint_id != 0;
         history_len--;
         free(history[history_len]);
         if (mlmode) linenoiseEditMoveEnd(l);
+        /* The accepted line stays frozen on screen above the answer, so drop
+         * the transient "paste again" hint before the last repaint. */
+        l->fold_hint_id = 0;
         if (hintsCallback) {
             /* Force a refresh without hints to leave the previous
              * line as the user typed it after a newline. */
@@ -2265,8 +2358,11 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
             hintsCallback = NULL;
             refreshLine(l);
             hintsCallback = hc;
+        } else if (hinted) {
+            refreshLine(l);
         }
         return strdup(l->buf);
+    }
     case CTRL_C:     /* ctrl-c */
         errno = EAGAIN;
         return NULL;
@@ -2302,6 +2398,7 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
             memmove(l->buf + prevstart + currlen, l->buf + prevstart, prevlen);
             memcpy(l->buf + prevstart, tmp, currlen);
             if (l->pos + currlen <= l->len) l->pos += currlen;
+            l->fold_hint_id = 0; /* Content changed without moving any fold. */
             refreshLine(l);
         }
         break;

--- a/linenoise.c
+++ b/linenoise.c
@@ -127,6 +127,13 @@
 #define HISTORY_FOLD_MULTILINE_LINES 16     // Min lines to fold shorter history.
 #define HISTORY_FOLD_CONTEXT 96             // Context chars kept around history folds.
 #define PASTE_MAX_BYTES LINENOISE_MAX_LINE
+/* U+21B5 stands in for hard newlines: the editor treats the buffer as one
+ * logical line, so a literal newline would desync the refresh cursor math.
+ * The glyph is East Asian Neutral, exactly one column on every terminal, and
+ * carries no escape sequence, so refreshSingleLine() can still slice the
+ * rendered text by characters when scrolling horizontally. */
+#define LINENOISE_NEWLINE_MARKER "\xe2\x86\xb5"
+#define LINENOISE_NEWLINE_MARKER_LEN 3
 static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
 static linenoiseCompletionCallback *completionCallback = NULL;
 static linenoiseHintsCallback *hintsCallback = NULL;
@@ -1104,39 +1111,60 @@ static int linenoiseGetRenderFolds(struct linenoiseState *l, struct linenoiseFol
     return fs->count != 0;
 }
 
+/* Rendered byte length of the buffer range [start,end), that is the same bytes
+ * except that every hard newline expands to the newline marker. Byte offsets
+ * are not preserved by the substitution, so translating an edit position into
+ * a render position requires scanning instead of subtracting. */
+static size_t renderPlainLen(const char *buf, size_t start, size_t end) {
+    size_t len = 0, j;
+
+    for (j = start; j < end; j++)
+        len += buf[j] == '\n' ? LINENOISE_NEWLINE_MARKER_LEN : 1;
+    return len;
+}
+
+/* Copy [start,end) into out with the same substitution, returning the number
+ * of bytes written, that is renderPlainLen() of the same range. */
+static size_t renderPlainCopy(const char *buf, size_t start, size_t end, char *out) {
+    size_t n = 0, j;
+
+    for (j = start; j < end; j++) {
+        if (buf[j] == '\n') {
+            memcpy(out+n,LINENOISE_NEWLINE_MARKER,LINENOISE_NEWLINE_MARKER_LEN);
+            n += LINENOISE_NEWLINE_MARKER_LEN;
+        } else {
+            out[n++] = buf[j];
+        }
+    }
+    return n;
+}
+
 /* Return the freshly allocated string content that is actually displayed in
  * the user prompt. It can be the actual edited line, or a special version
  * where pasted or multiline history ranges are replaced by their folded
- * "[...]" style versions. outpos is l->pos translated into this rendered
- * buffer. */
+ * "[...]" style versions. Newlines outside the folds are shown as markers.
+ * outpos is l->pos translated into this rendered buffer. */
 static int linenoiseRenderBuffer(struct linenoiseState *l, char **out, size_t *outlen, size_t *outpos) {
     struct linenoiseFolds fs;
     size_t len, pos, src, dst;
     char *r;
     int j, pos_set = 0;
 
-    if (!linenoiseGetRenderFolds(l,&fs)) {
-        /* Keep the refresh code simple: it always owns a temporary render
-         * buffer, even when the render is identical to the real edit buffer. */
-        r = malloc(l->len+1);
-        if (r == NULL) return -1;
-        memcpy(r,l->buf,l->len);
-        r[l->len] = '\0';
-        *out = r;
-        *outlen = l->len;
-        *outpos = l->pos;
-        return 0;
-    }
+    /* An empty fold set is not a special case: the loops below then just
+     * render the whole buffer as one gap. */
+    linenoiseGetRenderFolds(l,&fs);
 
-    /* Gaps are copied as-is, folded ranges are replaced by their markers.
-     * The bytes inside each [start,end) range stay in l->buf but are not
-     * emitted to the terminal. */
-    len = l->len;
+    /* Gaps are copied with their newlines substituted, folded ranges are
+     * replaced by their placeholder. The bytes inside each [start,end) range
+     * stay in l->buf but are not emitted to the terminal. */
+    len = 0;
+    src = 0;
     for (j = 0; j < fs.count; j++) {
         struct linenoiseFold *f = fs.fold+j;
-        len -= f->end - f->start;
-        len += f->displaylen;
+        len += renderPlainLen(l->buf,src,f->start) + f->displaylen;
+        src = f->end;
     }
+    len += renderPlainLen(l->buf,src,l->len);
     r = malloc(len+1);
     if (r == NULL) return -1;
 
@@ -1144,14 +1172,12 @@ static int linenoiseRenderBuffer(struct linenoiseState *l, char **out, size_t *o
     pos = 0;
     for (j = 0; j < fs.count; j++) {
         struct linenoiseFold *f = fs.fold+j;
-        size_t gap = f->start - src;
 
         if (!pos_set && l->pos <= f->start) {
-            pos = dst + (l->pos - src);
+            pos = dst + renderPlainLen(l->buf,src,l->pos);
             pos_set = 1;
         }
-        memcpy(r+dst,l->buf+src,gap);
-        dst += gap;
+        dst += renderPlainCopy(l->buf,src,f->start,r+dst);
 
         if (!pos_set && l->pos < f->end) {
             pos = dst + f->displaylen;
@@ -1165,8 +1191,8 @@ static int linenoiseRenderBuffer(struct linenoiseState *l, char **out, size_t *o
         }
         src = f->end;
     }
-    if (!pos_set) pos = dst + (l->pos - src);
-    memcpy(r+dst,l->buf+src,l->len-src);
+    if (!pos_set) pos = dst + renderPlainLen(l->buf,src,l->pos);
+    renderPlainCopy(l->buf,src,l->len,r+dst);
     r[len] = '\0';
 
     *out = r;
@@ -1692,8 +1718,13 @@ int linenoiseEditInsert(struct linenoiseState *l, const char *c, size_t clen) {
                              memchr(c, '\r', clen) != NULL;
 
         if (linenoiseEditInsertNoRefresh(l,c,clen) == -1) return 0;
+        /* The shortcut below appends the raw bytes and accounts for their
+         * width with utf8StrWidth(), which counts a newline as zero columns.
+         * A buffer that already holds newlines renders them as one-column
+         * markers instead, so it must take the full refresh path. */
         if (!needs_refresh && !mlmode && !linenoiseStatusActive(l) &&
             !l->oldstatusrows && !hintsCallback &&
+            memchr(l->buf,'\n',l->len) == NULL &&
             (maskmode || l->fold_count == 0))
         {
             size_t bufwidth = utf8StrWidth(l->buf,l->len);

--- a/linenoise.c
+++ b/linenoise.c
@@ -121,8 +121,8 @@
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
 #define LINENOISE_MAX_LINE (1024*1024)      // That will get dynamically allocated
 #define LINENOISE_INITIAL_BUFLEN 4096
-#define PASTE_FOLD_THRESHOLD 200            // Min bytes to fold a single-line paste.
-#define PASTE_FOLD_CONTEXT 8                // Context chars kept around generic folds.
+#define PASTE_FOLD_THRESHOLD 200            // Min bytes to fold a paste.
+#define PASTE_FOLD_LINES 5                  // Max lines shown inline unfolded.
 #define HISTORY_FOLD_THRESHOLD 4096         // Min bytes to fold single-line history.
 #define HISTORY_FOLD_MULTILINE_LINES 16     // Min lines to fold shorter history.
 #define HISTORY_FOLD_CONTEXT 96             // Context chars kept around history folds.
@@ -1028,10 +1028,13 @@ static size_t foldCountLines(const char *buf, size_t len) {
     return lines;
 }
 
-/* Return true if the text should be folded: if it contains newlines or is at
- * least PASTE_FOLD_THRESHOLD bytes long. */
+/* Return true if the text should be folded, that is if showing it inline
+ * would take over the prompt: long text, or more than PASTE_FOLD_LINES lines.
+ * A short snippet is easier to review as itself than as a placeholder, and
+ * its newlines are rendered as markers on the single prompt line. */
 static int shouldFoldText(const char *buf, size_t len) {
-    return memchr(buf, '\n', len) != NULL || len >= PASTE_FOLD_THRESHOLD;
+    return len >= PASTE_FOLD_THRESHOLD ||
+           foldCountLines(buf,len) > PASTE_FOLD_LINES;
 }
 
 /* History recall should not aggressively hide normal prompts.  A single-line
@@ -2180,37 +2183,30 @@ static int pasteBufferReserve(char **buf, size_t *cap, size_t len, size_t need) 
     return 0;
 }
 
-/* Append bytes to the temporary paste buffer, growing both it and l->buf as
- * needed. Return -1 if the paste is too large or allocation fails. */
-static int pasteBufferAppend(struct linenoiseState *l, char **buf, size_t *cap,
-                             size_t *len, const char *s, size_t slen, size_t maxlen) {
-    size_t needed;
-
-    if (*len > maxlen || slen > maxlen-*len) return -1;
+/* Append bytes to the temporary paste buffer. Return -1 if the paste is too
+ * large or allocation fails. Whether the edit buffer can hold the result is
+ * not decided here: the paste is collected first, because identical bytes may
+ * expand an existing fold instead of being inserted at all. */
+static int pasteBufferAppend(char **buf, size_t *cap, size_t *len,
+                             const char *s, size_t slen) {
     if (*len > SIZE_MAX-slen) return -1;
-    needed = *len+slen;
-    if (l->len > SIZE_MAX-needed) return -1;
-    if (linenoiseEditGrow(l,l->len+needed) == -1) return -1;
     if (pasteBufferReserve(buf,cap,*len,slen) == -1) return -1;
     memcpy(*buf+*len,s,slen);
-    *len = needed;
+    *len += slen;
     return 0;
 }
 
 /* Read a bracketed paste until ESC[201~ and insert the real bytes. If folding
- * is needed, remember the inserted range so only rendering is shortened. */
+ * is needed, remember the inserted range so only rendering is shortened. The
+ * paste is dropped, with a beep, only when it is over PASTE_MAX_BYTES or the
+ * edit buffer cannot hold it: running out of fold slots just leaves the text
+ * unfolded rather than silently losing it. */
 static void linenoiseEditPaste(struct linenoiseState *l) {
     static const char END[] = "\x1b[201~";
     const size_t ENDLEN = sizeof(END)-1;
     char *buf = NULL;
     size_t cap = 0, len = 0, match = 0;
-    size_t maxlen = l->buflen_max ? l->buflen_max : l->buflen;
     int overflowed = 0;
-
-    maxlen = maxlen > l->len ? maxlen - l->len : 0;
-    if (maxlen > PASTE_MAX_BYTES) maxlen = PASTE_MAX_BYTES;
-    /* Once all fold slots are used, consume later pastes without storing them. */
-    if (l->fold_count == LINENOISE_MAX_FOLDS) maxlen = 0;
 
     while (1) {
         char c;
@@ -2227,7 +2223,7 @@ static void linenoiseEditPaste(struct linenoiseState *l) {
 
         if (match > 0) {
             if (!overflowed &&
-                pasteBufferAppend(l,&buf,&cap,&len,END,match,maxlen) == -1)
+                pasteBufferAppend(&buf,&cap,&len,END,match) == -1)
                 overflowed = 1;
             match = 0;
             if (c == END[0]) {
@@ -2236,8 +2232,7 @@ static void linenoiseEditPaste(struct linenoiseState *l) {
             }
         }
 
-        if (!overflowed &&
-            pasteBufferAppend(l,&buf,&cap,&len,&c,1,maxlen) == -1)
+        if (!overflowed && pasteBufferAppend(&buf,&cap,&len,&c,1) == -1)
             overflowed = 1;
     }
 
@@ -2279,7 +2274,10 @@ static void linenoiseEditPaste(struct linenoiseState *l) {
         }
     }
 
-    if (!maskmode && shouldFoldText(buf,len)) {
+    /* The real bytes always enter the buffer first, then the range is marked
+     * as folded, and only then we repaint: raw pasted newlines must never
+     * reach the terminal. */
+    {
         size_t start = l->pos;
         if (linenoiseEditInsertNoRefresh(l,buf,len) == -1) {
             free(buf);
@@ -2288,10 +2286,9 @@ static void linenoiseEditPaste(struct linenoiseState *l) {
         }
         /* Point the inline hint at the fold just created, so the newest
          * placeholder is the one advertising how to expand it. */
-        l->fold_hint_id = linenoiseFoldAdd(l,start,start+len);
+        if (!maskmode && shouldFoldText(buf,len))
+            l->fold_hint_id = linenoiseFoldAdd(l,start,start+len);
         refreshLine(l);
-    } else {
-        linenoiseEditInsert(l,buf,len);
     }
     free(buf);
 }

--- a/linenoise.c
+++ b/linenoise.c
@@ -1154,13 +1154,16 @@ static int linenoiseGetRenderFolds(struct linenoiseState *l, struct linenoiseFol
     return fs->count != 0;
 }
 
-/* Rendered byte length of the buffer range [start,end), that is the same bytes
- * except that every hard newline expands to the newline marker. Byte offsets
- * are not preserved by the substitution, so translating an edit position into
- * a render position requires scanning instead of subtracting. */
-static size_t renderPlainLen(const char *buf, size_t start, size_t end) {
+/* Rendered byte length of the buffer range [start,end). With 'markers' every
+ * hard newline expands to the newline marker, which is what the renderers
+ * confined to a single row need; byte offsets are then not preserved, so
+ * translating an edit position into a render position requires scanning
+ * instead of subtracting. Without it the bytes are kept verbatim and
+ * refreshMultiLine() turns each newline into a real terminal row. */
+static size_t renderPlainLen(const char *buf, size_t start, size_t end, int markers) {
     size_t len = 0, j;
 
+    if (!markers) return end-start;
     for (j = start; j < end; j++)
         len += buf[j] == '\n' ? LINENOISE_NEWLINE_MARKER_LEN : 1;
     return len;
@@ -1168,9 +1171,13 @@ static size_t renderPlainLen(const char *buf, size_t start, size_t end) {
 
 /* Copy [start,end) into out with the same substitution, returning the number
  * of bytes written, that is renderPlainLen() of the same range. */
-static size_t renderPlainCopy(const char *buf, size_t start, size_t end, char *out) {
+static size_t renderPlainCopy(const char *buf, size_t start, size_t end, char *out, int markers) {
     size_t n = 0, j;
 
+    if (!markers) {
+        memcpy(out,buf+start,end-start);
+        return end-start;
+    }
     for (j = start; j < end; j++) {
         if (buf[j] == '\n') {
             memcpy(out+n,LINENOISE_NEWLINE_MARKER,LINENOISE_NEWLINE_MARKER_LEN);
@@ -1185,9 +1192,10 @@ static size_t renderPlainCopy(const char *buf, size_t start, size_t end, char *o
 /* Return the freshly allocated string content that is actually displayed in
  * the user prompt. It can be the actual edited line, or a special version
  * where pasted or multiline history ranges are replaced by their folded
- * "[...]" style versions. Newlines outside the folds are shown as markers.
+ * "[...]" style versions. Newlines outside the folds are kept verbatim, or
+ * replaced by markers when the caller can only paint one row.
  * outpos is l->pos translated into this rendered buffer. */
-static int linenoiseRenderBuffer(struct linenoiseState *l, char **out, size_t *outlen, size_t *outpos) {
+static int linenoiseRenderBuffer(struct linenoiseState *l, char **out, size_t *outlen, size_t *outpos, int markers) {
     struct linenoiseFolds fs;
     size_t len, pos, src, dst;
     char *r;
@@ -1204,10 +1212,10 @@ static int linenoiseRenderBuffer(struct linenoiseState *l, char **out, size_t *o
     src = 0;
     for (j = 0; j < fs.count; j++) {
         struct linenoiseFold *f = fs.fold+j;
-        len += renderPlainLen(l->buf,src,f->start) + f->displaylen;
+        len += renderPlainLen(l->buf,src,f->start,markers) + f->displaylen;
         src = f->end;
     }
-    len += renderPlainLen(l->buf,src,l->len);
+    len += renderPlainLen(l->buf,src,l->len,markers);
     r = malloc(len+1);
     if (r == NULL) return -1;
 
@@ -1217,10 +1225,10 @@ static int linenoiseRenderBuffer(struct linenoiseState *l, char **out, size_t *o
         struct linenoiseFold *f = fs.fold+j;
 
         if (!pos_set && l->pos <= f->start) {
-            pos = dst + renderPlainLen(l->buf,src,l->pos);
+            pos = dst + renderPlainLen(l->buf,src,l->pos,markers);
             pos_set = 1;
         }
-        dst += renderPlainCopy(l->buf,src,f->start,r+dst);
+        dst += renderPlainCopy(l->buf,src,f->start,r+dst,markers);
 
         if (!pos_set && l->pos < f->end) {
             pos = dst + f->displaylen;
@@ -1234,14 +1242,62 @@ static int linenoiseRenderBuffer(struct linenoiseState *l, char **out, size_t *o
         }
         src = f->end;
     }
-    if (!pos_set) pos = dst + renderPlainLen(l->buf,src,l->pos);
-    renderPlainCopy(l->buf,src,l->len,r+dst);
+    if (!pos_set) pos = dst + renderPlainLen(l->buf,src,l->pos,markers);
+    renderPlainCopy(l->buf,src,l->len,r+dst,markers);
     r[len] = '\0';
 
     *out = r;
     *outlen = len;
     *outpos = pos;
     return 0;
+}
+
+/* Where the terminal cursor ends up after printing the prompt followed by the
+ * first 'stop' bytes of a rendered buffer. The stream wraps at the right
+ * margin and every hard newline starts a fresh row, so once newlines are in
+ * play the position can only be known by walking the text.
+ *
+ * Rows are 1 based and counted from the prompt row; *col is the 0 based
+ * column. *pending reports the deferred wrap terminals implement: text that
+ * ends exactly on the right margin leaves the cursor logically at column 0 of
+ * the row below, but the terminal only moves there when the next glyph, CR or
+ * LF arrives. That distinction matters twice: a newline right after such text
+ * must not skip a row, and a buffer ending there needs an explicit CR LF so
+ * the row the cursor claims really exists.
+ *
+ * Segment widths come from utf8StrWidth(), so a double width character that
+ * does not fit in the last column is accounted where it was written rather
+ * than where the terminal wraps it. This approximation predates newline
+ * support and only shows up with CJK text straddling the margin. */
+static void linenoiseGeometry(const char *render, size_t stop, size_t pwidth,
+                              size_t cols, int *row, int *col, int *pending)
+{
+    size_t used = pwidth;   /* Columns used so far on the current row. */
+    size_t i = 0, seg = 0;
+    int r = 1, p = 0;
+
+    if (cols == 0) cols = 80;
+    while (1) {
+        int newline = i < stop && render[i] == '\n';
+
+        if (i == stop || newline) {
+            used += utf8StrWidth(render+seg,i-seg);
+            r += (int)(used/cols);
+            p = used > 0 && used%cols == 0;
+            used %= cols;
+            if (i == stop) break;
+            /* A newline resolves a deferred wrap instead of adding to it: the
+             * terminal already moved to the row below when it wrapped. */
+            if (!p) r++;
+            p = 0;
+            used = 0;
+            seg = i+1;
+        }
+        i++;
+    }
+    *row = r;
+    *col = (int)used;
+    *pending = p;
 }
 
 /* Return the number of bytes to move right from pos. If pos is at the start of
@@ -1382,18 +1438,21 @@ static void linenoiseAdjustFoldsAfterDelete(struct linenoiseState *l, size_t pos
     }
 }
 
-/* Number of terminal rows the prompt currently needs, mirroring the row math
- * of refreshMultiLine() plus the status footer. Return -1 if the buffer can't
+/* Number of terminal rows the prompt currently needs, with the same geometry
+ * refreshMultiLine() uses, plus the status footer. Text ending on the right
+ * margin counts the row the cursor would claim, which is what the multi row
+ * refresh reserves when the cursor sits there. Return -1 if the buffer can't
  * be rendered. */
 static int linenoiseRenderRows(struct linenoiseState *l) {
     char *render = NULL;
-    size_t render_len, render_pos, cols = l->cols ? l->cols : 80;
-    size_t width;
+    size_t render_len, render_pos;
+    int row, col, pending;
 
-    if (linenoiseRenderBuffer(l,&render,&render_len,&render_pos) == -1) return -1;
-    width = utf8StrWidth(l->prompt,l->plen) + utf8StrWidth(render,render_len);
+    if (linenoiseRenderBuffer(l,&render,&render_len,&render_pos,0) == -1) return -1;
+    linenoiseGeometry(render,render_len,utf8StrWidth(l->prompt,l->plen),
+                      l->cols,&row,&col,&pending);
     free(render);
-    return (int)((width+cols-1)/cols) + linenoiseStatusRows(l);
+    return row + linenoiseStatusRows(l);
 }
 
 /* Return the index of the fold hiding exactly the given text, or -1. A fold is
@@ -1432,19 +1491,21 @@ static int linenoiseFoldExpand(struct linenoiseState *l, int j) {
 }
 
 /* Helper of refreshSingleLine() and refreshMultiLine() to show hints
- * to the right of the prompt. Now uses display widths for proper UTF-8. */
-void refreshShowHints(struct abuf *ab, struct linenoiseState *l, int pwidth, size_t bufwidth) {
+ * to the right of the prompt. Now uses display widths for proper UTF-8.
+ * 'col' is the column the hint would start at, that is where the text just
+ * written left the cursor: with multiple rows only the last one is left. */
+void refreshShowHints(struct abuf *ab, struct linenoiseState *l, size_t col) {
     if (hintsCallback) {
         char seq[64];
         int color = -1, bold = 0;
         char *hint;
 
-        if (pwidth + bufwidth >= l->cols) return;
+        if (col >= l->cols) return;
         hint = hintsCallback(l->buf,&color,&bold);
         if (hint) {
             size_t hintlen = strlen(hint);
             size_t hintwidth = utf8StrWidth(hint, hintlen);
-            size_t hintmaxwidth = l->cols - (pwidth + bufwidth);
+            size_t hintmaxwidth = l->cols - col;
             /* Truncate hint to fit, respecting UTF-8 boundaries. */
             if (hintwidth > hintmaxwidth) {
                 size_t i = 0, w = 0;
@@ -1495,7 +1556,8 @@ static void refreshSingleLine(struct linenoiseState *l, int flags) {
     size_t fullwidth;        /* Display width before horizontal trimming. */
     struct abuf ab;
 
-    if (linenoiseRenderBuffer(l,&render,&len,&pos) == -1) return;
+    /* One row only: hard newlines have to be shown as markers here. */
+    if (linenoiseRenderBuffer(l,&render,&len,&pos,1) == -1) return;
     buf = render;
 
     /* Calculate the display width up to cursor and total display width. */
@@ -1543,7 +1605,7 @@ static void refreshSingleLine(struct linenoiseState *l, int flags) {
             abAppend(&ab,buf,len);
         }
         /* Show hints if any. */
-        refreshShowHints(&ab,l,pwidth,fullwidth);
+        refreshShowHints(&ab,l,pwidth+fullwidth);
     }
 
     /* Erase to right */
@@ -1569,14 +1631,17 @@ static void refreshSingleLine(struct linenoiseState *l, int flags) {
  * Flags is REFRESH_* macros. The function can just remove the old
  * prompt, just write it, or both.
  *
- * This function is UTF-8 aware and uses display widths for positioning. */
+ * This function is UTF-8 aware and uses display widths for positioning. Hard
+ * newlines in the buffer are painted as real terminal rows, so the row and
+ * cursor math walks the rendered text instead of dividing its total width. */
 static void refreshMultiLine(struct linenoiseState *l, int flags) {
     char seq[64];
     size_t pwidth = utf8StrWidth(l->prompt, l->plen);  /* Prompt display width */
+    size_t cols = l->cols ? l->cols : 80;
     char *render = NULL;
     size_t render_len, render_pos;
-    size_t bufwidth;
-    size_t poswidth;
+    int end_row, end_col, end_pending;   /* Geometry of the whole render. */
+    int cur_pending;    /* Deferred wrap at the cursor, same row either way. */
     int rows; /* rows used by current rendered buffer. */
     int rpos = l->oldrpos;   /* cursor relative row from previous refresh. */
     int rpos2; /* rpos after refresh. */
@@ -1588,13 +1653,19 @@ static void refreshMultiLine(struct linenoiseState *l, int flags) {
     int fd = l->ofd, j;
     struct abuf ab;
 
-    if (linenoiseRenderBuffer(l,&render,&render_len,&render_pos) == -1) return;
-    bufwidth = utf8StrWidth(render, render_len);
-    poswidth = utf8StrWidth(render, render_pos);
-    rows = (pwidth+bufwidth+l->cols-1)/l->cols;
-    int cursor_wrap_row = l->pos &&
-        render_pos == render_len &&
-        (poswidth+pwidth) % l->cols == 0;
+    /* Masked input is painted as one asterisk per character on a single row,
+     * so it needs the marker variant; everything else gets real newlines. */
+    if (linenoiseRenderBuffer(l,&render,&render_len,&render_pos,maskmode) == -1)
+        return;
+    linenoiseGeometry(render,render_len,pwidth,cols,&end_row,&end_col,&end_pending);
+    linenoiseGeometry(render,render_pos,pwidth,cols,&rpos2,&col,&cur_pending);
+
+    /* Text stopping exactly on the right margin has not made the terminal
+     * move to the next row yet, so that row is not painted and not counted.
+     * When the cursor is there we do materialize it below, and then it is a
+     * row of the prompt like any other. */
+    rows = end_row - (end_pending ? 1 : 0);
+    int cursor_wrap_row = end_pending && render_pos == render_len && render_pos;
     if (cursor_wrap_row) rows++;
 
     /* First step: clear all the lines used before. To do so start by
@@ -1659,11 +1730,22 @@ static void refreshMultiLine(struct linenoiseState *l, int flags) {
                 i += utf8NextCharLen(render, i, render_len);
             }
         } else {
-            abAppend(&ab,render,render_len);
+            /* Raw mode cleared OPOST, so a bare LF would drop one row while
+             * keeping the column and stair-step the input. Write CR LF for
+             * every hard newline instead, which also resolves a deferred
+             * wrap without skipping a row. */
+            size_t i, start = 0;
+            for (i = 0; i < render_len; i++) {
+                if (render[i] != '\n') continue;
+                abAppend(&ab,render+start,(int)(i-start));
+                abAppend(&ab,"\r\n",2);
+                start = i+1;
+            }
+            abAppend(&ab,render+start,(int)(render_len-start));
         }
 
-        /* Show hints if any. */
-        refreshShowHints(&ab,l,pwidth,bufwidth);
+        /* Show hints if any, right where the last row ended. */
+        refreshShowHints(&ab,l,(size_t)end_col);
 
         /* If we are at the very end of the screen with our prompt, we need to
          * emit a newline and move the prompt to the first column. */
@@ -1674,16 +1756,13 @@ static void refreshMultiLine(struct linenoiseState *l, int flags) {
             abAppend(&ab,seq,strlen(seq));
         }
 
-        /* Move cursor to right position. */
-        rpos2 = (pwidth+poswidth+l->cols)/l->cols; /* Current cursor relative row */
         lndebug("rpos2 %d", rpos2);
 
         if (linenoiseStatusActive(l)) {
             refreshStatusLine(&ab, l);
         }
 
-        /* Set column. */
-        col = (pwidth+poswidth) % l->cols;
+        /* Set column, already known from the cursor walk above. */
         if (layout_prompt_row > 0) {
             /* The owner has explicitly anchored the prompt block.  Avoid the
              * relative "go up from status row" cursor motion here: after the

--- a/linenoise.c
+++ b/linenoise.c
@@ -993,6 +993,8 @@ static void refreshStatusLine(struct abuf *ab, struct linenoiseState *l) {
 struct linenoiseFold {
     size_t start;
     size_t end;
+    int id;             /* Placeholder number, or 0 for unnumbered folds. */
+    int hinted;         /* Show the "paste again to expand" suffix. */
     char display[64];
     size_t displaylen;
 };
@@ -1027,17 +1029,37 @@ static int shouldFoldHistoryText(const char *buf, size_t len) {
            lines >= HISTORY_FOLD_MULTILINE_LINES;
 }
 
-/* Fill f->display with the text shown instead of the folded range. */
+/* Fill f->display with the text shown instead of the folded range. Folds
+ * created by a paste on the current line carry a number the user can refer
+ * to; folds reconstructed from history have no number, since they were never
+ * pasted here. */
 static void foldSetRenderedText(struct linenoiseFold *f, const char *buf) {
     size_t hidden = f->end - f->start;
     size_t lines = foldCountLines(buf + f->start, hidden);
+    const char *hint = f->hinted ? " (paste again to expand)" : "";
     int n;
 
-    if (lines > 1)
-        n = snprintf(f->display,sizeof(f->display),"[... %zu pasted lines ...]",lines);
-    else
-        n = snprintf(f->display,sizeof(f->display),"[... %zu pasted chars ...]",hidden);
+    /* Text ending with a newline still has that many lines: the final
+     * newline closes the last line instead of opening an empty one. */
+    if (lines > 1 && buf[f->end-1] == '\n') lines--;
+
+    if (f->id > 0) {
+        if (lines > 1)
+            n = snprintf(f->display,sizeof(f->display),
+                         "[Pasted text #%d +%zu lines]%s",f->id,lines,hint);
+        else
+            n = snprintf(f->display,sizeof(f->display),
+                         "[Pasted text #%d +%zu chars]%s",f->id,hidden,hint);
+    } else {
+        if (lines > 1)
+            n = snprintf(f->display,sizeof(f->display),"[... %zu lines ...]",lines);
+        else
+            n = snprintf(f->display,sizeof(f->display),"[... %zu chars ...]",hidden);
+    }
+    /* snprintf() reports the untruncated length: never trust it past the
+     * buffer, or the render would read out of bounds. */
     if (n < 0) n = 0;
+    if ((size_t)n >= sizeof(f->display)) n = (int)sizeof(f->display)-1;
     f->displaylen = (size_t)n;
 }
 
@@ -1047,6 +1069,7 @@ static void foldSetRenderedText(struct linenoiseFold *f, const char *buf) {
  * contains newlines. */
 static int linenoiseBuildHistoryFold(struct linenoiseState *l, struct linenoiseFold *f) {
     f->start = f->end = f->displaylen = 0;
+    f->id = f->hinted = 0;
     if (l->len == 0 || maskmode) return 0;
     if (!shouldFoldHistoryText(l->buf,l->len)) return 0;
 
@@ -1106,6 +1129,8 @@ static int linenoiseGetRenderFolds(struct linenoiseState *l, struct linenoiseFol
         f = fs->fold + fs->count++;
         f->start = start;
         f->end = end;
+        f->id = l->fold_id[j];
+        f->hinted = f->id > 0 && f->id == l->fold_hint_id;
         foldSetRenderedText(f,l->buf);
     }
     return fs->count != 0;
@@ -1231,25 +1256,45 @@ static size_t linenoiseEditPrevLen(struct linenoiseState *l, size_t pos) {
     return utf8PrevCharLen(l->buf,pos);
 }
 
-/* Add a fold range, keeping the array sorted by start offset. */
-static void linenoiseFoldAdd(struct linenoiseState *l, size_t start, size_t end) {
+/* Add a fold range with an explicit number, keeping the array sorted by start
+ * offset. Return 1 if the fold was stored. The number is kept beside the range
+ * because the array order follows the offsets, not the creation order. */
+static int linenoiseFoldInsert(struct linenoiseState *l, size_t start, size_t end, int id) {
     int j;
 
-    if (start >= end || l->fold_count == LINENOISE_MAX_FOLDS) return;
+    if (start >= end || l->fold_count == LINENOISE_MAX_FOLDS) return 0;
     j = l->fold_count;
     while (j > 0 && start < l->fold_start[j-1]) {
         l->fold_start[j] = l->fold_start[j-1];
         l->fold_end[j] = l->fold_end[j-1];
+        l->fold_id[j] = l->fold_id[j-1];
         j--;
     }
     l->fold_start[j] = start;
     l->fold_end[j] = end;
+    l->fold_id[j] = id;
     l->fold_count++;
+    return 1;
 }
 
-/* Clear all remembered fold ranges. */
+/* Add a fold for text just pasted on this line, giving it the next
+ * placeholder number. Return the assigned number, or 0 if there was no free
+ * fold slot. Numbers are never reused or reassigned, so expanding "#1" leaves
+ * the next paste as "#2" instead of renumbering what is on screen. */
+static int linenoiseFoldAdd(struct linenoiseState *l, size_t start, size_t end) {
+    int id = l->fold_next_id+1;
+
+    if (!linenoiseFoldInsert(l,start,end,id)) return 0;
+    l->fold_next_id = id;
+    return id;
+}
+
+/* Clear all remembered fold ranges. Numbering restarts from #1 with the next
+ * edited line, like a fresh prompt. */
 static void linenoiseFoldClear(struct linenoiseState *l) {
     l->fold_count = 0;
+    l->fold_next_id = 0;
+    l->fold_hint_id = 0;
 }
 
 /* Remove one remembered fold range. */
@@ -1258,6 +1303,8 @@ static void linenoiseFoldRemove(struct linenoiseState *l, int j) {
             sizeof(size_t)*(l->fold_count-j-1));
     memmove(l->fold_end+j,l->fold_end+j+1,
             sizeof(size_t)*(l->fold_count-j-1));
+    memmove(l->fold_id+j,l->fold_id+j+1,
+            sizeof(int)*(l->fold_count-j-1));
     l->fold_count--;
 }
 
@@ -1902,7 +1949,7 @@ void linenoiseEditHistoryNext(struct linenoiseState *l, int dir) {
          * If the recalled entry needs folding, create one display fold now
          * so text typed after recall remains outside the folded range. */
         if (linenoiseBuildHistoryFold(l,&f))
-            linenoiseFoldAdd(l,f.start,f.end);
+            linenoiseFoldInsert(l,f.start,f.end,0);
         refreshLine(l);
     }
 }

--- a/linenoise.h
+++ b/linenoise.h
@@ -80,6 +80,10 @@ struct linenoiseState {
     int fold_count;    /* Number of folded ranges. */
     size_t fold_start[LINENOISE_MAX_FOLDS]; /* Folded range start offsets. */
     size_t fold_end[LINENOISE_MAX_FOLDS];   /* Folded range end offsets. */
+    int fold_id[LINENOISE_MAX_FOLDS];  /* Placeholder number of each fold, or 0
+                                        * for folds not pasted on this line. */
+    int fold_next_id;   /* Last placeholder number given out on this line. */
+    int fold_hint_id;   /* Fold showing the "paste again" hint, or 0. */
     char *status;       /* Optional status/footer rendered below the prompt. */
     char *status_start; /* Optional escape sequence emitted before status. */
     char *status_end;   /* Optional escape sequence emitted after status. */

--- a/tests/test_linenoise_paste.c
+++ b/tests/test_linenoise_paste.c
@@ -1,0 +1,490 @@
+/* Unit tests for the paste handling of the bundled linenoise fork: newline
+ * markers, numbered placeholders, expanding a placeholder by pasting the same
+ * text again, and the inline hint.
+ *
+ * The editor is driven exactly like ds4-agent drives it: whole terminal byte
+ * sequences are queued with linenoiseEditQueueInput() and consumed by
+ * linenoiseEditFeed(). Rendering is a private detail of the line editor, so
+ * the implementation is included instead of linked.
+ *
+ * Pure C99: no model, no GPU, no terminal. LINENOISE_ASSUME_TTY replaces the
+ * isatty() gates, LINENOISE_COLS/LINENOISE_ROWS the terminal size, a non
+ * blocking pipe stands in for the keyboard and /dev/null for the screen. */
+
+#include "../linenoise.c"
+
+#include <fcntl.h>
+
+static int g_failed = 0;
+static int g_total  = 0;
+
+#define CHECK(cond, msg) do {                                                  \
+    g_total++;                                                                 \
+    if (!(cond)) {                                                             \
+        fprintf(stderr, "  FAIL: %s (line %d)\n", (msg), __LINE__);            \
+        g_failed++;                                                            \
+    }                                                                          \
+} while (0)
+
+#define RUN(fn) do {                                                           \
+    fprintf(stderr, "RUN: %s\n", #fn);                                         \
+    int _before = g_failed;                                                    \
+    (fn)();                                                                    \
+    fprintf(stderr, "  %s\n", (_before == g_failed) ? "ok" : "FAIL");          \
+} while (0)
+
+/* Compare against an expected string, showing both sides when they differ:
+ * a wrong placeholder is unreadable as a bare boolean. */
+static void check_str(const char *got, const char *expected, const char *msg) {
+    g_total++;
+    if (got == NULL || strcmp(got, expected) != 0) {
+        fprintf(stderr, "  FAIL: %s\n", msg);
+        fprintf(stderr, "  -- expected --\n%s\n", expected);
+        fprintf(stderr, "  -- got --\n%s\n", got ? got : "(null)");
+        g_failed++;
+    }
+}
+
+/* ============================ Editor fixture ============================== */
+
+struct editor {
+    struct linenoiseState l;
+    int pipefd[2];
+    int devnull;
+};
+
+static void editor_open(struct editor *e) {
+    char *buf = malloc(LINENOISE_INITIAL_BUFLEN);
+
+    if (buf == NULL || pipe(e->pipefd) == -1) abort();
+    /* A starved read must report EAGAIN so linenoiseEditFeed() returns
+     * linenoiseEditMore instead of blocking the test forever. */
+    fcntl(e->pipefd[0], F_SETFL, O_NONBLOCK);
+    e->devnull = open("/dev/null", O_WRONLY);
+    if (e->devnull == -1) abort();
+    linenoiseEditStart(&e->l, e->pipefd[0], e->devnull, buf,
+                       LINENOISE_INITIAL_BUFLEN, "> ");
+    /* Let the buffer grow like the blocking API does, so a large paste is
+     * limited by PASTE_MAX_BYTES and not by the initial allocation. */
+    e->l.buflen_max = LINENOISE_MAX_LINE;
+}
+
+static void editor_close(struct editor *e) {
+    linenoiseEditStop(&e->l);
+    free(e->l.buf);
+    close(e->pipefd[0]);
+    close(e->pipefd[1]);
+    close(e->devnull);
+}
+
+/* Feed raw terminal bytes and let the editor consume all of them. Return the
+ * submitted line if the bytes contained an ENTER, otherwise NULL. */
+static char *editor_feed(struct editor *e, const char *data, size_t len) {
+    if (linenoiseEditQueueInput(&e->l, data, len) == -1) abort();
+    while (linenoiseEditQueuedInput(&e->l) > 0) {
+        char *res = linenoiseEditFeed(&e->l);
+        if (res != linenoiseEditMore) return res;
+    }
+    return NULL;
+}
+
+static char *editor_feed_str(struct editor *e, const char *s) {
+    return editor_feed(e, s, strlen(s));
+}
+
+/* Send text the way a terminal in bracketed paste mode does. */
+static void editor_paste(struct editor *e, const char *text, size_t len) {
+    static const char START[] = "\x1b[200~", END[] = "\x1b[201~";
+    size_t startlen = sizeof(START)-1, endlen = sizeof(END)-1;
+    char *seq = malloc(startlen+len+endlen);
+
+    if (seq == NULL) abort();
+    memcpy(seq, START, startlen);
+    memcpy(seq+startlen, text, len);
+    memcpy(seq+startlen+len, END, endlen);
+    editor_feed(e, seq, startlen+len+endlen);
+    free(seq);
+}
+
+static void editor_paste_str(struct editor *e, const char *text) {
+    editor_paste(e, text, strlen(text));
+}
+
+/* What the terminal would show for the current buffer. Caller frees. */
+static char *editor_render(struct editor *e, size_t *outpos) {
+    char *render = NULL;
+    size_t len = 0, pos = 0;
+
+    if (linenoiseRenderBuffer(&e->l, &render, &len, &pos) == -1) abort();
+    if (outpos) *outpos = pos;
+    return render;
+}
+
+/* linenoiseBeep() writes BEL to stderr, where the test also reports its
+ * failures: swallow it around the cases that expect one, so a suite run stays
+ * readable and the terminal stays quiet. */
+static int beep_saved_fd = -1;
+
+static void beeps_mute(void) {
+    int devnull = open("/dev/null", O_WRONLY);
+
+    fflush(stderr);
+    beep_saved_fd = dup(STDERR_FILENO);
+    if (devnull != -1) {
+        dup2(devnull, STDERR_FILENO);
+        close(devnull);
+    }
+}
+
+static void beeps_unmute(void) {
+    fflush(stderr);
+    if (beep_saved_fd == -1) return;
+    dup2(beep_saved_fd, STDERR_FILENO);
+    close(beep_saved_fd);
+    beep_saved_fd = -1;
+}
+
+/* ============================ Text builders =============================== */
+
+/* Build 'count' lines named after their index and padded to 'width' chars, so
+ * that no two pastes in a test are ever the same text. */
+static char *make_lines(int count, int width, int trailing_newline) {
+    size_t cap = (size_t)count*((size_t)width+16)+2;
+    char *s = malloc(cap);
+    size_t n = 0;
+    int i;
+
+    if (s == NULL) abort();
+    for (i = 0; i < count; i++) {
+        int k = snprintf(s+n, cap-n, "line %d", i);
+        while (k < width) s[n+k++] = '.';
+        n += (size_t)k;
+        if (i+1 < count || trailing_newline) s[n++] = '\n';
+    }
+    s[n] = '\0';
+    return s;
+}
+
+/* The expected render of plain text: hard newlines become markers. */
+static char *make_marked(const char *s) {
+    size_t len = strlen(s), n = 0, i;
+    char *out = malloc(len*LINENOISE_NEWLINE_MARKER_LEN+1);
+
+    if (out == NULL) abort();
+    for (i = 0; i < len; i++) {
+        if (s[i] == '\n') {
+            memcpy(out+n, LINENOISE_NEWLINE_MARKER, LINENOISE_NEWLINE_MARKER_LEN);
+            n += LINENOISE_NEWLINE_MARKER_LEN;
+        } else {
+            out[n++] = s[i];
+        }
+    }
+    out[n] = '\0';
+    return out;
+}
+
+static char *make_repeated(char c, size_t len) {
+    char *s = malloc(len+1);
+
+    if (s == NULL) abort();
+    memset(s, c, len);
+    s[len] = '\0';
+    return s;
+}
+
+/* ================================ Tests =================================== */
+
+/* A short single line paste is ordinary text: no placeholder. */
+static void test_short_paste_is_inline(void) {
+    struct editor e;
+    char *render;
+
+    editor_open(&e);
+    editor_paste_str(&e, "hello world");
+    render = editor_render(&e, NULL);
+    CHECK(e.l.fold_count == 0, "short paste is not folded");
+    CHECK(e.l.len == 11, "short paste is fully inserted");
+    check_str(render, "hello world", "short paste render");
+    free(render);
+    editor_close(&e);
+}
+
+/* A few pasted lines stay visible, with newlines shown as markers. The render
+ * position must follow the substitution, not the byte offsets. */
+static void test_multiline_paste_is_inline(void) {
+    struct editor e;
+    char *render;
+    size_t pos = 0;
+
+    editor_open(&e);
+    editor_paste_str(&e, "a\nb");
+    render = editor_render(&e, &pos);
+    CHECK(e.l.fold_count == 0, "three byte paste is not folded");
+    CHECK(e.l.len == 3, "newlines are kept in the edit buffer");
+    check_str(render, "a" LINENOISE_NEWLINE_MARKER "b", "newline marker render");
+    CHECK(pos == 5, "cursor maps past the marker");
+    free(render);
+
+    /* Moving left over 'b' must land right after the marker. */
+    editor_feed_str(&e, "\x1b[D");
+    render = editor_render(&e, &pos);
+    CHECK(e.l.pos == 2, "cursor moved one byte left");
+    CHECK(pos == 4, "cursor maps to the end of the marker");
+    free(render);
+    editor_close(&e);
+}
+
+/* Long single line pastes fold into a numbered placeholder counting bytes. */
+static void test_long_paste_folds_chars(void) {
+    struct editor e;
+    char *text = make_repeated('x', 300);
+    char *render;
+
+    editor_open(&e);
+    editor_paste_str(&e, text);
+    render = editor_render(&e, NULL);
+    CHECK(e.l.fold_count == 1, "long paste is folded");
+    CHECK(e.l.len == 300, "folding keeps the real bytes");
+    check_str(render, "[Pasted text #1 +300 chars] (paste again to expand)",
+              "single line placeholder");
+    free(render);
+    editor_close(&e);
+    free(text);
+}
+
+/* Many pasted lines fold into a placeholder counting lines, and a trailing
+ * newline closes the last line instead of opening an empty one. */
+static void test_multiline_paste_folds_lines(void) {
+    struct editor e;
+    char *text = make_lines(10, 0, 0);
+    char *closed = make_lines(10, 0, 1);
+    char *render;
+
+    editor_open(&e);
+    editor_paste_str(&e, text);
+    render = editor_render(&e, NULL);
+    CHECK(e.l.fold_count == 1, "ten lines are folded");
+    check_str(render, "[Pasted text #1 +10 lines] (paste again to expand)",
+              "multiline placeholder");
+    free(render);
+
+    /* Ctrl+U clears the line, and with it the placeholder numbering. */
+    editor_feed_str(&e, "\x15");
+    editor_paste_str(&e, closed);
+    render = editor_render(&e, NULL);
+    check_str(render, "[Pasted text #1 +10 lines] (paste again to expand)",
+              "trailing newline is not a line");
+    free(render);
+    editor_close(&e);
+    free(text);
+    free(closed);
+}
+
+/* Numbers follow creation order and never change, even when a later paste
+ * lands before an earlier one in the buffer. */
+static void test_placeholder_numbers_are_stable(void) {
+    struct editor e;
+    char *a = make_repeated('a', 250);
+    char *b = make_repeated('b', 250);
+    char *c = make_repeated('c', 250);
+    char *render;
+
+    editor_open(&e);
+    editor_paste_str(&e, a);
+    editor_paste_str(&e, b);
+    editor_feed_str(&e, "\x1b[H"); /* Home. */
+    editor_paste_str(&e, c);
+    render = editor_render(&e, NULL);
+    CHECK(e.l.fold_count == 3, "three folds are remembered");
+    CHECK(e.l.fold_id[0] == 3 && e.l.fold_id[1] == 1 && e.l.fold_id[2] == 2,
+          "folds are sorted by offset, not by number");
+    CHECK(e.l.fold_start[0] == 0 && e.l.fold_start[1] == 250 &&
+          e.l.fold_start[2] == 500, "earlier folds moved with the insertion");
+    check_str(render,
+              "[Pasted text #3 +250 chars] (paste again to expand)"
+              "[Pasted text #1 +250 chars]"
+              "[Pasted text #2 +250 chars]",
+              "stable numbering render");
+    free(render);
+    editor_close(&e);
+    free(a);
+    free(b);
+    free(c);
+}
+
+/* Pasting the same text again reveals it instead of inserting a copy, and a
+ * further paste folds the new copy under a fresh number. */
+static void test_paste_again_expands(void) {
+    struct editor e;
+    char *text = make_lines(10, 0, 0);
+    char *marked = make_marked(text);
+    size_t len = strlen(text);
+    char *render, *expected;
+
+    editor_open(&e);
+    editor_paste_str(&e, text);
+    CHECK(e.l.fold_count == 1, "first paste is folded");
+
+    editor_paste_str(&e, text);
+    render = editor_render(&e, NULL);
+    CHECK(e.l.fold_count == 0, "second paste expands the placeholder");
+    CHECK(e.l.len == len, "second paste does not duplicate the text");
+    CHECK(e.l.pos == len, "cursor stays at the end of the revealed text");
+    check_str(render, marked, "expanded render uses newline markers");
+    free(render);
+
+    /* With nothing left to match, the same bytes are a new paste. */
+    editor_paste_str(&e, text);
+    render = editor_render(&e, NULL);
+    CHECK(e.l.fold_count == 1, "third paste folds again");
+    CHECK(e.l.len == len*2, "third paste is inserted");
+    expected = malloc(strlen(marked)+80);
+    if (expected == NULL) abort();
+    sprintf(expected, "%s[Pasted text #2 +10 lines] (paste again to expand)",
+            marked);
+    check_str(render, expected, "expanded text plus a new placeholder");
+    free(expected);
+    free(render);
+    editor_close(&e);
+    free(text);
+    free(marked);
+}
+
+/* Running out of fold slots must not lose the text: the extra paste simply
+ * goes in unfolded. */
+static void test_paste_past_fold_slots(void) {
+    struct editor e;
+    int i;
+
+    editor_open(&e);
+    for (i = 0; i < LINENOISE_MAX_FOLDS+1; i++) {
+        char *text = make_repeated((char)('a'+i), 250);
+        editor_paste_str(&e, text);
+        free(text);
+    }
+    CHECK(e.l.fold_count == LINENOISE_MAX_FOLDS, "fold slots are all used");
+    CHECK(e.l.len == 250*(LINENOISE_MAX_FOLDS+1), "no paste was dropped");
+    CHECK(e.l.buf[0] == 'a' && e.l.buf[e.l.len-1] == 'a'+LINENOISE_MAX_FOLDS,
+          "first and last paste are both in the buffer");
+    editor_close(&e);
+}
+
+/* Expanding must refuse to grow the prompt past the terminal. */
+static void test_expand_refused_when_too_tall(void) {
+    struct editor e;
+    char *text = make_lines(20, 40, 0);
+    char *render;
+
+    setenv("LINENOISE_ROWS", "6", 1);
+    editor_open(&e);
+    editor_paste_str(&e, text);
+    CHECK(e.l.fold_count == 1, "twenty lines are folded");
+
+    beeps_mute();
+    editor_paste_str(&e, text);
+    beeps_unmute();
+    render = editor_render(&e, NULL);
+    CHECK(e.l.fold_count == 1, "the fold survives a refused expansion");
+    CHECK(e.l.len == strlen(text), "a refused expansion inserts nothing");
+    check_str(render, "[Pasted text #1 +20 lines] (paste again to expand)",
+              "placeholder is unchanged");
+    free(render);
+    editor_close(&e);
+    setenv("LINENOISE_ROWS", "40", 1);
+    free(text);
+}
+
+/* A paste larger than PASTE_MAX_BYTES is refused with a beep, leaving the
+ * edited line untouched. */
+static void test_huge_paste_is_refused(void) {
+    struct editor e;
+    char *text = make_repeated('z', PASTE_MAX_BYTES+16);
+
+    editor_open(&e);
+    beeps_mute();
+    editor_paste(&e, text, PASTE_MAX_BYTES+16);
+    beeps_unmute();
+    CHECK(e.l.len == 0, "oversized paste is not inserted");
+    CHECK(e.l.fold_count == 0, "oversized paste creates no fold");
+    editor_close(&e);
+    free(text);
+}
+
+/* A recalled history entry is folded without a number: it was not pasted on
+ * this line. Submitting it still returns the real text. */
+static void test_history_recall_fold(void) {
+    struct editor e;
+    char *text = make_lines(40, 0, 0);
+    char *render, *line;
+
+    linenoiseHistoryAdd(text);
+    editor_open(&e);
+    editor_feed_str(&e, "\x1b[A"); /* Up. */
+    render = editor_render(&e, NULL);
+    CHECK(e.l.fold_count == 1, "recalled entry is folded");
+    CHECK(e.l.fold_id[0] == 0, "history folds are unnumbered");
+    check_str(render, "[... 40 lines ...]", "history placeholder");
+    free(render);
+
+    line = editor_feed_str(&e, "\r");
+    CHECK(line != NULL, "enter submits the line");
+    if (line) check_str(line, text, "submitted text is the real one");
+    free(line);
+    editor_close(&e);
+    free(text);
+}
+
+/* The hint is an aid for the paste that just happened: any edit removes it,
+ * and so does submitting the line. */
+static void test_hint_is_transient(void) {
+    struct editor e;
+    char *text = make_repeated('x', 300);
+    char *render, *line, *expected;
+
+    editor_open(&e);
+    editor_paste_str(&e, text);
+    CHECK(e.l.fold_hint_id == 1, "the new fold carries the hint");
+
+    editor_feed_str(&e, "y");
+    render = editor_render(&e, NULL);
+    CHECK(e.l.fold_hint_id == 0, "typing clears the hint");
+    check_str(render, "[Pasted text #1 +300 chars]y", "hint free placeholder");
+    free(render);
+
+    line = editor_feed_str(&e, "\r");
+    CHECK(e.l.fold_hint_id == 0, "submitting clears the hint");
+    expected = malloc(strlen(text)+2);
+    if (expected == NULL) abort();
+    sprintf(expected, "%sy", text);
+    if (line) check_str(line, expected, "submitted text is the real one");
+    free(line);
+    free(expected);
+    editor_close(&e);
+    free(text);
+}
+
+int main(void) {
+    /* Closing an editor prints the newline a real terminal needs after the
+     * accepted line. The suite reports on stderr, so drop that stray output
+     * instead of dotting the test log with blank lines. */
+    if (freopen("/dev/null", "w", stdout) == NULL) return 1;
+    setenv("LINENOISE_ASSUME_TTY", "1", 1);
+    setenv("LINENOISE_COLS", "80", 1);
+    setenv("LINENOISE_ROWS", "40", 1);
+
+    RUN(test_short_paste_is_inline);
+    RUN(test_multiline_paste_is_inline);
+    RUN(test_long_paste_folds_chars);
+    RUN(test_multiline_paste_folds_lines);
+    RUN(test_placeholder_numbers_are_stable);
+    RUN(test_paste_again_expands);
+    RUN(test_paste_past_fold_slots);
+    RUN(test_expand_refused_when_too_tall);
+    RUN(test_huge_paste_is_refused);
+    RUN(test_history_recall_fold);
+    RUN(test_hint_is_transient);
+
+    fprintf(stderr, "\ntest_linenoise_paste: %d/%d checks passed (%d failed)\n",
+            g_total - g_failed, g_total, g_failed);
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/test_linenoise_paste.c
+++ b/tests/test_linenoise_paste.c
@@ -1,15 +1,16 @@
-/* Unit tests for the paste handling of the bundled linenoise fork: newline
- * markers, numbered placeholders, expanding a placeholder by pasting the same
- * text again, and the inline hint.
+/* Unit tests for the paste and multi row handling of the bundled linenoise
+ * fork: terminal geometry with hard newlines, numbered placeholders, expanding
+ * a placeholder by pasting the same text again, and the inline hint.
  *
- * The editor is driven exactly like ds4-agent drives it: whole terminal byte
- * sequences are queued with linenoiseEditQueueInput() and consumed by
- * linenoiseEditFeed(). Rendering is a private detail of the line editor, so
- * the implementation is included instead of linked.
+ * The editor is driven exactly like ds4-agent drives it: multi line mode on,
+ * whole terminal byte sequences queued with linenoiseEditQueueInput() and
+ * consumed by linenoiseEditFeed(). Rendering is a private detail of the line
+ * editor, so the implementation is included instead of linked.
  *
  * Pure C99: no model, no GPU, no terminal. LINENOISE_ASSUME_TTY replaces the
  * isatty() gates, LINENOISE_COLS/LINENOISE_ROWS the terminal size, a non
- * blocking pipe stands in for the keyboard and /dev/null for the screen. */
+ * blocking pipe stands in for the keyboard and a temporary file for the
+ * screen, so what the editor paints can be read back. */
 
 #include "../linenoise.c"
 
@@ -50,7 +51,7 @@ static void check_str(const char *got, const char *expected, const char *msg) {
 struct editor {
     struct linenoiseState l;
     int pipefd[2];
-    int devnull;
+    FILE *screen;   /* Temporary file collecting everything painted. */
 };
 
 static void editor_open(struct editor *e) {
@@ -60,9 +61,9 @@ static void editor_open(struct editor *e) {
     /* A starved read must report EAGAIN so linenoiseEditFeed() returns
      * linenoiseEditMore instead of blocking the test forever. */
     fcntl(e->pipefd[0], F_SETFL, O_NONBLOCK);
-    e->devnull = open("/dev/null", O_WRONLY);
-    if (e->devnull == -1) abort();
-    linenoiseEditStart(&e->l, e->pipefd[0], e->devnull, buf,
+    e->screen = tmpfile();
+    if (e->screen == NULL) abort();
+    linenoiseEditStart(&e->l, e->pipefd[0], fileno(e->screen), buf,
                        LINENOISE_INITIAL_BUFLEN, "> ");
     /* Let the buffer grow like the blocking API does, so a large paste is
      * limited by PASTE_MAX_BYTES and not by the initial allocation. */
@@ -74,7 +75,32 @@ static void editor_close(struct editor *e) {
     free(e->l.buf);
     close(e->pipefd[0]);
     close(e->pipefd[1]);
-    close(e->devnull);
+    fclose(e->screen);
+}
+
+/* Forget what has been painted so far, so the next assertion only sees the
+ * bytes produced by the next keystroke. */
+static void editor_screen_clear(struct editor *e) {
+    int fd = fileno(e->screen);
+
+    if (ftruncate(fd, 0) == -1) abort();
+    if (lseek(fd, 0, SEEK_SET) == (off_t)-1) abort();
+}
+
+/* Everything painted since the last clear, nul terminated. Caller frees. */
+static char *editor_screen_text(struct editor *e) {
+    int fd = fileno(e->screen);
+    off_t end = lseek(fd, 0, SEEK_END);
+    char *out;
+
+    if (end < 0) abort();
+    out = malloc((size_t)end+1);
+    if (out == NULL) abort();
+    if (lseek(fd, 0, SEEK_SET) == (off_t)-1) abort();
+    if (read(fd, out, (size_t)end) != (ssize_t)end) abort();
+    if (lseek(fd, 0, SEEK_END) == (off_t)-1) abort();
+    out[end] = '\0';
+    return out;
 }
 
 /* Feed raw terminal bytes and let the editor consume all of them. Return the
@@ -110,14 +136,37 @@ static void editor_paste_str(struct editor *e, const char *text) {
     editor_paste(e, text, strlen(text));
 }
 
-/* What the terminal would show for the current buffer. Caller frees. */
+/* What the multi row refresh paints for the current buffer, with hard newlines
+ * kept as real row breaks. Caller frees. */
 static char *editor_render(struct editor *e, size_t *outpos) {
     char *render = NULL;
     size_t len = 0, pos = 0;
 
-    if (linenoiseRenderBuffer(&e->l, &render, &len, &pos) == -1) abort();
+    if (linenoiseRenderBuffer(&e->l, &render, &len, &pos, 0) == -1) abort();
     if (outpos) *outpos = pos;
     return render;
+}
+
+/* The same, for the renderers confined to one row: newlines become markers. */
+static char *editor_render_marked(struct editor *e, size_t *outpos) {
+    char *render = NULL;
+    size_t len = 0, pos = 0;
+
+    if (linenoiseRenderBuffer(&e->l, &render, &len, &pos, 1) == -1) abort();
+    if (outpos) *outpos = pos;
+    return render;
+}
+
+/* Row and column of the cursor for the current buffer, exactly as
+ * refreshMultiLine() computes them. */
+static void editor_cursor(struct editor *e, int *row, int *col) {
+    size_t pos = 0;
+    char *render = editor_render(e, &pos);
+    int pending;
+
+    linenoiseGeometry(render, pos, utf8StrWidth(e->l.prompt, e->l.plen),
+                      e->l.cols, row, col, &pending);
+    free(render);
 }
 
 /* linenoiseBeep() writes BEL to stderr, where the test also reports its
@@ -192,6 +241,119 @@ static char *make_repeated(char c, size_t len) {
     return s;
 }
 
+/* ============================ Geometry tests ============================== */
+
+static void check_geom(const char *render, size_t stop, size_t pwidth,
+                       size_t cols, int erow, int ecol, int epending,
+                       const char *msg) {
+    int row = 0, col = 0, pending = 0;
+
+    linenoiseGeometry(render, stop, pwidth, cols, &row, &col, &pending);
+    g_total++;
+    if (row != erow || col != ecol || pending != epending) {
+        fprintf(stderr, "  FAIL: %s\n", msg);
+        fprintf(stderr, "  -- expected -- row %d col %d pending %d\n",
+                erow, ecol, epending);
+        fprintf(stderr, "  -- got --      row %d col %d pending %d\n",
+                row, col, pending);
+        g_failed++;
+    }
+}
+
+/* Where the cursor lands once hard newlines paint real rows. Columns are 10
+ * wide here so the arithmetic stays readable. */
+static void test_geometry_rows_and_columns(void) {
+    /* No newline: the prompt simply shifts the first row. */
+    check_geom("abc", 3, 2, 10, 1, 5, 0, "short text");
+    check_geom("", 0, 2, 10, 1, 2, 0, "empty buffer");
+    check_geom("abcdefgh", 8, 2, 10, 2, 0, 1, "text ending on the margin");
+    check_geom("abcdefghi", 9, 2, 10, 2, 1, 0, "text past the margin");
+    check_geom("0123456789012345678901234", 25, 0, 10, 3, 5, 0, "several wraps");
+    check_geom("", 0, 10, 10, 2, 0, 1, "prompt ending on the margin");
+    check_geom("abcdef", 6, 8, 10, 2, 4, 0, "prompt pushes the first row");
+
+    /* Newlines: one row each, and none of them is skipped. */
+    check_geom("abc\n", 4, 2, 10, 2, 0, 0, "trailing newline opens a row");
+    check_geom("a\n\nb", 4, 2, 10, 3, 1, 0, "empty line keeps its row");
+    check_geom("ab\ncd", 3, 2, 10, 2, 0, 0, "cursor right after a newline");
+    check_geom("ab\ncd", 4, 2, 10, 2, 1, 0, "cursor inside the second row");
+    check_geom("ab\ncd", 5, 2, 10, 2, 2, 0, "cursor at the end");
+    check_geom("a\nb\nc", 5, 2, 10, 3, 1, 0, "three rows");
+
+    /* A newline right after text that filled a row resolves the deferred
+     * wrap: the terminal is already there, it must not drop another row. */
+    check_geom("abcdefgh\n", 9, 2, 10, 2, 0, 0, "newline after a full row");
+    check_geom("abcdefgh\nx", 10, 2, 10, 2, 1, 0, "text after a full row");
+
+    /* Widths, not bytes, drive the wrapping. */
+    check_geom("\344\270\255\344\270\255\344\270\255\344\270\255\344\270\255",
+               15, 0, 10, 2, 0, 1, "five wide chars fill a row");
+    check_geom("\344\270\255\344\270\255\344\270\255\344\270\255\344\270\255"
+               "\344\270\255", 18, 0, 10, 2, 2, 0, "six wide chars wrap");
+}
+
+/* The geometry must reproduce the flat width arithmetic the editor used
+ * before newlines became rows: on newline free input the two models can only
+ * agree, and any drift there would move every cursor in the common case. */
+static void test_geometry_matches_flat_formulas(void) {
+    static const size_t pwidths[] = {1, 2, 5, 12, 79};
+    static const size_t lens[] = {0, 1, 5, 68, 74, 78, 79, 80, 81, 160, 161};
+    size_t cols = 80;
+    char text[200];
+    size_t pi, li, k;
+    int mismatch = 0;
+
+    memset(text, 'x', sizeof(text));
+    for (pi = 0; pi < sizeof(pwidths)/sizeof(*pwidths); pi++) {
+        size_t pwidth = pwidths[pi];
+        for (li = 0; li < sizeof(lens)/sizeof(*lens); li++) {
+            size_t len = lens[li];
+            /* Interesting cursors: both ends, the middle, and the byte that
+             * lands exactly on the right margin. */
+            size_t stops[4];
+            stops[0] = 0;
+            stops[1] = len/2;
+            stops[2] = len;
+            stops[3] = cols > pwidth && cols-pwidth <= len ? cols-pwidth : len;
+            for (k = 0; k < 4; k++) {
+                size_t stop = stops[k];
+                int end_row, end_col, end_pending;
+                int cur_row, cur_col, cur_pending;
+                int rows, wrap, old_rows, old_rpos2, old_col, old_wrap;
+
+                linenoiseGeometry(text, len, pwidth, cols,
+                                  &end_row, &end_col, &end_pending);
+                linenoiseGeometry(text, stop, pwidth, cols,
+                                  &cur_row, &cur_col, &cur_pending);
+                /* Mirrors how refreshMultiLine() derives its numbers. */
+                rows = end_row - (end_pending ? 1 : 0);
+                wrap = end_pending && stop == len && stop != 0;
+                if (wrap) rows++;
+
+                old_rows = (int)((pwidth+len+cols-1)/cols);
+                old_rpos2 = (int)((pwidth+stop+cols)/cols);
+                old_col = (int)((pwidth+stop)%cols);
+                old_wrap = stop && stop == len && (pwidth+stop)%cols == 0;
+                if (old_wrap) old_rows++;
+
+                if (rows == old_rows && cur_row == old_rpos2 &&
+                    cur_col == old_col && wrap == old_wrap) continue;
+                if (!mismatch)
+                    fprintf(stderr, "  FAIL: pwidth %zu len %zu stop %zu: "
+                            "rows %d/%d rpos2 %d/%d col %d/%d wrap %d/%d\n",
+                            pwidth, len, stop, rows, old_rows, cur_row,
+                            old_rpos2, cur_col, old_col, wrap, old_wrap);
+                mismatch++;
+            }
+        }
+    }
+    g_total++;
+    if (mismatch) {
+        fprintf(stderr, "  FAIL: %d newline free geometry mismatches\n", mismatch);
+        g_failed++;
+    }
+}
+
 /* ================================ Tests =================================== */
 
 /* A short single line paste is ordinary text: no placeholder. */
@@ -209,29 +371,97 @@ static void test_short_paste_is_inline(void) {
     editor_close(&e);
 }
 
-/* A few pasted lines stay visible, with newlines shown as markers. The render
- * position must follow the substitution, not the byte offsets. */
+/* A few pasted lines stay visible and occupy real terminal rows. */
 static void test_multiline_paste_is_inline(void) {
     struct editor e;
-    char *render;
+    char *render, *screen;
     size_t pos = 0;
+    int row = 0, col = 0;
 
     editor_open(&e);
+    editor_screen_clear(&e);
     editor_paste_str(&e, "a\nb");
     render = editor_render(&e, &pos);
     CHECK(e.l.fold_count == 0, "three byte paste is not folded");
     CHECK(e.l.len == 3, "newlines are kept in the edit buffer");
-    check_str(render, "a" LINENOISE_NEWLINE_MARKER "b", "newline marker render");
-    CHECK(pos == 5, "cursor maps past the marker");
+    check_str(render, "a\nb", "newlines survive rendering");
+    CHECK(pos == 3, "render position is a plain byte offset");
     free(render);
 
-    /* Moving left over 'b' must land right after the marker. */
+    editor_cursor(&e, &row, &col);
+    CHECK(row == 2 && col == 1, "cursor sits on the second row");
+
+    /* Raw mode has no output post processing: a bare LF would keep the
+     * column, so the refresh has to write CR LF. */
+    screen = editor_screen_text(&e);
+    CHECK(strstr(screen, "\r\n") != NULL, "hard newlines are painted as CR LF");
+    CHECK(strstr(screen, LINENOISE_NEWLINE_MARKER) == NULL,
+          "multi row refresh paints no newline marker");
+    free(screen);
+
+    /* Moving left over 'b' must land at the start of the second row. */
     editor_feed_str(&e, "\x1b[D");
-    render = editor_render(&e, &pos);
+    editor_cursor(&e, &row, &col);
     CHECK(e.l.pos == 2, "cursor moved one byte left");
-    CHECK(pos == 4, "cursor maps to the end of the marker");
-    free(render);
+    CHECK(row == 2 && col == 0, "cursor is at the start of the second row");
     editor_close(&e);
+}
+
+/* Ctrl+J inserts a newline, which is the only way to type one: ENTER submits.
+ * It must behave exactly like a pasted newline. */
+static void test_ctrl_j_inserts_a_newline(void) {
+    struct editor e;
+    char *render, *screen;
+    int row = 0, col = 0;
+
+    editor_open(&e);
+    editor_screen_clear(&e);
+    editor_feed_str(&e, "ab\ncd");
+    render = editor_render(&e, NULL);
+    CHECK(e.l.len == 5, "the newline is stored in the buffer");
+    check_str(render, "ab\ncd", "typed newline renders as a row break");
+    free(render);
+    editor_cursor(&e, &row, &col);
+    CHECK(row == 2 && col == 2, "typing continues on the second row");
+    screen = editor_screen_text(&e);
+    CHECK(strstr(screen, "\r\n") != NULL, "typed newline is painted as CR LF");
+    free(screen);
+
+    /* Editing across the row break must not need any special handling. */
+    editor_feed_str(&e, "\x7f\x7f\x7f"); /* Three backspaces. */
+    CHECK(e.l.len == 2, "backspace deletes across the row break");
+    editor_cursor(&e, &row, &col);
+    CHECK(row == 1 && col == 4, "the prompt is back to one row");
+    editor_close(&e);
+}
+
+/* The single row renderers cannot paint a row break, so there the newline
+ * shows up as a marker. Both binaries run in multi line mode, but linenoise
+ * still supports the single line one. */
+static void test_single_line_render_uses_markers(void) {
+    struct editor e;
+    char *render, *screen;
+    size_t pos = 0;
+
+    char *expected = make_marked("a\nb");
+
+    linenoiseSetMultiLine(0);
+    editor_open(&e);
+    editor_screen_clear(&e);
+    editor_paste_str(&e, "a\nb");
+    render = editor_render_marked(&e, &pos);
+    check_str(render, expected, "newline marker render");
+    CHECK(pos == 5, "marker render maps the cursor past the marker");
+    free(render);
+    free(expected);
+
+    screen = editor_screen_text(&e);
+    CHECK(strstr(screen, LINENOISE_NEWLINE_MARKER) != NULL,
+          "single row refresh paints the marker");
+    CHECK(strstr(screen, "\r\n") == NULL, "single row refresh paints no row break");
+    free(screen);
+    editor_close(&e);
+    linenoiseSetMultiLine(1);
 }
 
 /* Long single line pastes fold into a numbered placeholder counting bytes. */
@@ -317,9 +547,9 @@ static void test_placeholder_numbers_are_stable(void) {
 static void test_paste_again_expands(void) {
     struct editor e;
     char *text = make_lines(10, 0, 0);
-    char *marked = make_marked(text);
     size_t len = strlen(text);
     char *render, *expected;
+    int row = 0, col = 0;
 
     editor_open(&e);
     editor_paste_str(&e, text);
@@ -330,24 +560,25 @@ static void test_paste_again_expands(void) {
     CHECK(e.l.fold_count == 0, "second paste expands the placeholder");
     CHECK(e.l.len == len, "second paste does not duplicate the text");
     CHECK(e.l.pos == len, "cursor stays at the end of the revealed text");
-    check_str(render, marked, "expanded render uses newline markers");
+    check_str(render, text, "expanded render is the text itself");
     free(render);
+    editor_cursor(&e, &row, &col);
+    CHECK(row == 10, "expanded text occupies one row per line");
 
     /* With nothing left to match, the same bytes are a new paste. */
     editor_paste_str(&e, text);
     render = editor_render(&e, NULL);
     CHECK(e.l.fold_count == 1, "third paste folds again");
     CHECK(e.l.len == len*2, "third paste is inserted");
-    expected = malloc(strlen(marked)+80);
+    expected = malloc(len+80);
     if (expected == NULL) abort();
     sprintf(expected, "%s[Pasted text #2 +10 lines] (paste again to expand)",
-            marked);
+            text);
     check_str(render, expected, "expanded text plus a new placeholder");
     free(expected);
     free(render);
     editor_close(&e);
     free(text);
-    free(marked);
 }
 
 /* Running out of fold slots must not lose the text: the extra paste simply
@@ -392,6 +623,34 @@ static void test_expand_refused_when_too_tall(void) {
     editor_close(&e);
     setenv("LINENOISE_ROWS", "40", 1);
     free(text);
+}
+
+/* The guard keeps two rows free, so text needing exactly the remaining rows
+ * still expands and one row more does not. */
+static void test_expand_fits_at_the_boundary(void) {
+    struct editor e;
+    char *fits = make_lines(8, 0, 0);
+    char *toobig = make_lines(9, 0, 0);
+
+    setenv("LINENOISE_ROWS", "10", 1);
+    editor_open(&e);
+    editor_paste_str(&e, fits);
+    editor_paste_str(&e, fits);
+    CHECK(e.l.fold_count == 0, "eight rows fit in ten minus two");
+    editor_close(&e);
+
+    editor_open(&e);
+    editor_paste_str(&e, toobig);
+    beeps_mute();
+    editor_paste_str(&e, toobig);
+    beeps_unmute();
+    CHECK(e.l.fold_count == 1, "nine rows do not fit in ten minus two");
+    CHECK(e.l.len == strlen(toobig), "the refused expansion inserts nothing");
+    editor_close(&e);
+
+    setenv("LINENOISE_ROWS", "40", 1);
+    free(fits);
+    free(toobig);
 }
 
 /* A paste larger than PASTE_MAX_BYTES is refused with a beep, leaving the
@@ -471,15 +730,22 @@ int main(void) {
     setenv("LINENOISE_ASSUME_TTY", "1", 1);
     setenv("LINENOISE_COLS", "80", 1);
     setenv("LINENOISE_ROWS", "40", 1);
+    /* Both binaries edit in multi line mode: test what they run. */
+    linenoiseSetMultiLine(1);
 
+    RUN(test_geometry_rows_and_columns);
+    RUN(test_geometry_matches_flat_formulas);
     RUN(test_short_paste_is_inline);
     RUN(test_multiline_paste_is_inline);
+    RUN(test_ctrl_j_inserts_a_newline);
+    RUN(test_single_line_render_uses_markers);
     RUN(test_long_paste_folds_chars);
     RUN(test_multiline_paste_folds_lines);
     RUN(test_placeholder_numbers_are_stable);
     RUN(test_paste_again_expands);
     RUN(test_paste_past_fold_slots);
     RUN(test_expand_refused_when_too_tall);
+    RUN(test_expand_fits_at_the_boundary);
     RUN(test_huge_paste_is_refused);
     RUN(test_history_recall_fold);
     RUN(test_hint_is_transient);


### PR DESCRIPTION
This upgrades the line editing of the bundled linenoise fork, shared by the `ds4` REPL and the `ds4-agent` TUI, in two related ways: Claude Code-style paste placeholders, and real multi-row rendering of hard newlines.

**Real multi-row input.** The editor previously modeled the input as one logical row: a hard newline that reached the terminal (typed with Ctrl+J, or recalled from multiline history) moved the cursor down without a carriage return (raw mode clears OPOST) and desynchronized the refresh row math, stair-stepping and corrupting the prompt. `refreshMultiLine` now derives its geometry from a newline-aware walk of the rendered text: every hard newline paints as a real terminal row (written as CR LF), and the row, cursor, and clear accounting is exact, including the deferred-wrap state terminals keep when text ends on the right margin. Ctrl+J is now a documented way to type a newline. In the paths confined to a single row — single-line mode and masked input — newlines render as a one-column `↵` marker (U+21B5, East Asian Neutral, exactly one column everywhere).

**Short pastes go inline.** A paste of up to 5 lines and under 200 bytes is inserted directly and shows as real rows. Previously any paste containing a newline was folded behind a placeholder.

**Long pastes collapse to a numbered placeholder.** `[Pasted text #1 +123 lines]` (or `+N chars` for a long single-line paste). Numbers are assigned in creation order per edited line and never renumbered, so `#2` still names the same text after `#1` is gone. History folds keep the old unnumbered `[... N lines ...]` text. The newest placeholder carries a `(paste again to expand)` suffix that disappears as soon as the buffer content changes or the line is submitted.

**Paste again to expand.** Pasting bytes that exactly match a fold reveals that text in place as real rows, fully editable, instead of inserting a duplicate. A screen-height guard measures the true expanded row count first: a big file pasted twice by mistake beeps and keeps the placeholder rather than pushing the prompt past the terminal.

**No silent drops.** Running out of the 16 fold slots used to discard the paste with only a beep; the text now goes in unfolded. The only refusals left are a paste over `PASTE_MAX_BYTES` or an edit buffer that genuinely cannot grow.

Enter semantics are unchanged: folds were always display-only and the real bytes are submitted exactly as before, so nothing downstream of the line editor changes.

Testing: `tests/test_linenoise_paste.c` drives the non-blocking editor API with a fake terminal (`LINENOISE_ASSUME_TTY`, pipe stdin, tmpfile stdout so emitted bytes can be asserted) — 81 checks covering the newline geometry (including a differential test asserting the new math reproduces the previous formulas exactly on newline-free input, so wrapping behavior for ordinary lines is provably unchanged), CR LF emission, marker rendering in single-line mode, numbered placeholders, expand/re-fold, the screen-height guard, fold-slot exhaustion, the >1MB refusal, history folds, and the transient hint. Wired into `make test`; `make ds4 ds4-agent` builds warning-free. Manual terminal checks were added to `QA_BEFORE_RELEASES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UazT9herrhVF4gFz3VwSar
