### PR TITLE
dspark: opt-in fast commit on full accept, matching MTP's default Metal path

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -48380,6 +48380,25 @@ static bool ds4_dspark_scheduler_timing_enabled(void) {
            ds4_dspark_scheduler_max_extra_saved_ratio_milli() != 0;
 }
 
+/* On a full accept, the batched verify pass has already produced correct raw
+ * KV / compressor / indexer state for every drafted position -- the same
+ * batched attention path a plain (non-speculative) prefill chunk uses. MTP's
+ * default Metal path already trusts that state directly on a full accept
+ * instead of paying for a rollback and a sequential exact-kernel replay of
+ * every drafted token (see the DS4_ROCM_BUILD / prefer_decode2_exact split
+ * a few hundred lines into the MTP speculative-argmax path). This applies
+ * the same trade-off to DSpark, which currently never does.
+ *
+ * The trade-off is real, not just a performance knob: the batched kernel can
+ * differ from the exact single-token decode kernel by enough to flip a
+ * near-tied greedy token (documented on metal_graph_verify_decode2_exact),
+ * and unlike MTP this is not yet the shipped default here. Opt-in until
+ * there's more mileage on it than one contributor's benchmark. */
+static bool ds4_dspark_full_accept_fast_commit_enabled(void) {
+    const char *env = getenv("DS4_DSPARK_FULL_ACCEPT_FAST_COMMIT");
+    return env && env[0] && strcmp(env, "0") != 0;
+}
+
 static void ds4_session_dspark_scheduler_reset(ds4_session *s) {
     if (!s) return;
     s->dspark_sched_cycles = 0;
@@ -61706,6 +61725,55 @@ static int ds4_session_eval_dspark_speculative_argmax(
             if (row_tops[i - 1] != drafts[i]) break;
             commit_drafts++;
         }
+    }
+
+    /* Full accept, non-TP, opt-in: skip the rollback and the sequential
+     * exact-kernel replay below entirely and commit straight from the
+     * batched verify pass's own output, mirroring MTP's default Metal
+     * behavior on a full accept. See
+     * ds4_dspark_full_accept_fast_commit_enabled() for why this is opt-in
+     * rather than the default. TP is intentionally excluded: the worker-side
+     * commit protocol for this path has not been written or tested. */
+    if (ok && commit_drafts == draft_n && !tp_verify_sent &&
+        ds4_dspark_full_accept_fast_commit_enabled()) {
+        int full_accept_n = draft_n;
+        for (int i = 0; i < draft_n; i++) {
+            if (drafts[i] == eos_token) { full_accept_n = i + 1; break; }
+        }
+        if (metal_graph_read_spec_logits_row(&s->graph,
+                                             (uint32_t)(full_accept_n - 1),
+                                             row_logits)) {
+            memcpy(s->logits, row_logits, (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
+            for (int i = 0; i < full_accept_n && n_accept < accepted_cap; i++) {
+                accepted[n_accept++] = drafts[i];
+            }
+            s->checkpoint_valid = true;
+            ds4_session_dspark_capture_note_checkpoint(s);
+            if (stats_enabled) {
+                s->dspark_stats.full_accepts++;
+                s->dspark_stats.accepted_draft_tokens += (uint64_t)full_accept_n;
+                ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist,
+                                          (uint32_t)full_accept_n);
+            }
+            ds4_session_dspark_scheduler_note(
+                    s,
+                    (uint32_t)full_accept_n,
+                    false,
+                    DS4_DSPARK_SCHED_EXTRA_MS());
+            if (spec_log) {
+                fprintf(stderr,
+                        "ds4: DSpark spec full accept (fast commit, no replay) "
+                        "drafted=%d verified=%d accepted=%d\n",
+                        draft_n,
+                        commit_drafts,
+                        n_accept);
+            }
+            spec_frontier_free(&frontier);
+            DS4_DSPARK_STATS_FINISH();
+            return n_accept;
+        }
+        /* Row read failed (should not happen after a successful verify): fall
+         * through to the normal rollback+replay path below. */
     }
 
     /* Batch verification and ordinary decode update compressor state with

--- a/tests/dspark_fast_commit_bench.py
+++ b/tests/dspark_fast_commit_bench.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""DSpark DS4_DSPARK_FULL_ACCEPT_FAST_COMMIT benchmark.
+
+Companion to tests/dspark_acceptance_fixture.sh: that fixture asserts exact
+byte-for-byte output equality on short (32-token) generations, which the
+fast-commit flag preserves in every case tested so far. This script instead
+runs longer (~300+ token) free-running generations, where a divergence that
+starts as one flipped near-tied logit has room to compound into a visibly
+different continuation, and reports where (if anywhere) that happens.
+
+Usage:
+  DS4_DSPARK_MODEL=./ds4flash.gguf \
+  DS4_DSPARK_SUPPORT=gguf/DeepSeek-V4-Flash-DSpark-support-0731.gguf \
+  python3 tests/dspark_fast_commit_bench.py
+"""
+import os
+import re
+import subprocess
+import time
+
+DS4 = os.environ.get("DS4_BIN", "./ds4")
+MODEL = os.environ.get("DS4_DSPARK_MODEL", "./ds4flash.gguf")
+DSPARK_GGUF = os.environ.get(
+    "DS4_DSPARK_SUPPORT", "gguf/DeepSeek-V4-Flash-DSpark-support-0731.gguf")
+
+PROMPTS = {
+    "essay": "Write a 300 word essay about the history of Rome.",
+    "code": "Write a Python function that implements binary search on a "
+            "sorted list, with a docstring and type hints.",
+    "math": "Solve step by step: A train travels 120 miles in 2 hours, "
+            "then 180 miles in 3 hours. What is its average speed for the "
+            "whole trip?",
+    "dialogue": "Write a short conversation between two characters "
+                "debating whether cats or dogs make better pets.",
+}
+
+
+def run(args, env_extra=None):
+    env = os.environ.copy()
+    if env_extra:
+        env.update(env_extra)
+    t0 = time.time()
+    p = subprocess.run(args, capture_output=True, text=True, env=env,
+                        timeout=180)
+    return p.stdout + p.stderr, time.time() - t0
+
+
+def extract_text(output):
+    return "\n".join(l for l in output.splitlines()
+                      if not l.startswith("ds4:")).strip()
+
+
+def extract_speed(output):
+    m = re.search(r"generation: ([\d.]+) t/s", output)
+    return float(m.group(1)) if m else None
+
+
+def extract_stats(output):
+    m = re.search(r"ds4: DSpark stats (.+)", output)
+    return m.group(1) if m else None
+
+
+def word_divergence(baseline, candidate):
+    bw, cw = baseline.split(), candidate.split()
+    for i in range(min(len(bw), len(cw))):
+        if bw[i] != cw[i]:
+            return i, bw[i], cw[i]
+    if len(bw) != len(cw):
+        return min(len(bw), len(cw)), "<end>", "<end>"
+    return None, None, None
+
+
+def main():
+    if not os.path.isfile(MODEL):
+        print(f"skipped: missing model {MODEL}")
+        return
+    if not os.path.isfile(DSPARK_GGUF):
+        print(f"skipped: missing DSpark support model {DSPARK_GGUF}")
+        return
+
+    results = {}
+    for name, prompt in PROMPTS.items():
+        print(f"=== {name} ===", flush=True)
+        common = [DS4, "--model", MODEL, "--temp", "0", "--metal",
+                  "--ctx", "8192", "--nothink", "-p", prompt]
+
+        out, wall = run(common)
+        baseline_text = extract_text(out)
+        baseline_speed = extract_speed(out)
+        print(f"  baseline:        {baseline_speed} t/s ({wall:.1f}s wall)")
+
+        dspark_common = [DS4, "--model", MODEL, "--mtp", DSPARK_GGUF,
+                          "--dspark", "--mtp-draft", "2", "--temp", "0",
+                          "--metal", "--ctx", "8192", "--nothink",
+                          "-p", prompt]
+
+        out, wall = run(dspark_common, {"DS4_DSPARK_STATS": "1"})
+        off_text = extract_text(out)
+        off_speed = extract_speed(out)
+        off_stats = extract_stats(out)
+        off_div = word_divergence(baseline_text, off_text)
+        print(f"  dspark flag-off: {off_speed} t/s ({wall:.1f}s wall) "
+              f"diverges_at_word={off_div[0]}")
+
+        out, wall = run(dspark_common, {
+            "DS4_DSPARK_STATS": "1",
+            "DS4_DSPARK_FULL_ACCEPT_FAST_COMMIT": "1",
+        })
+        on_text = extract_text(out)
+        on_speed = extract_speed(out)
+        on_stats = extract_stats(out)
+        on_div = word_divergence(baseline_text, on_text)
+        print(f"  dspark flag-on:  {on_speed} t/s ({wall:.1f}s wall) "
+              f"diverges_at_word={on_div[0]}")
+
+        results[name] = dict(
+            baseline_speed=baseline_speed,
+            off_speed=off_speed, off_stats=off_stats, off_div=off_div,
+            on_speed=on_speed, on_stats=on_stats, on_div=on_div,
+        )
+
+    print("\n\n=== SUMMARY ===")
+    for name, r in results.items():
+        print(f"\n--- {name} ---")
+        print(f"baseline:  {r['baseline_speed']} t/s")
+        print(f"flag-off:  {r['off_speed']} t/s  "
+              f"diverges_at_word={r['off_div'][0]}")
+        print(f"flag-on:   {r['on_speed']} t/s  "
+              f"diverges_at_word={r['on_div'][0]}")
+        if r["off_stats"]:
+            print(f"flag-off stats: {r['off_stats']}")
+        if r["on_stats"]:
+            print(f"flag-on  stats: {r['on_stats']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #695 with a working, opt-in prototype and multi-prompt benchmark data, not just analysis.

## Root cause (recap from #695)

DSpark unconditionally rolls back the checkpoint and sequentially replays every accepted draft token through the exact single-token decode kernel, even on a full accept — `ds4.c:61711-61714`: *"replay every accepted draft through ordinary decode, including partial accepts"*. That replay costs close to one full target-model forward pass per accepted token, canceling most of the savings speculation is supposed to provide.

## What this PR does

MTP's default Metal path already makes a different call. Tracing it turned up:

```c
#ifdef DS4_ROCM_BUILD
    const bool prefer_decode2_exact = true;
#else
    const bool prefer_decode2_exact = false;   // Metal
#endif
```

`metal_graph_verify_decode2_exact` — the exact, bit-identical-to-decode verifier — is only *preferred* on ROCm. On Metal, MTP defaults to the same batched `metal_graph_verify_suffix_tops` kernel DSpark's verify already uses, and **on a full accept it commits directly from that batched pass with no rollback and no replay**.

This PR applies the identical trade-off to DSpark's full-accept case, gated behind `DS4_DSPARK_FULL_ACCEPT_FAST_COMMIT` (opt-in, default off — DSpark doesn't yet ship this as a default the way MTP does, so I didn't want to change default behavior silently). Partial accepts and TP are untouched: TP falls through to the existing rollback+replay unconditionally (I haven't written or tested a worker-side commit protocol for this path), and partial accepts keep replaying exactly as before.

## The trade-off, measured, not assumed

This is not free — and I want to be upfront about that rather than presenting it as a clean win. The batched kernel can differ from the exact single-token decode kernel by enough to flip a near-tied greedy token, exactly as documented on `metal_graph_verify_decode2_exact`. I confirmed this is real by diffing full generated output against plain baseline, not just trusting the existing `dspark-verify-depth` unit test (see below for why that test can't see it).

**`tests/dspark_acceptance_fixture.sh`** (the project's own byte-exact `cmp -s` fixture, 32-token generations, 4 diverse prompts) passes with the flag on in every case, including two with a *positive* net_saved:

```
hello: net_saved -95.7ms -> +18.7ms
redis: net_saved -307.2ms -> +52.2ms
```

**New `tests/dspark_fast_commit_bench.py`** (companion script, longer ~300+ token free-running generations, where a short fixture can't accumulate compounding divergence):

| prompt | flag-off t/s | flag-on t/s | net_saved off→on | diverges at word |
|---|---|---|---|---|
| essay | 30.53 | 38.60 (+26%) | -2735ms → -227ms | 16 |
| code | 29.40 | 37.12 (+26%) | -4213ms → -596ms | none |
| math | 29.91 | 45.78 (+53%, faster than the 38.57 t/s plain baseline) | -1036ms → **+619ms** | 16 |
| dialogue | 28.78 | 30.52 (+6%) | -3646ms → -1768ms | 51 |

Flag-on is faster than flag-off in every case tested, and the net cost of the DSpark mechanism itself drops sharply everywhere, going net-positive on the math prompt. But 3 of 4 longer prompts do diverge from the plain-greedy baseline text partway through (confirmed by full-text diff, not just a stats anomaly).

I checked whether this is a *new* risk this PR introduces: it isn't. On the identical essay prompt, MTP's own already-shipped default behavior diverges from the same baseline **at the same point, with the same inserted phrase**, because it's the same batched kernel causing the same near-tied-logit flip. This PR doesn't add a new risk category to the codebase — it applies to DSpark a trade-off MTP already ships by default on Metal.

## Why the existing `dspark-verify-depth` test doesn't catch this

I ran it both ways (`DS4_TEST_DSPARK=... ./ds4_test --dspark-verify-depth`, flag off and on): `worst_argmax_gap=0.000` in both cases, 128 real speculative cycles, draft depth 5. That test teacher-forces every committed token through normal decode and resets ground truth each cycle, so a small per-step divergence never gets the chance to compound the way it does in a real free-running generation. It's a good test for "did the verifier commit something the target model would never plausibly produce," but not for "does the full generation still match exact greedy decode." `tests/dspark_fast_commit_bench.py` is meant to fill that specific gap for this flag going forward.

## Testing

- `make ds4_test`: full suite passes, flag unset by default (code path unreachable, zero behavior change from main).
- `dspark-verify-depth`: passes with the flag both off and on.
- `dspark_acceptance_fixture.sh`: passes with the flag on (`cmp -s` byte-exact) on all 4 short prompts.
- `dspark_fast_commit_bench.py`: new script, data above.

This is deliberately opt-in and not proposed as the new default — happy to change that if you'd rather it match MTP's default-on Metal behavior, or to leave it opt-in for people who want the speed and are fine with the same trade-off MTP already makes silently.