### PR TITLE
docs: add on-disk sizes for GLM 5.2 model variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ native tooling can be added later.
 GLM 5.2 support is limited to the GGUF files tested by this branch:
 
 ```sh
-./download_model.sh glm-unsloth-q4  # Unsloth UD-Q4_K_XL, 11 shards
-./download_model.sh glm-antirez-iq2xxs  # antirez routed IQ2_XXS single-file GGUF
-./download_model.sh glm-antirez-q2  # antirez routed Q2_K single-file GGUF
-./download_model.sh glm-antirez-q4  # antirez routed Q4_K single-file GGUF
+./download_model.sh glm-unsloth-q4  # Unsloth UD-Q4_K_XL, 11 shards (~467 GB)
+./download_model.sh glm-antirez-iq2xxs  # antirez routed IQ2_XXS single-file GGUF (~211 GB)
+./download_model.sh glm-antirez-q2  # antirez routed Q2_K single-file GGUF (~262 GB)
+./download_model.sh glm-antirez-q4  # antirez routed Q4_K single-file GGUF (~434 GB)
 ```
 
 The supported GLM layout keeps dense/model-control tensors in the existing

--- a/download_model.sh
+++ b/download_model.sh
@@ -95,6 +95,9 @@ Targets:
   glm-antirez-iq2xxs
        GLM 5.2 antirez routed IQ2_XXS GGUF from antirez/GLM-5.2-GGUF.
        Includes Q2_K block 78 and is intended for reduced-memory testing.
+       About 211 GB on disk. Does not fully fit in 128 GB RAM — use
+       --ssd-streaming (and --ssd-streaming-cache-experts) on single-node
+       96/128 GB machines; two-node tensor parallelism also works.
 
   glm-antirez-q2
        GLM 5.2 antirez routed Q2_K GGUF from antirez/GLM-5.2-GGUF.


### PR DESCRIPTION
## Summary

- Add measured on-disk sizes for the GLM 5.2 download targets in `download_model.sh` (iq2xxs was the only one missing a size; q2/q4 already had them)
- Note that iq2xxs (~211 GB) does **not** fully fit in 128 GB RAM — single-node 96/128 GB machines need `--ssd-streaming`
- Mirror the sizes in the README download list for a quick glance

## Context

Verified by downloading both `glm-antirez-iq2xxs` and `glm-antirez-q2` onto a DGX Spark (GB10, 128 GB unified memory) while setting up a local bake-off. The missing size on iq2xxs made it easy to confuse with the DeepSeek Flash `ds4f-q2` entry ("about 81 GB… recommended for 96 and 128 GB RAM machines"), which sits right above the GLM block in the help text.

Also confirmed `--ssd-streaming --ssd-streaming-cache-experts 40GB` loads iq2xxs successfully on a single Spark (~46 GiB resident: 0.94 model + 35 expert cache + 5.8 compressed KV + buffers).

## Test plan

- [x] `bash -n download_model.sh` (syntax)
- [x] Sizes measured with `ls -la` after full HF download of both files
- [ ] Maintainer eyeball of the wording