### PR TITLE
Fix reasoning_effort tier mapping and context-gate misreading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1290,10 +1290,14 @@ the saved prefix instead of processing the whole prompt again.
 ## Thinking Modes
 
 DeepSeek V4 Flash has distinct non-thinking, thinking, and Think Max modes.
-The server defaults to thinking mode. `reasoning_effort=max` requests Think
-Max, but it is only applied when the context size is large enough for the model
-card recommendation; smaller contexts fall back to normal thinking. OpenAI
-`reasoning_effort=xhigh` still maps to normal thinking, not Think Max.
+The server defaults to thinking mode. `reasoning_effort` selects among three
+prompt-level tiers: `low` keeps thinking enabled but adds no effort prefix, so
+the model reasons at its own pace; `medium`, `high`, and `xhigh` are synonyms
+that all request the model card's "high" reasoning-effort prefix; `max`
+requests Think Max, the model card's most exhaustive tier. `max` is honored at
+any context size — the model card's 384K figure is a recommended output-length
+cap for the high/max tiers, not a context precondition, so it is no longer used
+to downgrade `max` to `high` on smaller contexts.
 
 For direct replies, use `thinking: {"type":"disabled"}`, `think:false`, or a
 non-thinking model alias such as `deepseek-chat`.

--- a/ds4.c
+++ b/ds4.c
@@ -382,14 +382,30 @@ int         g_gpu_peer_ok[DS4_MAX_GPUS][DS4_MAX_GPUS];
 #define DS4_DEFAULT_COMPRESS_ROPE_FREQ_BASE (160000.0f)
 #define DS4_DEFAULT_ROPE_ORIG_CTX       UINT64_C(65536)
 
-static const char DS4_REASONING_EFFORT_MAX_PREFIX[] =
+/* Official DeepSeek-V4 "high" reasoning_effort prefix (deepseek-ai/DeepSeek-V4-Flash-0731,
+ * encoding/README.md). This was previously misnamed *_MAX_PREFIX and was the only
+ * prefix ever injected (for DS4_THINK_MAX), leaving DS4_THINK_HIGH with no prefix
+ * at all -- i.e. every non-"max" request silently rendered as official "low". */
+static const char DS4_REASONING_EFFORT_HIGH_PREFIX[] =
     "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
     "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
     "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
 
-/* DeepSeek recommends Think Max only with at least a 384K-token context window.
- * Below that size we keep ordinary thinking to avoid injecting a prompt that
- * asks for a reasoning budget the allocated context is not meant to hold. */
+/* Official DeepSeek-V4 "max" reasoning_effort prefix. Was previously unreachable:
+ * DS4_THINK_MAX rendered the "high" text above instead. Note the em dash (U+2014)
+ * right after "Beyond maximum" -- verified byte-for-byte against the primary source. */
+static const char DS4_REASONING_EFFORT_MAX_PREFIX[] =
+    "Reasoning Effort: Beyond maximum \xe2\x80\x94 exhaustive, relentless, and uncompromising.\n"
+    "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n"
+    "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n";
+
+/* Previously this gated Think Max behind a 384K *context* minimum, citing DeepSeek's
+ * recommendation as if it were an input-context requirement. It is not: the 0731
+ * model card recommends "a maximum output length of 384K tokens" for the high/max
+ * tiers -- an output-budget guideline, not a precondition for the tier to render at
+ * all. Kept as a documented no-op (see ds4_think_mode_for_context below) rather than
+ * removing the function, since ds4_server.c calls it from four request-handling
+ * sites and a caller-side output-length advisory may still want this constant. */
 #define DS4_THINK_MAX_MIN_CONTEXT 393216u
 
 static bool ds4_backend_uses_graph(ds4_backend backend) {
@@ -36860,6 +36876,8 @@ static void chat_push_think_prefix(const ds4_vocab *vocab,
             token_vec_push(out, vocab->system_id);
             bpe_tokenize_text(vocab, effort, out);
         }
+    } else if (think_mode == DS4_THINK_HIGH) {
+        bpe_tokenize_text(vocab, DS4_REASONING_EFFORT_HIGH_PREFIX, out);
     } else if (think_mode == DS4_THINK_MAX) {
         bpe_tokenize_text(vocab, DS4_REASONING_EFFORT_MAX_PREFIX, out);
     }
@@ -48107,6 +48125,10 @@ const char *ds4_think_mode_name(ds4_think_mode mode) {
     return "unknown";
 }
 
+const char *ds4_think_high_prefix(void) {
+    return DS4_REASONING_EFFORT_HIGH_PREFIX;
+}
+
 const char *ds4_think_max_prefix(void) {
     return DS4_REASONING_EFFORT_MAX_PREFIX;
 }
@@ -48115,10 +48137,12 @@ uint32_t ds4_think_max_min_context(void) {
     return DS4_THINK_MAX_MIN_CONTEXT;
 }
 
+/* No-op pass-through: see the comment on DS4_THINK_MAX_MIN_CONTEXT. Kept for the
+ * four ds4_server.c call sites and to preserve API surface; ds4_think_max_min_context()
+ * remains available for callers that want to advise clients on the model card's
+ * actual output-length guideline. */
 ds4_think_mode ds4_think_mode_for_context(ds4_think_mode mode, int ctx_size) {
-    if (mode == DS4_THINK_MAX && (uint32_t)(ctx_size > 0 ? ctx_size : 0) < DS4_THINK_MAX_MIN_CONTEXT) {
-        return DS4_THINK_HIGH;
-    }
+    (void)ctx_size;
     return mode;
 }
 

--- a/ds4.c
+++ b/ds4.c
@@ -36862,6 +36862,7 @@ const char *ds4_glm_reasoning_effort_text(ds4_think_mode mode) {
     switch (mode) {
     case DS4_THINK_HIGH: return "Reasoning Effort: High";
     case DS4_THINK_MAX:  return "Reasoning Effort: Max";
+    case DS4_THINK_LOW:  return NULL;
     case DS4_THINK_NONE: return NULL;
     }
     return NULL;
@@ -36870,6 +36871,12 @@ const char *ds4_glm_reasoning_effort_text(ds4_think_mode mode) {
 static void chat_push_think_prefix(const ds4_vocab *vocab,
                                    ds4_think_mode   think_mode,
                                    token_vec       *out) {
+    /* DS4_THINK_LOW intentionally falls through both branches below and
+     * pushes no prefix at all: per DeepSeek-V4's own encoding spec, "low" is
+     * the default reasoning_effort and its prompt prefix is "none" -- only
+     * "high" and "max" get an explicit prefix. Thinking is still enabled for
+     * LOW (see ds4_think_mode_enabled()); only the extra prompt text is
+     * absent. */
     if (DS4_MODEL_FAMILY == DS4_MODEL_FAMILY_GLM_DSA) {
         const char *effort = ds4_glm_reasoning_effort_text(think_mode);
         if (effort) {
@@ -48113,12 +48120,13 @@ static void ds4_linux_graph_backend_set_oom_score(ds4_backend backend) {
 }
 
 bool ds4_think_mode_enabled(ds4_think_mode mode) {
-    return mode == DS4_THINK_HIGH || mode == DS4_THINK_MAX;
+    return mode == DS4_THINK_LOW || mode == DS4_THINK_HIGH || mode == DS4_THINK_MAX;
 }
 
 const char *ds4_think_mode_name(ds4_think_mode mode) {
     switch (mode) {
     case DS4_THINK_NONE: return "none";
+    case DS4_THINK_LOW:  return "low";
     case DS4_THINK_HIGH: return "high";
     case DS4_THINK_MAX:  return "max";
     }

--- a/ds4.h
+++ b/ds4.h
@@ -24,6 +24,7 @@ typedef enum {
 
 typedef enum {
     DS4_THINK_NONE,
+    DS4_THINK_LOW,
     DS4_THINK_HIGH,
     DS4_THINK_MAX,
 } ds4_think_mode;

--- a/ds4.h
+++ b/ds4.h
@@ -252,6 +252,7 @@ bool ds4_engine_is_glm_dsa(ds4_engine *e);
 const char *ds4_backend_name(ds4_backend backend);
 bool ds4_think_mode_enabled(ds4_think_mode mode);
 const char *ds4_think_mode_name(ds4_think_mode mode);
+const char *ds4_think_high_prefix(void);
 const char *ds4_think_max_prefix(void);
 const char *ds4_glm_reasoning_effort_text(ds4_think_mode mode);
 uint32_t ds4_think_max_min_context(void);

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -1333,6 +1333,7 @@ static const char *repl_glm_reasoning_effort_text(ds4_think_mode mode) {
     switch (mode) {
     case DS4_THINK_HIGH: return "Reasoning Effort: High";
     case DS4_THINK_MAX:  return "Reasoning Effort: Max";
+    case DS4_THINK_LOW:  return NULL; /* low: no effort prefix, like the default */
     case DS4_THINK_NONE: return NULL;
     }
     return NULL;

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -2559,8 +2559,13 @@ static char *render_glm_chat_prompt_text(const chat_msgs *msgs,
     buf_puts(&out, "[gMASK]<sop>");
     if (think) {
         const char *effort = ds4_glm_reasoning_effort_text(think_mode);
-        buf_puts(&out, "<|system|>");
-        buf_puts(&out, effort ? effort : "Reasoning Effort: Max");
+        /* LOW returns no effort text on purpose (like DeepSeek's default).
+         * Falling back to "Max" here would resurrect the exact "low means the
+         * biggest prompt" bug this change fixes, on the GLM path. */
+        if (effort) {
+            buf_puts(&out, "<|system|>");
+            buf_puts(&out, effort);
+        }
     }
     if (tool_schemas && tool_schemas[0]) {
         buf tools = {0};
@@ -14939,6 +14944,26 @@ static void test_render_glm_chat_prompt_text(void) {
     chat_msgs_free(&msgs);
 }
 
+/* A LOW request intentionally carries no effort prefix; the GLM render must not
+ * fall back to "Reasoning Effort: Max" (the "low means the biggest prompt" bug
+ * this change fixes for DeepSeek, on the GLM path). Thinking stays enabled. */
+static void test_render_glm_low_effort_has_no_prefix(void) {
+    chat_msgs msgs = {0};
+    chat_msg user = {0};
+    user.role = xstrdup("user");
+    user.content = xstrdup("Hello");
+    chat_msgs_push(&msgs, user);
+
+    char *prompt = render_chat_prompt_text_for_syntax(
+        SERVER_MODEL_SYNTAX_GLM, &msgs, NULL, NULL, DS4_THINK_LOW);
+    TEST_ASSERT(prompt != NULL);
+    TEST_ASSERT(strstr(prompt, "Reasoning Effort:") == NULL);
+    TEST_ASSERT(strstr(prompt, "<|user|>Hello<|assistant|><think>") != NULL);
+
+    free(prompt);
+    chat_msgs_free(&msgs);
+}
+
 static void test_render_glm_drops_old_reasoning_without_tools(void) {
     chat_msgs msgs = {0};
     chat_msg user1 = {0};
@@ -17875,6 +17900,7 @@ static void ds4_server_unit_tests_run(void) {
     test_render_preserves_reasoning_with_tools();
     test_render_chat_prompt_text_renders_tools_before_system();
     test_render_glm_chat_prompt_text();
+    test_render_glm_low_effort_has_no_prefix();
     test_render_glm_drops_old_reasoning_without_tools();
     test_render_glm_preserves_reasoning_with_tools();
     test_tool_schema_order_from_anthropic_schema();

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -843,7 +843,7 @@ static void request_free(request *r) {
 
 static ds4_think_mode think_mode_from_enabled(bool enabled, ds4_think_mode effort) {
     if (!enabled || effort == DS4_THINK_NONE) return DS4_THINK_NONE;
-    return effort == DS4_THINK_MAX ? DS4_THINK_MAX : DS4_THINK_HIGH;
+    return effort;
 }
 
 static bool parse_reasoning_effort_name(const char *s, ds4_think_mode *out) {
@@ -852,14 +852,18 @@ static bool parse_reasoning_effort_name(const char *s, ds4_think_mode *out) {
         *out = DS4_THINK_MAX;
         return true;
     }
-    if (!strcmp(s, "xhigh") || !strcmp(s, "high") ||
-        !strcmp(s, "medium") || !strcmp(s, "low") ||
-        !strcmp(s, "minimal"))
-    {
-        /* DS4 only exposes HIGH and MAX above zero, so "minimal" collapses to
-         * the smallest non-zero level (HIGH). Callers that need *no* reasoning
-         * must use "none" instead. */
+    if (!strcmp(s, "xhigh") || !strcmp(s, "high") || !strcmp(s, "medium")) {
+        /* Not official DeepSeek-V4 reasoning_effort values (only "low",
+         * "high" and "max" are); treated as aliases for "high" absent any
+         * more specific guidance. */
         *out = DS4_THINK_HIGH;
+        return true;
+    }
+    if (!strcmp(s, "low") || !strcmp(s, "minimal")) {
+        /* Per DeepSeek-V4's own encoding spec, "low" is the default
+         * reasoning_effort and gets no prompt prefix at all -- distinct from
+         * "none", which disables thinking mode entirely. */
+        *out = DS4_THINK_LOW;
         return true;
     }
     if (!strcmp(s, "none")) {
@@ -2464,6 +2468,9 @@ static char *render_deepseek_chat_prompt_text(const chat_msgs *msgs, const char 
 
     buf out = {0};
     buf_puts(&out, "<｜begin▁of▁sentence｜>");
+    /* DS4_THINK_LOW deliberately falls through with no prefix: per DeepSeek-V4's
+     * own encoding spec it's the default reasoning_effort and has no prompt
+     * text, unlike "high"/"max". Thinking is still enabled for LOW. */
     if (think_mode == DS4_THINK_HIGH) buf_puts(&out, ds4_think_high_prefix());
     else if (think_mode == DS4_THINK_MAX) buf_puts(&out, ds4_think_max_prefix());
     buf_puts(&out, system.ptr ? system.ptr : "");
@@ -14656,7 +14663,14 @@ static void test_request_defaults_use_min_p_filtering(void) {
 
 static void test_reasoning_effort_mapping(void) {
     ds4_think_mode mode = DS4_THINK_NONE;
-    TEST_ASSERT(parse_reasoning_effort_name("low", &mode) && mode == DS4_THINK_HIGH);
+    /* Per DeepSeek-V4's own encoding spec, only "low"/"high"/"max" are real
+     * reasoning_effort values, and "low" is the default with no prompt text
+     * (see issue #660: mapping "low" to DS4_THINK_HIGH made it silently as
+     * verbose as "high", not the model's normal default behavior). "medium"
+     * and "xhigh" are not official DeepSeek values; treated as "high" aliases
+     * absent more specific guidance. */
+    TEST_ASSERT(parse_reasoning_effort_name("low", &mode) && mode == DS4_THINK_LOW);
+    TEST_ASSERT(parse_reasoning_effort_name("minimal", &mode) && mode == DS4_THINK_LOW);
     TEST_ASSERT(parse_reasoning_effort_name("medium", &mode) && mode == DS4_THINK_HIGH);
     TEST_ASSERT(parse_reasoning_effort_name("high", &mode) && mode == DS4_THINK_HIGH);
     TEST_ASSERT(parse_reasoning_effort_name("xhigh", &mode) && mode == DS4_THINK_HIGH);
@@ -14668,6 +14682,15 @@ static void test_reasoning_effort_mapping(void) {
     TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_MAX, 32768) == DS4_THINK_MAX);
     TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_MAX,
                                            (int)ds4_think_max_min_context()) == DS4_THINK_MAX);
+
+    /* LOW is "thinking enabled, no prefix" -- distinct from NONE (thinking
+     * disabled) and from HIGH/MAX (thinking enabled, with a prefix). */
+    TEST_ASSERT(ds4_think_mode_enabled(DS4_THINK_LOW));
+    TEST_ASSERT(!ds4_think_mode_enabled(DS4_THINK_NONE));
+    TEST_ASSERT(think_mode_from_enabled(true, DS4_THINK_LOW) == DS4_THINK_LOW);
+    TEST_ASSERT(think_mode_from_enabled(false, DS4_THINK_LOW) == DS4_THINK_NONE);
+    TEST_ASSERT(think_mode_from_enabled(true, DS4_THINK_HIGH) == DS4_THINK_HIGH);
+    TEST_ASSERT(think_mode_from_enabled(true, DS4_THINK_MAX) == DS4_THINK_MAX);
 }
 
 static void test_model_alias_thinking_controls(void) {
@@ -14744,6 +14767,34 @@ static void test_render_think_high_prompt_prefix(void) {
     TEST_ASSERT(prompt != NULL);
     TEST_ASSERT(!strncmp(prompt, "<｜begin▁of▁sentence｜>", strlen("<｜begin▁of▁sentence｜>")));
     TEST_ASSERT(strstr(prompt, ds4_think_high_prefix()) != NULL);
+    TEST_ASSERT(strstr(prompt, ds4_think_max_prefix()) == NULL);
+    TEST_ASSERT(strstr(prompt, "You are terse.<｜User｜>Hello<｜Assistant｜><think>") != NULL);
+    TEST_ASSERT(strstr(prompt, "</think>") == NULL);
+
+    free(prompt);
+    chat_msgs_free(&msgs);
+}
+
+/* Regression test for issue #660 ("low" reasoning_effort thinks forever):
+ * DS4_THINK_LOW must render no prefix at all (matching DeepSeek-V4's own
+ * spec, where "low" is the default and has no prompt text), while still
+ * enabling thinking mode -- distinct from DS4_THINK_NONE, which disables
+ * thinking entirely and closes </think> immediately. */
+static void test_render_think_low_prompt_prefix(void) {
+    chat_msgs msgs = {0};
+    chat_msg sys = {0};
+    sys.role = xstrdup("system");
+    sys.content = xstrdup("You are terse.");
+    chat_msgs_push(&msgs, sys);
+    chat_msg user = {0};
+    user.role = xstrdup("user");
+    user.content = xstrdup("Hello");
+    chat_msgs_push(&msgs, user);
+
+    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_LOW);
+    TEST_ASSERT(prompt != NULL);
+    TEST_ASSERT(!strncmp(prompt, "<｜begin▁of▁sentence｜>", strlen("<｜begin▁of▁sentence｜>")));
+    TEST_ASSERT(strstr(prompt, ds4_think_high_prefix()) == NULL);
     TEST_ASSERT(strstr(prompt, ds4_think_max_prefix()) == NULL);
     TEST_ASSERT(strstr(prompt, "You are terse.<｜User｜>Hello<｜Assistant｜><think>") != NULL);
     TEST_ASSERT(strstr(prompt, "</think>") == NULL);
@@ -17818,6 +17869,7 @@ static void ds4_server_unit_tests_run(void) {
     test_api_thinking_controls_parse();
     test_render_think_max_prompt_prefix();
     test_render_think_high_prompt_prefix();
+    test_render_think_low_prompt_prefix();
     test_render_non_thinking_prompt_closes_think();
     test_render_drops_old_reasoning_without_tools();
     test_render_preserves_reasoning_with_tools();

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -2464,7 +2464,8 @@ static char *render_deepseek_chat_prompt_text(const chat_msgs *msgs, const char 
 
     buf out = {0};
     buf_puts(&out, "<｜begin▁of▁sentence｜>");
-    if (think_mode == DS4_THINK_MAX) buf_puts(&out, ds4_think_max_prefix());
+    if (think_mode == DS4_THINK_HIGH) buf_puts(&out, ds4_think_high_prefix());
+    else if (think_mode == DS4_THINK_MAX) buf_puts(&out, ds4_think_max_prefix());
     buf_puts(&out, system.ptr ? system.ptr : "");
 
     bool pending_assistant = false;
@@ -14661,7 +14662,10 @@ static void test_reasoning_effort_mapping(void) {
     TEST_ASSERT(parse_reasoning_effort_name("xhigh", &mode) && mode == DS4_THINK_HIGH);
     TEST_ASSERT(parse_reasoning_effort_name("max", &mode) && mode == DS4_THINK_MAX);
     TEST_ASSERT(!parse_reasoning_effort_name("banana", &mode));
-    TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_MAX, 32768) == DS4_THINK_HIGH);
+    /* ds4_think_mode_for_context() is a documented pass-through (see ds4.c): the
+     * 384K figure in ds4_think_max_min_context() is the model card's *output*
+     * length guideline, not an input-context precondition for the tier to apply. */
+    TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_MAX, 32768) == DS4_THINK_MAX);
     TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_MAX,
                                            (int)ds4_think_max_min_context()) == DS4_THINK_MAX);
 }
@@ -14714,6 +14718,33 @@ static void test_render_think_max_prompt_prefix(void) {
     TEST_ASSERT(prompt != NULL);
     TEST_ASSERT(!strncmp(prompt, "<｜begin▁of▁sentence｜>", strlen("<｜begin▁of▁sentence｜>")));
     TEST_ASSERT(strstr(prompt, ds4_think_max_prefix()) != NULL);
+    TEST_ASSERT(strstr(prompt, ds4_think_high_prefix()) == NULL);
+    TEST_ASSERT(strstr(prompt, "You are terse.<｜User｜>Hello<｜Assistant｜><think>") != NULL);
+    TEST_ASSERT(strstr(prompt, "</think>") == NULL);
+
+    free(prompt);
+    chat_msgs_free(&msgs);
+}
+
+static void test_render_think_high_prompt_prefix(void) {
+    chat_msgs msgs = {0};
+    chat_msg sys = {0};
+    sys.role = xstrdup("system");
+    sys.content = xstrdup("You are terse.");
+    chat_msgs_push(&msgs, sys);
+    chat_msg user = {0};
+    user.role = xstrdup("user");
+    user.content = xstrdup("Hello");
+    chat_msgs_push(&msgs, user);
+
+    /* Regression test for the bug where DS4_THINK_HIGH rendered no prefix at
+     * all, silently downgrading every non-"max" reasoning_effort request to
+     * official DeepSeek "low". */
+    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_HIGH);
+    TEST_ASSERT(prompt != NULL);
+    TEST_ASSERT(!strncmp(prompt, "<｜begin▁of▁sentence｜>", strlen("<｜begin▁of▁sentence｜>")));
+    TEST_ASSERT(strstr(prompt, ds4_think_high_prefix()) != NULL);
+    TEST_ASSERT(strstr(prompt, ds4_think_max_prefix()) == NULL);
     TEST_ASSERT(strstr(prompt, "You are terse.<｜User｜>Hello<｜Assistant｜><think>") != NULL);
     TEST_ASSERT(strstr(prompt, "</think>") == NULL);
 
@@ -17786,6 +17817,7 @@ static void ds4_server_unit_tests_run(void) {
     test_model_alias_thinking_controls();
     test_api_thinking_controls_parse();
     test_render_think_max_prompt_prefix();
+    test_render_think_high_prompt_prefix();
     test_render_non_thinking_prompt_closes_think();
     test_render_drops_old_reasoning_without_tools();
     test_render_preserves_reasoning_with_tools();


### PR DESCRIPTION
Follows up on #635 (@kernelzeroday, @zom-2018) and #653 (@rell666) — this is the patch discussed there, posted as a comment first (https://github.com/antirez/ds4/issues/635#issuecomment-5192049609) and opened as a PR per @darkbasic's question.

## Two independent bugs, same two functions

1. **`DS4_THINK_HIGH` never rendered a prefix at all.** Only `DS4_THINK_MAX` did, using text that is actually the official **"high"** tier prefix per `deepseek-ai/DeepSeek-V4-Flash-0731`'s `encoding/README.md` (verified verbatim against the primary source). Every `reasoning_effort` other than `"max"` silently rendered as official **"low"**. The real `"max"` prefix (*"Beyond maximum — exhaustive, relentless, and uncompromising..."*, note the em dash U+2014) was absent from the codebase entirely — unreachable via the API regardless of setting. Fixed in both independent prompt-rendering paths that had this bug: `ds4.c`'s `chat_push_think_prefix()` (CLI/engine) and `ds4_server.c`'s `render_deepseek_chat_prompt_text()` (server).

2. **`ds4_think_mode_for_context()` downgraded `"max"`→`"high"` below a 384K *context* threshold**, citing DeepSeek's guidance as an input-context requirement. The model card's actual text: *"For the `high` and `max` reasoning effort levels, we recommend a maximum **output length** of 384K tokens."* That's an output-budget guideline, not a context-size precondition. Turned into a documented no-op rather than removed outright, since four `ds4_server.c` call sites use it and `ds4_think_max_min_context()` may still be useful for client-side output-length advice.

## Testing

- Adds `test_render_think_high_prompt_prefix()` — there was previously zero test coverage of the "high" tier ever rendering anything.
- Fixes the now-incorrect context-gate assertion in `test_reasoning_effort_mapping()`.
- Adds a mutual-exclusivity assertion to the existing `"max"` prompt test.
- `make ds4_test` passes clean against the full existing suite plus these changes.
- Smoke-tested live against a real 0731 quant: `reasoning_effort: high` and `: max` now produce visibly distinct prompts; `: max` no longer collapses to the "high" text below 384K context.

## Requirements

- I have read and agree with the contributing guidelines.
- AI usage disclosure: YES — diagnosed and patched with Claude Code, verified against the primary source (DeepSeek's own model card) and the project's existing test suite.

---

## Update: a real DS4_THINK_LOW tier (issue #660)

Found while looking for other reasoning_effort-related community reports to help with: issue #660 ("New 0731 iq2 thinks forever!") describes `reasoning_effort: "low"` producing 9k tokens of runaway reasoning.

Root cause, again verified against DeepSeek-V4's own encoding spec (`encoding/README.md`, "Reasoning Effort" section): it defines exactly three levels — `"low"` (the **default**, prompt prefix **"none"**), `"high"`, and `"max"`. DS4's `parse_reasoning_effort_name()` collapsed `"low"` (and `"medium"`/`"minimal"`) into the same `DS4_THINK_HIGH` enum value as an explicit `"high"` request — the code even had a comment acknowledging this: *"DS4 only exposes HIGH and MAX above zero, so minimal collapses to the smallest non-zero level (HIGH)."* So a client asking for `"low"` got the **most** elaborate non-max prompt DS4 has, instead of the model's own default behavior with no extra prompting — a very plausible direct cause of runaway reasoning on tasks that don't need it.

Added `DS4_THINK_LOW` as a genuine fourth `ds4_think_mode` value ("thinking enabled, no prompt prefix", distinct from `DS4_THINK_NONE` which disables thinking entirely) and wired it through every switch/branch over the enum. The default `reasoning_effort` when a client sends none at all is untouched (still high); this only fixes what an *explicit* `"low"`/`"minimal"` request does.

Tested the same way as the rest of this PR: full suite passes, new regression test (`test_render_think_low_prompt_prefix`) plus updated `test_reasoning_effort_mapping`, and a live A/B on the production Flash quant confirming `reasoning_effort: "low"` and `"high"` now produce genuinely different `reasoning_content` (they were byte-identical prompts before this fix).
