### PR TITLE
cuda: overlap streamed expert uploads with compute

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -20311,6 +20311,17 @@ static bool metal_graph_use_iq2_selected_async_early_commit(
 #endif
 }
 
+static bool metal_graph_streaming_async_load_requires_flush(void) {
+#if defined(DS4_ROCM_BUILD) || defined(__APPLE__) || defined(DS4_NO_GPU)
+    return true;
+#else
+    /* CUDA launches are already submitted to the decode stream. The ready
+     * event orders the upload stream, so a device-wide flush here would
+     * serialize the shared expert with the selected upload. */
+    return false;
+#endif
+}
+
 static bool metal_graph_use_pro_q4_expert_table_auto(const ds4_gpu_graph *g) {
     if (getenv("DS4_METAL_DISABLE_PRO_Q4_EXPERT_TABLE_AUTO") != NULL ||
         getenv("DS4_METAL_DISABLE_Q4_EXPERT_TABLE") != NULL) {
@@ -23889,7 +23900,8 @@ static bool metal_graph_encode_decode_layer_phase(
                                                        down_expert_bytes);
             async_load_started = ok;
         }
-        if (ok && async_early_commit) {
+        if (ok && async_early_commit &&
+            metal_graph_streaming_async_load_requires_flush()) {
             ok = ds4_gpu_flush_commands() != 0;
         }
         if (ok && fuse_shared_gate_up) {
@@ -23934,7 +23946,9 @@ static bool metal_graph_encode_decode_layer_phase(
         }
         DS4_METAL_PROFILE_DECODE_STAGE("shared_down");
         if (async_load_started) {
-            const bool flush_ok = ds4_gpu_flush_commands() != 0;
+            const bool flush_ok =
+                !metal_graph_streaming_async_load_requires_flush() ||
+                ds4_gpu_flush_commands() != 0;
             bool finish_ok =
                 metal_graph_selected_async_load_finish(&async_load);
             if (!finish_ok && async_load.ids_ok) {
@@ -40802,7 +40816,8 @@ static bool glm_graph_encode_sparse_ffn_one(
                 stream_t0 = glm_graph_streaming_async_profile_ms();
             }
 #ifndef DS4_ROCM_BUILD
-            if (ok && async_load_started) {
+            if (ok && async_load_started &&
+                metal_graph_streaming_async_load_requires_flush()) {
                 ok = ds4_gpu_flush_commands() != 0;
             }
 #endif
@@ -40875,7 +40890,9 @@ static bool glm_graph_encode_sparse_ffn_one(
     if (async_load_started) {
         bool flush_ok = true;
 #ifndef DS4_ROCM_BUILD
-        flush_ok = ds4_gpu_flush_commands() != 0;
+        if (metal_graph_streaming_async_load_requires_flush()) {
+            flush_ok = ds4_gpu_flush_commands() != 0;
+        }
 #endif
         if (async_profile) {
             g_glm_streaming_async_profile.async_flush_shared_ms +=

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -99,6 +99,8 @@ static int g_model_direct_fd = -1;
 static uint64_t g_model_direct_align = 1;
 static uint64_t g_model_file_size;
 static int g_model_cache_full;
+static uint64_t g_model_default_cache_limit;
+static int g_model_default_cache_limit_computed;
 static cudaStream_t g_model_prefetch_stream;
 static cudaStream_t g_model_upload_stream;
 static int g_cublas_ready;
@@ -703,13 +705,15 @@ static const char *cuda_model_ptr(const void *model_map, uint64_t offset) {
 static const char *cuda_model_range_ptr(const void *model_map, uint64_t offset, uint64_t bytes, const char *what) {
     if (bytes == 0) return cuda_model_ptr(model_map, offset);
     if (g_model_device_owned || g_model_registered) return cuda_model_ptr(model_map, offset);
-    if (g_model_hmm_direct &&
+    if (g_model_hmm_direct && !g_ssd_streaming_mode &&
         getenv("DS4_CUDA_WEIGHT_CACHE") == NULL &&
         getenv("DS4_CUDA_WEIGHT_PRELOAD") == NULL) {
         return cuda_model_ptr(model_map, offset);
     }
     const char *direct_env = getenv("DS4_CUDA_DIRECT_MODEL");
-    if (direct_env && direct_env[0]) return cuda_model_ptr(model_map, offset);
+    if (direct_env && direct_env[0] && !g_ssd_streaming_mode) {
+        return cuda_model_ptr(model_map, offset);
+    }
 
     const uint64_t end = offset + bytes;
     auto exact = g_model_range_by_offset.find(offset);
@@ -733,6 +737,15 @@ static const char *cuda_model_range_ptr(const void *model_map, uint64_t offset, 
     if (getenv("DS4_CUDA_NO_FD_CACHE") == NULL) {
         const char *fd_ptr = cuda_model_range_ptr_from_fd(model_map, offset, bytes, what);
         if (fd_ptr) return fd_ptr;
+    }
+
+    if (g_ssd_streaming_mode) {
+        if (getenv("DS4_CUDA_WEIGHT_CACHE_VERBOSE")) {
+            fprintf(stderr,
+                    "ds4: CUDA SSD streaming has no bounded device range for %s\n",
+                    what ? what : "weights");
+        }
+        return NULL;
     }
 
     cudaError_t err = cudaSuccess;
@@ -1893,6 +1906,7 @@ static void cuda_model_load_progress_note(uint64_t cached_bytes) {
 
 static int cuda_model_prefetch_range(const void *model_map, uint64_t model_size, uint64_t map_offset, uint64_t map_size) {
     if (!model_map || map_size == 0 || map_offset > model_size || map_size > model_size - map_offset) return 0;
+    if (g_ssd_streaming_mode) return 0;
     if (getenv("DS4_CUDA_NO_MODEL_PREFETCH") != NULL ||
         getenv("DS4_CUDA_COPY_MODEL") != NULL ||
         getenv("DS4_CUDA_WEIGHT_CACHE") != NULL ||
@@ -2289,8 +2303,35 @@ static uint64_t cuda_model_cache_limit_bytes(void) {
         unsigned long long v = strtoull(env, &end, 10);
         if (end != env) gb = (uint64_t)v;
     }
-    if (gb == 0) return UINT64_MAX;
-    return gb * 1073741824ull;
+    if (gb > 0) return gb * 1073741824ull;
+
+    if (!g_model_default_cache_limit_computed) {
+        g_model_default_cache_limit_computed = 1;
+        const uint64_t free_now = ds4_gpu_tier_free_vram(0);
+        if (free_now > 0) {
+            const uint64_t ceiling = (free_now / 100ull) * 92ull;
+            const uint64_t guard_pct = (free_now / 100ull) * 8ull;
+            const uint64_t guard_min = 1536ull * 1024ull * 1024ull;
+            const uint64_t guard = guard_pct > guard_min ? guard_pct : guard_min;
+            g_model_default_cache_limit = ceiling > guard ? ceiling - guard : 0;
+            if (getenv("DS4_CUDA_WEIGHT_CACHE_VERBOSE")) {
+                fprintf(stderr,
+                        "ds4: CUDA generic weight cache budget free=%.2f GiB "
+                        "ceiling=%.2f GiB guard=%.2f GiB limit=%.2f GiB\n",
+                        (double)free_now / 1073741824.0,
+                        (double)ceiling / 1073741824.0,
+                        (double)guard / 1073741824.0,
+                        (double)g_model_default_cache_limit / 1073741824.0);
+            }
+        }
+    }
+    return g_model_default_cache_limit > 0 ? g_model_default_cache_limit :
+        (g_ssd_streaming_mode ? 0 : UINT64_MAX);
+}
+
+static void cuda_model_cache_limit_reset(void) {
+    g_model_default_cache_limit = 0;
+    g_model_default_cache_limit_computed = 0;
 }
 
 static uint64_t cuda_model_arena_chunk_bytes(uint64_t need) {
@@ -2367,12 +2408,28 @@ static const char *cuda_model_range_ptr_from_fd(
                     (double)bytes / 1048576.0,
                     (double)limit / 1073741824.0);
         }
+        if (g_ssd_streaming_mode) {
+            fprintf(stderr,
+                    "ds4: CUDA SSD streaming refused host fallback for %s; "
+                    "device weight cache budget is exhausted (%.2f GiB)\n",
+                    what ? what : "weights",
+                    (double)limit / 1073741824.0);
+            return NULL;
+        }
         return cuda_model_ptr(model_map, offset);
     }
 
     char *dev = cuda_model_arena_alloc(bytes, what);
     if (!dev) {
-        if (getenv("DS4_CUDA_STRICT_WEIGHT_CACHE") != NULL) return NULL;
+        if (getenv("DS4_CUDA_STRICT_WEIGHT_CACHE") != NULL || g_ssd_streaming_mode) {
+            if (g_ssd_streaming_mode) {
+                fprintf(stderr,
+                        "ds4: CUDA SSD streaming refused host fallback for %s "
+                        "after device cache allocation failed\n",
+                        what ? what : "weights");
+            }
+            return NULL;
+        }
         return cuda_model_ptr(model_map, offset);
     }
     cudaError_t err = cudaSuccess;
@@ -2450,6 +2507,7 @@ static const char *cuda_model_range_ptr_from_fd(
 
 static int cuda_model_copy_chunked(const void *model_map, uint64_t model_size, uint64_t map_offset, uint64_t map_size) {
     if (!model_map || model_size == 0 || map_offset > model_size || map_size > model_size - map_offset) return 0;
+    if (g_ssd_streaming_mode) return 0;
     if (getenv("DS4_CUDA_NO_MODEL_COPY") != NULL ||
         getenv("DS4_CUDA_DIRECT_MODEL") != NULL ||
         getenv("DS4_CUDA_WEIGHT_CACHE") != NULL ||
@@ -2902,6 +2960,7 @@ extern "C" void ds4_gpu_cleanup(void) {
     g_model_direct_align = 1;
     g_model_file_size = 0;
     g_model_cache_full = 0;
+    cuda_model_cache_limit_reset();
     if (g_model_prefetch_stream) {
         (void)cudaStreamDestroy(g_model_prefetch_stream);
         g_model_prefetch_stream = NULL;
@@ -3718,12 +3777,13 @@ extern "C" int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size)
     g_model_range_mapping_supported = 1;
     g_model_hmm_direct = 0;
     g_model_cache_full = 0;
+    cuda_model_cache_limit_reset();
     if (g_model_fd >= 0 && g_model_fd_host_base == NULL) {
         g_model_fd_host_base = model_map;
     }
 
     const char *copy_env = getenv("DS4_CUDA_COPY_MODEL");
-    if (copy_env && copy_env[0]) {
+    if (copy_env && copy_env[0] && !g_ssd_streaming_mode) {
         void *dev = NULL;
         const double t0 = clock() / (double)CLOCKS_PER_SEC;
         cudaError_t err = cudaMalloc(&dev, (size_t)model_size);
@@ -3823,6 +3883,7 @@ extern "C" int ds4_gpu_register_model_map_no_copy(const void *model_map, uint64_
     g_model_range_mapping_supported = 1;
     g_model_hmm_direct = 0;
     g_model_cache_full = 0;
+    cuda_model_cache_limit_reset();
     if (g_model_fd >= 0 && g_model_fd_host_base == NULL) {
         g_model_fd_host_base = model_map;
     }
@@ -30504,6 +30565,7 @@ extern "C" void ds4_gpu_set_glm_model(bool enabled) {
 
 extern "C" void ds4_gpu_set_ssd_streaming(bool enabled) {
     g_ssd_streaming_mode = enabled ? 1 : 0;
+    cuda_model_cache_limit_reset();
     cuda_stream_selected_cache_invalidate();
     if (!g_ssd_streaming_mode) cuda_stream_selected_cache_release();
 }

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -154,6 +154,11 @@ typedef struct {
 } cuda_stream_selected_cache;
 
 static cuda_stream_selected_cache g_stream_selected_cache;
+static cudaEvent_t g_stream_selected_ready_event;
+static int g_stream_selected_ready_recorded;
+static int32_t *g_stream_selected_id_stage;
+static uint64_t g_stream_selected_id_stage_capacity;
+static cudaStream_t g_stream_selected_upload_stream;
 
 static void cuda_stream_selected_cache_invalidate(void) {
     g_stream_selected_cache.valid = 0;
@@ -163,6 +168,17 @@ static void cuda_stream_selected_cache_release(void) {
     const int tier = g_stream_selected_cache.logical_tier;
     if (tier >= 0 && tier < g_n_gpus) {
         (void)ds4_gpu_set_current_device(tier);
+    }
+    if (g_stream_selected_upload_stream) {
+        (void)cudaStreamSynchronize(g_stream_selected_upload_stream);
+    }
+    if (g_stream_selected_ready_event) {
+        if (g_stream_selected_ready_recorded) {
+            (void)cudaEventSynchronize(g_stream_selected_ready_event);
+        }
+        (void)cudaEventDestroy(g_stream_selected_ready_event);
+        g_stream_selected_ready_event = NULL;
+        g_stream_selected_ready_recorded = 0;
     }
     if (g_stream_selected_cache.gate_ptr) {
         (void)cudaFree(g_stream_selected_cache.gate_ptr);
@@ -175,6 +191,11 @@ static void cuda_stream_selected_cache_release(void) {
     }
     if (g_stream_selected_cache.slot_selected_ptr) {
         (void)cudaFree(g_stream_selected_cache.slot_selected_ptr);
+    }
+    if (g_stream_selected_id_stage) {
+        (void)cudaFreeHost(g_stream_selected_id_stage);
+        g_stream_selected_id_stage = NULL;
+        g_stream_selected_id_stage_capacity = 0;
     }
     memset(&g_stream_selected_cache, 0, sizeof(g_stream_selected_cache));
     g_stream_selected_cache.logical_tier = -1;
@@ -449,7 +470,8 @@ static void *g_stream_selected_stage_raw[4];
 static void *g_stream_selected_stage[4];
 static cudaEvent_t g_stream_selected_stage_event[4];
 static uint64_t g_stream_selected_stage_bytes;
-static cudaStream_t g_stream_selected_upload_stream;
+static uint64_t g_stream_selected_stage_next;
+static int g_stream_selected_stage_recorded[4];
 
 static int cuda_ok(cudaError_t err, const char *what);
 extern "C" void ds4_gpu_decode_graphs_invalidate(void);
@@ -2147,6 +2169,9 @@ static int cuda_model_stage_read(void *stage, uint64_t stage_bytes,
 }
 
 static void cuda_stream_selected_stage_release(void) {
+    if (g_stream_selected_upload_stream) {
+        (void)cudaStreamSynchronize(g_stream_selected_upload_stream);
+    }
     for (size_t i = 0; i < 4; i++) {
         if (g_stream_selected_stage_event[i]) {
             (void)cudaEventDestroy(g_stream_selected_stage_event[i]);
@@ -2159,6 +2184,9 @@ static void cuda_stream_selected_stage_release(void) {
         }
     }
     g_stream_selected_stage_bytes = 0;
+    g_stream_selected_stage_next = 0;
+    memset(g_stream_selected_stage_recorded, 0,
+           sizeof(g_stream_selected_stage_recorded));
     if (g_stream_selected_upload_stream) {
         (void)cudaStreamDestroy(g_stream_selected_upload_stream);
         g_stream_selected_upload_stream = NULL;
@@ -2211,6 +2239,9 @@ static int cuda_model_copy_to_device_streamed(
         uint64_t offset,
         uint64_t bytes,
         const char *what) {
+    /* Keep the upload stream live across gate/up/down tensors. The selected
+     * cache records one ready event after the complete compact table is
+     * queued, so the decode stream can consume it without a host barrier. */
     if (!dst || !model_map || offset > model_size ||
         bytes > model_size - offset) {
         return 0;
@@ -2218,25 +2249,40 @@ static int cuda_model_copy_to_device_streamed(
     if (bytes == 0) return 1;
     if (g_model_fd < 0 ||
         (g_model_fd_host_base != NULL && model_map != g_model_fd_host_base)) {
-        return cuda_ok(cudaMemcpy(dst,
-                                  (const char *)model_map + offset,
-                                  (size_t)bytes,
-                                  cudaMemcpyHostToDevice),
+        const cudaError_t err = g_stream_selected_upload_stream
+            ? cudaMemcpyAsync(dst,
+                               (const char *)model_map + offset,
+                               (size_t)bytes,
+                               cudaMemcpyHostToDevice,
+                               g_stream_selected_upload_stream)
+            : cudaMemcpy(dst,
+                          (const char *)model_map + offset,
+                          (size_t)bytes,
+                          cudaMemcpyHostToDevice);
+        return cuda_ok(err,
                        what ? what : "stream selected expert copy");
     }
 
     const uint64_t chunk = cuda_model_copy_chunk_bytes();
     const uint64_t stage_bytes =
         chunk + (g_model_direct_align > 1 ? g_model_direct_align : 1);
-    if (!cuda_stream_selected_stage_pool_alloc(stage_bytes)) return 0;
+    if (!cuda_stream_selected_stage_pool_alloc(stage_bytes)) {
+        /* Pinned host memory is an optimization, not a correctness
+         * prerequisite. Keep the compact device cache usable if the host
+         * cannot provide the staging pool. */
+        return cuda_ok(cudaMemcpy(dst,
+                                  (const char *)model_map + offset,
+                                  (size_t)bytes,
+                                  cudaMemcpyHostToDevice),
+                       what ? what : "stream selected expert sync fallback");
+    }
 
     uint64_t copied = 0;
-    uint64_t chunk_idx = 0;
     while (copied < bytes) {
         const uint64_t n = bytes - copied < chunk ? bytes - copied : chunk;
-        const uint64_t bi = chunk_idx % 4u;
+        const uint32_t bi = (uint32_t)(g_stream_selected_stage_next & 3u);
         cudaError_t err;
-        if (chunk_idx >= 4u) {
+        if (g_stream_selected_stage_recorded[bi]) {
             err = cudaEventSynchronize(g_stream_selected_stage_event[bi]);
             if (err != cudaSuccess) {
                 fprintf(stderr,
@@ -2276,23 +2322,65 @@ static int cuda_model_copy_to_device_streamed(
             (void)cudaGetLastError();
             return 0;
         }
+        g_stream_selected_stage_recorded[bi] = 1;
+        g_stream_selected_stage_next++;
         cuda_model_drop_file_pages(offset + copied, n);
         cuda_model_discard_source_pages(model_map, model_size,
                                         offset + copied, n);
         copied += n;
-        chunk_idx++;
     }
+    return 1;
+}
 
-    const cudaError_t err =
-        cudaStreamSynchronize(g_stream_selected_upload_stream);
+static int cuda_stream_selected_ready_event_ensure(void) {
+    if (g_stream_selected_ready_event) return 1;
+    const cudaError_t err = cudaEventCreateWithFlags(
+            &g_stream_selected_ready_event, cudaEventDisableTiming);
     if (err != cudaSuccess) {
         fprintf(stderr,
-                "ds4: CUDA streaming selected upload sync failed for %s: %s\n",
-                what ? what : "expert", cudaGetErrorString(err));
+                "ds4: CUDA streaming selected ready event creation failed: %s\n",
+                cudaGetErrorString(err));
         (void)cudaGetLastError();
         return 0;
     }
     return 1;
+}
+
+static int cuda_stream_selected_id_stage_ensure(uint64_t count) {
+    if (count == 0 || count > UINT64_MAX / sizeof(int32_t)) return 0;
+    if (g_stream_selected_id_stage &&
+        g_stream_selected_id_stage_capacity >= count) {
+        return 1;
+    }
+    if (g_stream_selected_id_stage) {
+        (void)cudaFreeHost(g_stream_selected_id_stage);
+        g_stream_selected_id_stage = NULL;
+        g_stream_selected_id_stage_capacity = 0;
+    }
+    void *ptr = NULL;
+    const cudaError_t err = cudaMallocHost(
+            &ptr, (size_t)(count * sizeof(int32_t)));
+    if (err != cudaSuccess) {
+        fprintf(stderr,
+                "ds4: CUDA streaming selected-id staging allocation failed: %s\n",
+                cudaGetErrorString(err));
+        (void)cudaGetLastError();
+        return 0;
+    }
+    g_stream_selected_id_stage = (int32_t *)ptr;
+    g_stream_selected_id_stage_capacity = count;
+    return 1;
+}
+
+static int cuda_stream_selected_cache_wait_ready(cudaStream_t stream) {
+    if (!g_stream_selected_ready_event ||
+        !g_stream_selected_ready_recorded) {
+        return 1;
+    }
+    return cuda_ok(cudaStreamWaitEvent(stream,
+                                       g_stream_selected_ready_event,
+                                       0),
+                   "stream selected expert ready wait");
 }
 
 static uint64_t cuda_model_cache_limit_bytes(void) {
@@ -23785,6 +23873,13 @@ static int routed_moe_launch(
             return 0;
         }
 
+        const cudaStream_t stream =
+            n_tokens == 1u ? cuda_decode_stream() : (cudaStream_t)0;
+        if (use_stream_selected_cache &&
+            !cuda_stream_selected_cache_wait_ready(stream)) {
+            return 0;
+        }
+
         const ds4_gpu_tensor *mx_selected = use_stream_selected_cache ?
             &g_stream_selected_cache.slot_selected_tensor : selected;
         const uint32_t weight_experts = use_stream_selected_cache ?
@@ -23803,8 +23898,6 @@ static int routed_moe_launch(
                                     logical_tier, "mxfp4 moe down");
         if (!gate_w || !up_w || !down_w || weight_experts == 0u) return 0;
 
-        const cudaStream_t stream =
-            n_tokens == 1u ? cuda_decode_stream() : (cudaStream_t)0;
         int rc = -1;
         if (n_tokens == 1u && n_expert == 6u) {
             rc = ds4_mmq_mxfp4_moe_gate_up_mid_vec(
@@ -23883,17 +23976,61 @@ static int routed_moe_launch(
         const uint64_t gate_total = (uint64_t)n_total_expert * gate_expert_bytes;
         const uint64_t down_total = (uint64_t)n_total_expert * down_expert_bytes;
         const int mmq_tier = ds4_tensor_device_idx(out);
-        const char *gate_w = cuda_resolve_weight_ptr(model_map, gate_offset, gate_total, mmq_tier, "moe gate mmq");
-        const char *up_w = gate_w ? cuda_resolve_weight_ptr(model_map, up_offset, gate_total, mmq_tier, "moe up mmq") : NULL;
-        const char *down_w = up_w ? cuda_resolve_weight_ptr(model_map, down_offset, down_total, mmq_tier, "moe down mmq") : NULL;
+        const uint64_t required_slot_count = (uint64_t)n_tokens * n_expert;
+        const int use_stream_selected_cache =
+            allow_streaming &&
+            g_ssd_streaming_mode &&
+            g_stream_selected_cache.valid &&
+            g_stream_selected_cache.logical_tier == mmq_tier &&
+            g_stream_selected_cache.model_map == model_map &&
+            g_stream_selected_cache.layer == layer_index &&
+            g_stream_selected_cache.n_total_expert == n_total_expert &&
+            g_stream_selected_cache.slot_count >= required_slot_count &&
+            g_stream_selected_cache.gate_offset == gate_offset &&
+            g_stream_selected_cache.up_offset == up_offset &&
+            g_stream_selected_cache.down_offset == down_offset &&
+            g_stream_selected_cache.gate_expert_bytes == gate_expert_bytes &&
+            g_stream_selected_cache.down_expert_bytes == down_expert_bytes &&
+            g_stream_selected_cache.gate_ptr &&
+            g_stream_selected_cache.up_ptr &&
+            g_stream_selected_cache.down_ptr &&
+            g_stream_selected_cache.slot_selected_tensor.ptr &&
+            g_stream_selected_cache.slot_selected_tensor.bytes >=
+                required_slot_count * sizeof(int32_t);
+        if (use_stream_selected_cache &&
+            !cuda_stream_selected_cache_wait_ready((cudaStream_t)0)) {
+            return 0;
+        }
+        const ds4_gpu_tensor *mmq_selected = use_stream_selected_cache
+            ? &g_stream_selected_cache.slot_selected_tensor
+            : selected;
+        const uint32_t mmq_expert_count = use_stream_selected_cache
+            ? g_stream_selected_cache.compact_count
+            : n_total_expert;
+        const char *gate_w = use_stream_selected_cache
+            ? g_stream_selected_cache.gate_ptr
+            : cuda_resolve_weight_ptr(model_map, gate_offset, gate_total,
+                                      mmq_tier, "moe gate mmq");
+        const char *up_w = gate_w
+            ? (use_stream_selected_cache
+                   ? g_stream_selected_cache.up_ptr
+                   : cuda_resolve_weight_ptr(model_map, up_offset, gate_total,
+                                             mmq_tier, "moe up mmq"))
+            : NULL;
+        const char *down_w = up_w
+            ? (use_stream_selected_cache
+                   ? g_stream_selected_cache.down_ptr
+                   : cuda_resolve_weight_ptr(model_map, down_offset, down_total,
+                                             mmq_tier, "moe down mmq"))
+            : NULL;
         if (down_w) {
             const uint64_t n_assignments = (uint64_t)n_tokens * n_expert;
             int rc = ds4_mmq_iq2_xxs_moe_pair(
                     gate_w, up_w, (const float *)x->ptr,
-                    (const int32_t *)selected->ptr,
+                    (const int32_t *)mmq_selected->ptr,
                     (float *)gate->ptr, (float *)up->ptr,
                     (int)expert_mid_dim, (int)expert_in_dim,
-                    (int)n_tokens, (int)n_total_expert, (int)n_expert,
+                    (int)n_tokens, (int)mmq_expert_count, (int)n_expert,
                     (cudaStream_t)0);
             if (rc == 0) {
                 const uint64_t mid_floats = n_assignments * expert_mid_dim;
@@ -23907,10 +24044,10 @@ static int routed_moe_launch(
             if (rc == 0) {
                 rc = ds4_mmq_q2_K_moe(
                         down_w, (const float *)mid->ptr,
-                        (const int32_t *)selected->ptr,
+                        (const int32_t *)mmq_selected->ptr,
                         (float *)down->ptr,
                         (int)out_dim, (int)expert_mid_dim,
-                        (int)n_assignments, (int)n_total_expert,
+                        (int)n_assignments, (int)mmq_expert_count,
                         /*n_expert_used=*/1,
                         (cudaStream_t)0);
             }
@@ -23976,6 +24113,11 @@ static int routed_moe_launch(
         fprintf(stderr,
                 "ds4: CUDA streaming selected experts are unavailable for layer %u\n",
                 layer_index);
+        return 0;
+    }
+    if (use_stream_selected_cache &&
+        !cuda_stream_selected_cache_wait_ready(
+            n_tokens == 1u ? cuda_decode_stream() : (cudaStream_t)0)) {
         return 0;
     }
     if (use_stream_selected_cache) {
@@ -26157,6 +26299,13 @@ static int cuda_stream_selected_cache_begin_load(
                 "ds4: CUDA SSD streaming requires single-GPU placement\n");
         return 0;
     }
+    if (g_stream_selected_ready_event && g_stream_selected_ready_recorded) {
+        if (!cuda_ok(cudaEventSynchronize(g_stream_selected_ready_event),
+                     "stream selected expert previous load wait")) {
+            return 0;
+        }
+        g_stream_selected_ready_recorded = 0;
+    }
 
     std::vector<int32_t> expert_to_slot;
     std::vector<int32_t> compact_ids;
@@ -26248,11 +26397,46 @@ static int cuda_stream_selected_cache_begin_load(
             return 0;
         }
     }
-    if (!cuda_ok(cudaMemcpy(g_stream_selected_cache.slot_selected_ptr,
-                            slot_ids.data(),
-                            (size_t)slot_count * sizeof(int32_t),
-                            cudaMemcpyHostToDevice),
-                 "stream selected-id remap copy")) {
+    if (g_stream_selected_upload_stream) {
+        const uint64_t selected_bytes =
+            (uint64_t)slot_count * sizeof(int32_t);
+        int async_ready = 0;
+        if (cuda_stream_selected_id_stage_ensure(slot_count) &&
+            cuda_stream_selected_ready_event_ensure()) {
+            memcpy(g_stream_selected_id_stage, slot_ids.data(),
+                   (size_t)selected_bytes);
+            async_ready = cuda_ok(cudaMemcpyAsync(
+                                      g_stream_selected_cache.slot_selected_ptr,
+                                      g_stream_selected_id_stage,
+                                      (size_t)selected_bytes,
+                                      cudaMemcpyHostToDevice,
+                                      g_stream_selected_upload_stream),
+                                  "stream selected-id remap copy") &&
+                          cuda_ok(cudaEventRecord(
+                                      g_stream_selected_ready_event,
+                                      g_stream_selected_upload_stream),
+                                  "stream selected expert ready record");
+        }
+        if (!async_ready) {
+            if (!cuda_ok(cudaStreamSynchronize(g_stream_selected_upload_stream),
+                         "stream selected expert synchronous fallback wait") ||
+                !cuda_ok(cudaMemcpy(g_stream_selected_cache.slot_selected_ptr,
+                                    slot_ids.data(),
+                                    (size_t)selected_bytes,
+                                    cudaMemcpyHostToDevice),
+                         "stream selected-id remap fallback copy")) {
+                cuda_stream_selected_cache_invalidate();
+                return 0;
+            }
+            g_stream_selected_ready_recorded = 0;
+        } else {
+            g_stream_selected_ready_recorded = 1;
+        }
+    } else if (!cuda_ok(cudaMemcpy(g_stream_selected_cache.slot_selected_ptr,
+                                   slot_ids.data(),
+                                   (size_t)slot_count * sizeof(int32_t),
+                                   cudaMemcpyHostToDevice),
+                      "stream selected-id remap copy")) {
         cuda_stream_selected_cache_invalidate();
         return 0;
     }
@@ -30438,7 +30622,8 @@ extern "C" int ds4_gpu_shared_mid_swiglu_q8_0_tensor(
 
 extern "C" int ds4_gpu_signal_selected_readback_ready(uint64_t *event_value) {
     if (event_value) *event_value = 1;
-    return cuda_ok(cudaDeviceSynchronize(), "selected readback signal");
+    return cuda_ok(cudaStreamSynchronize(cuda_decode_stream()),
+                   "selected readback signal");
 }
 
 extern "C" int ds4_gpu_stream_expert_cache_begin_selected_load(
@@ -30495,7 +30680,7 @@ extern "C" int ds4_gpu_tensor_read_after_selected_event(const ds4_gpu_tensor *te
         bytes > tensor->bytes - offset) {
         return 0;
     }
-    if (!cuda_ok(cudaDeviceSynchronize(),
+    if (!cuda_ok(cudaStreamSynchronize(cuda_decode_stream()),
                  label ? label : "selected readback wait")) {
         return 0;
     }
@@ -30523,7 +30708,7 @@ extern "C" void ds4_gpu_tp_set_attn_head_split(int enabled) {
 
 extern "C" int ds4_gpu_wait_selected_readback_ready(uint64_t event_value, const char *label) {
     (void)event_value;
-    return cuda_ok(cudaDeviceSynchronize(),
+    return cuda_ok(cudaStreamSynchronize(cuda_decode_stream()),
                    label ? label : "selected readback wait");
 }
 
@@ -30533,7 +30718,7 @@ extern "C" int ds4_gpu_wait_selected_readback_ready(uint64_t event_value, const 
 extern "C" int ds4_gpu_commit_and_wait_selected_readback(
         uint64_t event_value, const char *label) {
     (void)event_value;
-    return cuda_ok(cudaDeviceSynchronize(),
+    return cuda_ok(cudaStreamSynchronize(cuda_decode_stream()),
                    label ? label : "selected readback wait");
 }
 


### PR DESCRIPTION
Depends on #737 (the safety branch is the required base for this async path).

## Context

This change follows the SSD-streaming safety boundary in the dependent host-fallback PR. The existing DeepSeek selected-expert path copied each routed expert synchronously, leaving PCIe upload and CUDA compute serialized.

## Change

- Add a dedicated non-blocking upload stream.
- Use four pinned host staging buffers with per-buffer CUDA events so staging storage is not reused before its upload completes.
- Queue selected expert tensor copies asynchronously and record one ready event after the compact selected table is complete.
- Make the decode/default stream wait on that ready event before dispatching kernels.
- Keep pinned-allocation, stream, and event initialization failures on the synchronous path so the optimization cannot become a new correctness requirement.
- Replace device-wide flushes around the CUDA selected-expert path with stream/event ordering; ROCm, Apple, and no-GPU paths retain their existing flush behavior.

## Validation

Builds completed with no compiler warnings:

```text
make -B ds4 CUDA_HOME=/opt/cuda CUDA_ARCH=sm_86
make -B ds4 CUDA_HOME=/opt/cuda CUDA_ARCH=sm_89
```

`git diff --check` is clean. Target hardware is an RTX 4060 Ti 16 GiB (sm_89) and the workload is the DeepSeek V4 Flash 0731 IQ2XXS SSD-streamed GGUF. The CUDA device was not exposed to this coding environment, so this commit is reported as build-validated; the user's integration-branch smoke runs established the selected-expert path and its baseline throughput.

## Dependency

This branch is intentionally stacked on the SSD host-fallback safety change. Once that change is merged, this diff is the async-overlap feature alone.
