### PR TITLE
cuda: give the token-tile ldmatrix its shared state space

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -10316,7 +10316,7 @@ __device__ __forceinline__ uint32_t tt_ring_off_bytes(uint32_t row, uint32_t c) 
 
 __device__ __forceinline__ void tt_ldmatrix_x4_addr(uint32_t (&r)[4], unsigned a) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
-    asm volatile("ldmatrix.sync.aligned.m8n8.x4.b16 {%0, %1, %2, %3}, [%4];"
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared::cta.b16 {%0, %1, %2, %3}, [%4];"
                  : "=r"(r[0]), "=r"(r[1]), "=r"(r[2]), "=r"(r[3])
                  : "r"(a));
 #else
@@ -10327,7 +10327,7 @@ __device__ __forceinline__ void tt_ldmatrix_x4_addr(uint32_t (&r)[4], unsigned a
 
 __device__ __forceinline__ void tt_ldmatrix_x2_addr(uint32_t (&r)[2], unsigned a) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
-    asm volatile("ldmatrix.sync.aligned.m8n8.x2.b16 {%0, %1}, [%2];"
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared::cta.b16 {%0, %1}, [%2];"
                  : "=r"(r[0]), "=r"(r[1])
                  : "r"(a));
 #else
@@ -10338,7 +10338,7 @@ __device__ __forceinline__ void tt_ldmatrix_x2_addr(uint32_t (&r)[2], unsigned a
 
 __device__ __forceinline__ void tt_ldmatrix_x2_trans_addr(uint32_t (&r)[2], unsigned a) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
-    asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.b16 {%0, %1}, [%2];"
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared::cta.b16 {%0, %1}, [%2];"
                  : "=r"(r[0]), "=r"(r[1])
                  : "r"(a));
 #else


### PR DESCRIPTION
Fixes #734.

The three ldmatrix wrappers carried no state space qualifier, so the PTX asks
for generic addressing, while the operand comes from tt_smem_addr(), that is
__cvta_generic_to_shared(). ptxas then subtracts the shared window base from an
address that is already relative. SASS on sm_89, the same kernel twice:

    no .shared::cta:  IADD3 R0, R0, -c[0x0][0x18], RZ
                      LDSM.16.M88.2 R6, [R0]
    .shared::cta:     LDSM.16.M88.2 R6, [R0]

That killed every batch prefill of 128 tokens or more under --ssd-streaming,
which is where the token-tile gate engages. Whether ptxas emits the conversion
is a toolchain decision, so the same source can be fine on CUDA 12 and fatal on
CUDA 13.

Verified with DS4_CUDA_MMQ=0 and no other workaround: 128 / 512 / 2048 / 8192
tokens in one chunk, plus 2048 with --prefill-chunk 256 and 512, all clean and
coherent. The 8192-token prefill used to die even with
DS4_CUDA_NO_WINDOW_ATTENTION=1, so that was the same defect. At 2048 tokens the
token-tile path now gives 9.60 t/s against 7.91 for the generic fallback.

RTX 3500 Ada 12 GB (sm_89), CUDA 13.0, WSL2, DeepSeek-V4-Flash IQ2_XXS 80.8 GB.
