### PR TITLE
metal: fix staged B-tile tensor extents in the mm_id mpp kernel

### DIFF
--- a/metal/moe.metal
+++ b/metal/moe.metal
@@ -8941,7 +8941,13 @@ kernel void kernel_mul_mm_id_mpp(
         + args.nb10*iy);
 
     auto tA = tensor(sa, dextents<int32_t, 2>(NK, NR0));
-    auto tB = tensor(sb, dextents<int32_t, 2>(NR1, NK));
+    /* The staged B tile stores element (n, k) at sb[n*NK + k]: dim0 is K
+     * (stride 1), dim1 is N (stride NK) — the same convention as tA above.
+     * The historical (NR1, NK) extents order only described it correctly
+     * because NR1 == NK == 32; spell it (NK, NR1) so narrower future
+     * instantiations keep the true layout. Identical extents and strides
+     * while NR1 == 32. */
+    auto tB = tensor(sb, dextents<int32_t, 2>(NK, NR1));
 
     matmul2d<
         matmul2d_descriptor(NR1, NR0, NK, false, true, false,


### PR DESCRIPTION
The staged B tile in `kernel_mul_mm_id_mpp` stores element (n, k) at `sb[n*NK + k]`: dim0 is K (stride 1), dim1 is N (stride NK). The `tB` tensor declares its extents as `(NR1, NK)`, which only describes that layout correctly because `NR1 == NK == 32` — the transposed extents happen to be identical. Any future instantiation with `NR1 != NK` (e.g. a narrower N tile) would silently compute against a transposed view of the staged tile and produce garbage for every routed row.

This spells the extents `(NK, NR1)`, matching the actual store order. Extents and strides are bit-identical while `NR1 == 32`, so the shipped kernel is unchanged: verified bit-exact on full-vocabulary logit frontiers on M5 Max (8 runs, abort-on-diff), and `--metal-kernels` tests pass.

Found while experimenting with an NR1=16 tail-tile instantiation, where the transposed view produced 100% differing logits until the declaration was fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)