### PR TITLE
fix: support MXFP4 in mixed GGUF splicer

### DIFF
--- a/gguf-tools/mixed/splice_mixed_expert_layers_gguf.py
+++ b/gguf-tools/mixed/splice_mixed_expert_layers_gguf.py
@@ -61,6 +61,7 @@ GGML_QUANT_SIZES = {
     12: (256, 144, "Q4_K"),
     16: (256, 66, "IQ2_XXS"),
     26: (1, 4, "I32"),
+    39: (32, 17, "MXFP4"),
 }
 
 EXPERT_TENSOR_RE = re.compile(r"^blk\.(\d+)\.ffn_(gate|up|down)_exps\.weight$")


### PR DESCRIPTION
## Summary

Add GGML tensor type 39 to the mixed GGUF splicer's quantization-size table, allowing it to parse MXFP4 tensors.

Fixes #693

## Validation

- `py -m py_compile gguf-tools/mixed/splice_mixed_expert_layers_gguf.py`
- Verified that 32 MXFP4 elements occupy 17 bytes.
- Verified that 64 MXFP4 elements occupy 34 bytes.
- Verified that type 39 is displayed as `MXFP4`.

## Environment

- Windows
- Python 3.12

A full dry run with the published GGUF files was not performed locally because of their size.