### PR TITLE
cuda: keep the raw MMQ MoE tier off streamed routed experts

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -23818,7 +23818,19 @@ static int routed_moe_launch(
      * [n_tokens, n_expert, *] by the validation above.  Any entry
      * failure falls through to the legacy sorted-pairs path (the
      * buffers are scratch there too). */
-    if (iq2_path && n_tokens > 1u && !owned_filtered && cuda_use_mmq()) {
+    /* Not while the experts are streamed. This tier needs a pointer to the whole
+     * routed tensor of the layer, and under SSD streaming that tensor is not
+     * resident: resolving it makes the fallback cache materialise hundreds of MiB
+     * per layer that the streaming path deliberately keeps off the device. On a
+     * card with room to spare that is merely wasteful; on one without, the
+     * allocation fails and the sticky CUDA error takes the run down with it
+     * (measured on a 12 GiB card: "moe gate mmq (528.00 MiB): out of memory",
+     * then an illegal memory access, exit 1, with any real prompt).
+     *
+     * The aligned variant of this tier a few lines above already carries the same
+     * guard for the same reason; the raw variant was missing it. */
+    if (iq2_path && n_tokens > 1u && !owned_filtered && !g_ssd_streaming_mode &&
+        cuda_use_mmq()) {
         const uint64_t gate_total = (uint64_t)n_total_expert * gate_expert_bytes;
         const uint64_t down_total = (uint64_t)n_total_expert * down_expert_bytes;
         const int mmq_tier = ds4_tensor_device_idx(out);


### PR DESCRIPTION
Fixes #732.

The tier needs a pointer to the whole routed tensor of a layer. Under
--ssd-streaming that tensor is not resident, so resolving it makes the fallback
cache build it: 528 MiB gate, 528 up, 1792 down, per routed layer. It tries to
cache 32.06 GiB, the alloc fails on a 12 GB card, and any real prompt then dies
with an illegal memory access.

The guard is !g_ssd_streaming_mode. The aligned IQ2 variant above already has
it, and the MXFP4 tier below also declines under streaming, so only the raw
variant was missing it. Failures here already fall back to the sorted-pairs
path.

Outside streaming nothing changes: the flag is set in one place, from the CLI
toggle, and the tier is prefill-only. The dense MMQ tiers stay on, which is
where the win is: prefill 9.14 / 16.08 / 17.61 t/s at 512 / 1024 / 2048 tokens,
and 21.40 t/s at 2048 with #734, about 2.1x the DS4_CUDA_MMQ=0 baseline.

Tested only on 12 GB: RTX 3500 Ada (sm_89), CUDA 13.0, WSL2, DeepSeek-V4-Flash
IQ2_XXS 80.8 GB. Bigger cards should show the same bug with a milder symptom.
