### PR TITLE
download: honour HF_ENDPOINT in the curl path

### DIFF
--- a/download_model.sh
+++ b/download_model.sh
@@ -111,6 +111,10 @@ Options:
 Environment:
   DS4_GGUF_DIR   Directory used for downloaded GGUF files.
                  Default: ./gguf
+  HF_ENDPOINT    Hugging Face host used for downloads. Useful where
+                 huggingface.co is slow or unreachable. The official Hugging
+                 Face CLI already honours it; this script applies it to the
+                 curl path too. Default: https://huggingface.co
 
 After main-model downloads the script updates:
   ./ds4flash.gguf -> <download directory>/<selected model>
@@ -278,7 +282,7 @@ download_one_hf() {
     fi
 
     echo "Downloading $file"
-    echo "from https://huggingface.co/$REPO"
+    echo "from ${HF_ENDPOINT:-https://huggingface.co}/$REPO"
     echo "using $HF_CMD download"
     echo "If the download stops, run the same command again to resume it."
 
@@ -305,7 +309,7 @@ download_one() {
     out="$OUT_DIR/$local_file"
     part="$out.part"
     aria2_part="$out.aria2"
-    url="https://huggingface.co/$REPO/resolve/main/$file"
+    url="${HF_ENDPOINT:-https://huggingface.co}/$REPO/resolve/main/$file"
 
     if needs_hf_download "$file"; then
         download_one_hf "$file"
@@ -326,7 +330,7 @@ download_one() {
     fi
 
     echo "Downloading $file"
-    echo "from https://huggingface.co/$REPO"
+    echo "from ${HF_ENDPOINT:-https://huggingface.co}/$REPO"
     echo "If the download stops, run the same command again to resume it."
 
     if [ -n "$TOKEN" ]; then


### PR DESCRIPTION
### Problem

`download_model.sh` has two download paths, and they disagree about which host to use.

The `pro-*`, `glm-*`, and `ds4f-mxfp4` targets go through the official Hugging Face CLI, which already reads `HF_ENDPOINT`, so those can be pointed at a mirror today. The curl path used for the smaller DeepSeek Flash GGUFs hardcodes `huggingface.co`, so exactly the targets most people download — `ds4f-q2` and friends — cannot use one.

Where `huggingface.co` is slow or unreachable, an 81 GB download is the difference between a working and a non-working setup, and there is currently no way to redirect it short of editing the script.

### Change

Read the same `HF_ENDPOINT` variable in the curl path and in the two "from ..." progress messages, so both downloaders resolve to the same host. Also document it in the `Environment:` help block next to `DS4_GGUF_DIR`.

Unset behaviour is unchanged: `${HF_ENDPOINT:-https://huggingface.co}` yields the current URL, so no existing invocation changes.

3 substituted lines + 4 lines of help text. No inference code touched.

### Testing

Machine: MacBook Pro M5 Max, 128 GB, macOS 26.4, Metal backend.
Model quant: `ds4f-q2` (`...chat-v2-imatrix-0731.gguf`, 80.76 GiB).

- Downloaded the full `ds4f-q2` target through `HF_ENDPOINT=https://hf-mirror.com` with this patch applied: completed in one attempt, and the resulting file is byte-exact against the size `huggingface.co` reports (`86720111488`).
- Verified the model afterwards: `./ds4 --inspect` reports the expected 43 layers / 1328 tensors / 284.33 B parameters, and `./ds4 -p ... --nothink` generates correctly.
- Verified the unset path still resolves to `https://huggingface.co/...` (default preserved).
- `sh -n download_model.sh` clean; `./download_model.sh --help` renders the new `Environment:` entry.

No correctness or speed regression tests were run, as the change is confined to the download shell script and cannot affect any inference backend.
