### PR TITLE
ROCm: fuse QKV RMSNorm and KV RoPE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 /tests/test_mxfp4_dot
 /tests/test_mxfp4_metal
 /tests/test_q4k_dot
+/tests/test_rocm_qkv_fusion
 /tests/test_sampling
 *.o
 *.dSYM/

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ CPU_CORE_OBJS = ds4_cpu.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
 CUDA_LDLIBS ?= -lm -Xcompiler -pthread -L$(CUDA_HOME)/targets/sbsa-linux/lib -L$(CUDA_HOME)/lib64 -lcudart -lcublas
 HIPCC ?= $(shell command -v hipcc 2>/dev/null || echo /opt/rocm/bin/hipcc)
 ROCM_ARCH ?= gfx1151
+ROCM_HOST_CFLAGS ?= -fPIC
 ROCM_CFLAGS ?= -O3 -ffast-math -g -fno-finite-math-only -pthread -D__HIP_PLATFORM_AMD__ -Wno-unused-command-line-argument --offload-arch=$(ROCM_ARCH)
 ROCM_LDLIBS ?= -lm -pthread -lhipblas -lhipblaslt
 DS4_LINK ?= $(NVCC) $(NVCCFLAGS)
@@ -62,7 +63,7 @@ DS4_LINK_LIBS ?= $(CUDA_LDLIBS)
 METAL_LDLIBS := $(LDLIBS)
 endif
 
-.PHONY: all help clean test test-metal-session-batch test-mxfp4-cuda test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
+.PHONY: all help clean test test-metal-session-batch test-mxfp4-cuda test-rocm-qkv-fusion test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
 
 ifeq ($(UNAME_S),Darwin)
 .PHONY: metal-decode-schedule-bench metal-prefill-variant-bench check-mxfp4-half-lut
@@ -156,6 +157,7 @@ help:
 	@echo "  make cuda CUDA_ARCH=sm_N Build CUDA with an explicit nvcc -arch value"
 	@echo "  make strix-halo          Build ROCm for Strix Halo / gfx1151"
 	@echo "  make rocm                Alias for make strix-halo"
+	@echo "  make test-rocm-qkv-fusion  Run fused QKV RMSNorm + KV RoPE correctness test"
 	@echo "  make cpu                 Build CPU-only ./ds4, ./ds4-server, ./ds4-bench, ./ds4-eval, and ./ds4-agent"
 	@echo "  make test                Build and run tests"
 	@echo "  make dspark-verify-depth Run DSpark speculative verification smoke if support GGUF is present"
@@ -331,6 +333,15 @@ cuda/mmq/ds4_repack.o: cuda/mmq/ds4_repack.cu cuda/mmq/ds4_repack.h
 ds4_rocm.o: ds4_rocm.cu ds4_gpu.h ds4_iq2_tables_cuda.inc $(ROCM_SRCS)
 	$(HIPCC) $(ROCM_CFLAGS) -c -o $@ ds4_rocm.cu
 
+tests/test_rocm_qkv_fusion.o: tests/test_rocm_qkv_fusion.c ds4_gpu.h
+	$(CC) $(filter-out -ffast-math,$(CFLAGS)) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD -I. -c -o $@ $<
+
+tests/test_rocm_qkv_fusion: tests/test_rocm_qkv_fusion.o ds4_rocm.o
+	$(HIPCC) $(ROCM_CFLAGS) -o $@ $^ $(ROCM_LDLIBS)
+
+test-rocm-qkv-fusion: tests/test_rocm_qkv_fusion
+	./tests/test_rocm_qkv_fusion
+
 ds4_rocm_compat.o: ds4_rocm_compat.cu ds4_gpu.h ds4_gpu_mgpu.h ds4_gpu_args.h
 	$(HIPCC) $(ROCM_CFLAGS) -c -o $@ ds4_rocm_compat.cu
 
@@ -488,4 +499,4 @@ mxfp4-dot-test: tests/test_mxfp4_dot.c
 	./tests/test_mxfp4_dot
 
 clean:
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_rocm_qkv_fusion tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o

--- a/QA_BEFORE_RELEASES.md
+++ b/QA_BEFORE_RELEASES.md
@@ -463,6 +463,9 @@ a substitute for CUDA or Metal release testing.
 - Build:
   `make clean && make strix-halo`.
 - Require the ROCm build to complete without compiler warnings.
+- If ROCm Q/KV normalization, RoPE, or launch selection changed, run
+  `make HIPCC=/opt/rocm-therock/bin/hipcc test-rocm-qkv-fusion` and require
+  bit-exact PASS for all positive and invalid-shape cases.
 - Use the q2 Flash imatrix GGUF for release smoke tests:
   `DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix-0731.gguf`.
 - Do not use the mixed q2-q4 or Q4 Flash GGUFs for routine Strix Halo QA yet.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,22 @@ make strix-halo       # Linux ROCm, AMD Strix Halo
 make cpu              # CPU-only diagnostics build
 ```
 
+Resident single-token DeepSeek V4 decode on ROCm fuses Q/KV weighted RMS
+normalization and KV RoPE into one launch when the shape has at most 256 RoPE
+pairs. This attention optimization is independent of the routed-expert
+quantization and applies to both Q4_K and MXFP4 models. Larger shapes retain the
+two-launch path. Set `DS4_ROCM_DISABLE_QKV_KV_ROPE_FUSION=1` before process
+startup for a diagnostic rollback. Run the model-independent, bit-exact
+reference test with:
+
+```sh
+make HIPCC=/opt/rocm-therock/bin/hipcc test-rocm-qkv-fusion
+```
+
+It covers dense and YaRN parameters, inverse and multi-row/head layouts,
+zero rotation, the 256-pair boundary, the 257-pair fallback, and rejected
+shapes, requiring bit-exact Q and KV output.
+
 `./ds4flash.gguf` is the default model path used by both binaries. Pass `-m` to
 select another supported GGUF from `./gguf/`. Run `./ds4 --help` and
 `./ds4-server --help` for the full flag list.

--- a/ds4_rocm_compat.cu
+++ b/ds4_rocm_compat.cu
@@ -240,25 +240,6 @@ extern "C" int ds4_gpu_matmul_f16_router_rows_exact_tensor(
                                      4096u, 256u, x, n_rows);
 }
 
-extern "C" int ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(
-        ds4_gpu_tensor *q_out, const ds4_gpu_tensor *q,
-        const void *model_map, uint64_t model_size,
-        uint64_t q_weight_offset, uint32_t q_n,
-        ds4_gpu_tensor *kv_out, const ds4_gpu_tensor *kv,
-        uint64_t kv_weight_offset, uint32_t kv_n, uint32_t rows,
-        uint32_t kv_n_head, uint32_t kv_head_dim, uint32_t n_rot,
-        uint32_t pos0, uint32_t n_ctx_orig, bool inverse,
-        float freq_base, float freq_scale, float ext_factor,
-        float attn_factor, float beta_fast, float beta_slow, float eps) {
-    return ds4_gpu_dsv4_qkv_rms_norm_rows_tensor(
-                   q_out, q, model_map, model_size, q_weight_offset, q_n,
-                   kv_out, kv, kv_weight_offset, kv_n, rows, eps) != 0 &&
-           ds4_gpu_rope_tail_tensor(
-                   kv_out, rows, kv_n_head, kv_head_dim, n_rot, pos0,
-                   n_ctx_orig, inverse, freq_base, freq_scale, ext_factor,
-                   attn_factor, beta_fast, beta_slow) != 0;
-}
-
 extern "C" int ds4_gpu_embed_token_quant_tensor(
         ds4_gpu_tensor *out, const void *model_map, uint64_t model_size,
         uint64_t weight_offset, uint32_t weight_type, uint32_t n_vocab,

--- a/rocm/ds4_rocm_norm_rope.cuh
+++ b/rocm/ds4_rocm_norm_rope.cuh
@@ -80,6 +80,110 @@ __global__ static void dsv4_qkv_rms_norm_rows_kernel(
     }
 }
 
+__device__ static float rope_yarn_ramp_dev(float low, float high, int i0);
+
+/* Keep the weighted RMS output in kv_out exactly as the two-launch path does,
+ * then rotate the normalized KV tail after a block-wide barrier.  This removes
+ * one launch per layer without changing the float value that RoPE consumes. */
+__global__ static void dsv4_qkv_rms_norm_rows_kv_rope_kernel(
+        float *q_out,
+        const float *q,
+        const float *q_w,
+        uint32_t q_n,
+        float *kv_out,
+        const float *kv,
+        const float *kv_w,
+        uint32_t kv_n,
+        uint32_t rows,
+        uint32_t kv_n_head,
+        uint32_t kv_head_dim,
+        uint32_t n_rot,
+        uint32_t pos0,
+        uint32_t n_ctx_orig,
+        int inverse,
+        float freq_base,
+        float freq_scale,
+        float ext_factor,
+        float attn_factor,
+        float beta_fast,
+        float beta_slow,
+        float eps) {
+    const uint32_t row = blockIdx.x;
+    const uint32_t which = blockIdx.y;
+    if (row >= rows || which > 1u) return;
+    const uint32_t n = which == 0u ? q_n : kv_n;
+    const float *xr = (which == 0u ? q : kv) + (uint64_t)row * n;
+    float *orow = (which == 0u ? q_out : kv_out) + (uint64_t)row * n;
+    const float *w = which == 0u ? q_w : kv_w;
+    float sum = 0.0f;
+    for (uint32_t i = threadIdx.x; i < n; i += blockDim.x) {
+        const float v = xr[i];
+        sum += v * v;
+    }
+    __shared__ float partial[256];
+    partial[threadIdx.x] = sum;
+    __syncthreads();
+    for (uint32_t stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride)
+            partial[threadIdx.x] += partial[threadIdx.x + stride];
+        __syncthreads();
+    }
+    const float scale = rsqrtf(partial[0] / (float)n + eps);
+    for (uint32_t i = threadIdx.x; i < n; i += blockDim.x) {
+        orow[i] = xr[i] * scale * w[i];
+    }
+    if (which == 0u) return;
+    __syncthreads();
+    if (n_rot == 0u) return;
+
+    const uint32_t n_nope = kv_head_dim - n_rot;
+    const uint32_t pairs_per_head = n_rot / 2u;
+    const uint32_t total_pairs = kv_n_head * pairs_per_head;
+    if (threadIdx.x >= total_pairs) return;
+
+    float corr0 = 0.0f, corr1 = 0.0f;
+    if (ext_factor != 0.0f) {
+        const float denom = 2.0f * logf(freq_base);
+        corr0 = floorf((float)n_rot *
+            logf((float)n_ctx_orig /
+                 (beta_fast * 2.0f * (float)M_PI)) / denom);
+        corr1 = ceilf((float)n_rot *
+            logf((float)n_ctx_orig /
+                 (beta_slow * 2.0f * (float)M_PI)) / denom);
+        corr0 = fmaxf(0.0f, corr0);
+        corr1 = fminf((float)(n_rot - 1u), corr1);
+    }
+    const float theta_scale = powf(freq_base, -2.0f / (float)n_rot);
+    const uint32_t p = threadIdx.x;
+    const uint32_t h = p / pairs_per_head;
+    const uint32_t pair = p - h * pairs_per_head;
+    const uint32_t i = pair * 2u;
+    const uint32_t i0 = h * kv_head_dim + n_nope + i;
+    const float theta_extrap =
+        (float)(pos0 + row) * powf(theta_scale, (float)pair);
+    const float theta_interp = freq_scale * theta_extrap;
+    float theta = theta_interp;
+    float mscale = attn_factor;
+    if (ext_factor != 0.0f) {
+        const float ramp = rope_yarn_ramp_dev(corr0, corr1, (int)i);
+        /* Keep the retained rope_tail kernel's operation order.  A loop here
+         * lets fast-math hoist a reciprocal for the YaRN ramp and changes
+         * output bits.  The launcher sends shapes over one block to the
+         * reference two-kernel path. */
+        const float theta_delta = theta_extrap - theta_interp;
+        const float scaled_delta = theta_delta * ext_factor;
+        theta = scaled_delta * ramp + theta_interp;
+        mscale *= 1.0f + 0.1f * logf(1.0f / freq_scale);
+    }
+    const float c = cosf(theta) * mscale;
+    float s = sinf(theta) * mscale;
+    if (inverse) s = -s;
+    const float x0 = orow[i0];
+    const float x1 = orow[i0 + 1u];
+    orow[i0] = x0 * c - x1 * s;
+    orow[i0 + 1u] = x0 * s + x1 * c;
+}
+
 __global__ static void head_rms_norm_kernel(float *x, uint32_t n_tok, uint32_t n_head, uint32_t head_dim, float eps) {
     uint32_t row = blockIdx.x;
     if (row >= n_tok * n_head) return;
@@ -99,8 +203,6 @@ __global__ static void head_rms_norm_kernel(float *x, uint32_t n_tok, uint32_t n
     float scale = rsqrtf(partial[0] / (float)head_dim + eps);
     for (uint32_t i = threadIdx.x; i < head_dim; i += blockDim.x) xr[i] *= scale;
 }
-
-__device__ static float rope_yarn_ramp_dev(float low, float high, int i0);
 
 __global__ static void head_rms_norm_rope_tail_kernel(
         float *x,
@@ -512,6 +614,121 @@ extern "C" int ds4_gpu_dsv4_qkv_rms_norm_rows_tensor(
             eps);
     return cuda_ok(cudaGetLastError(), "dsv4 qkv rms norm rows launch");
 }
+
+extern "C" int ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(
+        ds4_gpu_tensor       *q_out,
+        const ds4_gpu_tensor *q,
+        const void           *model_map,
+        uint64_t              model_size,
+        uint64_t              q_weight_offset,
+        uint32_t              q_n,
+        ds4_gpu_tensor       *kv_out,
+        const ds4_gpu_tensor *kv,
+        uint64_t              kv_weight_offset,
+        uint32_t              kv_n,
+        uint32_t              rows,
+        uint32_t              kv_n_head,
+        uint32_t              kv_head_dim,
+        uint32_t              n_rot,
+        uint32_t              pos0,
+        uint32_t              n_ctx_orig,
+        bool                  inverse,
+        float                 freq_base,
+        float                 freq_scale,
+        float                 ext_factor,
+        float                 attn_factor,
+        float                 beta_fast,
+        float                 beta_slow,
+        float                 eps) {
+    uint64_t q_weight_bytes = 0, kv_weight_bytes = 0, kv_shape = 0;
+    if (!q_out || !q || !kv_out || !kv || !model_map ||
+        q_n == 0u || kv_n == 0u || kv_n_head == 0u ||
+        kv_head_dim == 0u || n_rot > kv_head_dim || (n_rot & 1u) ||
+        !cuda_u64_mul_checked(kv_n_head, kv_head_dim, &kv_shape) ||
+        kv_shape != kv_n ||
+        !cuda_u64_mul_checked(q_n, sizeof(float), &q_weight_bytes) ||
+        !cuda_u64_mul_checked(kv_n, sizeof(float), &kv_weight_bytes) ||
+        !cuda_model_range_fits(model_size,
+                               q_weight_offset,
+                               q_weight_bytes) ||
+        !cuda_model_range_fits(model_size,
+                               kv_weight_offset,
+                               kv_weight_bytes) ||
+        !cuda_tensor_has_elems2(q_out, q_n, rows, sizeof(float)) ||
+        !cuda_tensor_has_elems2(q, q_n, rows, sizeof(float)) ||
+        !cuda_tensor_has_elems2(kv_out, kv_n, rows, sizeof(float)) ||
+        !cuda_tensor_has_elems2(kv, kv_n, rows, sizeof(float))) {
+        return 0;
+    }
+    if (rows == 0u) return 1;
+    const uint64_t rope_pairs =
+        (uint64_t)kv_n_head * (uint64_t)(n_rot / 2u);
+    if (cuda_runtime_config()->disable_qkv_kv_rope_fusion ||
+        rope_pairs > 256u) {
+        if (!ds4_gpu_dsv4_qkv_rms_norm_rows_tensor(
+                q_out,
+                q,
+                model_map,
+                model_size,
+                q_weight_offset,
+                q_n,
+                kv_out,
+                kv,
+                kv_weight_offset,
+                kv_n,
+                rows,
+                eps)) {
+            return 0;
+        }
+        return n_rot == 0u ||
+               ds4_gpu_rope_tail_tensor(
+                   kv_out,
+                   rows,
+                   kv_n_head,
+                   kv_head_dim,
+                   n_rot,
+                   pos0,
+                   n_ctx_orig,
+                   inverse,
+                   freq_base,
+                   freq_scale,
+                   ext_factor,
+                   attn_factor,
+                   beta_fast,
+                   beta_slow);
+    }
+    const float *q_w = (const float *)cuda_model_range_ptr(
+        model_map, q_weight_offset, q_weight_bytes, "q_rms_weight");
+    const float *kv_w = (const float *)cuda_model_range_ptr(
+        model_map, kv_weight_offset, kv_weight_bytes, "kv_rms_weight");
+    if (!q_w || !kv_w) return 0;
+    const dim3 grid(rows, 2u, 1u);
+    dsv4_qkv_rms_norm_rows_kv_rope_kernel<<<grid, 256>>>(
+        (float *)q_out->ptr,
+        (const float *)q->ptr,
+        q_w,
+        q_n,
+        (float *)kv_out->ptr,
+        (const float *)kv->ptr,
+        kv_w,
+        kv_n,
+        rows,
+        kv_n_head,
+        kv_head_dim,
+        n_rot,
+        pos0,
+        n_ctx_orig,
+        inverse ? 1 : 0,
+        freq_base,
+        freq_scale,
+        ext_factor,
+        attn_factor,
+        beta_fast,
+        beta_slow,
+        eps);
+    return cuda_ok(cudaGetLastError(),
+                   "dsv4 qkv rms norm kv rope launch");
+}
 extern "C" int ds4_gpu_head_rms_norm_tensor(ds4_gpu_tensor *x, uint32_t n_tok, uint32_t n_head, uint32_t head_dim, float eps) {
     uint64_t rows64 = 0;
     if (!cuda_u64_mul_checked(n_tok, n_head, &rows64) || rows64 > UINT32_MAX ||
@@ -601,9 +818,19 @@ extern "C" int ds4_gpu_attn_q_b_f16_head_rms_rope_tail_tensor(
 }
 
 static int cuda_rope_tail_stride_tensor(ds4_gpu_tensor *x, uint32_t n_tok, uint32_t n_head, uint32_t head_dim, uint32_t n_rot, uint32_t pos0, uint32_t pos_stride, uint32_t n_ctx_orig, bool inverse, float freq_base, float freq_scale, float ext_factor, float attn_factor, float beta_fast, float beta_slow) {
-    if (!x || n_rot > head_dim || (n_rot & 1) || x->bytes < (uint64_t)n_tok * n_head * head_dim * sizeof(float)) return 0;
-    uint32_t pairs = n_tok * n_head * (n_rot / 2);
-    rope_tail_kernel<<<(pairs + 255) / 256, 256>>>((float *)x->ptr, n_tok, n_head, head_dim, n_rot, pos0, pos_stride, n_ctx_orig, inverse ? 1 : 0, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
+    uint64_t row_count = 0, elem_count = 0, bytes = 0, pairs64 = 0;
+    if (!x || n_rot > head_dim || (n_rot & 1) ||
+        !cuda_u64_mul_checked(n_tok, n_head, &row_count) ||
+        !cuda_u64_mul_checked(row_count, head_dim, &elem_count) ||
+        !cuda_u64_mul_checked(elem_count, sizeof(float), &bytes) ||
+        !cuda_u64_mul_checked(row_count, n_rot / 2u, &pairs64) ||
+        pairs64 > UINT32_MAX || x->bytes < bytes) {
+        return 0;
+    }
+    if (pairs64 == 0u) return 1;
+    const uint32_t pairs = (uint32_t)pairs64;
+    const uint32_t blocks = ((pairs - 1u) / 256u) + 1u;
+    rope_tail_kernel<<<blocks, 256>>>((float *)x->ptr, n_tok, n_head, head_dim, n_rot, pos0, pos_stride, n_ctx_orig, inverse ? 1 : 0, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
     return cuda_ok(cudaGetLastError(), "rope_tail launch");
 }
 

--- a/rocm/ds4_rocm_runtime.cuh
+++ b/rocm/ds4_rocm_runtime.cuh
@@ -4757,6 +4757,7 @@ struct ds4_rocm_runtime_config {
     int glm_grouped_value_project;
     int glm_grouped_qk_low;
     int q8_decode_sharedx_64k;
+    int disable_qkv_kv_rope_fusion;
     int graph_dump;
     uint32_t q8_decode_rpb;
     uint32_t q8_hc_decode_rpb;
@@ -4811,6 +4812,9 @@ static const ds4_rocm_runtime_config *cuda_runtime_config(void) {
         g_rocm_cfg.q8_decode_sharedx_64k =
             q8_decode_sharedx_64k_env == NULL ||
             cuda_env_present(q8_decode_sharedx_64k_env);
+        g_rocm_cfg.disable_qkv_kv_rope_fusion =
+            cuda_env_present(
+                getenv("DS4_ROCM_DISABLE_QKV_KV_ROPE_FUSION"));
         const int graph_dump_requested =
             cuda_env_present(getenv("DS4_ROCM_GRAPH_DUMP_PREFIX")) ||
             cuda_env_present(getenv("DS4_METAL_GRAPH_DUMP_PREFIX"));

--- a/tests/test_rocm_qkv_fusion.c
+++ b/tests/test_rocm_qkv_fusion.c
@@ -1,0 +1,505 @@
+/* Correctness coverage for the ROCm DeepSeek V4 fused Q/KV RMSNorm + KV RoPE.
+ *
+ * The reference path deliberately uses the existing two launches:
+ * ds4_gpu_dsv4_qkv_rms_norm_rows_tensor() followed by
+ * ds4_gpu_rope_tail_tensor().  The fused result must be bit-identical for both
+ * Q and KV, including multi-row, inverse, and YaRN-style compressed settings.
+ */
+
+#include "ds4_gpu.h"
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+enum {
+    Q_N = 1024u,
+    /* Large enough to cover the fused kernel's 256-pair boundary and the
+     * public entry point's greater-than-256-pair host fallback. */
+    KV_N = 768u,
+    MAX_ROWS = 7u,
+};
+
+typedef struct {
+    const char *name;
+    uint32_t rows;
+    uint32_t kv_n_head;
+    uint32_t kv_head_dim;
+    uint32_t n_rot;
+    uint32_t pos0;
+    uint32_t n_ctx_orig;
+    bool inverse;
+    float freq_base;
+    float freq_scale;
+    float ext_factor;
+    float attn_factor;
+    float beta_fast;
+    float beta_slow;
+} fusion_case;
+
+static uint64_t align_up(uint64_t value, uint64_t alignment) {
+    return (value + alignment - 1u) / alignment * alignment;
+}
+
+static uint32_t mix32(uint32_t x) {
+    x ^= x >> 16u;
+    x *= 0x7feb352du;
+    x ^= x >> 15u;
+    x *= 0x846ca68bu;
+    x ^= x >> 16u;
+    return x;
+}
+
+static uint32_t float_bits(float value) {
+    uint32_t bits = 0;
+    memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
+static int compare_exact(const char *case_name,
+                         const char *tensor_name,
+                         const float *reference,
+                         const float *fused,
+                         size_t count) {
+    enum { MAX_REPORTED_MISMATCHES = 8 };
+    size_t mismatches = 0;
+    float max_abs = 0.0f;
+    size_t first = 0;
+    for (size_t i = 0; i < count; i++) {
+        if (float_bits(reference[i]) == float_bits(fused[i])) continue;
+        const float diff = fabsf(reference[i] - fused[i]);
+        if (mismatches == 0u) first = i;
+        if (diff > max_abs) max_abs = diff;
+        mismatches++;
+    }
+    if (mismatches != 0u) {
+        fprintf(stderr,
+                "ROCm QKV fusion %s %s mismatch: %zu/%zu, first=%zu "
+                "ref=%a (0x%08x) fused=%a (0x%08x), max_abs=%g\n",
+                case_name,
+                tensor_name,
+                mismatches,
+                count,
+                first,
+                reference[first],
+                float_bits(reference[first]),
+                fused[first],
+                float_bits(fused[first]),
+                max_abs);
+        size_t reported = 0;
+        for (size_t i = 0;
+             i < count && reported < MAX_REPORTED_MISMATCHES;
+             i++) {
+            if (float_bits(reference[i]) == float_bits(fused[i])) continue;
+            fprintf(stderr,
+                    "  mismatch[%zu]: index=%zu ref=%a (0x%08x) "
+                    "fused=%a (0x%08x)\n",
+                    reported,
+                    i,
+                    reference[i],
+                    float_bits(reference[i]),
+                    fused[i],
+                    float_bits(fused[i]));
+            reported++;
+        }
+        return 0;
+    }
+    return 1;
+}
+
+static void fill_inputs(float *q,
+                        float *kv,
+                        uint32_t rows,
+                        uint32_t case_index) {
+    for (uint32_t row = 0; row < rows; row++) {
+        for (uint32_t i = 0; i < Q_N; i++) {
+            const uint32_t h = mix32(i + 1u + row * 0x9e3779b9u +
+                                     case_index * 0x85ebca6bu);
+            const int32_t centered = (int32_t)(h % 4093u) - 2046;
+            q[(uint64_t)row * Q_N + i] = (float)centered / 1024.0f;
+        }
+        for (uint32_t i = 0; i < KV_N; i++) {
+            const uint32_t h = mix32(i + 17u + row * 0xc2b2ae35u +
+                                     case_index * 0x27d4eb2du);
+            const int32_t centered = (int32_t)(h % 2039u) - 1019;
+            kv[(uint64_t)row * KV_N + i] = (float)centered / 768.0f;
+        }
+
+        /* Deterministic nonuniform magnitudes exercise every reduction row. */
+        q[(uint64_t)row * Q_N + (13u + row * 97u) % Q_N] =
+            (row & 1u) ? -7.25f : 7.5f;
+        kv[(uint64_t)row * KV_N + (29u + row * 53u) % KV_N] =
+            (row & 1u) ? 5.75f : -6.0f;
+    }
+}
+
+static int run_case(const fusion_case *tc,
+                    uint32_t case_index,
+                    const void *model,
+                    uint64_t model_size,
+                    uint64_t q_weight_offset,
+                    uint64_t kv_weight_offset) {
+    const uint64_t q_count = (uint64_t)tc->rows * Q_N;
+    const uint64_t kv_count = (uint64_t)tc->rows * KV_N;
+    const uint64_t q_bytes = q_count * sizeof(float);
+    const uint64_t kv_bytes = kv_count * sizeof(float);
+    float *q_host = (float *)malloc((size_t)q_bytes);
+    float *kv_host = (float *)malloc((size_t)kv_bytes);
+    float *q_reference = (float *)malloc((size_t)q_bytes);
+    float *q_fused = (float *)malloc((size_t)q_bytes);
+    float *kv_reference = (float *)malloc((size_t)kv_bytes);
+    float *kv_fused = (float *)malloc((size_t)kv_bytes);
+    ds4_gpu_tensor *q = NULL;
+    ds4_gpu_tensor *kv = NULL;
+    ds4_gpu_tensor *q_ref_tensor = NULL;
+    ds4_gpu_tensor *kv_ref_tensor = NULL;
+    ds4_gpu_tensor *q_fused_tensor = NULL;
+    ds4_gpu_tensor *kv_fused_tensor = NULL;
+    int ok = q_host && kv_host && q_reference && q_fused &&
+             kv_reference && kv_fused;
+
+    if (ok) {
+        fill_inputs(q_host, kv_host, tc->rows, case_index);
+        q = ds4_gpu_tensor_alloc(q_bytes);
+        kv = ds4_gpu_tensor_alloc(kv_bytes);
+        q_ref_tensor = ds4_gpu_tensor_alloc(q_bytes);
+        kv_ref_tensor = ds4_gpu_tensor_alloc(kv_bytes);
+        q_fused_tensor = ds4_gpu_tensor_alloc(q_bytes);
+        kv_fused_tensor = ds4_gpu_tensor_alloc(kv_bytes);
+        ok = q && kv && q_ref_tensor && kv_ref_tensor &&
+             q_fused_tensor && kv_fused_tensor;
+    }
+    if (ok) {
+        ok = ds4_gpu_tensor_write(q, 0u, q_host, q_bytes) != 0 &&
+             ds4_gpu_tensor_write(kv, 0u, kv_host, kv_bytes) != 0;
+    }
+
+    int begun = 0;
+    if (ok) {
+        begun = ds4_gpu_begin_commands();
+        ok = begun != 0;
+        if (ok) {
+            ok = ds4_gpu_dsv4_qkv_rms_norm_rows_tensor(
+                     q_ref_tensor, q, model, model_size,
+                     q_weight_offset, Q_N,
+                     kv_ref_tensor, kv, kv_weight_offset, KV_N,
+                     tc->rows, 1.0e-6f) != 0;
+        }
+        if (ok && tc->n_rot != 0u) {
+            ok = ds4_gpu_rope_tail_tensor(
+                     kv_ref_tensor,
+                     tc->rows,
+                     tc->kv_n_head,
+                     tc->kv_head_dim,
+                     tc->n_rot,
+                     tc->pos0,
+                     tc->n_ctx_orig,
+                     tc->inverse,
+                     tc->freq_base,
+                     tc->freq_scale,
+                     tc->ext_factor,
+                     tc->attn_factor,
+                     tc->beta_fast,
+                     tc->beta_slow) != 0;
+        }
+        if (begun && ds4_gpu_end_commands() == 0) ok = 0;
+    }
+
+    begun = 0;
+    if (ok) {
+        begun = ds4_gpu_begin_commands();
+        ok = begun != 0;
+        if (ok) {
+            ok = ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(
+                     q_fused_tensor, q, model, model_size,
+                     q_weight_offset, Q_N,
+                     kv_fused_tensor, kv, kv_weight_offset, KV_N,
+                     tc->rows,
+                     tc->kv_n_head,
+                     tc->kv_head_dim,
+                     tc->n_rot,
+                     tc->pos0,
+                     tc->n_ctx_orig,
+                     tc->inverse,
+                     tc->freq_base,
+                     tc->freq_scale,
+                     tc->ext_factor,
+                     tc->attn_factor,
+                     tc->beta_fast,
+                     tc->beta_slow,
+                     1.0e-6f) != 0;
+        }
+        if (begun && ds4_gpu_end_commands() == 0) ok = 0;
+    }
+
+    if (ok) {
+        ok = ds4_gpu_tensor_read(
+                 q_ref_tensor, 0u, q_reference, q_bytes) != 0 &&
+             ds4_gpu_tensor_read(
+                 q_fused_tensor, 0u, q_fused, q_bytes) != 0 &&
+             ds4_gpu_tensor_read(
+                 kv_ref_tensor, 0u, kv_reference, kv_bytes) != 0 &&
+             ds4_gpu_tensor_read(
+                 kv_fused_tensor, 0u, kv_fused, kv_bytes) != 0;
+    }
+    if (ok) {
+        const int q_ok = compare_exact(
+            tc->name, "Q", q_reference, q_fused, (size_t)q_count);
+        const int kv_ok = compare_exact(
+            tc->name, "KV", kv_reference, kv_fused, (size_t)kv_count);
+        ok = q_ok && kv_ok;
+    }
+
+    fprintf(stderr,
+            "ROCm QKV fusion %-22s rows=%u heads=%u head_dim=%u "
+            "rot=%u pos=%u ctx_orig=%u inverse=%u base=%a scale=%a "
+            "ext=%a attn=%a beta_fast=%a beta_slow=%a: %s\n",
+            tc->name,
+            tc->rows,
+            tc->kv_n_head,
+            tc->kv_head_dim,
+            tc->n_rot,
+            tc->pos0,
+            tc->n_ctx_orig,
+            tc->inverse ? 1u : 0u,
+            tc->freq_base,
+            tc->freq_scale,
+            tc->ext_factor,
+            tc->attn_factor,
+            tc->beta_fast,
+            tc->beta_slow,
+            ok ? "PASS" : "FAIL");
+
+    ds4_gpu_tensor_free(kv_fused_tensor);
+    ds4_gpu_tensor_free(q_fused_tensor);
+    ds4_gpu_tensor_free(kv_ref_tensor);
+    ds4_gpu_tensor_free(q_ref_tensor);
+    ds4_gpu_tensor_free(kv);
+    ds4_gpu_tensor_free(q);
+    free(kv_fused);
+    free(kv_reference);
+    free(q_fused);
+    free(q_reference);
+    free(kv_host);
+    free(q_host);
+    return ok;
+}
+
+static int run_invalid_shape_cases(const void *model,
+                                   uint64_t model_size,
+                                   uint64_t q_weight_offset,
+                                   uint64_t kv_weight_offset) {
+    const uint32_t rows = 2u;
+    const uint64_t q_bytes = (uint64_t)rows * Q_N * sizeof(float);
+    const uint64_t kv_bytes = (uint64_t)rows * KV_N * sizeof(float);
+    ds4_gpu_tensor *q = ds4_gpu_tensor_alloc(q_bytes);
+    ds4_gpu_tensor *kv = ds4_gpu_tensor_alloc(kv_bytes);
+    ds4_gpu_tensor *q_out = ds4_gpu_tensor_alloc(q_bytes);
+    ds4_gpu_tensor *kv_out = ds4_gpu_tensor_alloc(kv_bytes);
+    ds4_gpu_tensor *short_q_out = ds4_gpu_tensor_alloc(q_bytes - sizeof(float));
+    int ok = q && kv && q_out && kv_out && short_q_out;
+
+#define EXPECT_REJECT(label, call) do { \
+        const int accepted = (call); \
+        if (accepted) { \
+            fprintf(stderr, "ROCm QKV fusion invalid case accepted: %s\n", label); \
+            ok = 0; \
+        } \
+    } while (0)
+
+    if (ok) {
+        EXPECT_REJECT("KV head product mismatch",
+            ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(
+                q_out, q, model, model_size, q_weight_offset, Q_N,
+                kv_out, kv, kv_weight_offset, KV_N, rows,
+                3u, 170u, 64u, 17u, 0u, false,
+                10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f, 1.0e-6f));
+        EXPECT_REJECT("odd rotation width",
+            ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(
+                q_out, q, model, model_size, q_weight_offset, Q_N,
+                kv_out, kv, kv_weight_offset, KV_N, rows,
+                1u, KV_N, 63u, 17u, 0u, false,
+                10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f, 1.0e-6f));
+        EXPECT_REJECT("rotation wider than head",
+            ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(
+                q_out, q, model, model_size, q_weight_offset, Q_N,
+                kv_out, kv, kv_weight_offset, KV_N, rows,
+                1u, KV_N, KV_N + 2u, 17u, 0u, false,
+                10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f, 1.0e-6f));
+        EXPECT_REJECT("zero head count",
+            ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(
+                q_out, q, model, model_size, q_weight_offset, Q_N,
+                kv_out, kv, kv_weight_offset, KV_N, rows,
+                0u, KV_N, 64u, 17u, 0u, false,
+                10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f, 1.0e-6f));
+        EXPECT_REJECT("zero Q width",
+            ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(
+                q_out, q, model, model_size, q_weight_offset, 0u,
+                kv_out, kv, kv_weight_offset, KV_N, rows,
+                1u, KV_N, 64u, 17u, 0u, false,
+                10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f, 1.0e-6f));
+        EXPECT_REJECT("undersized Q output",
+            ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(
+                short_q_out, q, model, model_size, q_weight_offset, Q_N,
+                kv_out, kv, kv_weight_offset, KV_N, rows,
+                1u, KV_N, 64u, 17u, 0u, false,
+                10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f, 1.0e-6f));
+        EXPECT_REJECT("Q weight range overflow",
+            ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(
+                q_out, q, model, model_size, model_size - sizeof(float), Q_N,
+                kv_out, kv, kv_weight_offset, KV_N, rows,
+                1u, KV_N, 64u, 17u, 0u, false,
+                10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f, 1.0e-6f));
+
+        const int zero_rows_ok =
+            ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(
+                q_out, q, model, model_size, q_weight_offset, Q_N,
+                kv_out, kv, kv_weight_offset, KV_N, 0u,
+                1u, KV_N, 64u, 17u, 0u, false,
+                10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f, 1.0e-6f);
+        if (!zero_rows_ok) {
+            fprintf(stderr, "ROCm QKV fusion rejected valid zero-row no-op\n");
+            ok = 0;
+        }
+    }
+
+#undef EXPECT_REJECT
+
+    /* Drain any launch if a rejection regresses before releasing tensors. */
+    if (ds4_gpu_end_commands() == 0) ok = 0;
+    ds4_gpu_tensor_free(short_q_out);
+    ds4_gpu_tensor_free(kv_out);
+    ds4_gpu_tensor_free(q_out);
+    ds4_gpu_tensor_free(kv);
+    ds4_gpu_tensor_free(q);
+    fprintf(stderr, "ROCm QKV fusion invalid shapes: %s\n", ok ? "PASS" : "FAIL");
+    return ok;
+}
+
+int main(void) {
+    const float compressed_scale = 1.0f / 16.0f;
+    const float compressed_attn =
+        1.0f / (1.0f + 0.1f * logf(1.0f / compressed_scale));
+    const fusion_case cases[] = {
+        { "dense-single", 1u, 1u, KV_N, 64u, 17u, 0u, false,
+          10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f },
+        { "dense-inverse-multi", 4u, 2u, KV_N / 2u, 64u, 4093u, 0u, true,
+          10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f },
+        { "dense-high-position", 2u, 1u, KV_N, 64u, 70000u, 0u, false,
+          10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f },
+        { "scaled-no-yarn", 2u, 1u, KV_N, 64u, 70000u, 0u, false,
+          10000.0f, compressed_scale, 0.0f, 1.0f, 32.0f, 1.0f },
+        { "ext-unity-scale", 2u, 1u, KV_N, 64u, 70000u, 65536u, false,
+          10000.0f, 1.0f, 1.0f, 1.0f, 32.0f, 1.0f },
+        /* corr0 is clamped to zero, so pair zero's ramp is necessarily one.
+         * Oversized equal betas make corr1 negative and every later pair's
+         * ramp exactly zero, the closest realizable uniform-zero control. */
+        { "yarn-zero-ramp", 2u, 1u, KV_N, 64u, 70000u, 65536u, false,
+          10000.0f, compressed_scale, 1.0f, compressed_attn,
+          65536.0f, 65536.0f },
+        { "yarn-low-position", 2u, 1u, KV_N, 64u, 17u, 65536u, false,
+          10000.0f, compressed_scale, 1.0f, compressed_attn, 32.0f, 1.0f },
+        { "yarn-multi", 3u, 1u, KV_N, 64u, 65520u, 65536u, false,
+          10000.0f, compressed_scale, 1.0f, compressed_attn, 32.0f, 1.0f },
+        { "yarn-inverse-multi", 7u, 2u, KV_N / 2u, 64u, 70000u, 65536u, true,
+          10000.0f, compressed_scale, 1.0f, compressed_attn, 32.0f, 1.0f },
+        /* One 512-wide rotated tail is exactly 256 pairs, so this case must
+         * remain on the fused launch.  The following 514-wide tail is 257
+         * pairs and therefore exercises the two-launch host fallback. */
+        { "rope-pairs-256-boundary", 3u, 1u, KV_N, 512u, 65520u, 65536u, false,
+          10000.0f, compressed_scale, 1.0f, compressed_attn, 32.0f, 1.0f },
+        { "rope-pairs-257-fallback", 3u, 1u, KV_N, 514u, 65520u, 65536u, false,
+          10000.0f, compressed_scale, 1.0f, compressed_attn, 32.0f, 1.0f },
+        { "norm-only", 2u, 4u, KV_N / 4u, 0u, 0u, 0u, false,
+          10000.0f, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f },
+    };
+    const uint64_t q_weight_bytes = (uint64_t)Q_N * sizeof(float);
+    const uint64_t kv_weight_bytes = (uint64_t)KV_N * sizeof(float);
+    const uint64_t q_weight_offset = 0u;
+    const uint64_t kv_weight_offset = align_up(q_weight_bytes, 4096u);
+    const uint64_t model_size =
+        align_up(kv_weight_offset + kv_weight_bytes, 4096u);
+    FILE *model_file = NULL;
+    void *model = MAP_FAILED;
+    int initialized = 0;
+    int ok = 1;
+
+    model_file = tmpfile();
+    if (model_file &&
+        ftruncate(fileno(model_file), (off_t)model_size) == 0) {
+        model = mmap(NULL, (size_t)model_size, PROT_READ | PROT_WRITE,
+                     MAP_SHARED, fileno(model_file), 0);
+    }
+    if (!model_file || model == MAP_FAILED) {
+        fprintf(stderr, "ROCm QKV fusion model-map allocation failed\n");
+        ok = 0;
+        goto cleanup;
+    }
+    memset(model, 0, (size_t)model_size);
+    float *q_weight = (float *)((uint8_t *)model + q_weight_offset);
+    float *kv_weight = (float *)((uint8_t *)model + kv_weight_offset);
+    for (uint32_t i = 0; i < Q_N; i++) {
+        q_weight[i] = 0.75f + (float)((int32_t)(i % 29u) - 14) / 128.0f;
+    }
+    for (uint32_t i = 0; i < KV_N; i++) {
+        kv_weight[i] = 0.875f + (float)((int32_t)(i % 23u) - 11) / 96.0f;
+    }
+    if (msync(model, (size_t)model_size, MS_SYNC) != 0) {
+        fprintf(stderr, "ROCm QKV fusion model-map sync failed\n");
+        ok = 0;
+        goto cleanup;
+    }
+
+    ok = ds4_gpu_init();
+    initialized = ok;
+    if (!ok) {
+        fprintf(stderr, "ROCm QKV fusion ds4_gpu_init failed\n");
+        goto cleanup;
+    }
+    ds4_gpu_set_quality(false);
+    ds4_gpu_set_ssd_streaming(false);
+    const uint64_t model_offsets[] = {
+        q_weight_offset, kv_weight_offset,
+    };
+    const uint64_t model_sizes[] = {
+        q_weight_bytes, kv_weight_bytes,
+    };
+    ok = ds4_gpu_set_model_map(model, model_size) &&
+         ds4_gpu_set_model_fd(fileno(model_file)) &&
+         ds4_gpu_set_model_map_spans(
+             model, model_size, model_offsets, model_sizes,
+             sizeof(model_offsets) / sizeof(model_offsets[0]),
+             q_weight_bytes);
+    if (!ok) {
+        fprintf(stderr, "ROCm QKV fusion model cache setup failed\n");
+        goto cleanup;
+    }
+
+    for (uint32_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        if (!run_case(&cases[i], i, model, model_size,
+                      q_weight_offset, kv_weight_offset)) {
+            ok = 0;
+        }
+    }
+    if (!run_invalid_shape_cases(model, model_size,
+                                 q_weight_offset, kv_weight_offset)) {
+        ok = 0;
+    }
+
+cleanup:
+    if (initialized) {
+        ds4_gpu_set_model_fd(-1);
+        ds4_gpu_cleanup();
+    }
+    if (model != MAP_FAILED) munmap(model, (size_t)model_size);
+    if (model_file) fclose(model_file);
+    fprintf(stderr, "ROCm fused QKV RMSNorm + KV RoPE: %s\n",
+            ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## What this does

The ROCm backend implemented the "Q/KV weighted RMS normalization plus KV rotary embedding" entry point as two kernel launches. This pull request replaces the pair with a single fused kernel for shapes up to 256 rotary pairs, removing one kernel launch and its synchronization from every decoded layer.

- Shapes larger than 256 rotary pairs keep the existing two-launch path.
- Setting `DS4_ROCM_DISABLE_QKV_KV_ROPE_FUSION=1` at process start restores the two-launch path, as a diagnostic rollback.
- New differential tests cover dense, inverse, scaled, YaRN, zero-rotation, the 256-pair boundary, the 257-pair fallback, and invalid shapes. Each case is verified byte for byte against the unfused path.

The DeepSeek V4 graph and the public GPU API are unchanged: the graph already calls this entry point, whose ROCm implementation simply chained the two launches. The change is independent of expert quantization and applies to both Q4_K and MXFP4 models.

## Performance

A balanced comparison in one binary, ordered fallback → fused → fused → fallback, each arm a fresh process with a discarded warmup and 800 measured decode tokens:

- server decode: 14.5749 → 14.6032 tokens/s (+0.19%)
- sampled QKV stage time: −1.38%
- sampled total GPU stream time: −0.22%

Both paired comparisons favored the fused kernel. The gain is small because this stage is a small share of decode time; the point of the change is removing a launch per decoded layer without changing any output. The runs used the version-3 TCP transport, which this change does not touch. Absolute throughput was measured on an integration tree that also contains #656; the same-binary toggle isolates the fusion itself.

## Correctness

On Radeon 8060S (gfx1151):

- Warning-free ROCm builds on both test machines.
- `make HIPCC=/opt/rocm-therock/bin/hipcc test-rocm-qkv-fusion` passes all twelve positive cases and the invalid-shape cases, byte for byte.
- Full-model runs with the fusion enabled and disabled produced identical output across all 40 measured responses.
- The standalone commit also passes a warning-clean strict CPU build, and its ROCm implementation and test payload are byte-identical to the integration source that ran the full-model comparisons.

## Scope

This is a ROCm attention-launch optimization only. It does not include the MXFP4 expert kernels (#656), transport work (#820), or any batching changes.
