### PR TITLE
cuda: sanitize non-finite router scores

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -11830,6 +11830,19 @@ __device__ static float softplus_dev(float x) {
     return log1pf(expf(x));
 }
 
+/* Keep malformed router inputs out of the fixed-size top-k ordering. */
+__device__ __forceinline__ static float router_prob_dev(float logit) {
+    const float p = sqrtf(softplus_dev(logit));
+    return isfinite(p) ? p : 0.0f;
+}
+
+__device__ __forceinline__ static float router_bias_dev(
+        const float *bias, int has_bias, int index) {
+    if (!has_bias) return 0.0f;
+    const float value = bias[index];
+    return isfinite(value) ? value : 0.0f;
+}
+
 __global__ static void router_select_kernel(
         int32_t *selected,
         float *weights,
@@ -11850,7 +11863,7 @@ __global__ static void router_select_kernel(
     int32_t *sel = selected + (uint64_t)t * 6;
     float *w = weights + (uint64_t)t * 6;
 
-    for (int i = 0; i < 256; i++) prob[i] = sqrtf(softplus_dev(log[i]));
+    for (int i = 0; i < 256; i++) prob[i] = router_prob_dev(log[i]);
 
     if (hash_mode) {
         int32_t tok = tokens ? tokens[t] : token_scalar;
@@ -11860,9 +11873,10 @@ __global__ static void router_select_kernel(
     } else {
         for (int i = 0; i < 6; i++) sel[i] = -1;
         for (int i = 0; i < 256; i++) {
-            float score = prob[i] + (has_bias ? bias[i] : 0.0f);
+            float score = prob[i] + router_bias_dev(bias, has_bias, i);
             for (int j = 0; j < 6; j++) {
-                if (sel[j] < 0 || score > prob[sel[j]] + (has_bias ? bias[sel[j]] : 0.0f)) {
+                if (sel[j] < 0 || score > prob[sel[j]] +
+                                      router_bias_dev(bias, has_bias, sel[j])) {
                     for (int k = 5; k > j; k--) sel[k] = sel[k - 1];
                     sel[j] = i;
                     break;
@@ -11904,7 +11918,7 @@ __global__ static void router_select_parallel_kernel(
     float *w = weights + (uint64_t)t * 6;
     __shared__ float sprob[256];
 
-    const float p = sqrtf(softplus_dev(log[i]));
+    const float p = router_prob_dev(log[i]);
     sprob[i] = p;
     prob[i] = p;
     __syncthreads();
@@ -11918,9 +11932,10 @@ __global__ static void router_select_parallel_kernel(
     } else {
         for (int j = 0; j < 6; j++) sel[j] = -1;
         for (int e = 0; e < 256; e++) {
-            float score = sprob[e] + (has_bias ? bias[e] : 0.0f);
+            float score = sprob[e] + router_bias_dev(bias, has_bias, e);
             for (int j = 0; j < 6; j++) {
-                if (sel[j] < 0 || score > sprob[sel[j]] + (has_bias ? bias[sel[j]] : 0.0f)) {
+                if (sel[j] < 0 || score > sprob[sel[j]] +
+                                      router_bias_dev(bias, has_bias, sel[j])) {
                     for (int k = 5; k > j; k--) sel[k] = sel[k - 1];
                     sel[j] = e;
                     break;
@@ -11973,9 +11988,9 @@ __global__ static void router_select_warp_topk_kernel(
     #pragma unroll
     for (uint32_t j = 0; j < 8u; j++) {
         const uint32_t e = lane + j * 32u;
-        const float p = sqrtf(softplus_dev(log[e]));
+        const float p = router_prob_dev(log[e]);
         local_prob[j] = p;
-        local_score[j] = p + (has_bias ? bias[e] : 0.0f);
+        local_score[j] = p + router_bias_dev(bias, has_bias, e);
         sprob[row_in_block][e] = p;
         prob[e] = p;
     }


### PR DESCRIPTION
## Problem

The CUDA router computes probabilities and scores used by fixed-size top-k selection. A NaN or Inf in a router logit or bias can poison comparisons and leave an invalid expert selection, which later becomes an unsafe expert-tensor index.

## Change

- Centralize router probability conversion and clamp non-finite results to zero.
- Treat non-finite router bias entries as zero during score comparison.
- Apply the same guards to scalar, parallel, and warp top-k kernels.

This keeps selection deterministic and prevents malformed numeric input from becoming an invalid routed-expert address. It does not change finite-input behavior.

## Validation

Builds completed with no compiler warnings:

```text
make -B ds4 CUDA_HOME=/opt/cuda CUDA_ARCH=sm_86
make -B ds4 CUDA_HOME=/opt/cuda CUDA_ARCH=sm_89
```

`git diff --check` is clean. Target hardware is an RTX 4060 Ti 16 GiB (sm_89); the guard is independent of model quantization and applies to the CUDA DeepSeek router.
