### PR TITLE
cuda: accelerate long-context B1 indexer and 1M HCA

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -35,7 +35,8 @@ enum {
      * compressed scores in shared memory.  The host routes larger unmasked
      * decode calls to the online attention kernel so this fixed buffer never
      * becomes an out-of-bounds write at long context. */
-    DS4_CUDA_ATTENTION_SCORE_CAP = 8192u,
+    /* 1M HCA has 8192 compressed rows plus up to 256 raw rows. */
+    DS4_CUDA_ATTENTION_SCORE_CAP = 8448u,
     DS4_CUDA_ATTENTION_RAW_SCORE_CAP = 256u,
     DS4_CUDA_TOPK_MERGE_GROUP = 8u,
     /* perf-02 split-KV: fixed logical rows per chunk (shared scores = 2KB),
@@ -13937,7 +13938,12 @@ static int indexer_scores_launch(
         scores, q, weights, index_comp, n_comp, n_tokens, pos0,
         n_head, head_dim, ratio, scale);
     if (mxf4 != 0) return mxf4 > 0;
+    /* The tensor-core scorer overtakes the direct B1 kernel once the
+     * compressed history is long enough; keep the exact path for quality
+     * mode and short contexts where launch/staging overhead dominates. */
     if (n_tokens == 1u && head_dim == 128u && n_head == 64u &&
+        (g_quality_mode || n_comp < 8192u ||
+         getenv("DS4_CUDA_NO_INDEXER_WMMA") != NULL) &&
         getenv("DS4_CUDA_NO_INDEXER_DIRECT_ONE") == NULL) {
         indexer_score_one_direct_kernel<<<n_comp, 128>>>((float *)scores->ptr,
                                                          (const float *)q->ptr,

--- a/tests/cuda_long_context_smoke.c
+++ b/tests/cuda_long_context_smoke.c
@@ -1,5 +1,6 @@
 #include "ds4_gpu.h"
 
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,6 +18,15 @@ static double getenv_seconds(const char *name, double fallback) {
     char *end = NULL;
     const double v = strtod(s, &end);
     return end != s && v > 0.0 ? v : fallback;
+}
+
+static float qat_value(uint64_t i) {
+    static const float levels[] = {
+        0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f,
+    };
+    const float scale = ldexpf(1.0f, (int)((i / 32u) % 7u) - 4);
+    const float sign = ((i * 0x9e3779b97f4a7c15ull) >> 63) ? -1.0f : 1.0f;
+    return sign * scale * levels[(i * 13u + i / 17u) & 7u];
 }
 
 static int check_large_topk(void) {
@@ -90,7 +100,7 @@ static int check_decode_attention_overflow_path(void) {
     const uint32_t n_head = 8;
     const uint32_t head_dim = 512;
     const uint32_t n_raw = 128;
-    const uint32_t n_comp = 8100;
+    const uint32_t n_comp = 8192;
     const uint64_t q_count = (uint64_t)n_head * head_dim;
     const uint64_t raw_count = (uint64_t)n_raw * head_dim;
     const uint64_t comp_count = (uint64_t)n_comp * head_dim;
@@ -137,7 +147,7 @@ static int check_decode_attention_overflow_path(void) {
         for (uint32_t h = 0; h < n_head; h++) {
             const float v = heads_host[(uint64_t)h * head_dim];
             if (v < 0.90f) {
-                fprintf(stderr, "attention fallback ignored compressed rows for head=%u value=%f\n",
+                fprintf(stderr, "long attention ignored compressed rows for head=%u value=%f\n",
                         h, (double)v);
                 rc = 1;
             }
@@ -156,10 +166,118 @@ static int check_decode_attention_overflow_path(void) {
     return rc;
 }
 
+static int check_b1_indexer_wmma(void) {
+    const uint32_t n_comp = 8192u;
+    const uint32_t n_head = 64u;
+    const uint32_t head_dim = 128u;
+    const uint32_t top_k = 512u;
+    const uint64_t q_count = (uint64_t)n_head * head_dim;
+    const uint64_t cache_count = (uint64_t)n_comp * head_dim;
+    float *q_host = malloc((size_t)q_count * sizeof(*q_host));
+    float *weights_host = malloc((size_t)n_head * sizeof(*weights_host));
+    float *cache_host = malloc((size_t)cache_count * sizeof(*cache_host));
+    float *direct_host = malloc((size_t)n_comp * sizeof(*direct_host));
+    float *wmma_host = malloc((size_t)n_comp * sizeof(*wmma_host));
+    uint32_t *direct_topk = malloc((size_t)top_k * sizeof(*direct_topk));
+    uint32_t *wmma_topk = malloc((size_t)top_k * sizeof(*wmma_topk));
+    if (!q_host || !weights_host || !cache_host || !direct_host ||
+        !wmma_host || !direct_topk || !wmma_topk) {
+        free(wmma_topk);
+        free(direct_topk);
+        free(wmma_host);
+        free(direct_host);
+        free(cache_host);
+        free(weights_host);
+        free(q_host);
+        return 1;
+    }
+
+    for (uint64_t i = 0; i < q_count; i++) {
+        q_host[i] = qat_value(i + 7u);
+    }
+    for (uint32_t i = 0; i < n_head; i++) {
+        weights_host[i] = 0.25f + (float)((i * 19u) % 31u) / 31.0f;
+    }
+    for (uint64_t i = 0; i < cache_count; i++) {
+        cache_host[i] = qat_value(i + (i / head_dim) * 97u + 23u);
+    }
+
+    ds4_gpu_tensor *q = ds4_gpu_tensor_alloc(q_count * sizeof(float));
+    ds4_gpu_tensor *weights = ds4_gpu_tensor_alloc(n_head * sizeof(float));
+    ds4_gpu_tensor *cache = ds4_gpu_tensor_alloc(cache_count * sizeof(float));
+    ds4_gpu_tensor *scores = ds4_gpu_tensor_alloc(n_comp * sizeof(float));
+    ds4_gpu_tensor *selected = ds4_gpu_tensor_alloc(top_k * sizeof(uint32_t));
+    int rc = 1;
+    if (!q || !weights || !cache || !scores || !selected ||
+        !ds4_gpu_tensor_write(q, 0, q_host, q_count * sizeof(float)) ||
+        !ds4_gpu_tensor_write(weights, 0, weights_host,
+                              n_head * sizeof(float)) ||
+        !ds4_gpu_tensor_write(cache, 0, cache_host,
+                              cache_count * sizeof(float))) {
+        goto cleanup;
+    }
+
+    setenv("DS4_CUDA_NO_INDEXER_WMMA", "1", 1);
+    if (!ds4_gpu_indexer_score_one_tensor(scores, q, weights, cache,
+                                          n_comp, n_head, head_dim,
+                                          1.0f / sqrtf(8192.0f)) ||
+        !ds4_gpu_indexer_topk_tensor(selected, scores, n_comp, 1u, top_k) ||
+        !ds4_gpu_synchronize() ||
+        !ds4_gpu_tensor_read(scores, 0, direct_host,
+                             n_comp * sizeof(float)) ||
+        !ds4_gpu_tensor_read(selected, 0, direct_topk,
+                             top_k * sizeof(uint32_t))) {
+        goto cleanup;
+    }
+    unsetenv("DS4_CUDA_NO_INDEXER_WMMA");
+    if (!ds4_gpu_indexer_score_one_tensor(scores, q, weights, cache,
+                                          n_comp, n_head, head_dim,
+                                          1.0f / sqrtf(8192.0f)) ||
+        !ds4_gpu_indexer_topk_tensor(selected, scores, n_comp, 1u, top_k) ||
+        !ds4_gpu_synchronize() ||
+        !ds4_gpu_tensor_read(scores, 0, wmma_host,
+                             n_comp * sizeof(float)) ||
+        !ds4_gpu_tensor_read(selected, 0, wmma_topk,
+                             top_k * sizeof(uint32_t))) {
+        goto cleanup;
+    }
+
+    float max_abs = 0.0f;
+    for (uint32_t i = 0; i < n_comp; i++) {
+        const float delta = fabsf(direct_host[i] - wmma_host[i]);
+        if (delta > max_abs) max_abs = delta;
+    }
+    uint32_t topk_diff = 0u;
+    for (uint32_t i = 0; i < top_k; i++) {
+        if (direct_topk[i] != wmma_topk[i]) topk_diff++;
+    }
+    fprintf(stderr,
+            "cuda-regression: B1 indexer n_comp=%u max_abs=%g topk_diff=%u\n",
+            n_comp, (double)max_abs, topk_diff);
+    rc = max_abs <= 1.0e-3f && topk_diff == 0u ? 0 : 1;
+
+cleanup:
+    unsetenv("DS4_CUDA_NO_INDEXER_WMMA");
+    ds4_gpu_tensor_free(selected);
+    ds4_gpu_tensor_free(scores);
+    ds4_gpu_tensor_free(cache);
+    ds4_gpu_tensor_free(weights);
+    ds4_gpu_tensor_free(q);
+    free(wmma_topk);
+    free(direct_topk);
+    free(wmma_host);
+    free(direct_host);
+    free(cache_host);
+    free(weights_host);
+    free(q_host);
+    return rc;
+}
+
 int main(void) {
     if (!ds4_gpu_init()) return 1;
     int rc = check_large_topk();
     if (check_decode_attention_overflow_path() != 0) rc = 1;
+    if (check_b1_indexer_wmma() != 0) rc = 1;
     ds4_gpu_cleanup();
     if (rc == 0) puts("cuda long-context regression: OK");
     return rc;


### PR DESCRIPTION
Fixes #762.

## What changed

- Route non-quality B1 indexer scoring to the existing WMMA scorer at
  `n_comp >= 8192`; retain the direct scorer for shorter contexts, quality
  mode, and the existing `DS4_CUDA_NO_INDEXER_WMMA` escape hatch.
- Raise the attention score capacity from 8192 to 8448 rows so the 1M HCA
  shape fits 8192 compressed rows plus the existing 256-row raw reserve.
- Extend the CUDA long-context smoke test to cover 8192 compressed HCA rows
  and direct-vs-WMMA B1 score/top-k equivalence on QAT-format values.

The HCA change does not add a new attention implementation. It keeps the
existing exact score-split path active instead of falling back to the slow
online kernel for the last 256 rows at 1M.

## DGX Spark results

Base: `84cc882`, NVIDIA GB10 (`sm_121`), DeepSeek-V4-Flash IQ2XXS Q2 model,
Q8-to-F16 weight cache disabled. A/B paths alternate in one process/session,
with 3 warmups and 30 samples each.

| Context | Base tok/s | PR tok/s | Speedup |
|---:|---:|---:|---:|
| 128K | 12.168 | 12.468 | 1.025x |
| 256K | 10.642 | 11.290 | 1.061x |
| 512K | 8.647 | 9.574 | 1.107x |
| 1M | 4.372 | 6.981 | 1.597x |

At 1M, Nsight Systems attributes the main change to:

- CSA: direct scorer `78.036 ms` -> WMMA scorer `48.565 ms` across 21 layers.
- HCA: online kernel `97.286 ms` -> exact score-split score+finalize
  `25.400 ms` across 20 layers.

Full benchmark details and the existing-work audit are in #762. Related #258
uses approximate HISA pruning and is complementary to this full-top-512 flat
scorer optimization.

## Correctness

- B1 QAT score max delta: `6.10352e-05`.
- B1 top-512 differences: `0/512`.
- Isolated 8192-row HCA regression output delta: `0`.
- Full synthetic-frontier logits are bit-identical through 512K.
- At 1M, legacy online vs existing exact score-split has max logit delta
  `0.0469046`, RMSE `0.00876944`, and identical argmax.
- Real 30,474-token story fact-recall regression passes.

## Validation

```sh
make cuda-regression CUDA_ARCH=sm_121
```

Passes on DGX Spark / GB10.

`--logprob-vectors` currently fails `short_code_completion` identically on
both base and PR builds with this GGUF, so it is not a regression from this
change.
