### PR TITLE
cli: reject imatrix collection on distributed roles

### DIFF
--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -2032,6 +2032,10 @@ static cli_config parse_options(int argc, char **argv) {
         fprintf(stderr, "ds4: --imatrix-dataset requires --imatrix-out\n");
         exit(2);
     }
+    if (c.gen.imatrix_output_path && ds4_dist_enabled(c.dist)) {
+        fprintf(stderr, "ds4: --imatrix-out does not support distributed roles\n");
+        exit(2);
+    }
     if (c.gen.perplexity_file_path && c.gen.prompt) {
         fprintf(stderr, "ds4: --perplexity-file does not use -p/--prompt-file\n");
         exit(2);

--- a/tests/test_gpu_args_cli.sh
+++ b/tests/test_gpu_args_cli.sh
@@ -202,6 +202,19 @@ if [ -x ./ds4 ]; then
     fi
 fi
 
+# 8: imatrix collection requires the complete model, not a distributed slice.
+if [ -x ./ds4 ]; then
+    ./ds4 --role coordinator --listen 127.0.0.1 9911 --layers 0:20 \
+        --imatrix-dataset /dev/null --imatrix-out /tmp/imatrix.bin -m /dev/null > "$LOG" 2>&1
+    rc=$?
+    if [ $rc -ne 0 ] && grep -q -- "--imatrix-out does not support distributed roles" "$LOG"; then
+        ok "imatrix collection rejects distributed coordinator"
+    else
+        fail "imatrix collection did not reject distributed coordinator"
+        head -10 "$LOG" | sed 's/^/    /'
+    fi
+fi
+
 rm -f "$LOG"
 
 echo ""


### PR DESCRIPTION
## Summary
- Reject `--imatrix-out` when a distributed role is selected.
- Add a CLI regression test for a coordinator layer slice.

## Root cause
Distributed coordinators load only a model slice, while imatrix collection requires every layer and could dereference missing layers.

## Validation
- `make -j2 cpu`
- `tr -d '\r' < tests/test_gpu_args_cli.sh | bash -s` (45 passed)