### PR TITLE
kv-cache: serialize only occupied compressor rows in checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 /tests/cuda_long_context_smoke
 /tests/test_layer_pack
 /tests/test_metal_session_batch
+/tests/test_kv_frontier_state
 /tests/test_mxfp4_cuda
 /tests/test_mxfp4_dot
 /tests/test_mxfp4_metal

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 .PHONY: all help clean test test-metal-session-batch test-mxfp4-cuda test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
 
 ifeq ($(UNAME_S),Darwin)
-.PHONY: metal-decode-schedule-bench metal-prefill-variant-bench check-mxfp4-half-lut
+.PHONY: metal-decode-schedule-bench metal-prefill-variant-bench check-mxfp4-half-lut test-kv-frontier-state
 
 all: ds4 ds4-server ds4-bench ds4-eval ds4-agent
 
@@ -108,6 +108,18 @@ tests/test_metal_session_batch: tests/test_metal_session_batch.o $(CORE_OBJS)
 
 test-metal-session-batch: tests/test_metal_session_batch
 	DS4_TEST_MODEL="$(DS4_TEST_MODEL)" ./tests/test_metal_session_batch
+
+ds4_metal_test_hooks.o: ds4.c ds4.h ds4_gpu.h ds4_gpu_mgpu.h ds4_layer_pack.h
+	$(CC) $(CFLAGS) -Wno-unused-function -DDS4_TEST_HOOKS -c -o $@ ds4.c
+
+tests/test_kv_frontier_state.o: tests/test_kv_frontier_state.c ds4.h
+	$(CC) $(CFLAGS) -DDS4_TEST_HOOKS -I. -c -o $@ tests/test_kv_frontier_state.c
+
+tests/test_kv_frontier_state: tests/test_kv_frontier_state.o ds4_metal_test_hooks.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_metal.o ds4_layer_pack.o
+	$(CC) $(CFLAGS) -o $@ $^ $(METAL_LDLIBS)
+
+test-kv-frontier-state: tests/test_kv_frontier_state
+	DS4_TEST_MODEL="$(DS4_TEST_MODEL)" ./tests/test_kv_frontier_state
 
 speed-bench/metal_decode_schedule_bench.o: speed-bench/metal_decode_schedule_bench.c ds4.h
 	$(CC) $(CFLAGS) -I. -c -o $@ $<

--- a/ds4.c
+++ b/ds4.c
@@ -49746,6 +49746,40 @@ static DS4_MAYBE_UNUSED uint64_t layer_index_state_bytes(uint32_t ratio) {
     return (uint64_t)coff * DS4_N_INDEXER_HEAD_DIM * coff * ratio * sizeof(float);
 }
 
+/* Compressor frontier-state occupancy.
+ *
+ * Single-lane layers (compress_ratio != 0 && != 4, i.e. coff == 1) use the
+ * attn_state_* buffers as a ring of `ratio` rows, one written per token at
+ * index pos % ratio.  At a checkpoint of live length L only the `partial =
+ * L % ratio` rows accumulated in the current block are live; rows [partial,
+ * ratio) are stale leftovers from the previous committed block and are
+ * overwritten before they are ever read (they are still inside the raw SWA
+ * window, so no attention path reads the in-progress compressor state
+ * mid-block).  We therefore serialize only the occupied rows plus a u32 count.
+ *
+ * Ratio-4 layers are two-lane (coff == 2): the pooler reads the one-block-old
+ * lane A by design, so the stale-rows-never-read invariant is false there and
+ * they keep the full-capacity layout byte-for-byte.
+ *
+ * No new struct fields: partial is derived from the checkpoint length and
+ * cross-checked against the already-serialized n_comp on load
+ * (n_comp * ratio + partial == checkpoint_len). */
+static uint32_t layer_state_partial_rows(uint32_t ratio, uint32_t checkpoint_len) {
+    return checkpoint_len % ratio;
+}
+
+/* Bytes occupied by both compressor-state tensors (kv + score) for one layer
+ * in the on-disk payload.  Single-lane: one u32 partial count + partial rows
+ * of kv + partial rows of score.  Ratio-4: full capacity, unchanged. */
+static uint64_t layer_attn_state_payload_bytes(uint32_t ratio, uint32_t checkpoint_len) {
+    if (ratio != 4) {
+        const uint32_t partial = layer_state_partial_rows(ratio, checkpoint_len);
+        const uint64_t span = (uint64_t)partial * DS4_N_HEAD_DIM * sizeof(float);
+        return 2u * span + sizeof(uint32_t);
+    }
+    return 2u * layer_attn_state_bytes(ratio);
+}
+
 #ifndef DS4_NO_GPU
 /* Only the last logical sliding-window rows are needed from the raw cache.
  * The physical Metal tensor is a ring sized for ubatches, but after restore
@@ -49771,8 +49805,7 @@ static uint64_t session_payload_live_tensor_bytes(const ds4_gpu_graph *g, uint32
         const uint32_t ratio = ds4_layer_compress_ratio(il);
         if (ratio == 0) continue;
         bytes += (uint64_t)g->layer_n_comp[il] * DS4_N_HEAD_DIM * sizeof(float);
-        bytes += layer_attn_state_bytes(ratio);
-        bytes += layer_attn_state_bytes(ratio);
+        bytes += layer_attn_state_payload_bytes(ratio, checkpoint_len);
         if (ratio == 4) {
             bytes += (uint64_t)g->layer_n_index_comp[il] * DS4_N_INDEXER_HEAD_DIM * sizeof(float);
             bytes += layer_index_state_bytes(ratio);
@@ -50160,6 +50193,7 @@ static uint32_t session_cpu_comp_cap(const ds4_session *s) {
 }
 
 static uint64_t session_cpu_payload_live_tensor_bytes(const ds4_session *s) {
+    const uint32_t checkpoint_len = (uint32_t)s->checkpoint.len;
     uint64_t bytes = 0;
     const uint32_t raw_live = session_cpu_raw_live_rows(s);
     for (uint32_t il = 0; il < DS4_N_LAYER; il++) {
@@ -50168,8 +50202,7 @@ static uint64_t session_cpu_payload_live_tensor_bytes(const ds4_session *s) {
         const uint32_t ratio = layer->compress_ratio;
         if (ratio == 0) continue;
         bytes += (uint64_t)layer->n_comp * DS4_N_HEAD_DIM * sizeof(float);
-        bytes += layer_attn_state_bytes(ratio);
-        bytes += layer_attn_state_bytes(ratio);
+        bytes += layer_attn_state_payload_bytes(ratio, checkpoint_len);
         if (ratio == 4) {
             bytes += (uint64_t)layer->n_index_comp * DS4_N_INDEXER_HEAD_DIM * sizeof(float);
             bytes += layer_index_state_bytes(ratio);
@@ -50183,6 +50216,66 @@ static void session_cpu_reset_cache(ds4_session *s) {
     kv_cache_free(&s->cpu_cache);
     kv_cache_init(&s->cpu_cache, (uint32_t)s->ctx_size, 0);
 }
+
+#ifdef DS4_TEST_HOOKS
+/* Test helper: byte offset of the compressor-state partial count for layer
+ * il_target within a payload ds4_session_save_payload would write at the
+ * session's current checkpoint.  Returns false for ratio-0/4 layers (no partial
+ * field) or unsupported backends.  Reuses the same per-layer accounting as the
+ * real save so it cannot drift from the on-disk layout; used only to let tests
+ * flip the count and assert the load rejects the inconsistency. */
+bool ds4_test_payload_partial_offset(ds4_session *s, uint32_t il_target,
+                                     uint64_t *offset_out) {
+    if (!s || !s->checkpoint_valid || !offset_out) return false;
+    if (ds4_session_is_glm(s) || ds4_session_is_distributed(s)) return false;
+    const uint32_t checkpoint_len = (uint32_t)s->checkpoint.len;
+
+    uint32_t raw_live;
+    uint32_t n_comp_l[DS4_MAX_LAYER];
+    uint32_t n_index_l[DS4_MAX_LAYER];
+    if (ds4_session_is_cpu(s)) {
+        raw_live = session_cpu_raw_live_rows(s);
+        for (uint32_t i = 0; i < DS4_N_LAYER; i++) {
+            n_comp_l[i] = s->cpu_cache.layer[i].n_comp;
+            n_index_l[i] = s->cpu_cache.layer[i].n_index_comp;
+        }
+    } else {
+#ifdef DS4_NO_GPU
+        return false;
+#else
+        const ds4_gpu_graph *g = &s->graph;
+        raw_live = session_raw_live_rows(g, checkpoint_len);
+        for (uint32_t i = 0; i < DS4_N_LAYER; i++) {
+            n_comp_l[i] = g->layer_n_comp[i];
+            n_index_l[i] = g->layer_n_index_comp[i];
+        }
+#endif
+    }
+
+    uint64_t off = (uint64_t)DS4_SESSION_PAYLOAD_U32_FIELDS * sizeof(uint32_t);
+    off += (uint64_t)checkpoint_len * sizeof(uint32_t);   /* token array */
+    off += (uint64_t)DS4_N_VOCAB * sizeof(float);         /* logits       */
+    off += (uint64_t)DS4_N_LAYER * sizeof(uint32_t);      /* n_comp array */
+    off += (uint64_t)DS4_N_LAYER * sizeof(uint32_t);      /* n_index array */
+    for (uint32_t il = 0; il <= il_target && il < DS4_N_LAYER; il++) {
+        const uint32_t ratio = ds4_layer_compress_ratio(il);
+        off += (uint64_t)raw_live * DS4_N_HEAD_DIM * sizeof(float);  /* raw rows */
+        if (ratio == 0) continue;
+        off += (uint64_t)n_comp_l[il] * DS4_N_HEAD_DIM * sizeof(float);  /* comp rows */
+        if (il == il_target) {
+            if (ratio == 4) return false;   /* ratio-4 has no partial field */
+            *offset_out = off;              /* partial u32 sits here */
+            return true;
+        }
+        off += layer_attn_state_payload_bytes(ratio, checkpoint_len);
+        if (ratio == 4) {
+            off += (uint64_t)n_index_l[il] * DS4_N_INDEXER_HEAD_DIM * sizeof(float);
+            off += 2u * layer_index_state_bytes(ratio);
+        }
+    }
+    return false;
+}
+#endif /* DS4_TEST_HOOKS */
 
 static bool ds4_layer_payload_range_valid(uint32_t layer_start, uint32_t layer_end) {
     const uint32_t n_layers = ds4_model_normal_layer_count();
@@ -50238,7 +50331,8 @@ uint64_t ds4_session_layer_payload_bytes(ds4_session *s,
     return 0;
 #else
     const ds4_gpu_graph *g = &s->graph;
-    const uint32_t raw_live = session_raw_live_rows(g, (uint32_t)s->checkpoint.len);
+    const uint32_t checkpoint_len = (uint32_t)s->checkpoint.len;
+    const uint32_t raw_live = session_raw_live_rows(g, checkpoint_len);
     uint64_t bytes = (uint64_t)DS4_SESSION_LAYER_PAYLOAD_U32_FIELDS * sizeof(uint32_t);
     const uint32_t n_layers = layer_end - layer_start + 1u;
     bytes += (uint64_t)n_layers * sizeof(uint32_t);
@@ -50248,8 +50342,7 @@ uint64_t ds4_session_layer_payload_bytes(ds4_session *s,
         const uint32_t ratio = ds4_layer_compress_ratio(il);
         if (ratio == 0) continue;
         bytes += (uint64_t)g->layer_n_comp[il] * DS4_N_HEAD_DIM * sizeof(float);
-        bytes += layer_attn_state_bytes(ratio);
-        bytes += layer_attn_state_bytes(ratio);
+        bytes += layer_attn_state_payload_bytes(ratio, checkpoint_len);
         if (ratio == 4) {
             bytes += (uint64_t)g->layer_n_index_comp[il] * DS4_N_INDEXER_HEAD_DIM * sizeof(float);
             bytes += layer_index_state_bytes(ratio);
@@ -50447,10 +50540,18 @@ int ds4_session_save_layer_payload(ds4_session *s, FILE *fp,
                                            err,
                                            errlen);
         }
+        uint64_t attn_state_span = layer_attn_state_bytes(ratio);
+        if (ratio != 4) {
+            /* Single-lane layer: prefix the occupied rows with a u32 partial
+             * count (partial = L % ratio) and serialize only [0, partial). */
+            const uint32_t partial = layer_state_partial_rows(ratio, (uint32_t)s->checkpoint.len);
+            if (rc == 0 && payload_write_u32(fp, partial, err, errlen) != 0) rc = 1;
+            attn_state_span = (uint64_t)partial * DS4_N_HEAD_DIM * sizeof(float);
+        }
         if (rc == 0) rc = payload_write_tensor_span(fp,
                                                     g->layer_attn_state_kv[il],
                                                     0,
-                                                    layer_attn_state_bytes(ratio),
+                                                    attn_state_span,
                                                     buf,
                                                     DS4_SESSION_IO_CHUNK,
                                                     err,
@@ -50458,7 +50559,7 @@ int ds4_session_save_layer_payload(ds4_session *s, FILE *fp,
         if (rc == 0) rc = payload_write_tensor_span(fp,
                                                     g->layer_attn_state_score[il],
                                                     0,
-                                                    layer_attn_state_bytes(ratio),
+                                                    attn_state_span,
                                                     buf,
                                                     DS4_SESSION_IO_CHUNK,
                                                     err,
@@ -50863,10 +50964,30 @@ int ds4_session_load_layer_payload(ds4_session *s, FILE *fp,
                                           err,
                                           errlen);
         }
+        uint64_t attn_state_span = layer_attn_state_bytes(ratio);
+        if (ratio != 4) {
+            /* Single-lane: refresh-init the whole block buffer (kv=0,
+             * score=DS4_NEG_INF) so the unserialized tail is correct, then
+             * overwrite the occupied head with the saved partial rows. */
+            uint32_t partial = 0;
+            if (rc == 0 && payload_read_u32(fp, &partial, &remaining, err, errlen) != 0) rc = 1;
+            if (rc == 0 && (partial != saved_tokens % ratio ||
+                            (uint64_t)n_comp[i] * ratio + partial != saved_tokens)) {
+                payload_set_err(err, errlen, "KV shard compressor partial count is inconsistent");
+                rc = 1;
+            }
+            if (rc == 0) {
+                const uint64_t total_state_floats = layer_attn_state_bytes(ratio) / sizeof(float);
+                if (!metal_tensor_fill_f32(g->layer_attn_state_kv[il], 0.0f, total_state_floats) ||
+                    !metal_tensor_fill_f32(g->layer_attn_state_score[il], DS4_NEG_INF, total_state_floats))
+                    rc = 1;
+            }
+            attn_state_span = (uint64_t)partial * DS4_N_HEAD_DIM * sizeof(float);
+        }
         if (rc == 0) rc = payload_read_tensor_span(fp,
                                                    g->layer_attn_state_kv[il],
                                                    0,
-                                                   layer_attn_state_bytes(ratio),
+                                                   attn_state_span,
                                                    buf,
                                                    DS4_SESSION_IO_CHUNK,
                                                    &remaining,
@@ -50875,7 +50996,7 @@ int ds4_session_load_layer_payload(ds4_session *s, FILE *fp,
         if (rc == 0) rc = payload_read_tensor_span(fp,
                                                    g->layer_attn_state_score[il],
                                                    0,
-                                                   layer_attn_state_bytes(ratio),
+                                                   attn_state_span,
                                                    buf,
                                                    DS4_SESSION_IO_CHUNK,
                                                    &remaining,
@@ -51409,8 +51530,16 @@ int ds4_session_save_payload(ds4_session *s, FILE *fp, char *err, size_t errlen)
                                     (uint64_t)layer->n_comp * DS4_N_HEAD_DIM * sizeof(float),
                                     err,
                                     errlen) != 0) return 1;
-            if (payload_write_bytes(fp, layer->attn_state_kv, layer_attn_state_bytes(ratio), err, errlen) != 0) return 1;
-            if (payload_write_bytes(fp, layer->attn_state_score, layer_attn_state_bytes(ratio), err, errlen) != 0) return 1;
+            uint64_t attn_state_span = layer_attn_state_bytes(ratio);
+            if (ratio != 4) {
+                /* Single-lane layer: prefix the occupied rows with a u32 partial
+                 * count (partial = L % ratio) and serialize only [0, partial). */
+                const uint32_t partial = layer_state_partial_rows(ratio, (uint32_t)s->checkpoint.len);
+                if (payload_write_u32(fp, partial, err, errlen) != 0) return 1;
+                attn_state_span = (uint64_t)partial * DS4_N_HEAD_DIM * sizeof(float);
+            }
+            if (payload_write_bytes(fp, layer->attn_state_kv, attn_state_span, err, errlen) != 0) return 1;
+            if (payload_write_bytes(fp, layer->attn_state_score, attn_state_span, err, errlen) != 0) return 1;
             if (ratio == 4) {
                 if (payload_write_bytes(fp,
                                         layer->index_comp_kv,
@@ -51511,10 +51640,18 @@ int ds4_session_save_payload(ds4_session *s, FILE *fp, char *err, size_t errlen)
                                            err,
                                            errlen);
         }
+        uint64_t attn_state_span = layer_attn_state_bytes(ratio);
+        if (ratio != 4) {
+            /* Single-lane layer: prefix the occupied rows with a u32 partial
+             * count (partial = L % ratio) and serialize only [0, partial). */
+            const uint32_t partial = layer_state_partial_rows(ratio, (uint32_t)s->checkpoint.len);
+            if (rc == 0 && payload_write_u32(fp, partial, err, errlen) != 0) rc = 1;
+            attn_state_span = (uint64_t)partial * DS4_N_HEAD_DIM * sizeof(float);
+        }
         if (rc == 0) rc = payload_write_tensor_span(fp,
                                                     g->layer_attn_state_kv[il],
                                                     0,
-                                                    layer_attn_state_bytes(ratio),
+                                                    attn_state_span,
                                                     buf,
                                                     DS4_SESSION_IO_CHUNK,
                                                     err,
@@ -51522,7 +51659,7 @@ int ds4_session_save_payload(ds4_session *s, FILE *fp, char *err, size_t errlen)
         if (rc == 0) rc = payload_write_tensor_span(fp,
                                                     g->layer_attn_state_score[il],
                                                     0,
-                                                    layer_attn_state_bytes(ratio),
+                                                    attn_state_span,
                                                     buf,
                                                     DS4_SESSION_IO_CHUNK,
                                                     err,
@@ -51873,14 +52010,18 @@ int ds4_session_load_payload(ds4_session *s, FILE *fp, uint64_t payload_bytes, c
                                    (uint64_t)n_comp[il] * DS4_N_HEAD_DIM * sizeof(float),
                                    &remaining,
                                    err,
-                                   errlen) != 0 ||
-                payload_read_bytes(fp, layer->attn_state_kv, layer_attn_state_bytes(ratio), &remaining, err, errlen) != 0 ||
-                payload_read_bytes(fp, layer->attn_state_score, layer_attn_state_bytes(ratio), &remaining, err, errlen) != 0)
+                                   errlen) != 0)
             {
                 token_vec_free(&new_checkpoint);
                 return 1;
             }
             if (ratio == 4) {
+                if (payload_read_bytes(fp, layer->attn_state_kv, layer_attn_state_bytes(ratio), &remaining, err, errlen) != 0 ||
+                    payload_read_bytes(fp, layer->attn_state_score, layer_attn_state_bytes(ratio), &remaining, err, errlen) != 0)
+                {
+                    token_vec_free(&new_checkpoint);
+                    return 1;
+                }
                 if (payload_read_bytes(fp,
                                        layer->index_comp_kv,
                                        (uint64_t)n_index_comp[il] * DS4_N_INDEXER_HEAD_DIM * sizeof(float),
@@ -51889,6 +52030,30 @@ int ds4_session_load_payload(ds4_session *s, FILE *fp, uint64_t payload_bytes, c
                                        errlen) != 0 ||
                     payload_read_bytes(fp, layer->index_state_kv, layer_index_state_bytes(ratio), &remaining, err, errlen) != 0 ||
                     payload_read_bytes(fp, layer->index_state_score, layer_index_state_bytes(ratio), &remaining, err, errlen) != 0)
+                {
+                    token_vec_free(&new_checkpoint);
+                    return 1;
+                }
+            } else {
+                /* Single-lane layer: read the u32 partial count, validate it
+                 * against the checkpoint length and n_comp, then read only the
+                 * occupied rows.  The tail [partial, ratio) is already cleared
+                 * to fresh-init values (kv=0, score=DS4_NEG_INF) by the
+                 * session_cpu_reset_cache call above. */
+                uint32_t partial = 0;
+                if (payload_read_u32(fp, &partial, &remaining, err, errlen) != 0) {
+                    token_vec_free(&new_checkpoint);
+                    return 1;
+                }
+                if (partial != saved_tokens % ratio ||
+                    (uint64_t)n_comp[il] * ratio + partial != saved_tokens) {
+                    token_vec_free(&new_checkpoint);
+                    payload_set_err(err, errlen, "KV checkpoint compressor partial count is inconsistent");
+                    return 1;
+                }
+                const uint64_t state_span = (uint64_t)partial * DS4_N_HEAD_DIM * sizeof(float);
+                if (payload_read_bytes(fp, layer->attn_state_kv, state_span, &remaining, err, errlen) != 0 ||
+                    payload_read_bytes(fp, layer->attn_state_score, state_span, &remaining, err, errlen) != 0)
                 {
                     token_vec_free(&new_checkpoint);
                     return 1;
@@ -52045,10 +52210,30 @@ int ds4_session_load_payload(ds4_session *s, FILE *fp, uint64_t payload_bytes, c
                                           err,
                                           errlen);
         }
+        uint64_t attn_state_span = layer_attn_state_bytes(ratio);
+        if (ratio != 4) {
+            /* Single-lane: refresh-init the whole block buffer (kv=0,
+             * score=DS4_NEG_INF) so the unserialized tail is correct, then
+             * overwrite the occupied head with the saved partial rows. */
+            uint32_t partial = 0;
+            if (rc == 0 && payload_read_u32(fp, &partial, &remaining, err, errlen) != 0) rc = 1;
+            if (rc == 0 && (partial != saved_tokens % ratio ||
+                            (uint64_t)n_comp[il] * ratio + partial != saved_tokens)) {
+                payload_set_err(err, errlen, "KV checkpoint compressor partial count is inconsistent");
+                rc = 1;
+            }
+            if (rc == 0) {
+                const uint64_t total_state_floats = layer_attn_state_bytes(ratio) / sizeof(float);
+                if (!metal_tensor_fill_f32(g->layer_attn_state_kv[il], 0.0f, total_state_floats) ||
+                    !metal_tensor_fill_f32(g->layer_attn_state_score[il], DS4_NEG_INF, total_state_floats))
+                    rc = 1;
+            }
+            attn_state_span = (uint64_t)partial * DS4_N_HEAD_DIM * sizeof(float);
+        }
         if (rc == 0) rc = payload_read_tensor_span(fp,
                                                    g->layer_attn_state_kv[il],
                                                    0,
-                                                   layer_attn_state_bytes(ratio),
+                                                   attn_state_span,
                                                    buf,
                                                    DS4_SESSION_IO_CHUNK,
                                                    &remaining,
@@ -52057,7 +52242,7 @@ int ds4_session_load_payload(ds4_session *s, FILE *fp, uint64_t payload_bytes, c
         if (rc == 0) rc = payload_read_tensor_span(fp,
                                                    g->layer_attn_state_score[il],
                                                    0,
-                                                   layer_attn_state_bytes(ratio),
+                                                   attn_state_span,
                                                    buf,
                                                    DS4_SESSION_IO_CHUNK,
                                                    &remaining,

--- a/ds4.h
+++ b/ds4.h
@@ -376,6 +376,11 @@ int ds4_test_sample_logits(const float *logits, uint32_t n_vocab,
 int ds4_test_argmax_excluding_logits(const float *logits, uint32_t n_vocab,
                                      int excluded_id);
 uint64_t ds4_test_mixed_native_count(void);
+/* Byte offset of the compressor-state partial count for layer il_target within
+ * a payload ds4_session_save_payload would write now; false for ratio-0/4
+ * layers or unsupported backends. */
+bool ds4_test_payload_partial_offset(ds4_session *s, uint32_t il_target,
+                                     uint64_t *offset_out);
 #endif
 int ds4_session_top_logprobs(ds4_session *s, ds4_token_score *out, int k);
 int ds4_session_token_logprob(ds4_session *s, int token, ds4_token_score *out);
@@ -448,10 +453,14 @@ int ds4_session_eval_output_head_from_hc(ds4_session *s,
 /* Disk KV payload helpers.  HTTP/agent code owns the outer file header and
  * persistence policy; the engine owns the DS4-specific serialized graph state. */
 #define DS4_SESSION_PAYLOAD_MAGIC UINT32_C(0x34565344) /* "DSV4" */
-#define DS4_SESSION_PAYLOAD_VERSION UINT32_C(2)
+/* Bumped 2 -> 3: single-lane compressor layers serialize only the occupied
+ * partial = checkpoint_len % ratio rows of the in-progress block, prefixed by
+ * a u32 count.  Ratio-4 layers stay byte-identical. */
+#define DS4_SESSION_PAYLOAD_VERSION UINT32_C(3)
 #define DS4_SESSION_PAYLOAD_U32_FIELDS 13u
 #define DS4_SESSION_LAYER_PAYLOAD_MAGIC UINT32_C(0x4c565344) /* "DSVL" */
-#define DS4_SESSION_LAYER_PAYLOAD_VERSION UINT32_C(1)
+/* Bumped 1 -> 2: same frontier-state occupancy change as the full payload. */
+#define DS4_SESSION_LAYER_PAYLOAD_VERSION UINT32_C(2)
 #define DS4_SESSION_LAYER_PAYLOAD_U32_FIELDS 14u
 
 uint64_t ds4_session_payload_bytes(ds4_session *s);

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -4639,13 +4639,13 @@ static bool dist_kv_layer_tensor_bytes(
             !dist_u64_mul(tmp, sizeof(float), &tmp) ||
             !dist_u64_add(&bytes, tmp))
             return false;
-        bool ok = true;
-        const uint64_t attn_state = dist_kv_state_bytes(ratio, layout->head_dim, &ok);
-        if (!ok ||
-            !dist_u64_add(&bytes, attn_state) ||
-            !dist_u64_add(&bytes, attn_state))
-            return false;
         if (ratio == 4u) {
+            bool ok = true;
+            const uint64_t attn_state = dist_kv_state_bytes(ratio, layout->head_dim, &ok);
+            if (!ok ||
+                !dist_u64_add(&bytes, attn_state) ||
+                !dist_u64_add(&bytes, attn_state))
+                return false;
             if (!dist_u64_mul(n_index_comp, layout->indexer_head_dim, &tmp) ||
                 !dist_u64_mul(tmp, sizeof(float), &tmp) ||
                 !dist_u64_add(&bytes, tmp))
@@ -4655,6 +4655,18 @@ static bool dist_kv_layer_tensor_bytes(
             if (!ok ||
                 !dist_u64_add(&bytes, index_state) ||
                 !dist_u64_add(&bytes, index_state))
+                return false;
+        } else {
+            /* Single-lane compressor layers serialize only the occupied
+             * partial = token_count % ratio rows of the in-progress block,
+             * prefixed by one u32 count covering both kv and score.  Mirrors
+             * the per-layer layout math in ds4_session_save/load_layer_payload. */
+            const uint32_t partial = layout->token_count % ratio;
+            if (!dist_u64_mul(partial, layout->head_dim, &tmp) ||
+                !dist_u64_mul(tmp, sizeof(float), &tmp) ||
+                !dist_u64_add(&bytes, tmp) ||
+                !dist_u64_add(&bytes, tmp) ||
+                !dist_u64_add(&bytes, sizeof(uint32_t)))
                 return false;
         }
     }

--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -28,8 +28,11 @@
 #define KV_CACHE_VERSION 1u
 /* Header byte 20 carries the graph-payload ABI.  It is separate from the outer
  * file version because the KVC envelope can remain stable while the serialized
- * ds4_session internals become unsafe to restore across runtime changes. */
-#define KV_CACHE_PAYLOAD_ABI 2u
+ * ds4_session internals become unsafe to restore across runtime changes.
+ * Bumped to 3 for compressor frontier-state occupancy serialization: single-lane
+ * layers (ratio != 0 && != 4) now write a u32 partial count + only the occupied
+ * rows of the in-progress compressor block instead of the full-capacity buffer. */
+#define KV_CACHE_PAYLOAD_ABI 3u
 #define KV_CACHE_DEFAULT_MIN_TOKENS 512
 #define KV_CACHE_DEFAULT_COLD_MAX_TOKENS 30000
 /* Tokenizers may merge text across the prompt boundary. Trimming a small tail

--- a/tests/test_kv_frontier_state.c
+++ b/tests/test_kv_frontier_state.c
@@ -1,0 +1,354 @@
+/* Regression test: compressor frontier-state occupancy serialization.
+ *
+ * Single-lane compressor layers (compress_ratio != 0 && != 4) now serialize
+ * only the occupied partial = checkpoint_len % ratio rows of the in-progress
+ * compressor block (plus a u32 count), instead of the full-capacity buffer.
+ * Ratio-4 layers keep the full-capacity layout and are untouched by this.
+ *
+ * This test verifies, on the Metal backend:
+ *   - Round-trip exactness (gate #1/#6): greedy-decode GEN_N tokens from a
+ *     live session, then save + warm-restore the checkpoint and decode again.
+ *     The two continuations must be byte-for-byte identical.  The restore is
+ *     done warm (the session has already advanced past the checkpoint), so the
+ *     tail-clear path is exercised: a missing clear would leave stale rows in
+ *     [partial, ratio) and corrupt the next compressed row.
+ *   - Size math (gate #2): the saved file size equals ds4_session_payload_bytes.
+ *   - Both a ratio-aligned checkpoint (partial = 0, gate #5) and an un-aligned
+ *     one (partial > 0), where generating GEN_N crosses a ratio-128 commit.
+ *   - Version rejection: a payload whose version field is corrupted must be
+ *     rejected (the ABI bump that retires pre-change .kv files).
+ *
+ * Requires DS4_TEST_MODEL.  Generation is kept short and ctx modest.
+ */
+#include "ds4.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#define GEN_N          8
+#define TEST_CTX       2048
+#define STATE_HEADER_BYTES 4u   /* u32 version lives at file offset 4 */
+
+static void fail(const char *msg) {
+    fprintf(stderr, "FAIL: %s\n", msg);
+    exit(1);
+}
+
+#define CHECK(cond, msg) do { if (!(cond)) fail(msg); } while (0)
+
+/* Greedy-decode exactly n tokens from the current session position. */
+static void greedy_n(ds4_session *s, int *out, int n) {
+    char err[256] = {0};
+    for (int i = 0; i < n; i++) {
+        int t = ds4_session_argmax(s);
+        CHECK(t >= 0, "argmax");
+        out[i] = t;
+        CHECK(ds4_session_eval(s, t, err, sizeof(err)) == 0, "eval");
+    }
+}
+
+/* One save -> warm-restore round-trip at target_len. Returns the saved byte count. */
+static uint64_t run_target(ds4_engine *e, const ds4_tokens *prompt, int target_len) {
+    char err[256] = {0};
+    ds4_session *s = NULL;
+    CHECK(ds4_session_create(&s, e, TEST_CTX) == 0, "session create");
+    CHECK(ds4_session_sync(s, prompt, err, sizeof(err)) == 0, "session sync");
+
+    /* Greedy-eval forward to the target checkpoint length. */
+    while (ds4_session_pos(s) < target_len) {
+        int t = ds4_session_argmax(s);
+        CHECK(t >= 0, "argmax to target");
+        CHECK(ds4_session_eval(s, t, err, sizeof(err)) == 0, "eval to target");
+    }
+    CHECK(ds4_session_pos(s) == target_len, "reached target length");
+
+    /* Save the payload at the target checkpoint. */
+    FILE *fp = tmpfile();
+    CHECK(fp != NULL, "tmpfile");
+    CHECK(ds4_session_save_payload(s, fp, err, sizeof(err)) == 0, "save payload");
+    const uint64_t saved_bytes = (uint64_t)ftello(fp);
+    const uint64_t predicted = ds4_session_payload_bytes(s);
+    if (saved_bytes != predicted) {
+        fprintf(stderr,
+                "FAIL: size math target=%d file=%llu payload_bytes=%llu\n",
+                target_len, (unsigned long long)saved_bytes,
+                (unsigned long long)predicted);
+        exit(1);
+    }
+
+    /* Baseline continuation from the live (un-checkpointed) session. */
+    int baseline[GEN_N];
+    greedy_n(s, baseline, GEN_N);
+
+    /* Warm restore: reload the saved checkpoint into the now-advanced session,
+     * resetting it to target_len.  Exercises the compressor tail-clear path. */
+    rewind(fp);
+    CHECK(ds4_session_load_payload(s, fp, saved_bytes, err, sizeof(err)) == 0,
+          "load payload");
+    CHECK(ds4_session_pos(s) == target_len, "restored to target length");
+
+    int restored[GEN_N];
+    greedy_n(s, restored, GEN_N);
+
+    for (int i = 0; i < GEN_N; i++) {
+        if (baseline[i] != restored[i]) {
+            fprintf(stderr,
+                    "FAIL: token divergence target=%d step=%d baseline=%d restored=%d\n",
+                    target_len, i, baseline[i], restored[i]);
+            exit(1);
+        }
+    }
+
+    fclose(fp);
+    ds4_session_free(s);
+    return saved_bytes;
+}
+
+/* Compare two open files byte-for-byte from their current positions up to
+ * `bytes`. Returns true if identical. Restores the file positions afterwards. */
+static bool files_identical(FILE *a, FILE *b, uint64_t bytes) {
+    rewind(a); rewind(b);
+    uint8_t ba[8192], bb[8192];
+    uint64_t left = bytes;
+    while (left > 0) {
+        size_t n = left > sizeof(ba) ? sizeof(ba) : (size_t)left;
+        if (fread(ba, 1, n, a) != n || fread(bb, 1, n, b) != n) return false;
+        if (memcmp(ba, bb, n) != 0) return false;
+        left -= n;
+    }
+    rewind(a); rewind(b);
+    return true;
+}
+
+/* Deep single-target check used by the fuzz sweep: save -> warm-restore ->
+ * generate must match the live baseline exactly; re-saving after restore must
+ * be byte-identical (derivation is deterministic); and a second warm restore
+ * into the dirty session must again match (repeated tail-clear). */
+static void run_fuzz_target(ds4_engine *e, const ds4_tokens *prompt, int target_len) {
+    char err[256] = {0};
+    ds4_session *s = NULL;
+    CHECK(ds4_session_create(&s, e, TEST_CTX) == 0, "fuzz session create");
+    CHECK(ds4_session_sync(s, prompt, err, sizeof(err)) == 0, "fuzz sync");
+    while (ds4_session_pos(s) < target_len) {
+        int t = ds4_session_argmax(s);
+        CHECK(t >= 0, "fuzz argmax to target");
+        CHECK(ds4_session_eval(s, t, err, sizeof(err)) == 0, "fuzz eval to target");
+    }
+    CHECK(ds4_session_pos(s) == target_len, "fuzz reached target");
+
+    FILE *fa = tmpfile(); CHECK(fa != NULL, "fuzz tmpfile a");
+    CHECK(ds4_session_save_payload(s, fa, err, sizeof(err)) == 0, "fuzz save a");
+    const uint64_t bytes_a = (uint64_t)ftello(fa);
+    CHECK(bytes_a == ds4_session_payload_bytes(s), "fuzz size math");
+
+    int baseline[GEN_N];
+    greedy_n(s, baseline, GEN_N);
+
+    /* 1st warm restore. */
+    rewind(fa);
+    CHECK(ds4_session_load_payload(s, fa, bytes_a, err, sizeof(err)) == 0, "fuzz load 1");
+    CHECK(ds4_session_pos(s) == target_len, "fuzz pos after load 1");
+
+    /* Re-save immediately (still at target_len) and confirm a byte-identical
+     * payload: the partial derivation is deterministic and the state was
+     * restored exactly, so the serialized bytes must match the original save. */
+    FILE *fb = tmpfile(); CHECK(fb != NULL, "fuzz tmpfile b");
+    CHECK(ds4_session_save_payload(s, fb, err, sizeof(err)) == 0, "fuzz save b");
+    const uint64_t bytes_b = (uint64_t)ftello(fb);
+    CHECK(bytes_b == bytes_a, "fuzz re-save size changed");
+    CHECK(files_identical(fa, fb, bytes_a), "fuzz re-save bytes differ");
+    fclose(fb);
+
+    /* Generate from the restored checkpoint; must match the live baseline. */
+    int restored[GEN_N];
+    greedy_n(s, restored, GEN_N);
+    for (int i = 0; i < GEN_N; i++)
+        CHECK(baseline[i] == restored[i], "fuzz gen mismatch after load 1");
+
+    /* 2nd warm restore into the now-dirty session + generate (repeated clear). */
+    rewind(fa);
+    CHECK(ds4_session_load_payload(s, fa, bytes_a, err, sizeof(err)) == 0, "fuzz load 2");
+    CHECK(ds4_session_pos(s) == target_len, "fuzz pos after load 2");
+    greedy_n(s, restored, GEN_N);
+    for (int i = 0; i < GEN_N; i++)
+        CHECK(baseline[i] == restored[i], "fuzz gen mismatch after load 2");
+
+    fclose(fa);
+    ds4_session_free(s);
+    fprintf(stderr, "  fuzz target=%d (partial128=%d) OK\n",
+            target_len, target_len % 128);
+}
+
+/* A payload whose version field is corrupted must be rejected on load. */
+static void test_version_rejection(ds4_engine *e, const ds4_tokens *prompt) {
+    char err[256] = {0};
+    ds4_session *s = NULL;
+    CHECK(ds4_session_create(&s, e, TEST_CTX) == 0, "vr session create");
+    CHECK(ds4_session_sync(s, prompt, err, sizeof(err)) == 0, "vr sync");
+
+    FILE *fp = tmpfile();
+    CHECK(fp != NULL, "vr tmpfile");
+    CHECK(ds4_session_save_payload(s, fp, err, sizeof(err)) == 0, "vr save");
+    const uint64_t bytes = (uint64_t)ftello(fp);
+
+    /* Overwrite the version u32 (header word 1, byte offset 4). */
+    const uint32_t bad_version = 0xFFFFFFFFu;
+    CHECK(fseek(fp, (long)STATE_HEADER_BYTES, SEEK_SET) == 0, "vr seek");
+    CHECK(fwrite(&bad_version, sizeof(bad_version), 1, fp) == 1, "vr corrupt");
+    rewind(fp);
+
+    const int rc = ds4_session_load_payload(s, fp, bytes, err, sizeof(err));
+    if (rc == 0) fail("version rejection: corrupt payload was accepted");
+
+    fclose(fp);
+    ds4_session_free(s);
+    fprintf(stderr, "version-rejection OK (corrupt payload rejected)\n");
+}
+
+/* A payload whose single-lane compressor partial count is inconsistent with
+ * the checkpoint length must be rejected (gate #3: no silent acceptance). */
+static void test_partial_corruption(ds4_engine *e, const ds4_tokens *prompt,
+                                    int unaligned_target) {
+    char err[256] = {0};
+    ds4_session *s = NULL;
+    CHECK(ds4_session_create(&s, e, TEST_CTX) == 0, "pc session create");
+    CHECK(ds4_session_sync(s, prompt, err, sizeof(err)) == 0, "pc sync");
+    while (ds4_session_pos(s) < unaligned_target) {
+        int t = ds4_session_argmax(s);
+        CHECK(t >= 0, "pc argmax");
+        CHECK(ds4_session_eval(s, t, err, sizeof(err)) == 0, "pc eval");
+    }
+    CHECK(ds4_session_pos(s) == unaligned_target, "pc reached target");
+
+    /* Locate the first single-lane layer's partial-count field in a payload
+     * written at this checkpoint (reuses the engine's own layout accounting). */
+    uint64_t off = 0;
+    int found = -1;
+    const int n_layers = ds4_engine_layer_count(e);
+    for (int il = 0; il < n_layers; il++) {
+        if (ds4_test_payload_partial_offset(s, (uint32_t)il, &off)) {
+            found = il;
+            break;
+        }
+    }
+    if (found < 0) {
+        fprintf(stderr, "partial-corruption: no single-lane layers; skipping\n");
+        ds4_session_free(s);
+        return;
+    }
+
+    FILE *fp = tmpfile();
+    CHECK(fp != NULL, "pc tmpfile");
+    CHECK(ds4_session_save_payload(s, fp, err, sizeof(err)) == 0, "pc save");
+    const uint64_t bytes = (uint64_t)ftello(fp);
+
+    /* Flip the partial count's low bit so it can no longer equal
+     * checkpoint_len % ratio.  The load validates this right after reading the
+     * count, before consuming any state rows, so the rejection is clean. */
+    uint32_t partial = 0;
+    CHECK(fseeko(fp, (off_t)off, SEEK_SET) == 0, "pc seek");
+    CHECK(fread(&partial, sizeof(partial), 1, fp) == 1, "pc read partial");
+    const uint32_t corrupted = partial ^ 1u;
+    CHECK(fseeko(fp, (off_t)off, SEEK_SET) == 0, "pc seek2");
+    CHECK(fwrite(&corrupted, sizeof(corrupted), 1, fp) == 1, "pc corrupt");
+    rewind(fp);
+
+    const int rc = ds4_session_load_payload(s, fp, bytes, err, sizeof(err));
+    if (rc == 0) fail("partial-corruption: inconsistent partial was accepted");
+
+    fclose(fp);
+    ds4_session_free(s);
+    fprintf(stderr,
+            "partial-corruption OK (inconsistent partial rejected, layer %d)\n",
+            found);
+}
+
+int main(void) {
+    const char *model = getenv("DS4_TEST_MODEL");
+    if (!model || !model[0]) {
+        fprintf(stderr, "FAIL: DS4_TEST_MODEL is not set\n");
+        return 1;
+    }
+
+    ds4_engine_options opt;
+    memset(&opt, 0, sizeof(opt));
+    opt.model_path = model;
+    opt.backend = DS4_BACKEND_METAL;
+    opt.n_threads = 1;
+    opt.warm_weights = false;
+    opt.quality = false;
+
+    ds4_engine *e = NULL;
+    if (ds4_engine_open(&e, &opt) != 0 || !e) fail("engine open");
+
+    ds4_tokens prompt = {0};
+    ds4_encode_chat_prompt(e, /*system=*/NULL, "What is the capital of France?",
+                           DS4_THINK_NONE, &prompt);
+    CHECK(prompt.len > 0, "tokenize prompt");
+    const int prompt_len = prompt.len;
+
+    /* Opt-in broad sweep: many checkpoint lengths covering partial 0, edge
+     * values (1, 127), mid values, and lengths crossing several ratio-128
+     * commits, each with exact restore + byte-stable re-save + repeated warm
+     * restore.  Default run (no env) stays at the two representative lengths. */
+    if (getenv("DS4_TEST_FUZZ") && getenv("DS4_TEST_FUZZ")[0] != '0') {
+        const int base = ((prompt_len + 64 + 127) / 128) * 128;  /* first mult of 128 */
+        fprintf(stderr, "FUZZ mode: base=%d prompt_len=%d\n", base, prompt_len);
+        const int aligned[] = { base, base * 2, base * 4 };
+        const int offs[] = { 1, 2, 7, 32, 63, 64, 65, 100, 120, 127 };
+        for (size_t i = 0; i < sizeof(aligned) / sizeof(aligned[0]); i++)
+            run_fuzz_target(e, &prompt, aligned[i]);
+        for (size_t i = 0; i < sizeof(offs) / sizeof(offs[0]); i++)
+            run_fuzz_target(e, &prompt, base + offs[i]);
+        run_fuzz_target(e, &prompt, base - 1);   /* partial 127, n_comp one less */
+        run_fuzz_target(e, &prompt, base * 4 - 12);  /* partial 116, crosses 3 commits */
+        ds4_tokens_free(&prompt);
+        ds4_engine_close(e);
+        fprintf(stderr, "test_kv_frontier_state FUZZ PASS\n");
+        return 0;
+    }
+
+    /* Aligned target: a multiple of 128 (hence also of 4) past the prompt. */
+    const int margin = 192;
+    int aligned_target = ((prompt_len + margin + 127) / 128) * 128;
+    /* Un-aligned target: aligned - GEN_N so generating GEN_N crosses the
+     * ratio-128 commit boundary at aligned_target. */
+    int unaligned_target = aligned_target - GEN_N;
+    while (unaligned_target <= prompt_len) {
+        aligned_target += 128;
+        unaligned_target = aligned_target - GEN_N;
+    }
+
+    fprintf(stderr, "prompt_len=%d aligned_target=%d unaligned_target=%d\n",
+            prompt_len, aligned_target, unaligned_target);
+
+    const uint64_t aligned_bytes = run_target(e, &prompt, aligned_target);
+    const uint64_t unaligned_bytes = run_target(e, &prompt, unaligned_target);
+
+    /* Occupancy varies with checkpoint length: at the un-aligned checkpoint the
+     * single-lane layers hold partial > 0 occupied rows, so the payload must be
+     * strictly larger than the aligned (partial = 0) one. */
+    if (unaligned_bytes <= aligned_bytes) {
+        fprintf(stderr,
+                "FAIL: frontier-state size is not length-dependent "
+                "(aligned=%llu unaligned=%llu)\n",
+                (unsigned long long)aligned_bytes,
+                (unsigned long long)unaligned_bytes);
+        return 1;
+    }
+    fprintf(stderr,
+            "payload bytes: aligned=%llu unaligned=%llu delta=%llu\n",
+            (unsigned long long)aligned_bytes,
+            (unsigned long long)unaligned_bytes,
+            (unsigned long long)(unaligned_bytes - aligned_bytes));
+
+    test_version_rejection(e, &prompt);
+    test_partial_corruption(e, &prompt, unaligned_target);
+
+    ds4_tokens_free(&prompt);
+    ds4_engine_close(e);
+    fprintf(stderr, "test_kv_frontier_state PASS\n");
+    return 0;
+}


### PR DESCRIPTION
This PR removes about ~5MB fixed overhead per KV cache disk checkpoint (on average; ~10MB per checkpoint max, if stars are aligned - or if we start actively aligning the checkpoints later). This is done by storing only useful part of ratio-128 layers on disk, not the whole buffer always. Before this change there was ~23MB fixed overhead per checkpoint, now it's ~17MB on average.

It is possible to optimize ratio-4 layers as well, but it's kept out of scope for this PR, to simplify the code (they give much less savings).

Checked with unit tests, and also with various probes against live server.

5-10MB savings per checkpoint are nice, but not super important right now. Although they're still nice. But I think they become much more valuable if some kind of KV disk cache optimization lands (see https://github.com/antirez/ds4/issues/771). 

AI-generated description:

---

Single-lane compressor layers (compress_ratio != 0 && != 4) use the attn_state_* buffers as a ring of `ratio` rows, but checkpoints wrote the full capacity.  Only the `partial = checkpoint_len % ratio` rows accumulated in the current block are live; the rest are stale leftovers overwritten before they are ever read (they stay inside the raw SWA window, so no attention path reads the in-progress compressor state mid-block).  Serialize just those rows plus a u32 count, and clear the tail on restore.

Ratio-4 layers (coff == 2) keep the full-capacity layout byte-for-byte: their two-lane pooler reads the one-block-old lane A by design, so the stale-rows-never-read invariant is false there.

`partial` is derived from the checkpoint length and cross-checked against the already-serialized n_comp on load (n_comp*ratio + partial == len); no new struct fields or counters, and an inconsistent payload is a hard load error. All four size-accounting sites (including the separate copy in ds4_distributed) are updated to match bytes written.  Bump the three payload format constants: kvstore ABI 2->3, session payload 2->3, layer payload 1->2.

Add tests/test_kv_frontier_state: Metal round-trip at aligned (partial=0) and un-aligned (partial>0) checkpoints with size math, warm-restore tail-clear check, version rejection, partial-corruption rejection, and an opt-in fuzz sweep (DS4_TEST_FUZZ=1) over the full occupancy range with byte-stable re-save and repeated warm restore.