### PR TITLE
kvstore: don't let a shared fixed payload cost bias eviction toward big files

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -57271,20 +57271,40 @@ bool ds4_engine_is_glm_dsa(ds4_engine *e) {
 
 /* Estimate for the disk KV cache's eviction scoring (see
  * ds4_kvstore_entry_eviction_score()): the fixed, checkpoint-length-independent
- * portion of a saved session payload. session_payload_live_tensor_bytes()
- * caps the persisted raw SWA cache at raw_window rows regardless of how many
- * tokens the checkpoint actually holds (session_raw_live_rows()), so every
- * checkpoint beyond raw_window tokens -- the common case for anything past
- * the disk cache's default min_tokens floor -- pays roughly this many bytes
- * of raw-cache overhead no matter its length. GLM's dense KV cache scales
- * with checkpoint length instead and has no equivalent fixed cost. */
+ * portion of a saved session payload. Mirrors session_payload_live_tensor_bytes()'s
+ * per-layer terms, keeping only the ones that don't scale with checkpoint
+ * length:
+ * - the raw SWA cache, capped at raw_window rows regardless of how many
+ *   tokens the checkpoint actually holds (session_raw_live_rows()), so every
+ *   checkpoint beyond raw_window tokens -- the common case for anything past
+ *   the disk cache's default min_tokens floor -- pays roughly this many bytes
+ *   of raw-cache overhead no matter its length;
+ * - each compressed layer's attention/index *state* (layer_attn_state_bytes(),
+ *   layer_index_state_bytes()), which depends only on that layer's fixed
+ *   compress ratio, not on the number of compressed rows actually stored
+ *   (g->layer_n_comp[]/layer_n_index_comp[] scale with tokens and are
+ *   deliberately excluded here).
+ * GLM's dense KV cache scales with checkpoint length instead and has no
+ * equivalent fixed cost. */
 uint64_t ds4_engine_checkpoint_fixed_overhead_bytes(ds4_engine *e, int ctx_size) {
 #ifndef DS4_NO_GPU
     if (!e || DS4_MODEL_FAMILY == DS4_MODEL_FAMILY_GLM_DSA) return 0;
     uint32_t raw_window = DS4_N_SWA;
     if (raw_window > (uint32_t)ctx_size) raw_window = (uint32_t)ctx_size;
     if (raw_window == 0) raw_window = 1;
-    return (uint64_t)DS4_N_LAYER * raw_window * DS4_N_HEAD_DIM * sizeof(float);
+    uint64_t bytes = 0;
+    for (uint32_t il = 0; il < DS4_N_LAYER; il++) {
+        bytes += (uint64_t)raw_window * DS4_N_HEAD_DIM * sizeof(float);
+        const uint32_t ratio = ds4_layer_compress_ratio(il);
+        if (ratio == 0) continue;
+        bytes += layer_attn_state_bytes(ratio);
+        bytes += layer_attn_state_bytes(ratio);
+        if (ratio == 4) {
+            bytes += layer_index_state_bytes(ratio);
+            bytes += layer_index_state_bytes(ratio);
+        }
+    }
+    return bytes;
 #else
     (void)e;
     (void)ctx_size;

--- a/ds4.c
+++ b/ds4.c
@@ -57269,6 +57269,29 @@ bool ds4_engine_is_glm_dsa(ds4_engine *e) {
     return DS4_MODEL_FAMILY == DS4_MODEL_FAMILY_GLM_DSA;
 }
 
+/* Estimate for the disk KV cache's eviction scoring (see
+ * ds4_kvstore_entry_eviction_score()): the fixed, checkpoint-length-independent
+ * portion of a saved session payload. session_payload_live_tensor_bytes()
+ * caps the persisted raw SWA cache at raw_window rows regardless of how many
+ * tokens the checkpoint actually holds (session_raw_live_rows()), so every
+ * checkpoint beyond raw_window tokens -- the common case for anything past
+ * the disk cache's default min_tokens floor -- pays roughly this many bytes
+ * of raw-cache overhead no matter its length. GLM's dense KV cache scales
+ * with checkpoint length instead and has no equivalent fixed cost. */
+uint64_t ds4_engine_checkpoint_fixed_overhead_bytes(ds4_engine *e, int ctx_size) {
+#ifndef DS4_NO_GPU
+    if (!e || DS4_MODEL_FAMILY == DS4_MODEL_FAMILY_GLM_DSA) return 0;
+    uint32_t raw_window = DS4_N_SWA;
+    if (raw_window > (uint32_t)ctx_size) raw_window = (uint32_t)ctx_size;
+    if (raw_window == 0) raw_window = 1;
+    return (uint64_t)DS4_N_LAYER * raw_window * DS4_N_HEAD_DIM * sizeof(float);
+#else
+    (void)e;
+    (void)ctx_size;
+    return 0;
+#endif
+}
+
 void ds4_engine_close(ds4_engine *e) {
     if (!e) return;
 #if !defined(DS4_NO_GPU) && defined(__APPLE__)

--- a/ds4.h
+++ b/ds4.h
@@ -249,6 +249,7 @@ bool ds4_engine_glm_layer_payload_bytes(ds4_engine *e,
  * Pro and later shapes must use nonzero ids. */
 int ds4_engine_model_id(ds4_engine *e);
 bool ds4_engine_is_glm_dsa(ds4_engine *e);
+uint64_t ds4_engine_checkpoint_fixed_overhead_bytes(ds4_engine *e, int ctx_size);
 const char *ds4_backend_name(ds4_backend backend);
 bool ds4_think_mode_enabled(ds4_think_mode mode);
 const char *ds4_think_mode_name(ds4_think_mode mode);

--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -533,6 +533,7 @@ double ds4_kvstore_entry_eviction_score(
         const ds4_kvstore_entry *e,
         const ds4_tokens *live,
         uint64_t now,
+        uint64_t fixed_overhead_bytes,
         const ds4_kvstore_eviction_context *incoming) {
     if (!e || e->file_size == 0) return 0.0;
     (void)live;
@@ -545,8 +546,22 @@ double ds4_kvstore_entry_eviction_score(
         effective_hits *= exp2(-elapsed / (double)DS4_KVSTORE_HIT_HALF_LIFE_SECONDS);
         if (effective_hits < KV_CACHE_MIN_EFFECTIVE_HITS) effective_hits = 0.0;
     }
-    double score = (effective_hits + 1.0) *
-                   (double)e->tokens / (double)e->file_size;
+    /* tokens/file_size alone double-penalizes short checkpoints: every saved
+     * payload pays roughly the same fixed_overhead_bytes regardless of token
+     * count (e.g. the engine's raw SWA cache persists a checkpoint-length-
+     * independent row count once past a small threshold), so that shared
+     * fixed cost dilutes a short checkpoint's density far more than a long
+     * one's -- even at equal hit counts, the earliest checkpoints in a
+     * growing conversation would always look cheapest to evict, and are
+     * evicted first purely because they are short, not because they are less
+     * useful. Score on the marginal (variable) bytes instead, so density
+     * reflects what this checkpoint's own token range actually costs beyond
+     * the fixed cost every checkpoint pays once. */
+    double denom = (double)e->file_size;
+    if (fixed_overhead_bytes > 0 && (double)fixed_overhead_bytes < denom) {
+        denom -= (double)fixed_overhead_bytes;
+    }
+    double score = (effective_hits + 1.0) * (double)e->tokens / denom;
     if (kv_cache_reason_is_anchor(e->reason))
         score *= KV_CACHE_ANCHOR_REASON_SCORE_FACTOR;
     if (kv_cache_incoming_supersedes_continued(e, incoming)) {
@@ -572,11 +587,11 @@ void ds4_kvstore_evict(ds4_kvstore *kc, const ds4_tokens *live,
         int victim = 0;
         double victim_score =
             ds4_kvstore_entry_eviction_score(&kc->entry[0], live, now,
-                                             incoming);
+                                             kc->fixed_overhead_bytes, incoming);
         for (int i = 1; i < kc->len; i++) {
             double score =
                 ds4_kvstore_entry_eviction_score(&kc->entry[i], live, now,
-                                                 incoming);
+                                                 kc->fixed_overhead_bytes, incoming);
             if (score < victim_score ||
                 (score == victim_score &&
                  kc->entry[i].last_used < kc->entry[victim].last_used))

--- a/ds4_kvstore.h
+++ b/ds4_kvstore.h
@@ -77,6 +77,11 @@ typedef struct {
     const char *log_name;
     void *log_ud;
     void (*log)(void *ud, ds4_kvstore_log_type type, const char *msg);
+    /* Estimated fixed, checkpoint-length-independent bytes present in every
+     * saved payload (see ds4_kvstore_entry_eviction_score()). 0 means
+     * "unknown/not applicable" and preserves plain tokens/file_size scoring,
+     * so callers that don't set this (e.g. ds4-agent) are unaffected. */
+    uint64_t fixed_overhead_bytes;
 } ds4_kvstore;
 
 typedef struct {
@@ -152,6 +157,7 @@ bool ds4_kvstore_file_size_fits(const ds4_kvstore *kc,
 double ds4_kvstore_entry_eviction_score(const ds4_kvstore_entry *e,
                                         const ds4_tokens *live,
                                         uint64_t now,
+                                        uint64_t fixed_overhead_bytes,
                                         const ds4_kvstore_eviction_context *incoming);
 void ds4_kvstore_evict(ds4_kvstore *kc, const ds4_tokens *live,
                        uint64_t extra_bytes,

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -9337,8 +9337,10 @@ static void kv_cache_restore_tool_memory_for_messages(server *s, const chat_msgs
 #ifdef DS4_SERVER_TEST
 static double kv_entry_eviction_score(const kv_entry *e, const ds4_tokens *live,
                                       uint64_t now,
+                                      uint64_t fixed_overhead_bytes,
                                       const ds4_kvstore_eviction_context *incoming) {
-    return ds4_kvstore_entry_eviction_score(e, live, now, incoming);
+    return ds4_kvstore_entry_eviction_score(e, live, now, fixed_overhead_bytes,
+                                            incoming);
 }
 #endif
 
@@ -13138,6 +13140,8 @@ int main(int argc, char **argv) {
     if (cfg.kv_disk_dir) {
         kv_cache_open(&s.kv, cfg.kv_disk_dir, cfg.kv_disk_space_mb,
                       cfg.kv_cache_reject_different_quant, cfg.kv_cache);
+        s.kv.fixed_overhead_bytes =
+            ds4_engine_checkpoint_fixed_overhead_bytes(engine, cfg.ctx_size);
     }
     if (s.disable_exact_dsml_tool_replay) {
         server_log(DS4_LOG_DEFAULT,
@@ -17431,13 +17435,45 @@ static void test_kv_cache_eviction_score_decays_stale_hits(void) {
     kv_entry stale = {.tokens = 1024, .hits = 10, .file_size = 4096, .last_used = 1000};
     kv_entry fresh = {.tokens = 2048, .hits = 0,  .file_size = 4096, .last_used = now};
 
-    double s_on = kv_entry_eviction_score(&stale, NULL, now, NULL);
-    double f_on = kv_entry_eviction_score(&fresh, NULL, now, NULL);
+    double s_on = kv_entry_eviction_score(&stale, NULL, now, 0, NULL);
+    double f_on = kv_entry_eviction_score(&fresh, NULL, now, 0, NULL);
     TEST_ASSERT(s_on < f_on);
 
     /* A fresh entry's score never decays below its (0+1) * tokens/size floor,
      * regardless of how old another entry's hit history is. */
     TEST_ASSERT(f_on == 1.0 * (double)fresh.tokens / (double)fresh.file_size);
+}
+
+/* Regression test for issue #444: a short checkpoint and a long checkpoint
+ * from the same growing conversation, both never hit, with the exact same
+ * marginal (per-token) storage cost but a shared fixed overhead (e.g. the
+ * engine's raw SWA cache, persisted at a checkpoint-length-independent row
+ * count -- see ds4_engine_checkpoint_fixed_overhead_bytes()) baked into both
+ * file sizes. Plain tokens/file_size scores the short one lower purely
+ * because the shared fixed cost is a larger fraction of its total size, so
+ * it would always be evicted first even though both are equally "dense"
+ * once that shared cost is set aside -- exactly the self-defeating cascade
+ * the issue reports (early, still-reusable prefixes evicted first, leaving
+ * only a full snapshot that no longer matches after any mid-prompt edit). */
+static void test_kv_cache_eviction_ignores_shared_fixed_overhead(void) {
+    const uint64_t now = 1000;
+    const uint64_t overhead = 1000;
+    kv_entry small = {.tokens = 1000, .hits = 0, .file_size = 2000, .last_used = now};
+    kv_entry big   = {.tokens = 8000, .hits = 0, .file_size = 9000, .last_used = now};
+
+    double small_plain = kv_entry_eviction_score(&small, NULL, now, 0, NULL);
+    double big_plain = kv_entry_eviction_score(&big, NULL, now, 0, NULL);
+    TEST_ASSERT(small_plain < big_plain);
+
+    double small_adj = kv_entry_eviction_score(&small, NULL, now, overhead, NULL);
+    double big_adj = kv_entry_eviction_score(&big, NULL, now, overhead, NULL);
+    TEST_ASSERT(fabs(small_adj - big_adj) < 1e-9);
+
+    /* An overhead estimate that would swallow the whole file must not divide
+     * by zero or go negative. */
+    kv_entry tiny = {.tokens = 10, .hits = 0, .file_size = 50, .last_used = now};
+    double tiny_adj = kv_entry_eviction_score(&tiny, NULL, now, 1000000, NULL);
+    TEST_ASSERT(tiny_adj > 0.0 && isfinite(tiny_adj));
 }
 
 static void test_kv_cache_eviction_decayed_hits_tie_break_by_age(void) {
@@ -17893,6 +17929,7 @@ static void ds4_server_unit_tests_run(void) {
     test_kv_cache_eviction_prefers_superseded_continued_prefix();
     test_kv_cache_eviction_keeps_smaller_context_prefix();
     test_kv_cache_eviction_score_decays_stale_hits();
+    test_kv_cache_eviction_ignores_shared_fixed_overhead();
     test_kv_cache_eviction_decayed_hits_tie_break_by_age();
     test_kv_cache_eviction_keeps_aligned_continued_frontiers();
 }


### PR DESCRIPTION
Fixes #444.

## The reported symptom

Under disk-KV pressure, small "continued" checkpoints (the early, still-reusable prefixes of a growing conversation) get evicted before large ones. Eventually only the largest (full-length) snapshot survives, and once the incoming prompt diverges anywhere before its stored length, it no longer matches — forcing a full re-prefill that a smaller, earlier checkpoint would have avoided. The issue's own math pointed at "token density increases slightly with file size due to fixed header overhead."

## Where the fixed cost actually comes from

Not the 48-byte file header (negligible) — `session_payload_live_tensor_bytes()` caps the persisted raw SWA cache at `raw_window` rows regardless of checkpoint length (`session_raw_live_rows()`). So every checkpoint beyond `raw_window` tokens — the common case for anything past the disk cache's default `min_tokens` floor — pays roughly the *same* fixed number of raw-cache bytes no matter how many tokens it actually holds. That shared fixed cost is a much bigger fraction of a short checkpoint's `file_size` than a long one's, so `tokens/file_size` scores short checkpoints lower than long ones at equal hit counts — not because they're less useful, but purely because they're short.

## Fix

`ds4_kvstore` now carries an optional `fixed_overhead_bytes` estimate (defaults to 0, so `ds4-agent` and any other caller that doesn't set it are completely unaffected — this is opt-in). `ds4_kvstore_entry_eviction_score()` subtracts it from `file_size` before computing density, so the score reflects each checkpoint's own marginal bytes rather than a cost every checkpoint pays once regardless of length.

New `ds4_engine_checkpoint_fixed_overhead_bytes()` computes the estimate from the engine's own `raw_window`/layer-count/head-dim shape (returns 0 for GLM, whose dense KV cache scales with checkpoint length and has no equivalent fixed cost — I didn't want to apply an unverified correction there). `ds4-server` wires it in once at `kv_cache_open()` time, right next to the existing `budget_bytes` setup — no new config surface.

## Testing

- Full existing `ds4_test` suite passes unchanged (`fixed_overhead_bytes` defaults to 0, so behavior is bit-for-bit identical when unset).
- New regression test `test_kv_cache_eviction_ignores_shared_fixed_overhead`: two entries with the exact same marginal (per-token) cost but different sizes — scores differ without the fix (reproducing the reported bias) and become equal with it — plus an edge-case check that an overestimated overhead can't divide by zero or go negative.

I considered a couple of alternatives before landing here — worth saying why I didn't:
- Estimating the overhead by fitting it from the existing on-disk entry population (no cross-module engine knowledge needed) — works but adds real complexity/fragility to a hot eviction path for what the engine already knows exactly.
- Actually reworking "value" to account for short prefixes being *more* robust to future divergence than long ones (not just equally dense) — a real effect, but a deeper design change than this specific bug needs; happy to discuss separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)