### PR TITLE
Exiting ds4-server when CUDA runs into terminal errors

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -1832,6 +1832,15 @@ static float *cuda_q8_f32_ptr(
 static int cuda_ok(cudaError_t err, const char *what) {
     if (err == cudaSuccess) return 1;
     fprintf(stderr, "ds4: CUDA %s failed: %s\n", what, cudaGetErrorString(err));
+    /* Fatal CUDA errors leave this process's context unusable. */
+    if (err == cudaErrorIllegalAddress ||
+        err == cudaErrorLaunchFailure ||
+        err == cudaErrorAssert) {
+        fprintf(stderr,
+                "ds4: fatal CUDA context error; exiting\n");
+        fflush(stderr);
+        _Exit(EXIT_FAILURE);
+    }
     return 0;
 }
 


### PR DESCRIPTION
This attempts to solve the issue where the server continues running when running into terminal CUDA memory access failures where the CUDA context is no longer healthy in #759 

This will allow process managers to start the process back up and continue serving requests.  It doesn't address the underlying issue, but helps recovery.