### PR TITLE
metal: add optional polled release fence for the TP gate (~23% decode gain with `--tensor-parallel`)

### DIFF
--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -8436,6 +8436,16 @@ static NSUInteger g_tp_slab_buffer_off;
 static volatile uint32_t *g_tp_gpu_flags;   /* CPU view of the flag words */
 static uint64_t g_tp_gpu_flags_off;
 static uint64_t g_tp_seq;
+
+/* Fast release fence (DS4_METAL_FAST_SYNC=1, default off).  Resuming the
+ * command processor from g_tp_cpu_event costs ~186us of a 508us gate; spinning
+ * on a word this process writes instead removes most of it.  Row gates only;
+ * batch and big gates keep the shared event. */
+#define DS4_TP_FENCE_SLOTS 1024u            /* layer * 2 + gate, generously sized */
+static id<MTLBuffer> g_tp_release_buffer;
+static volatile uint32_t *g_tp_release_words;
+static bool g_tp_fast_sync;
+static uint32_t g_tp_fence_max_iters;
 static ds4_gpu_tp_exchange_fn g_tp_exchange_fn;
 static ds4_gpu_tp_batch_exchange_fn g_tp_batch_exchange_fn;
 static ds4_gpu_tp_big_exchange_fn g_tp_big_exchange_fn;
@@ -8605,9 +8615,19 @@ static void *ds4_gpu_tp_service_thread(void *arg) {
                         req.layer, req.gate, (unsigned long long)req.seq);
             g_tp_failed_flag = 1;
         }
-        /* Release the GPU even on failure so end_commands can drain. */
-        if (req.rows > 0) g_tp_batch_cpu_event.signaledValue = req.seq;
-        else g_tp_cpu_event.signaledValue = req.seq;
+        /* Release the GPU even on failure so end_commands can drain.  Must
+         * match what gate_encode chose; both key off the same init-fixed
+         * conditions. */
+        const uint32_t rel_slot = req.layer * 2u + req.gate;
+        if (req.rows > 0) {
+            g_tp_batch_cpu_event.signaledValue = req.seq;
+        } else if (g_tp_fast_sync && g_tp_release_words != NULL &&
+                   req.big_bytes == 0 && rel_slot < DS4_TP_FENCE_SLOTS) {
+            __atomic_store_n(&g_tp_release_words[rel_slot],
+                             (uint32_t)req.seq, __ATOMIC_RELEASE);
+        } else {
+            g_tp_cpu_event.signaledValue = req.seq;
+        }
         if (profile) {
             g_tp_stat_gpu_wait_ms += t1 - t0;
             g_tp_stat_exchange_ms += ds4_gpu_now_ms() - t1;
@@ -8640,6 +8660,29 @@ int ds4_gpu_tp_init(uint32_t rank,
      * (A/B 2026-07-06, byte-identical output).  DS4_TP_EVENT_GATES falls
      * back to the shared-event arrival path. */
     g_tp_flag_gates = g_tp_gpu_flags != NULL && getenv("DS4_TP_EVENT_GATES") == NULL;
+    /* Opt-in: relies on an undocumented Metal qualifier, so fall back to the
+     * shared event if anything is unavailable. */
+    g_tp_fast_sync = getenv("DS4_METAL_FAST_SYNC") != NULL;
+    if (g_tp_fast_sync) {
+        g_tp_fence_max_iters = (uint32_t)ds4_gpu_env_u64(
+                "DS4_TP_FENCE_MAX_ITERS", 200000000ull, 1000ull, 4000000000ull);
+        g_tp_release_buffer =
+            [g_device newBufferWithLength:DS4_TP_FENCE_SLOTS * sizeof(uint32_t)
+                                  options:MTLResourceStorageModeShared];
+        if (g_tp_release_buffer &&
+            ds4_gpu_get_pipeline("kernel_dsv4_tp_fence_wait") != nil) {
+            g_tp_release_words = (volatile uint32_t *)g_tp_release_buffer.contents;
+            memset((void *)g_tp_release_words, 0,
+                   DS4_TP_FENCE_SLOTS * sizeof(uint32_t));
+            fprintf(stderr, "ds4: TP fast release fence enabled\n");
+        } else {
+            fprintf(stderr,
+                    "ds4: TP fast release fence unavailable; using shared events\n");
+            g_tp_release_buffer = nil;
+            g_tp_release_words = NULL;
+            g_tp_fast_sync = false;
+        }
+    }
     g_tp_gpu_event = [g_device newSharedEvent];
     g_tp_cpu_event = [g_device newSharedEvent];
     g_tp_batch_gpu_event = [g_device newSharedEvent];
@@ -8703,6 +8746,9 @@ void ds4_gpu_tp_shutdown(void) {
     g_tp_split_rank = 0;
     g_tp_split_world = 1;
     g_tp_session_batch_mode = 0;
+    g_tp_release_buffer = nil;
+    g_tp_release_words = NULL;
+    g_tp_fast_sync = false;
 }
 
 void ds4_gpu_tp_suspend_expert_sharding(int suspend) {
@@ -8721,17 +8767,25 @@ int ds4_gpu_tp_gate_encode(uint32_t layer, uint32_t gate) {
         return 0;
     }
     const uint64_t seq = ++g_tp_seq;
+    const uint32_t gate_slot = layer * 2u + gate;
+    const bool fast_release =
+        g_tp_fast_sync && g_tp_release_words != NULL &&
+        gate_slot < DS4_TP_FENCE_SLOTS;
     const bool event_arrival = g_tp_session_batch_mode || !g_tp_flag_gates;
     if (!event_arrival) {
         /* Publish arrival through the slab word; the buffer hazard against
          * the partial-output kernels orders the store after the payload. */
-        const uint32_t slot = layer * 2u + gate;
+        const uint32_t slot = gate_slot;
         const uint32_t value = (uint32_t)seq;
         int owned = 0;
         id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
         if (!cb || owned) return 0;
+        /* The relaxed store is only safe because the event block that follows
+         * flushes it; under the fence nothing does, so use the scoped variant. */
         id<MTLComputePipelineState> pipeline =
-            ds4_gpu_get_pipeline("kernel_dsv4_tp_flag_set");
+            ds4_gpu_get_pipeline(fast_release ?
+                                 "kernel_dsv4_tp_flag_set_coherent" :
+                                 "kernel_dsv4_tp_flag_set");
         if (!pipeline) return 0;
         id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:pipeline];
@@ -8747,7 +8801,30 @@ int ds4_gpu_tp_gate_encode(uint32_t layer, uint32_t gate) {
         ds4_gpu_close_batch_encoder();
         [g_batch_cb encodeSignalEvent:g_tp_gpu_event value:seq];
     }
-    [g_batch_cb encodeWaitForEvent:g_tp_cpu_event value:seq];
+    if (fast_release) {
+        /* One threadgroup of one thread: two threadgroups cost 21% of a
+         * saturated GPU against 4% for one, so the shape is not tunable. */
+        const uint32_t want = (uint32_t)seq;
+        int owned = 0;
+        id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
+        if (!cb || owned) return 0;
+        id<MTLComputePipelineState> pipeline =
+            ds4_gpu_get_pipeline("kernel_dsv4_tp_fence_wait");
+        if (!pipeline) return 0;
+        id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
+        [enc setComputePipelineState:pipeline];
+        [enc setBuffer:g_tp_release_buffer
+                offset:(NSUInteger)gate_slot * sizeof(uint32_t)
+               atIndex:0];
+        [enc setBytes:&want length:sizeof(want) atIndex:1];
+        [enc setBytes:&g_tp_fence_max_iters length:sizeof(g_tp_fence_max_iters) atIndex:2];
+        [enc dispatchThreadgroups:MTLSizeMake(1, 1, 1)
+             threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
+        ds4_gpu_end_compute_encoder(cb, enc);
+        ds4_gpu_close_batch_encoder();
+    } else {
+        [g_batch_cb encodeWaitForEvent:g_tp_cpu_event value:seq];
+    }
     pthread_mutex_lock(&g_tp_mutex);
     if (g_tp_queue_count >= DS4_GPU_TP_QUEUE) {
         pthread_mutex_unlock(&g_tp_mutex);

--- a/metal/dsv4_misc.metal
+++ b/metal/dsv4_misc.metal
@@ -6368,6 +6368,49 @@ kernel void kernel_dsv4_tp_flag_set(
     }
 }
 
+// Tensor-parallel gate release fence (CPU->GPU): the GPU spins on a word the
+// service thread writes instead of blocking the command processor on a shared
+// event, whose resume costs ~186us per gate here.  After MLX ml-explore/mlx#1773.
+// coherent(system) is required for correctness -- weaker qualifiers drop
+// wakeups -- and reaching it needs the internals pragma.
+#pragma METAL internals : enable
+#ifndef __METAL_MEMORY_SCOPE_SYSTEM__
+#define __METAL_MEMORY_SCOPE_SYSTEM__ 3
+#endif
+namespace metal {
+constexpr constant metal::thread_scope thread_scope_system =
+    static_cast<thread_scope>(__METAL_MEMORY_SCOPE_SYSTEM__);
+}
+
+// Bounded so a dead peer cannot wedge the command processor into a watchdog
+// kill; the service thread writes the release even on failure.
+kernel void kernel_dsv4_tp_fence_wait(
+        volatile coherent(system) device uint * release [[buffer(0)]],
+        constant uint & value [[buffer(1)]],
+        constant uint & max_iters [[buffer(2)]]) {
+    for (uint i = 0; i < max_iters; i++) {
+        metal::atomic_thread_fence(metal::mem_flags::mem_device,
+                                   metal::memory_order_seq_cst,
+                                   metal::thread_scope_system);
+        if (release[0] >= value) {
+            return;
+        }
+    }
+}
+
+// Arrival publish for the fast-sync path.  kernel_dsv4_tp_flag_set relies on
+// the event block that follows it to flush the store; with no such stall the
+// write must carry system scope itself or the CPU spins on a stale word.
+kernel void kernel_dsv4_tp_flag_set_coherent(
+        volatile coherent(system) device uint * flag [[buffer(0)]],
+        constant uint & value [[buffer(1)]]) {
+    flag[0] = value;
+    metal::atomic_thread_fence(metal::mem_flags::mem_device,
+                               metal::memory_order_seq_cst,
+                               metal::thread_scope_system);
+}
+#pragma METAL internals : disable
+
 // Ratio-4 compressor pooling without materializing the [n_comp, 8, head_dim]
 // KV and score packs. The row mapping and both reduction loops deliberately
 // match kernel_dsv4_softmax_pool so the arithmetic order is unchanged.


### PR DESCRIPTION
This PR ports the fast cpu/gpu sync primitive in https://github.com/ml-explore/mlx/pull/1773 to ds4. With this, and setting an already existing DS4 flag to increase the GPU duty cycle, TP decode performance roughly **doubled** in my testing.

I'm leaving this opt-in because it's still off by default in MLX/exo so there seems to be some hesitancy given it's largely undocumented, but works fine in my testing. I'm not a metal eng and all credit goes to prior art in https://github.com/ml-explore/mlx/pull/1773, I've just had an LLM help port it and track down why the GPU was idle for so long during TP.

# Speedup

All testing on 2x M3 Ultra. no MTP, 1M context:

coord:
```
 DS4_TP_NO_KEEPALIVE=1 DS4_METAL_FAST_SYNC=1  ./ds4 -m ~/Downloads/DeepSeek-V4-Flash-MXFP4Experts-F16HC-F16Compressor-F16Indexer-Q8Attn-Q8Shared-Q8Out-chat-v2-mxfp4-0731.gguf --role coordinator --tensor-parallel --transport rdma  --ctx 1048576 --listen 0.0.0.0 1234  --rdma-device rdma_en7
```

worker:

```
DS4_METAL_FAST_SYNC=1 DS4_TP_NO_KEEPALIVE=1 ./ds4 -m ~/Downloads/DeepSeek-V4-Flash-MXFP4Experts-F16HC-F16Compressor-F16Indexer-Q8Attn-Q8Shared-Q8Out-chat-v2-mxfp4-0731.gguf --role worker  --coordinator 192.168.0.14 1234 --transport rdma --ctx 1048576 --tensor-parallel
```


Enabled the fast fence alone(via `DS4_METAL_FAST_SYNC=1`) results in a decode gain of ~23%
**tg2048@0 16.56t/s -> 20.44t/s**

However - by setting one other (existing)flag that drastically increase GPU util in TP we can achieve a net ~2x gain, because speedup from the fast fence is magnified:

With `DS4_TP_NO_KEEPALIVE=1` and  `DS4_METAL_FAST_SYNC=1` 
**tg2048@0 goes from ~16.56t/s(baseline TP) to 33.12t/s**     <--------------------------------------!!


DS4_TP_NO_KEEPALIVE spins a dummy kernel on the GPU for power gating reasons, but in testing it drastically reduced GPU util because while there is some pause logic to stop it from spinning while real work is happening, we don't(can't?) interrupt the spin when work arrives, so we can end up with a lot of "spin" time per token. Disabling it completely resolves that. With it off - total system draw increases by ~10W during decode, imo the strongest signal that this is problematic.

With both `DS4_TP_NO_KEEPALIVE=1` and  `DS4_METAL_FAST_SYNC=1`  - system draw goes from ~60W to 88W during decode. (Closing the gap we see vs prefill at ~115W, though I don't expect we'll reach that during decode because of the nature of the workload).

With this - TP eclipses layer parallel distributed decode tg/s in my 2 node setup(even after enabling RDMA for layer parallel in #715)

cc @antirez  - I'm making this all opt-in and not changing the default `DS4_TP_NO_KEEPALIVE` behaviour because looks like some extensive work has gone into adding it, so don't want to break an edge case I haven't run into.