### PR TITLE
ssd: enforce streaming cache floor at one-prefill minimum

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -54583,6 +54583,28 @@ static bool ds4_engine_configure_streaming_cache_budget(ds4_engine *e) {
                     "ds4: --ssd-streaming-cache-experts byte budget is too small or invalid for this model\n");
             return false;
         }
+
+        /*
+         * Enforce a floor: the cache must hold at least one full prefill's
+         * routed working set (n_layers * DS4_N_EXPERT_USED experts). Below
+         * that the cache is smaller than a single token's routed set and
+         * every slot evicts what it is about to reuse, so prefill always
+         * fails with "cannot reserve a slot".
+         */
+        const uint32_t min_prefill_experts =
+            DS4_N_LAYER * DS4_N_EXPERT_USED;
+        if (budget < min_prefill_experts) {
+            fprintf(stderr,
+                    "ds4: SSD streaming expert cache budget (%u) below "
+                    "one-prefill minimum (%u layers x %d experts = %u); "
+                    "raising to %u\n",
+                    budget,
+                    DS4_N_LAYER,
+                    DS4_N_EXPERT_USED,
+                    min_prefill_experts,
+                    min_prefill_experts);
+            budget = min_prefill_experts;
+        }
         e->ssd_streaming_cache_experts = budget;
         e->ssd_streaming_cache_bytes =
             (uint64_t)budget * budget_expert_bytes;


### PR DESCRIPTION
Hello! While I was try to make ds4 work on my machine I hit some error that where not clear (at least, to me) therefore after a little bit of digging with AI supported I realize that I was miss configuring the system, is not always easy to drive through this type of situation, therefore I would like to propose a change to guarantee that if miss configuration happen the system try to "auto heal" reporting a warning to the user. That been say, here is the technical description of the changes:

## Summary 
Enforce a floor on the SSD streaming expert cache budget: it must hold at least one full prefill's routed working set (n_layers x DS4_N_EXPERT_USED experts). 

## Problem 
When the cache budget is smaller than a single token's routed expert set, every slot evicts what it is about to reuse. This causes prefill to always fail with \"cannot reserve a slot\". 

## Fix 
Added a floor check after budget calculation. If the budget is below \`DS4_N_LAYER * DS4_N_EXPERT_USED\`, it is raised to that minimum and a diagnostic message is printed. 

## Files Changed 
- \`ds4.c\` - Added floor enforcement in \`ds4_engine_configure_streaming_cache_budget()\` 
 
## Testing 
- Builds cleanly on CUDA and ROCm targets 
- No behavioral change when budget is already above the floor (typical case) 
- Fixes eviction storms when budget is below the floor 