### PR TITLE
Fix misleading refusal message for --ssd-streaming

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -56437,7 +56437,8 @@ static int ds4_engine_open_internal(ds4_engine **out,
     }
     if (e->ssd_streaming && e->multi_tier) {
         fprintf(stderr,
-                "ds4: --ssd-streaming is not compatible with multi-GPU placement\n");
+                "ds4: --ssd-streaming is not compatible with multi-tier placement "
+                "(e.g. CPU spill)\n");
         ds4_engine_close(e);
         *out = NULL;
         return 1;


### PR DESCRIPTION
`--ssd-streaming` is refused with:

```
ds4: --ssd-streaming is not compatible with multi-GPU placement
```

but the guard is `e->ssd_streaming && e->multi_tier`, and `multi_tier` is not
"more than one GPU". `engine_classify_multi_tier` sets it when the placement
spans more than one tier **or** when any entry lands on `DS4_LAYER_PACK_CPU`:

```c
for (int i = 1; i < e->n_placement_entries; i++)
    if (e->placement[i] != first_tier) { multi_tier = 1; break; }
if (!multi_tier)
    for (int i = 0; i < e->n_placement_entries; i++)
        if (e->placement[i] == DS4_LAYER_PACK_CPU) { multi_tier = 1; break; }
```

Neither loop reads `cfg->n_gpus` or `g_n_gpus`. So on a single-GPU placement
whose model does not fit the VRAM budget, every layer spills to CPU,
`multi_tier` becomes 1, and the operator is told the placement is "multi-GPU"
even though exactly one device was requested.

Observed with a single visible GPU (RTX 5060 Ti 16GB — the host has two,
deliberately restricted to one with `CUDA_VISIBLE_DEVICES=0` and a single
`--gpu-vram 15` budget) using the MXFP4 Flash GGUF. Note that ds4 itself
reports one device on the line immediately above the refusal:

```
ds4: GPU config: 1 device [0] requested, budgets 15 GB; auto=false
ds4: --ssd-streaming is not compatible with multi-GPU placement
```

Dropping `--ssd-streaming` shows the real reason, and the layout confirms only
GPU0 and the CPU tier participate — GPU1 never appears:

```
multi-GPU layout:
  GPU0: layers 0-1 + embedding  (7.7 / 10.8 GB)
  CPU : layers 2-42 + output head
ds4: CPU-spill placement detected; CPU-tier execution wiring is the
     wave-3b mgpu-graph-session-cpu-spill follow-up.
ds4:   42 placement entries spilled to CPU (138.38 GiB unaccommodated of
       10.79 GiB total per-device budget).
```

This patch just names the actual condition. No behaviour change.