### PR TITLE
server: anchor dsml_attr attribute match to a name boundary

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -4680,16 +4680,22 @@ static char *dsml_unescape_text(const char *s) {
 
 static char *dsml_attr(const char *tag, const char *name) {
     char pat[64];
-    snprintf(pat, sizeof(pat), "%s=\"", name);
-    const char *p = strstr(tag, pat);
-    if (!p) return NULL;
-    p += strlen(pat);
-    const char *q = strchr(p, '"');
-    if (!q) return NULL;
-    char *raw = xstrndup(p, (size_t)(q - p));
-    char *decoded = dsml_unescape_text(raw);
-    free(raw);
-    return decoded;
+    const int patlen = snprintf(pat, sizeof(pat), "%s=\"", name);
+    if (patlen < 0 || (size_t)patlen >= sizeof(pat)) return NULL;
+    /* Anchor the match to an attribute boundary: `name="` must start right after
+     * `<`, the tag name, or whitespace, so it is not matched inside a longer
+     * attribute like `fullname="..."` earlier in the same tag. */
+    for (const char *p = strstr(tag, pat); p; p = strstr(p + 1, pat)) {
+        if (p != tag && !isspace((unsigned char)p[-1]) && p[-1] != '<') continue;
+        const char *v = p + patlen;
+        const char *q = strchr(v, '"');
+        if (!q) return NULL;
+        char *raw = xstrndup(v, (size_t)(q - v));
+        char *decoded = dsml_unescape_text(raw);
+        free(raw);
+        return decoded;
+    }
+    return NULL;
 }
 
 static void tool_call_json_args_add(buf *args, const char *name, const char *value, const char *is_string) {
@@ -15044,6 +15050,30 @@ static void test_parse_glm_tool_call_message(void) {
     tool_calls_free(&calls);
 }
 
+static void test_dsml_attr_anchors_attribute_name(void) {
+    /* A preceding attribute whose name ends in the sought name (here `fullname`
+     * vs `name`) must not be matched: the value belongs to the real `name`. */
+    char *v = dsml_attr("<invoke fullname=\"wrong\" name=\"right\">", "name");
+    TEST_ASSERT(v && !strcmp(v, "right"));
+    free(v);
+
+    /* The ordinary single-attribute case still resolves. */
+    v = dsml_attr("<invoke name=\"tool\">", "name");
+    TEST_ASSERT(v && !strcmp(v, "tool"));
+    free(v);
+
+    /* A parameter named with a `string` suffix must not shadow the real
+     * `string=` type attribute that follows it. */
+    v = dsml_attr("<parameter name=\"mystring\" string=\"false\">", "string");
+    TEST_ASSERT(v && !strcmp(v, "false"));
+    free(v);
+
+    /* A genuinely absent attribute stays absent. */
+    v = dsml_attr("<invoke fullname=\"x\">", "name");
+    TEST_ASSERT(v == NULL);
+    free(v);
+}
+
 static void test_dsml_parser_recovers_loose_nested_parameters(void) {
     const char *generated =
         "review done\n\n"
@@ -17802,6 +17832,7 @@ static void ds4_server_unit_tests_run(void) {
     test_responses_input_tool_search_output_rejects_bad_tools();
     test_responses_input_function_call_namespace_round_trips_to_dsml();
     test_responses_output_sends_tool_search_call_item();
+    test_dsml_attr_anchors_attribute_name();
     test_dsml_tool_args_preserve_call_order();
     test_openai_tool_args_preserve_call_order();
     test_anthropic_thinking_and_tool_args_preserve_call_order();


### PR DESCRIPTION
## Bug

`dsml_attr()` locates an attribute with an unanchored `strstr(tag, "name=\"")`.
An earlier attribute whose name ends in the sought name followed by `="` shadows
the real one:

- `<｜DSML｜invoke fullname="wrong" name="right">` → `dsml_attr(tag, "name")` returns `"wrong"`.
- `<｜DSML｜invoke fullname="x">` → `dsml_attr(tag, "name")` returns `"x"` for a `name` that is absent.

The generated-DSML tool-call parser (`parse_deepseek_generated_message_ex`) feeds
whole `invoke`/`parameter` tags through this helper, so a drifted model tag
carrying an extra attribute could yield the wrong tool name or argument value.

Low severity: the server's own renderer emits fixed single attributes in a fixed
order, so round-tripping its output is unaffected — the bug needs a model tag
that puts a colliding attribute before `name`/`string`. It is still a real
correctness defect in the helper.

## Fix

Match only at an attribute boundary (start of tag, or after whitespace), and
guard the `snprintf` pattern against truncation.

## Test

`--server` gains `test_dsml_attr_anchors_attribute_name`. It **fails on the old
helper** (returns `"wrong"` / `"x"`, two assertions) and **passes after the fix**.
Built `-Wall -Wextra`, 0 warnings, Apple M5 Max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
