### PR TITLE
dspark: fold first-token forward into verify + bit-exact M5 Metal decode wins

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -16227,6 +16227,12 @@ static bool metal_graph_debug_wants(const char *name, uint32_t il, uint32_t pos)
     return metal_graph_debug_prefix_for(name, il, pos) != NULL;
 }
 
+/* Fusions that skip per-row dispatches also skip the per-row debug dump
+ * hooks; they must stand down whenever a dump prefix is configured. */
+static bool metal_graph_debug_dump_enabled(void) {
+    return metal_graph_debug_get_config()->prefix != NULL;
+}
+
 static void metal_graph_debug_dump_tensor(
         const char       *name,
         ds4_gpu_tensor *t,
@@ -25506,11 +25512,18 @@ static bool metal_graph_output_logits_head_matmul(
             (uint64_t)n_tokens * vocab_dim * sizeof(float)) {
         return false;
     }
+    /* CUDA keeps the historical eight-row padding for its shard matmuls.
+     * The Metal mv_ext head covers 2..5 rows in a single row-tile, where
+     * padding to eight forces a second full read of the vocab matrix. */
+#if defined(__APPLE__)
+    const uint32_t head_rows = n_tokens;
+#else
     const uint32_t head_rows =
         (n_tokens > 1 && n_tokens < 8 &&
          ds4_gpu_tensor_bytes(dst_logits) >= 8u * vocab_dim * sizeof(float) &&
          ds4_gpu_tensor_bytes(norm_full) >=
              8u * DS4_N_EMBD * sizeof(float)) ? 8u : n_tokens;
+#endif
     ds4_gpu_tensor *output_norm =
         ds4_gpu_tensor_view(norm_full,
                             0,
@@ -28856,7 +28869,107 @@ static bool metal_graph_encode_layer_attention_batch(
                 }
                 metal_graph_attn_comp_prefill_target_free(attn_comp_target);
             } else {
-                for (uint32_t t = 0; ok && t < n_tokens; t++) {
+                /* Fused batch-path compressor rows update: one sequential
+                 * single-threadgroup dispatch replaces the per-token host
+                 * loop below (store + emit chain + prefix captures), with
+                 * every phase's arithmetic order preserved bit-exactly.
+                 * Any ineligible shape or a failed dispatch falls back to
+                 * the loop, which stays authoritative. */
+                bool rows_fused = false;
+                const uint32_t rows_n_emit =
+                    (pos0 + n_tokens) / ratio - pos0 / ratio;
+                const uint32_t rows_capture_slots =
+                    g->spec_capture_prefixes
+                        ? (n_tokens - 1u < DS4_SPEC_PREFIX_SLOTS
+                               ? n_tokens - 1u
+                               : DS4_SPEC_PREFIX_SLOTS)
+                        : 0u;
+                const bool rows_fuse_ok = ok &&
+                    /* Small verify batches measured slower fused (the
+                     * replaced encoder seams cost ~2 us each); the win is
+                     * the per-row loop of large non-aligned chunks. */
+                    n_tokens >= 16u &&
+                    (ratio == 4u || ratio == 128u) &&
+                    DS4_GPU_ATTN_COMP_CACHE_F16 &&
+                    DS4_N_HEAD_DIM == 512u &&
+                    layer->attn_compressor_norm->type == DS4_TENSOR_F32 &&
+                    g->layer_attn_comp_cache[il] != NULL &&
+                    metal_graph_attn_comp_stage(g) != NULL &&
+                    !g->ssd_streaming && !g->ssd_streaming_cold &&
+                    !metal_graph_debug_dump_enabled() &&
+                    g->layer_n_comp[il] + rows_n_emit <=
+                        g->layer_comp_cap[il] &&
+                    (rows_capture_slots == 0u ||
+                     (g->spec_prefix1_attn_state_kv[il] != NULL &&
+                      g->spec_prefix1_attn_state_score[il] != NULL)) &&
+                    metal_graph_ported_m5_decode_feature_enabled(
+                            "DS4_METAL_DISABLE_PRE_M5_COMP_ROWS_FUSE",
+                            "DS4_METAL_DISABLE_M5_COMP_ROWS_FUSE");
+                if (rows_fuse_ok) {
+                    const uint32_t comp_before = g->layer_n_comp[il];
+                    const int fused = ds4_gpu_dsv4_comp_rows_update_tensor(
+                            metal_graph_batch_comp_kv(g),
+                            metal_graph_batch_comp_sc(g),
+                            comp_width,
+                            g->layer_attn_state_kv[il],
+                            g->layer_attn_state_score[il],
+                            metal_graph_attn_comp_stage(g),
+                            g->layer_attn_comp_cache[il],
+                            comp_before,
+                            metal_graph_attn_comp_cache_row_bytes(),
+                            1,
+                            0,
+                            rows_capture_slots
+                                ? g->spec_prefix1_attn_state_kv[il] : NULL,
+                            rows_capture_slots
+                                ? g->spec_prefix1_attn_state_score[il] : NULL,
+                            rows_capture_slots,
+                            model->map,
+                            model->size,
+                            layer->attn_compressor_ape->abs_offset,
+                            layer->attn_compressor_ape->type,
+                            layer->attn_compressor_norm->abs_offset,
+                            DS4_N_HEAD_DIM,
+                            ratio,
+                            pos0,
+                            n_tokens,
+                            DS4_N_ROT,
+                            compressed ? (uint32_t)DS4_ROPE_ORIG_CTX : 0,
+                            freq_base,
+                            freq_scale,
+                            ext_factor,
+                            attn_factor,
+                            DS4_ROPE_YARN_BETA_FAST,
+                            DS4_ROPE_YARN_BETA_SLOW,
+                            DS4_RMS_EPS);
+                    if (fused != 0) {
+                        if (getenv("DS4_METAL_COMP_ROWS_LOG") != NULL) {
+                            static int rows_fuse_logged;
+                            if (!rows_fuse_logged) {
+                                rows_fuse_logged = 1;
+                                fprintf(stderr,
+                                        "ds4: comp rows fuse engaged il=%u n_tokens=%u\n",
+                                        il, n_tokens);
+                            }
+                        }
+                        rows_fused = true;
+                        g->layer_n_comp[il] = comp_before + rows_n_emit;
+                        for (uint32_t t = 0; t < n_tokens; t++) {
+                            const uint32_t emitted =
+                                (pos0 + t + 1u) / ratio - pos0 / ratio;
+                            if (comp_counts) {
+                                comp_counts[t] = comp_before + emitted;
+                            }
+                            /* The kernel captured the states; mirror the
+                             * per-slot counter bookkeeping here. */
+                            if (t + 1u < n_tokens && t < rows_capture_slots) {
+                                g->spec_prefix_n_comp[t][il] =
+                                    comp_before + emitted;
+                            }
+                        }
+                    }
+                }
+                for (uint32_t t = 0; !rows_fused && ok && t < n_tokens; t++) {
                     const uint32_t pos = pos0 + t;
                     const bool emit = ((pos + 1u) % ratio) == 0u;
                     if (emit && g->layer_n_comp[il] >= g->layer_comp_cap[il]) {
@@ -28893,7 +29006,10 @@ static bool metal_graph_encode_layer_attention_batch(
                                                             DS4_ROPE_YARN_BETA_SLOW,
                                                             DS4_RMS_EPS,
                                                             false,
-                                                            false,
+                                                            /* The packed ratio-4 pool is bit-identical to the
+                                                             * concat chain (ds4_test compressor pack gate) and
+                                                             * folds seven pool dispatches into one per row. */
+                                                            true,
                                                             false) != 0;
                     if (ok && emit) {
                         ds4_gpu_tensor *comp_row_view = metal_graph_attn_comp_row_view(g, il, comp_row);
@@ -29157,7 +29273,95 @@ static bool metal_graph_encode_layer_attention_batch(
                     }
                     ds4_gpu_tensor_free(index_view);
                 } else {
-                    for (uint32_t t = 0; ok && t < n_tokens; t++) {
+                    /* Same fused sequential rows update as the attention
+                     * compressor above, for the ratio-4 indexer: the F32
+                     * cache row finalizes in place (no F16 commit) and the
+                     * emit quantize is the Hadamard+FP4 QAT. */
+                    bool index_rows_fused = false;
+                    const uint32_t index_rows_n_emit =
+                        (pos0 + n_tokens) / ratio - pos0 / ratio;
+                    const uint32_t index_rows_capture_slots =
+                        g->spec_capture_prefixes
+                            ? (n_tokens - 1u < DS4_SPEC_PREFIX_SLOTS
+                                   ? n_tokens - 1u
+                                   : DS4_SPEC_PREFIX_SLOTS)
+                            : 0u;
+                    const bool index_rows_fuse_ok = ok &&
+                        n_tokens >= 16u &&
+                        DS4_N_INDEXER_HEAD_DIM == 128u &&
+                        layer->indexer_compressor_norm->type ==
+                            DS4_TENSOR_F32 &&
+                        g->layer_index_comp_cache[il] != NULL &&
+                        !g->ssd_streaming && !g->ssd_streaming_cold &&
+                        !metal_graph_debug_dump_enabled() &&
+                        g->layer_n_index_comp[il] + index_rows_n_emit <=
+                            g->layer_comp_cap[il] &&
+                        (index_rows_capture_slots == 0u ||
+                         (g->spec_prefix1_index_state_kv[il] != NULL &&
+                          g->spec_prefix1_index_state_score[il] != NULL)) &&
+                        metal_graph_ported_m5_decode_feature_enabled(
+                                "DS4_METAL_DISABLE_PRE_M5_COMP_ROWS_FUSE",
+                                "DS4_METAL_DISABLE_M5_COMP_ROWS_FUSE");
+                    if (index_rows_fuse_ok) {
+                        const uint32_t index_before = g->layer_n_index_comp[il];
+                        const int fused = ds4_gpu_dsv4_comp_rows_update_tensor(
+                                metal_graph_batch_comp_kv(g),
+                                metal_graph_batch_comp_sc(g),
+                                index_width,
+                                g->layer_index_state_kv[il],
+                                g->layer_index_state_score[il],
+                                NULL,
+                                g->layer_index_comp_cache[il],
+                                index_before,
+                                (uint64_t)DS4_N_INDEXER_HEAD_DIM *
+                                    sizeof(float),
+                                0,
+                                1,
+                                index_rows_capture_slots
+                                    ? g->spec_prefix1_index_state_kv[il]
+                                    : NULL,
+                                index_rows_capture_slots
+                                    ? g->spec_prefix1_index_state_score[il]
+                                    : NULL,
+                                index_rows_capture_slots,
+                                model->map,
+                                model->size,
+                                layer->indexer_compressor_ape->abs_offset,
+                                layer->indexer_compressor_ape->type,
+                                layer->indexer_compressor_norm->abs_offset,
+                                DS4_N_INDEXER_HEAD_DIM,
+                                ratio,
+                                pos0,
+                                n_tokens,
+                                DS4_N_ROT,
+                                compressed ? (uint32_t)DS4_ROPE_ORIG_CTX : 0,
+                                freq_base,
+                                freq_scale,
+                                ext_factor,
+                                attn_factor,
+                                DS4_ROPE_YARN_BETA_FAST,
+                                DS4_ROPE_YARN_BETA_SLOW,
+                                DS4_RMS_EPS);
+                        if (fused != 0) {
+                            index_rows_fused = true;
+                            g->layer_n_index_comp[il] =
+                                index_before + index_rows_n_emit;
+                            for (uint32_t t = 0; t < n_tokens; t++) {
+                                const uint32_t emitted =
+                                    (pos0 + t + 1u) / ratio - pos0 / ratio;
+                                if (index_counts) {
+                                    index_counts[t] = index_before + emitted;
+                                }
+                                if (t + 1u < n_tokens &&
+                                    t < index_rows_capture_slots) {
+                                    g->spec_prefix_n_index_comp[t][il] =
+                                        index_before + emitted;
+                                }
+                            }
+                        }
+                    }
+                    for (uint32_t t = 0;
+                         !index_rows_fused && ok && t < n_tokens; t++) {
                         const uint32_t pos = pos0 + t;
                         const bool emit = ((pos + 1u) % ratio) == 0u;
                         if (emit && g->layer_n_index_comp[il] >= g->layer_comp_cap[il]) {
@@ -29194,7 +29398,7 @@ static bool metal_graph_encode_layer_attention_batch(
                                                                 DS4_ROPE_YARN_BETA_SLOW,
                                                                 DS4_RMS_EPS,
                                                                 false,
-                                                                false,
+                                                                true,
                                                                 false) != 0;
                         if (ok && emit) {
                             ds4_gpu_tensor *index_row_view = ds4_gpu_tensor_view(
@@ -33394,6 +33598,34 @@ static bool dspark_apply_markov_greedy_probe(
     return true;
 }
 
+/* Position-graded confidence pruning: acceptance falls with draft depth, so
+ * a schedule like DS4_DSPARK_CONFIDENCE_GRID=0.5,0.55,0.65 can admit easy
+ * first positions while pruning deep ones harder than one flat threshold.
+ * Unset, the flat threshold is used unchanged. */
+static float dspark_confidence_threshold_for(uint32_t draft, float flat) {
+    static int   parsed = -1;
+    static float grid[16];
+    static int   grid_len;
+    if (parsed < 0) {
+        parsed = 0;
+        const char *env = getenv("DS4_DSPARK_CONFIDENCE_GRID");
+        if (env && env[0]) {
+            const char *p = env;
+            while (grid_len < 16) {
+                char *end = NULL;
+                float v = strtof(p, &end);
+                if (end == p || v <= 0.0f || v >= 1.0f) break;
+                grid[grid_len++] = v;
+                if (*end != ',') break;
+                p = end + 1;
+            }
+            if (grid_len > 0) parsed = 1;
+        }
+    }
+    if (parsed != 1) return flat;
+    return grid[draft < (uint32_t)grid_len ? draft : (uint32_t)grid_len - 1u];
+}
+
 static bool dspark_confidence_probe_ready(
         const ds4_dspark_weights *dw) {
     if (!dspark_markov_probe_ready(dw)) return false;
@@ -33544,16 +33776,25 @@ static bool dspark_apply_markov_confidence_lazy_runtime(
         }
         if (draft == 0 && confidence0) *confidence0 = confidence_logit;
         if (confidence_len) *confidence_len = draft + 1u;
-        if (sigmoid_stable(confidence_logit) < confidence_threshold) {
+        if (sigmoid_stable(confidence_logit) <
+            dspark_confidence_threshold_for(draft, confidence_threshold)) {
             ok = true;
             break;
         }
 
         int32_t token = -1;
-#ifndef __APPLE__
-        /* CUDA can apply the Markov bias and argmax without reading back the
-         * full logits row. Metal currently falls through to the CPU path. */
-        if (ok && !dspark_markov_bias_disabled() &&
+        /* The fused GPU markov argmax avoids the full-row readback, but on
+         * Metal the per-position submit latency outweighs the CPU matvec it
+         * replaces (measured 90 -> 160 ms per 512-token run), so Apple keeps
+         * the CPU fold unless explicitly asked; CUDA keeps the GPU default.
+         * The kernel remains the building block for a batched chain. */
+#if defined(__APPLE__)
+        const bool gpu_markov_requested =
+            getenv("DS4_DSPARK_GPU_MARKOV") != NULL;
+#else
+        const bool gpu_markov_requested = true;
+#endif
+        if (ok && gpu_markov_requested && !dspark_markov_bias_disabled() &&
             getenv("DS4_DSPARK_NO_GPU_MARKOV") == NULL &&
             g->dspark_draft_tokens &&
             dw->markov_rank != 0 && (dw->markov_rank & 31u) == 0 &&
@@ -33590,7 +33831,6 @@ static bool dspark_apply_markov_confidence_lazy_runtime(
                 continue;
             }
         }
-#endif
         if (ok) {
             ok = ds4_gpu_tensor_read(g->spec_logits,
                                      (uint64_t)draft * logits_bytes,
@@ -33695,7 +33935,10 @@ static uint32_t dspark_confident_prefix_len(
         return confidence_len;
     }
     for (uint32_t i = 0; i < confidence_len; i++) {
-        if (sigmoid_stable(confidence_logits[i]) < threshold) return i;
+        if (sigmoid_stable(confidence_logits[i]) <
+            dspark_confidence_threshold_for(i, threshold)) {
+            return i;
+        }
     }
     return confidence_len;
 }
@@ -49304,11 +49547,15 @@ struct ds4_session {
     int mtp_draft_token;
 #ifndef DS4_NO_GPU
     int dspark_draft_tokens[DS4_DSPARK_MAX_BLOCK_SIZE];
+    /* Folded drafts were proposed for this predicted next token, before its
+     * target forward ran; the fold cycle verifies it as batch row zero. */
+    int dspark_draft_prev_token;
     uint32_t dspark_draft_len;
     uint32_t dspark_sched_cycles;
     uint32_t dspark_sched_accepted;
     uint32_t dspark_sched_no_draft;
     uint32_t dspark_sched_skip;
+    uint32_t dspark_sched_backoff;
     uint32_t dspark_sched_lifetime_accepted;
     double dspark_sched_life_extra_ms;
     double dspark_sched_life_saved_ms;
@@ -49318,6 +49565,7 @@ struct ds4_session {
     double dspark_last_propose_ms;
     float dspark_last_confidence0;
     bool dspark_draft_valid;
+    bool dspark_draft_folded;
     bool dspark_sched_skipped_cycle;
     bool dspark_sched_long_accept_seen;
     bool dspark_last_confidence0_valid;
@@ -49426,6 +49674,7 @@ static void ds4_session_dspark_scheduler_reset(ds4_session *s) {
     s->dspark_sched_cycles = 0;
     s->dspark_sched_accepted = 0;
     s->dspark_sched_no_draft = 0;
+    /* Window resets keep the pause backoff: only acceptance clears it. */
     s->dspark_sched_extra_ms = 0.0;
     s->dspark_sched_saved_ms = 0.0;
 }
@@ -49484,6 +49733,17 @@ static void ds4_session_dspark_scheduler_note(
         }
     }
 
+    /* Exponential pause backoff: consecutive unproductive pauses double
+     * the skip (bounded), one accepted draft re-arms instantly. Counting
+     * only, so greedy streams stay reproducible. Opt-in via
+     * DS4_DSPARK_SCHEDULER_BACKOFF=1. */
+    static int sched_backoff_enabled = -1;
+    if (sched_backoff_enabled < 0) {
+        sched_backoff_enabled =
+            getenv("DS4_DSPARK_SCHEDULER_BACKOFF") != NULL;
+    }
+    if (accepted_drafts > 0) s->dspark_sched_backoff = 0;
+
     const uint32_t no_draft_skip =
         ds4_dspark_scheduler_no_draft_skip_cycles();
     if (no_draft && no_draft_skip != 0) {
@@ -49500,6 +49760,11 @@ static void ds4_session_dspark_scheduler_note(
             const uint32_t cold_low_conf_skip =
                 ds4_dspark_scheduler_cold_low_confidence_skip_cycles();
             if (skip < cold_low_conf_skip) skip = cold_low_conf_skip;
+        }
+        if (sched_backoff_enabled) {
+            skip <<= (s->dspark_sched_backoff < 3u
+                          ? s->dspark_sched_backoff : 3u);
+            if (s->dspark_sched_backoff < 8u) s->dspark_sched_backoff++;
         }
         if (s->dspark_sched_skip < skip) {
             s->dspark_sched_skip = skip;
@@ -49574,6 +49839,11 @@ static void ds4_session_dspark_scheduler_note(
             if (s->dspark_sched_skip < slow_skip) {
                 s->dspark_sched_skip = slow_skip;
             }
+        }
+        if (sched_backoff_enabled) {
+            s->dspark_sched_skip <<= (s->dspark_sched_backoff < 3u
+                                          ? s->dspark_sched_backoff : 3u);
+            if (s->dspark_sched_backoff < 8u) s->dspark_sched_backoff++;
         }
         if (getenv("DS4_DSPARK_SPEC_LOG") != NULL) {
             fprintf(stderr,
@@ -59009,6 +59279,11 @@ int ds4_session_eval_output_head_from_hc(ds4_session *s,
 }
 
 
+#ifndef DS4_NO_GPU
+static float ds4_dspark_margin_gate(void);
+static bool ds4_dspark_margin_allows_propose(const ds4_session *s);
+#endif
+
 static int ds4_session_eval_internal(ds4_session *s, int token, bool probe_mtp,
                                      char *err, size_t errlen);
 
@@ -61129,7 +61404,18 @@ static bool ds4_session_prepare_dspark_draft_impl(ds4_session *s,
             if (conf0_ok) {
                 confidence_ok = true;
                 confidence_len = 1;
-                if (sigmoid_stable(confidence0) >= confidence_threshold) {
+                float conf0_threshold =
+                    dspark_confidence_threshold_for(0, confidence_threshold);
+                /* Regime selectivity: consecutive unproductive cycles raise
+                 * the engagement bar so low-yield content only verifies
+                 * near-certain proposals; one accepted draft resets it. */
+                if (getenv("DS4_DSPARK_SCHEDULER_BACKOFF") != NULL) {
+                    const uint32_t b = s->dspark_sched_backoff < 4u
+                                           ? s->dspark_sched_backoff : 4u;
+                    conf0_threshold += 0.05f * (float)b;
+                    if (conf0_threshold > 0.95f) conf0_threshold = 0.95f;
+                }
+                if (sigmoid_stable(confidence0) >= conf0_threshold) {
                     confidence_prefix_len = 1;
                     const double logits_t0 = DS4_DSPARK_PROP_T0();
                     base_logits_ok =
@@ -61614,11 +61900,23 @@ static int ds4_session_eval_internal(ds4_session *s, int token, bool probe_mtp,
     token_vec_push(&s->checkpoint, token);
     s->checkpoint_valid = true;
     ds4_session_dspark_capture_note_checkpoint(s);
-    ds4_session_prepare_support_draft(s,
-                                      token,
-                                      (uint32_t)(s->checkpoint.len - 1),
-                                      probe_mtp,
-                                      mtp_probe_log);
+    {
+        bool probe_now = probe_mtp;
+#ifndef DS4_NO_GPU
+        if (probe_now && s->engine &&
+            s->engine->support_kind == DS4_SUPPORT_DSPARK) {
+            probe_now = ds4_dspark_margin_allows_propose(s);
+        }
+#endif
+        ds4_session_prepare_support_draft(s,
+                                          token,
+                                          (uint32_t)(s->checkpoint.len - 1),
+                                          probe_now,
+                                          mtp_probe_log);
+    }
+#ifndef DS4_NO_GPU
+    s->dspark_draft_folded = false;
+#endif
     return 0;
 #endif
 }
@@ -62577,6 +62875,49 @@ int ds4_sessions_eval_batch_with_prefill(
 }
 
 #ifndef DS4_NO_GPU
+/* DS4_DSPARK_FOLD folds the committed token's target forward into the
+ * verify batch as row zero (the DFlash block layout): a fold cycle skips the
+ * standalone one-token eval and re-proposes at commit time for the predicted
+ * next token. Any miss or partial accept drops back to the standalone path,
+ * which refreshes the draft conditioning and returns control to the
+ * scheduler, so low-acceptance content degrades to today's behavior. */
+static bool ds4_dspark_fold_enabled(void) {
+    static int cached = -1;
+    if (cached < 0) cached = getenv("DS4_DSPARK_FOLD") != NULL;
+    return cached != 0;
+}
+
+/* DS4_DSPARK_MARGIN_GATE=<logits>: skip proposing when the target's own
+ * top1-top2 logit margin is below the bar. A hesitant target is a regime
+ * signal the weaker draft cannot beat, and the margin is free: the logits
+ * are already on the host every cycle. 0/unset disables the gate. */
+static float ds4_dspark_margin_gate(void) {
+    static float cached = -1.0f;
+    if (cached < 0.0f) {
+        const char *env = getenv("DS4_DSPARK_MARGIN_GATE");
+        cached = env && env[0] ? strtof(env, NULL) : 0.0f;
+        if (!(cached >= 0.0f)) cached = 0.0f;
+    }
+    return cached;
+}
+
+static bool ds4_dspark_margin_allows_propose(const ds4_session *s) {
+    const float gate = ds4_dspark_margin_gate();
+    if (gate <= 0.0f || !s || !s->logits) return true;
+    float m1 = -INFINITY;
+    float m2 = -INFINITY;
+    for (uint32_t i = 0; i < DS4_N_VOCAB; i++) {
+        const float v = s->logits[i];
+        if (v > m1) {
+            m2 = m1;
+            m1 = v;
+        } else if (v > m2) {
+            m2 = v;
+        }
+    }
+    return m1 - m2 >= gate;
+}
+
 static int ds4_session_eval_dspark_speculative_argmax(
         ds4_session *s,
         int          n_accept,
@@ -62584,6 +62925,8 @@ static int ds4_session_eval_dspark_speculative_argmax(
         int          eos_token,
         int         *accepted,
         int          accepted_cap,
+        int          first_token,
+        bool         folded,
         char        *err,
         size_t       errlen) {
     const bool spec_log = getenv("DS4_DSPARK_SPEC_LOG") != NULL;
@@ -62649,6 +62992,17 @@ static int ds4_session_eval_dspark_speculative_argmax(
         return n_accept;
     }
 
+    if (folded) {
+        /* The committed token joins the block, so every budget below must
+         * leave one slot for it. */
+        if (draft_n > max_tokens - 1) draft_n = max_tokens - 1;
+        if (draft_n > accepted_cap - 1) draft_n = accepted_cap - 1;
+        if (draft_n > room - 2) draft_n = room - 2;
+        if (draft_n <= 0) {
+            DS4_DSPARK_STATS_FINISH();
+            return n_accept;
+        }
+    }
     int drafts[DS4_DSPARK_MAX_BLOCK_SIZE];
     for (int i = 0; i < draft_n; i++) {
         drafts[i] = s->dspark_draft_tokens[i];
@@ -62677,8 +63031,23 @@ static int ds4_session_eval_dspark_speculative_argmax(
     s->dspark_draft_valid = false;
     s->dspark_draft_len = 0;
 
+    /* Fold: the committed token rides as verify row zero. Its correctness
+     * holds by construction (the greedy first_token is the argmax of the
+     * previous cycle's logits), so acceptance starts at row zero's top
+     * versus the first proposal, through the unchanged accept loop. */
+    int block[DS4_DSPARK_MAX_BLOCK_SIZE + 1];
+    const int *vtok = drafts;
+    int vn = draft_n;
+    if (folded) {
+        block[0] = first_token;
+        memcpy(block + 1, drafts, (size_t)draft_n * sizeof(block[0]));
+        vtok = block;
+        vn = draft_n + 1;
+        if (stats_enabled) s->dspark_stats.first_tokens++;
+    }
+
     const int target_top = sample_argmax(s->logits, DS4_N_VOCAB);
-    if (target_top != drafts[0]) {
+    if (target_top != vtok[0]) {
         if (stats_enabled) {
             s->dspark_stats.first_misses++;
             ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
@@ -62694,13 +63063,16 @@ static int ds4_session_eval_dspark_speculative_argmax(
         DS4_DSPARK_STATS_FINISH();
         return n_accept;
     }
-    if (drafts[0] == eos_token) draft_n = 1;
+    if (draft_n > 0 && drafts[0] == eos_token) {
+        draft_n = 1;
+        vn = folded ? 2 : 1;
+    }
 
     ds4_engine *e = s->engine;
     ds4_spec_frontier frontier;
     memset(&frontier, 0, sizeof(frontier));
-    int row_tops_buf[DS4_DSPARK_MAX_BLOCK_SIZE];
-    int *row_tops = draft_n > 1 ? row_tops_buf : NULL;
+    int row_tops_buf[DS4_DSPARK_MAX_BLOCK_SIZE + 1];
+    int *row_tops = vn > 1 ? row_tops_buf : NULL;
     float *row_logits = s->spec_row_logits;
     const int start = s->checkpoint.len;
     const double snapshot_t0 = stats_enabled ? now_sec() : 0.0;
@@ -62708,7 +63080,7 @@ static int ds4_session_eval_dspark_speculative_argmax(
     if (stats_enabled) {
         s->dspark_stats.snapshot_ms += (now_sec() - snapshot_t0) * 1000.0;
     }
-    bool ok = have_frontier && row_logits && (draft_n <= 1 || row_tops);
+    bool ok = have_frontier && row_logits && (vn <= 1 || row_tops);
     bool verifier_may_have_mutated = false;
     bool tp_verify_sent = false;
     if (ok && ds4_session_tp_leader(s)) {
@@ -62724,7 +63096,7 @@ static int ds4_session_eval_dspark_speculative_argmax(
         tp_verify_sent = true;
     }
     if (ok) {
-        for (int i = 0; i < draft_n; i++) token_vec_push(&s->checkpoint, drafts[i]);
+        for (int i = 0; i < vn; i++) token_vec_push(&s->checkpoint, vtok[i]);
         verifier_may_have_mutated = true;
         ds4_verify_suffix_timing verify_timing;
         const double verify_t0 = stats_enabled ? now_sec() : 0.0;
@@ -62733,9 +63105,9 @@ static int ds4_session_eval_dspark_speculative_argmax(
                                             &e->weights,
                                             &s->checkpoint,
                                             (uint32_t)start,
-                                            (uint32_t)draft_n,
-                                            draft_n > 1 &&
-                                                draft_n <=
+                                            (uint32_t)vn,
+                                            vn > 1 &&
+                                                vn <=
                                                     (int)DS4_SPEC_PREFIX_SLOTS + 1,
                                             true,
                                             row_tops,
@@ -62756,8 +63128,8 @@ static int ds4_session_eval_dspark_speculative_argmax(
     int commit_drafts = 0;
     if (ok) {
         commit_drafts = 1;
-        for (int i = 1; i < draft_n; i++) {
-            if (row_tops[i - 1] != drafts[i]) break;
+        for (int i = 1; i < vn; i++) {
+            if (row_tops[i - 1] != vtok[i]) break;
             commit_drafts++;
         }
     }
@@ -62769,17 +63141,17 @@ static int ds4_session_eval_dspark_speculative_argmax(
      * decode. A failed direct commit still falls back to rollback and replay. */
 
     bool final_logits_ok = false;
-    if (ok && commit_drafts == draft_n) {
+    if (ok && commit_drafts == vn) {
         const double read_t0 = stats_enabled ? now_sec() : 0.0;
         final_logits_ok = metal_graph_read_spec_logits_row(
-                &s->graph, (uint32_t)(draft_n - 1), row_logits);
+                &s->graph, (uint32_t)(vn - 1), row_logits);
         if (stats_enabled) {
             s->dspark_stats.verify_read_ms +=
                 (now_sec() - read_t0) * 1000.0;
         }
     }
 
-    if (ok && commit_drafts == draft_n && final_logits_ok) {
+    if (ok && commit_drafts == vn && final_logits_ok) {
         if (tp_verify_sent &&
             !ds4_tp_send_verify_commit(e->tp.ctx, 1, 0)) {
             snprintf(err, errlen, "tp: verify commit send failed");
@@ -62791,28 +63163,45 @@ static int ds4_session_eval_dspark_speculative_argmax(
         memcpy(s->logits, row_logits,
                (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
         int emitted_drafts = 0;
-        for (int i = 0; i < draft_n && n_accept < accepted_cap; i++) {
-            accepted[n_accept++] = drafts[i];
+        for (int i = 0; i < vn && n_accept < accepted_cap; i++) {
+            accepted[n_accept++] = vtok[i];
             emitted_drafts++;
-            if (drafts[i] == eos_token) break;
+            if (vtok[i] == eos_token) break;
         }
+        /* Row zero is the committed token, not a draft. */
+        const uint32_t emitted_stats =
+            (uint32_t)(folded && emitted_drafts > 0 ? emitted_drafts - 1
+                                                    : emitted_drafts);
         s->checkpoint_valid = true;
         ds4_session_dspark_capture_note_checkpoint(s);
         if (stats_enabled) {
             s->dspark_stats.full_accepts++;
             s->dspark_stats.direct_full_commits++;
             s->dspark_stats.accepted_draft_tokens +=
-                (uint64_t)emitted_drafts;
+                (uint64_t)emitted_stats;
             ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist,
-                                      (uint32_t)emitted_drafts);
+                                      emitted_stats);
         }
         ds4_session_dspark_scheduler_note(
-                s, (uint32_t)emitted_drafts, false,
+                s, emitted_stats, false,
                 DS4_DSPARK_SCHED_EXTRA_MS());
+        /* No margin gate here: a full accept just validated this chain,
+         * and gating its continuation is what costs codegen its streaks. */
+        if (ds4_dspark_fold_enabled() &&
+            accepted[n_accept - 1] != eos_token &&
+            !ds4_session_tp_leader(s)) {
+            const int next = sample_argmax(s->logits, DS4_N_VOCAB);
+            if (next >= 0 && next != eos_token) {
+                ds4_session_prepare_support_draft(
+                        s, next, (uint32_t)s->checkpoint.len, true, false);
+                s->dspark_draft_prev_token = next;
+                s->dspark_draft_folded = s->dspark_draft_valid;
+            }
+        }
         if (spec_log) {
             fprintf(stderr,
                     "ds4: DSpark spec direct-full drafted=%d accepted=%d\n",
-                    draft_n,
+                    vn,
                     n_accept);
         }
         spec_frontier_free(&frontier);
@@ -62824,7 +63213,7 @@ static int ds4_session_eval_dspark_speculative_argmax(
      * not yet receive these intermediate snapshots, so TP partial accepts use
      * the existing mirrored replay fallback. */
     if (ok && !tp_verify_sent &&
-        commit_drafts > 0 && commit_drafts < draft_n &&
+        commit_drafts > 0 && commit_drafts < vn &&
         commit_drafts <= (int)DS4_SPEC_PREFIX_SLOTS) {
         const double read_t0 = stats_enabled ? now_sec() : 0.0;
         bool prefix_ok = metal_graph_read_spec_logits_row(
@@ -62844,29 +63233,32 @@ static int ds4_session_eval_dspark_speculative_argmax(
                    (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
             int emitted_drafts = 0;
             for (int i = 0; i < commit_drafts && n_accept < accepted_cap; i++) {
-                token_vec_push(&s->checkpoint, drafts[i]);
-                accepted[n_accept++] = drafts[i];
+                token_vec_push(&s->checkpoint, vtok[i]);
+                accepted[n_accept++] = vtok[i];
                 emitted_drafts++;
-                if (drafts[i] == eos_token) break;
+                if (vtok[i] == eos_token) break;
             }
+            const uint32_t emitted_stats =
+                (uint32_t)(folded && emitted_drafts > 0 ? emitted_drafts - 1
+                                                        : emitted_drafts);
             s->checkpoint_valid = true;
             ds4_session_dspark_capture_note_checkpoint(s);
             if (stats_enabled) {
                 s->dspark_stats.partial_accepts++;
                 s->dspark_stats.direct_partial_commits++;
                 s->dspark_stats.accepted_draft_tokens +=
-                    (uint64_t)emitted_drafts;
+                    (uint64_t)emitted_stats;
                 ds4_dspark_stats_note_len(
                         s->dspark_stats.accepted_len_hist,
-                        (uint32_t)emitted_drafts);
+                        emitted_stats);
             }
             ds4_session_dspark_scheduler_note(
-                    s, (uint32_t)emitted_drafts, false,
+                    s, emitted_stats, false,
                     DS4_DSPARK_SCHED_EXTRA_MS());
             if (spec_log) {
                 fprintf(stderr,
                         "ds4: DSpark spec direct-partial drafted=%d committed=%d accepted=%d\n",
-                        draft_n,
+                        vn,
                         emitted_drafts,
                         n_accept);
             }
@@ -62926,7 +63318,7 @@ static int ds4_session_eval_dspark_speculative_argmax(
         replay_budget = accepted_cap - n_accept;
     if (replay_budget < 0) replay_budget = 0;
     for (int i = 0; i < replay_budget; i++) {
-        if (drafts[i] == eos_token) { replay_budget = i + 1; break; }
+        if (vtok[i] == eos_token) { replay_budget = i + 1; break; }
     }
     if (tp_verify_sent &&
         !ds4_tp_send_verify_commit(e->tp.ctx, 0, replay_budget)) {
@@ -62944,7 +63336,7 @@ static int ds4_session_eval_dspark_speculative_argmax(
         ok = metal_graph_eval_token_raw_swa(&s->graph,
                                             &e->model,
                                             &e->weights,
-                                            drafts[i],
+                                            vtok[i],
                                             (uint32_t)s->checkpoint.len,
                                             row_logits);
         if (!ok) {
@@ -62959,10 +63351,10 @@ static int ds4_session_eval_dspark_speculative_argmax(
             DS4_DSPARK_STATS_FINISH();
             return -1;
         }
-        token_vec_push(&s->checkpoint, drafts[i]);
-        accepted[n_accept++] = drafts[i];
+        token_vec_push(&s->checkpoint, vtok[i]);
+        accepted[n_accept++] = vtok[i];
         replayed_drafts++;
-        if (drafts[i] == eos_token) break;
+        if (vtok[i] == eos_token) break;
     }
     if (stats_enabled) {
         s->dspark_stats.replay_ms += (now_sec() - replay_t0) * 1000.0;
@@ -62983,21 +63375,29 @@ static int ds4_session_eval_dspark_speculative_argmax(
         memcpy(s->logits, row_logits, (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
         s->checkpoint_valid = true;
         ds4_session_dspark_capture_note_checkpoint(s);
+        const uint32_t replayed_stats =
+            (uint32_t)(folded && replayed_drafts > 0 ? replayed_drafts - 1
+                                                     : replayed_drafts);
         if (stats_enabled) {
-            if (replayed_drafts == draft_n) s->dspark_stats.full_accepts++;
+            if (replayed_drafts == vn) s->dspark_stats.full_accepts++;
             else s->dspark_stats.partial_accepts++;
-            s->dspark_stats.accepted_draft_tokens += (uint64_t)replayed_drafts;
+            s->dspark_stats.accepted_draft_tokens += (uint64_t)replayed_stats;
             ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist,
-                                      (uint32_t)replayed_drafts);
+                                      replayed_stats);
         }
     } else if (stats_enabled) {
         ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
     }
-    ds4_session_dspark_scheduler_note(
-            s,
-            (uint32_t)replayed_drafts,
-            false,
-            DS4_DSPARK_SCHED_EXTRA_MS());
+    {
+        const uint32_t sched_accepted =
+            (uint32_t)(folded && replayed_drafts > 0 ? replayed_drafts - 1
+                                                     : replayed_drafts);
+        ds4_session_dspark_scheduler_note(
+                s,
+                sched_accepted,
+                false,
+                DS4_DSPARK_SCHED_EXTRA_MS());
+    }
     if (spec_log) {
         fprintf(stderr,
                 "ds4: DSpark spec partial drafted=%d verified=%d accepted=%d\n",
@@ -66035,6 +66435,21 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
             }
         }
     }
+    if (e->support_kind == DS4_SUPPORT_DSPARK &&
+        ds4_dspark_fold_enabled() &&
+        can_prepare_support_draft && !strict_dspark && !dspark_tail_skip &&
+        !ds4_session_tp_leader(s) &&
+        s->dspark_draft_valid && s->dspark_draft_folded &&
+        s->dspark_draft_len > 0 &&
+        s->dspark_draft_prev_token == first_token &&
+        first_token != eos_token && max_tokens > 1 && accepted_cap > 1) {
+        const int fold_accept = ds4_session_eval_dspark_speculative_argmax(
+                s, 0, max_tokens, eos_token, accepted, accepted_cap,
+                first_token, true, err, errlen);
+        if (fold_accept != 0) return fold_accept;
+        /* The fold declined before mutating anything; fall through to the
+         * standalone forward with the draft already cleared. */
+    }
     if (ds4_session_eval_probe_tp(s,
                                   first_token,
                                   can_prepare_support_draft,
@@ -66053,6 +66468,8 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                                                           eos_token,
                                                           accepted,
                                                           accepted_cap,
+                                                          first_token,
+                                                          false,
                                                           err,
                                                           errlen);
     }

--- a/ds4.c
+++ b/ds4.c
@@ -24941,8 +24941,13 @@ static bool metal_graph_encode_decode_layer_phase(
                 DS4_N_HC) != 0;
     } else if (parallel_full_ffn) {
 #if defined(__APPLE__)
+        /* The join publishes routed/shared outputs inside the still-open
+         * concurrent encoder so the single HC expansion dispatch lands
+         * there too; the island is closed right after it. */
         const bool parallel_joined =
-            ds4_gpu_parallel_ffn_finish() != 0;
+            ds4_gpu_parallel_ffn_finish_into_hc(
+                    metal_graph_routed_out(g),
+                    metal_graph_shared_out(g)) != 0;
         ok = ok && parallel_joined;
 #else
         ok = false;
@@ -24957,6 +24962,9 @@ static bool metal_graph_encode_decode_layer_phase(
                     DS4_N_EMBD,
                     DS4_N_HC) != 0;
         }
+#if defined(__APPLE__)
+        (void)ds4_gpu_parallel_ffn_island_close();
+#endif
     } else if (ok && fuse_shared_down_hc) {
         if (cuda_tp_moe_peer_tmp) {
             ok = ds4_gpu_shared_down_hc_expand_add_q8_0_tensor(

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -15877,6 +15877,76 @@ extern "C" int ds4_gpu_matmul_f16_pair_compressor_store_tensor(
     return 0;
 }
 
+/* Metal-only batch-path compressor rows-update fusion; CUDA keeps the
+ * per-token host loop. */
+extern "C" int ds4_gpu_dsv4_comp_rows_update_tensor(
+        const ds4_gpu_tensor *batch_kv,
+        const ds4_gpu_tensor *batch_sc,
+        uint32_t              row_stride,
+        ds4_gpu_tensor       *state_kv,
+        ds4_gpu_tensor       *state_score,
+        ds4_gpu_tensor       *work,
+        ds4_gpu_tensor       *comp_cache,
+        uint32_t              comp_row0,
+        uint64_t              cache_row_bytes,
+        int                   out_f16,
+        int                   quant_mode,
+        ds4_gpu_tensor       *prefix_kv,
+        ds4_gpu_tensor       *prefix_score,
+        uint32_t              capture_slots,
+        const void           *model_map,
+        uint64_t              model_size,
+        uint64_t              ape_offset,
+        uint32_t              ape_type,
+        uint64_t              norm_offset,
+        uint32_t              head_dim,
+        uint32_t              ratio,
+        uint32_t              pos0,
+        uint32_t              n_tokens,
+        uint32_t              n_rot,
+        uint32_t              n_ctx_orig,
+        float                 freq_base,
+        float                 freq_scale,
+        float                 ext_factor,
+        float                 attn_factor,
+        float                 beta_fast,
+        float                 beta_slow,
+        float                 rms_eps) {
+    (void)batch_kv;
+    (void)batch_sc;
+    (void)row_stride;
+    (void)state_kv;
+    (void)state_score;
+    (void)work;
+    (void)comp_cache;
+    (void)comp_row0;
+    (void)cache_row_bytes;
+    (void)out_f16;
+    (void)quant_mode;
+    (void)prefix_kv;
+    (void)prefix_score;
+    (void)capture_slots;
+    (void)model_map;
+    (void)model_size;
+    (void)ape_offset;
+    (void)ape_type;
+    (void)norm_offset;
+    (void)head_dim;
+    (void)ratio;
+    (void)pos0;
+    (void)n_tokens;
+    (void)n_rot;
+    (void)n_ctx_orig;
+    (void)freq_base;
+    (void)freq_scale;
+    (void)ext_factor;
+    (void)attn_factor;
+    (void)beta_fast;
+    (void)beta_slow;
+    (void)rms_eps;
+    return 0;
+}
+
 extern "C" int ds4_gpu_matmul_f32_tensor(ds4_gpu_tensor *out, const void *model_map, uint64_t model_size, uint64_t weight_offset, uint64_t in_dim, uint64_t out_dim, const ds4_gpu_tensor *x, uint64_t n_tok) {
     if (!out || !x || !model_map || in_dim == 0 || out_dim == 0 || n_tok == 0) return 0;
     if (weight_offset > model_size || out_dim > UINT64_MAX / in_dim) return 0;

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -80,6 +80,9 @@ int ds4_gpu_flush_commands(void);
 int ds4_gpu_commands_active(void);
 #ifdef __APPLE__
 int ds4_gpu_parallel_ffn_finish(void);
+int ds4_gpu_parallel_ffn_finish_into_hc(const ds4_gpu_tensor *routed_out,
+                                        const ds4_gpu_tensor *shared_out);
+int ds4_gpu_parallel_ffn_island_close(void);
 void ds4_gpu_parallel_ffn_abort(void);
 int ds4_gpu_parallel_ffn_start(
         ds4_gpu_tensor       *gate,

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -913,6 +913,46 @@ int ds4_gpu_dsv4_comp_row_finalize_tensor(
         float                 beta_slow,
         float                 rms_eps);
 
+/* Batch-path M5 fusion: replay the per-token compressor state-update loop
+ * (speculative verify and unaligned prefill chunks) in one sequential
+ * single-threadgroup dispatch: store, and per emitted row pool + norm +
+ * rope + quantize (+ F16 commit for attention) + ratio-4 shift, plus the
+ * speculative prefix state captures.  Bit-exact vs the per-token dispatch
+ * chain.  Returns 1 when fused, 0 to fall back to the host loop. */
+int ds4_gpu_dsv4_comp_rows_update_tensor(
+        const ds4_gpu_tensor *batch_kv,
+        const ds4_gpu_tensor *batch_sc,
+        uint32_t              row_stride,
+        ds4_gpu_tensor       *state_kv,
+        ds4_gpu_tensor       *state_score,
+        ds4_gpu_tensor       *work,
+        ds4_gpu_tensor       *comp_cache,
+        uint32_t              comp_row0,
+        uint64_t              cache_row_bytes,
+        int                   out_f16,
+        int                   quant_mode,
+        ds4_gpu_tensor       *prefix_kv,
+        ds4_gpu_tensor       *prefix_score,
+        uint32_t              capture_slots,
+        const void           *model_map,
+        uint64_t              model_size,
+        uint64_t              ape_offset,
+        uint32_t              ape_type,
+        uint64_t              norm_offset,
+        uint32_t              head_dim,
+        uint32_t              ratio,
+        uint32_t              pos0,
+        uint32_t              n_tokens,
+        uint32_t              n_rot,
+        uint32_t              n_ctx_orig,
+        float                 freq_base,
+        float                 freq_scale,
+        float                 ext_factor,
+        float                 attn_factor,
+        float                 beta_fast,
+        float                 beta_slow,
+        float                 rms_eps);
+
 /* Decode-only M5 fusion: q_a/kv Q8 pair projection + F16 quad compressor
  * projection/store in one dispatch.  Bit-exact vs the separate dispatches.
  * Returns 1 when fused, 0 to fall back, -1 on error. */

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -94,6 +94,7 @@ static id<MTLComputePipelineState> g_hc_split_sinkhorn_pipeline;
 static id<MTLComputePipelineState> g_hc_split_weighted_sum_pipeline;
 static id<MTLComputePipelineState> g_hc_split_weighted_sum_norm_pipeline;
 static id<MTLComputePipelineState> g_dsv4_hc_producer_pre_norm_pipeline;
+static id<MTLComputePipelineState> g_dsv4_hc_producer_pre_norm_spread_pipeline;
 static id<MTLComputePipelineState> g_hc_weighted_sum_pipeline;
 static id<MTLComputePipelineState> g_output_hc_weights4_pipeline;
 static uint32_t g_test_flags;
@@ -9386,6 +9387,41 @@ int ds4_gpu_parallel_ffn_finish(void) {
      * safe and idempotent as an explicit abort. */
     ds4_gpu_parallel_ffn_reset_state(YES);
     return completed;
+}
+
+/* Extends the concurrent FFN island through the HC expansion: instead of
+ * closing the encoder at the join, publish the routed and shared outputs
+ * with an explicit barrier and let the next wrapper's single dispatch land
+ * in the same encoder, saving one encoder transition per layer. The caller
+ * must close the island with ds4_gpu_parallel_ffn_island_close immediately
+ * after that dispatch; only the FFN bookkeeping is cleared here so stray
+ * work cannot re-enter the island protocol. Returns the same completion
+ * flag as ds4_gpu_parallel_ffn_finish. */
+int ds4_gpu_parallel_ffn_finish_into_hc(
+        const ds4_gpu_tensor *routed_out,
+        const ds4_gpu_tensor *shared_out) {
+    const int completed =
+        g_parallel_q8_pending && g_parallel_q8_encoded &&
+        g_parallel_ffn_stage == 2 && g_batch_encoder_concurrent;
+    id<MTLBuffer> a = routed_out ? ds4_gpu_tensor_buffer(routed_out) : nil;
+    id<MTLBuffer> b = shared_out ? ds4_gpu_tensor_buffer(shared_out) : nil;
+    if (!completed || !a || !b || !g_batch_enc ||
+        getenv("DS4_METAL_DISABLE_M5_FFN_ISLAND_INTO_HC") != NULL) {
+        ds4_gpu_parallel_ffn_reset_state(YES);
+        return completed;
+    }
+    id<MTLResource> published[2] = { a, b };
+    [g_batch_enc memoryBarrierWithResources:published count:2];
+    g_parallel_q8_pending = NO;
+    g_parallel_q8_encoded = NO;
+    g_parallel_ffn_mode = 0;
+    g_parallel_ffn_stage = 0;
+    return completed;
+}
+
+int ds4_gpu_parallel_ffn_island_close(void) {
+    ds4_gpu_parallel_ffn_reset_state(YES);
+    return 1;
 }
 
 
@@ -42637,12 +42673,26 @@ int ds4_gpu_hc_rms_norm_mix_split_norm_f16_tensor(
             model_map, model_size, norm_weight_offset, out_bytes, &norm_inner);
         if (!mix_weight || !scalebuf || !basebuf || !norm_weight) return 0;
 
-        if (!g_dsv4_hc_producer_pre_norm_pipeline) {
+        /* Spread shape: one live NR0=2 cluster per comb group raises the
+         * grid from 6 to 10 threadgroups; per-row math is identical, so the
+         * outputs are bit-exact across both shapes. Default on M5-class
+         * GPUs, where the wider grid measured ~+0.13% decode. */
+        const bool comb_spread =
+            ds4_gpu_device_is_m5_apple_silicon() &&
+            getenv("DS4_METAL_DISABLE_M5_HC_SPREAD") == NULL;
+        if (comb_spread) {
+            if (!g_dsv4_hc_producer_pre_norm_spread_pipeline) {
+                g_dsv4_hc_producer_pre_norm_spread_pipeline =
+                    ds4_gpu_get_pipeline(
+                    "kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm_spread");
+            }
+        } else if (!g_dsv4_hc_producer_pre_norm_pipeline) {
             g_dsv4_hc_producer_pre_norm_pipeline = ds4_gpu_get_pipeline(
                 "kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm");
         }
-        id<MTLComputePipelineState> producer =
-            g_dsv4_hc_producer_pre_norm_pipeline;
+        id<MTLComputePipelineState> producer = comb_spread
+            ? g_dsv4_hc_producer_pre_norm_spread_pipeline
+            : g_dsv4_hc_producer_pre_norm_pipeline;
         if (!producer || producer.maxTotalThreadsPerThreadgroup < 512u) {
             return 0;
         }
@@ -42718,7 +42768,7 @@ int ds4_gpu_hc_rms_norm_mix_split_norm_f16_tensor(
         [enc setBuffer:normbuf offset:ds4_gpu_tensor_offset(norm_out) atIndex:10];
         [enc setBuffer:completion offset:0 atIndex:11];
         [enc setThreadgroupMemoryLength:shared_bytes atIndex:0];
-        [enc dispatchThreadgroups:MTLSizeMake(6, 1, 1)
+        [enc dispatchThreadgroups:MTLSizeMake(comb_spread ? 10 : 6, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(32, 16, 1)];
 
         ds4_gpu_end_compute_encoder(cb, enc);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -988,6 +988,16 @@ static void ds4_gpu_close_batch_encoder(void) {
 static double g_gpu_busy_accum;
 static uint64_t g_gpu_busy_cbs;
 
+/* DS4_METAL_GAP_PROFILE: GPU-timeline holes between consecutive command
+ * buffers, split into the token-boundary hole (logits readback + host
+ * sampling + next-token encode land there) and mid-token flush seams.
+ * Command buffers are waited in commit order, so the first buffer waited
+ * after ds4_gpu_end_commands owns the boundary gap. */
+static double g_gap_last_gpu_end;
+static int g_gap_next_is_boundary;
+static double g_gap_intra_accum, g_gap_boundary_accum, g_gap_boundary_max;
+static uint64_t g_gap_intra_cbs, g_gap_boundary_cbs;
+
 /* A failed command buffer can leave a cross-threadgroup arrival counter at an
  * arbitrary partial value.  Drop cached ownership instead of CPU-resetting
  * buffers that another in-flight command buffer might still reference; bound
@@ -1009,6 +1019,33 @@ static int ds4_gpu_wait_command_buffer(id<MTLCommandBuffer> cb, const char *labe
                     g_gpu_busy_accum * 1000.0,
                     (unsigned long long)g_gpu_busy_cbs);
         }
+    }
+    if (getenv("DS4_METAL_GAP_PROFILE")) {
+        const double start = cb.GPUStartTime;
+        if (g_gap_last_gpu_end > 0.0 && start > g_gap_last_gpu_end) {
+            const double gap = start - g_gap_last_gpu_end;
+            if (g_gap_next_is_boundary) {
+                g_gap_boundary_accum += gap;
+                if (gap > g_gap_boundary_max) g_gap_boundary_max = gap;
+                if ((++g_gap_boundary_cbs % 64u) == 0u) {
+                    fprintf(stderr,
+                            "ds4: gpu gap boundary avg %.3f max %.3f ms (%llu) "
+                            "intra avg %.3f ms (%llu)\n",
+                            g_gap_boundary_accum / g_gap_boundary_cbs * 1000.0,
+                            g_gap_boundary_max * 1000.0,
+                            (unsigned long long)g_gap_boundary_cbs,
+                            g_gap_intra_cbs
+                                ? g_gap_intra_accum / g_gap_intra_cbs * 1000.0
+                                : 0.0,
+                            (unsigned long long)g_gap_intra_cbs);
+                }
+            } else {
+                g_gap_intra_accum += gap;
+                g_gap_intra_cbs++;
+            }
+        }
+        g_gap_next_is_boundary = 0;
+        if (cb.GPUEndTime > g_gap_last_gpu_end) g_gap_last_gpu_end = cb.GPUEndTime;
     }
     if (cb.status == MTLCommandBufferStatusError) {
         fprintf(stderr, "ds4: Metal %s failed: %s\n",
@@ -5058,12 +5095,14 @@ static int16_t ds4_gpu_mv_ext_nxpsg(uint64_t in_dim, uint64_t n_tok) {
 static int16_t ds4_gpu_mv_ext_r1ptg(uint64_t n_tok) {
     switch (n_tok) {
     case 2: return 2;
-    case 3:
-    case 6: return 3;
-    case 4:
-    case 7:
-    case 8: return 4;
+    case 3: return 3;
+    case 4: return 4;
     case 5: return 5;
+    /* One row-tile per batch: a second y-tile rereads every weight row,
+     * which doubles the dense read for the 6..8-row verify blocks. */
+    case 6: return 6;
+    case 7: return 7;
+    case 8: return 8;
     default: return n_tok > 8 ? 4 : 0;
     }
 }
@@ -5075,6 +5114,9 @@ static const char *ds4_gpu_mv_ext_name(int q8, int16_t r1ptg) {
         case 3: return "kernel_mul_mv_ext_q8_0_f32_r1_3";
         case 4: return "kernel_mul_mv_ext_q8_0_f32_r1_4";
         case 5: return "kernel_mul_mv_ext_q8_0_f32_r1_5";
+        case 6: return "kernel_mul_mv_ext_q8_0_f32_r1_6";
+        case 7: return "kernel_mul_mv_ext_q8_0_f32_r1_7";
+        case 8: return "kernel_mul_mv_ext_q8_0_f32_r1_8";
         default: return NULL;
         }
     }
@@ -5084,6 +5126,9 @@ static const char *ds4_gpu_mv_ext_name(int q8, int16_t r1ptg) {
     case 3: return "kernel_mul_mv_ext_f16_f32_r1_3";
     case 4: return "kernel_mul_mv_ext_f16_f32_r1_4";
     case 5: return "kernel_mul_mv_ext_f16_f32_r1_5";
+    case 6: return "kernel_mul_mv_ext_f16_f32_r1_6";
+    case 7: return "kernel_mul_mv_ext_f16_f32_r1_7";
+    case 8: return "kernel_mul_mv_ext_f16_f32_r1_8";
     default: return NULL;
     }
 }
@@ -5603,6 +5648,28 @@ typedef struct {
     float    rms_eps;
     uint32_t pad0;
 } ds4_gpu_comp_finalize_args;
+
+/* Matches ds4_metal_args_dsv4_comp_rows_update in dsv4_rope.metal. */
+typedef struct {
+    ds4_gpu_rope_affine_pair_args rope;
+    float    rms_eps;
+    uint32_t head_dim;
+    uint32_t width;
+    uint32_t ratio;
+    uint32_t pos0;
+    uint32_t n_tokens;
+    uint32_t row_stride;
+    uint32_t ape_type;
+    uint32_t comp_row0;
+    uint32_t cache_row_stride;
+    uint32_t out_f16;
+    uint32_t quant_mode;
+    uint32_t capture_slots;
+    uint32_t state_rows;
+} ds4_gpu_comp_rows_update_args;
+
+_Static_assert(sizeof(ds4_gpu_comp_rows_update_args) == 120,
+               "Metal compressor rows-update argument ABI changed");
 
 /* Set by ds4.c immediately before the decode attention call when the inverse
  * RoPE tail is deferred into the reduce kernel. Cleared by the encoder. */
@@ -10076,7 +10143,10 @@ int ds4_gpu_end_commands(void) {
     g_batch_has_work = NO;
     g_stream_expert_cache_owned_seq = g_stream_expert_cache_batch_seq;
     g_stream_expert_cache_batch_seq = 0;
-    return ds4_gpu_finish_command_buffer(cb, 1, "command batch");
+    const int finished = ds4_gpu_finish_command_buffer(cb, 1, "command batch");
+    /* The next buffer waited after a completed batch owns the boundary gap. */
+    g_gap_next_is_boundary = 1;
+    return finished;
 }
 
 static int ds4_gpu_flash_attn_stage_profile_boundary(
@@ -17805,6 +17875,86 @@ int ds4_gpu_indexer_topk_tensor(
     return 1;
 }
 
+int ds4_gpu_dspark_markov_argmax_tensor(
+        ds4_gpu_tensor       *out_idx,
+        const ds4_gpu_tensor *logits_row,
+        const void           *model_map,
+        uint64_t              model_size,
+        uint64_t              w1_offset,
+        uint64_t              w2_offset,
+        uint32_t              prev_token,
+        uint32_t              vocab,
+        uint32_t              rank) {
+    if (!g_initialized && !ds4_gpu_init()) return 0;
+    if (!out_idx || !logits_row || !model_map || vocab == 0 ||
+        rank == 0 || (rank & 31u) != 0u || rank > 256u ||
+        ds4_gpu_tensor_bytes(out_idx) < sizeof(uint64_t) ||
+        ds4_gpu_tensor_bytes(logits_row) < (uint64_t)vocab * sizeof(float)) {
+        return 0;
+    }
+    const uint32_t rank_blocks = rank / 32u;
+    const uint64_t row_bytes = (uint64_t)rank_blocks * 34u;
+    if (w1_offset > model_size ||
+        (uint64_t)prev_token * row_bytes + row_bytes > model_size - w1_offset ||
+        w2_offset > model_size ||
+        (uint64_t)vocab * row_bytes > model_size - w2_offset) {
+        return 0;
+    }
+    @autoreleasepool {
+        uint64_t w1_inner = 0;
+        uint64_t w2_inner = 0;
+        id<MTLBuffer> w1 = ds4_gpu_wrap_model_range(
+                model_map, model_size,
+                w1_offset + (uint64_t)prev_token * row_bytes, row_bytes,
+                &w1_inner);
+        id<MTLBuffer> w2 = ds4_gpu_wrap_model_range(
+                model_map, model_size, w2_offset,
+                (uint64_t)vocab * row_bytes, &w2_inner);
+        if (!w1 || !w2) return 0;
+        static id<MTLComputePipelineState> stage1;
+        static id<MTLComputePipelineState> stage2;
+        if (!stage1) {
+            stage1 = ds4_gpu_get_pipeline(
+                    "kernel_dspark_markov_argmax_stage1_f32");
+        }
+        if (!stage2) {
+            stage2 = ds4_gpu_get_pipeline(
+                    "kernel_dspark_markov_argmax_stage2_f32");
+        }
+        if (!stage1 || !stage2) return 0;
+        const uint32_t ntg = 128u;
+        id<MTLBuffer> partials = ds4_gpu_new_transient_buffer(
+                (NSUInteger)ntg * 8u, "dspark markov partials");
+        if (!partials) return 0;
+        int owned = 0;
+        id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
+        if (!cb) return 0;
+        id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
+        [enc setComputePipelineState:stage1];
+        [enc setBuffer:ds4_gpu_tensor_buffer(logits_row)
+                offset:ds4_gpu_tensor_offset(logits_row) atIndex:0];
+        [enc setBuffer:w1 offset:(NSUInteger)w1_inner atIndex:1];
+        [enc setBuffer:w2 offset:(NSUInteger)w2_inner atIndex:2];
+        [enc setBuffer:partials offset:0 atIndex:3];
+        [enc setBytes:&vocab length:sizeof(vocab) atIndex:4];
+        [enc setBytes:&rank_blocks length:sizeof(rank_blocks) atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake(ntg, 1, 1)
+             threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        [enc setComputePipelineState:stage2];
+        [enc setBuffer:partials offset:0 atIndex:0];
+        [enc setBuffer:ds4_gpu_tensor_buffer(out_idx)
+                offset:ds4_gpu_tensor_offset(out_idx) atIndex:1];
+        [enc setBytes:&ntg length:sizeof(ntg) atIndex:2];
+        [enc dispatchThreadgroups:MTLSizeMake(1, 1, 1)
+             threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+        ds4_gpu_end_compute_encoder(cb, enc);
+        if (!ds4_gpu_finish_command_buffer(cb, owned, "DSpark markov argmax")) {
+            return 0;
+        }
+        return 1;
+    }
+}
+
 int ds4_gpu_argmax_tensor(
         ds4_gpu_tensor       *out_idx,
         const ds4_gpu_tensor *logits,
@@ -20158,6 +20308,219 @@ int ds4_gpu_dsv4_comp_row_finalize_tensor(
         ds4_gpu_end_compute_encoder(cb, enc);
 
         if (!ds4_gpu_finish_command_buffer(cb, owned, "compressor row finalize")) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+static int ds4_gpu_ensure_compressor_pool_ggml_scratch(
+        uint32_t n_rows,
+        uint32_t head_dim);
+
+/* Batch-path fusion: replay the per-token compressor state-update loop of the
+ * speculative verify / unaligned prefill path in one sequential single-
+ * threadgroup dispatch (store, and per emitted row pool + norm + rope +
+ * quantize + optional F16 commit + shift, plus the speculative prefix state
+ * captures).  Bit-exact vs the per-token dispatch chain; see
+ * kernel_dsv4_comp_rows_update_f32.  Returns 1 when the fused dispatch ran,
+ * 0 to fall back to the host loop. */
+int ds4_gpu_dsv4_comp_rows_update_tensor(
+        const ds4_gpu_tensor *batch_kv,
+        const ds4_gpu_tensor *batch_sc,
+        uint32_t              row_stride,
+        ds4_gpu_tensor       *state_kv,
+        ds4_gpu_tensor       *state_score,
+        ds4_gpu_tensor       *work,
+        ds4_gpu_tensor       *comp_cache,
+        uint32_t              comp_row0,
+        uint64_t              cache_row_bytes,
+        int                   out_f16,
+        int                   quant_mode,
+        ds4_gpu_tensor       *prefix_kv,
+        ds4_gpu_tensor       *prefix_score,
+        uint32_t              capture_slots,
+        const void           *model_map,
+        uint64_t              model_size,
+        uint64_t              ape_offset,
+        uint32_t              ape_type,
+        uint64_t              norm_offset,
+        uint32_t              head_dim,
+        uint32_t              ratio,
+        uint32_t              pos0,
+        uint32_t              n_tokens,
+        uint32_t              n_rot,
+        uint32_t              n_ctx_orig,
+        float                 freq_base,
+        float                 freq_scale,
+        float                 ext_factor,
+        float                 attn_factor,
+        float                 beta_fast,
+        float                 beta_slow,
+        float                 rms_eps) {
+    if (!g_initialized && !ds4_gpu_init()) return 0;
+    if (!batch_kv || !batch_sc || !state_kv || !state_score || !comp_cache ||
+        !model_map || n_tokens == 0 ||
+        (ratio != 4u && ratio != 128u) ||
+        (head_dim != 128u && head_dim != 512u) ||
+        (ape_type != 0u && ape_type != 1u)) {
+        return 0;
+    }
+
+    @autoreleasepool {
+        const uint32_t coff = ratio == 4u ? 2u : 1u;
+        const uint32_t width = coff * head_dim;
+        const uint32_t state_rows = coff * ratio;
+        const uint32_t n_emit =
+            (pos0 + n_tokens) / ratio - pos0 / ratio;
+        const uint32_t eff_slots =
+            capture_slots < n_tokens - 1u ? capture_slots : n_tokens - 1u;
+
+        /* The fused kernel reproduces the finalize-phase virtual widths of
+         * the decode fusion: FP8 needs full 64-lane blocks and the F16
+         * commit / Hadamard phases are written for the 512/128 rows. */
+        if (row_stride < width ||
+            n_rot > head_dim || (n_rot & 1u) != 0u ||
+            (quant_mode == 0 && ((head_dim - n_rot) & 63u) != 0u) ||
+            (quant_mode == 1 && head_dim != 128u) ||
+            (quant_mode != 0 && quant_mode != 1) ||
+            (out_f16 && (head_dim != 512u || !work))) {
+            return 0;
+        }
+
+        const uint64_t elem_ape = ape_type == 1u ? 2u : 4u;
+        const uint64_t ape_bytes = (uint64_t)width * ratio * elem_ape;
+        const uint64_t norm_bytes = (uint64_t)head_dim * sizeof(float);
+        if (ape_offset > model_size || ape_bytes > model_size - ape_offset ||
+            norm_offset > model_size || norm_bytes > model_size - norm_offset) {
+            return 0;
+        }
+
+        const uint64_t elem_out = out_f16 ? sizeof(uint16_t) : sizeof(float);
+        const uint64_t cache_row_stride = cache_row_bytes / elem_out;
+        const uint64_t batch_bytes =
+            ((uint64_t)(n_tokens - 1u) * row_stride + width) * sizeof(float);
+        const uint64_t state_bytes =
+            (uint64_t)state_rows * width * sizeof(float);
+        if ((cache_row_bytes % elem_out) != 0 ||
+            cache_row_stride < head_dim ||
+            ds4_gpu_tensor_bytes(batch_kv) < batch_bytes ||
+            ds4_gpu_tensor_bytes(batch_sc) < batch_bytes ||
+            ds4_gpu_tensor_bytes(state_kv) < state_bytes ||
+            ds4_gpu_tensor_bytes(state_score) < state_bytes) {
+            return 0;
+        }
+        if (n_emit != 0 &&
+            ds4_gpu_tensor_bytes(comp_cache) <
+                ((uint64_t)comp_row0 + n_emit) * cache_row_bytes) {
+            return 0;
+        }
+        if (out_f16 &&
+            ds4_gpu_tensor_bytes(work) < (uint64_t)head_dim * sizeof(float)) {
+            return 0;
+        }
+        if (eff_slots != 0 &&
+            (!prefix_kv || !prefix_score ||
+             ds4_gpu_tensor_bytes(prefix_kv) <
+                 (uint64_t)eff_slots * state_bytes ||
+             ds4_gpu_tensor_bytes(prefix_score) <
+                 (uint64_t)eff_slots * state_bytes)) {
+            return 0;
+        }
+
+        /* Same host scratch the fallback pool dispatches use, so the fused
+         * kernel's volatile softmax/product round-trips hit device memory
+         * with identical layouts. */
+        if (!ds4_gpu_ensure_compressor_pool_ggml_scratch(state_rows,
+                                                         head_dim)) {
+            return 0;
+        }
+
+        uint64_t ape_inner = 0, norm_inner = 0;
+        id<MTLBuffer> apebuf = ds4_gpu_wrap_model_range(
+            model_map, model_size, ape_offset, ape_bytes, &ape_inner);
+        id<MTLBuffer> normbuf = ds4_gpu_wrap_model_range(
+            model_map, model_size, norm_offset, norm_bytes, &norm_inner);
+        if (!apebuf || !normbuf) return 0;
+
+        id<MTLComputePipelineState> pipeline =
+            ds4_gpu_get_pipeline("kernel_dsv4_comp_rows_update_f32");
+        if (!pipeline || pipeline.maxTotalThreadsPerThreadgroup < 1024u) {
+            return 0;
+        }
+
+        ds4_gpu_tensor *work_t = out_f16 ? work : comp_cache;
+        ds4_gpu_tensor *prefix_kv_t = eff_slots != 0 ? prefix_kv : state_kv;
+        ds4_gpu_tensor *prefix_sc_t = eff_slots != 0 ? prefix_score
+                                                     : state_score;
+
+        ds4_gpu_comp_rows_update_args args = {
+            .rope = {
+                .row_bytes = 0,
+                .token_bytes = 0,
+                .head_dim = 0,
+                .n_dims = (int32_t)n_rot,
+                .n_ctx_orig = (int32_t)n_ctx_orig,
+                .inverse = 0,
+                .pos0 = 0,
+                .pos_step = 0,
+                .freq_base = freq_base,
+                .freq_scale = freq_scale,
+                .ext_factor = ext_factor,
+                .attn_factor = attn_factor,
+                .beta_fast = beta_fast,
+                .beta_slow = beta_slow,
+            },
+            .rms_eps = rms_eps,
+            .head_dim = head_dim,
+            .width = width,
+            .ratio = ratio,
+            .pos0 = pos0,
+            .n_tokens = n_tokens,
+            .row_stride = row_stride,
+            .ape_type = ape_type,
+            .comp_row0 = comp_row0,
+            .cache_row_stride = (uint32_t)cache_row_stride,
+            .out_f16 = out_f16 ? 1u : 0u,
+            .quant_mode = (uint32_t)quant_mode,
+            .capture_slots = eff_slots,
+            .state_rows = state_rows,
+        };
+
+        int owned = 0;
+        id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
+        if (!cb) return 0;
+        id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
+        [enc setComputePipelineState:pipeline];
+        [enc setBytes:&args length:sizeof(args) atIndex:0];
+        [enc setBuffer:ds4_gpu_tensor_buffer(batch_kv)
+                offset:ds4_gpu_tensor_offset(batch_kv) atIndex:1];
+        [enc setBuffer:ds4_gpu_tensor_buffer(batch_sc)
+                offset:ds4_gpu_tensor_offset(batch_sc) atIndex:2];
+        [enc setBuffer:apebuf offset:(NSUInteger)ape_inner atIndex:3];
+        [enc setBuffer:ds4_gpu_tensor_buffer(state_kv)
+                offset:ds4_gpu_tensor_offset(state_kv) atIndex:4];
+        [enc setBuffer:ds4_gpu_tensor_buffer(state_score)
+                offset:ds4_gpu_tensor_offset(state_score) atIndex:5];
+        [enc setBuffer:normbuf offset:(NSUInteger)norm_inner atIndex:6];
+        [enc setBuffer:g_compressor_pool_softmax_buffer offset:0 atIndex:7];
+        [enc setBuffer:g_compressor_pool_product_buffer offset:0 atIndex:8];
+        [enc setBuffer:ds4_gpu_tensor_buffer(work_t)
+                offset:ds4_gpu_tensor_offset(work_t) atIndex:9];
+        [enc setBuffer:ds4_gpu_tensor_buffer(comp_cache)
+                offset:ds4_gpu_tensor_offset(comp_cache) atIndex:10];
+        [enc setBuffer:ds4_gpu_tensor_buffer(prefix_kv_t)
+                offset:ds4_gpu_tensor_offset(prefix_kv_t) atIndex:11];
+        [enc setBuffer:ds4_gpu_tensor_buffer(prefix_sc_t)
+                offset:ds4_gpu_tensor_offset(prefix_sc_t) atIndex:12];
+        [enc setThreadgroupMemoryLength:1024u * sizeof(float) atIndex:0];
+        [enc dispatchThreadgroups:MTLSizeMake(1, 1, 1)
+             threadsPerThreadgroup:MTLSizeMake(1024, 1, 1)];
+        ds4_gpu_end_compute_encoder(cb, enc);
+
+        if (!ds4_gpu_finish_command_buffer(cb, owned,
+                                           "compressor rows update")) {
             return 0;
         }
     }

--- a/metal/dense.metal
+++ b/metal/dense.metal
@@ -1874,11 +1874,17 @@ template [[host_name("kernel_mul_mv_ext_f16_f32_r1_2")]]  kernel mul_mv_ext_q4_f
 template [[host_name("kernel_mul_mv_ext_f16_f32_r1_3")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, half4,      4,  dequantize_f16_t4>;
 template [[host_name("kernel_mul_mv_ext_f16_f32_r1_4")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, half4,      4,  dequantize_f16_t4>;
 template [[host_name("kernel_mul_mv_ext_f16_f32_r1_5")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, half4,      4,  dequantize_f16_t4>;
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_6")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<6, half4,      4,  dequantize_f16_t4>;
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_7")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<7, half4,      4,  dequantize_f16_t4>;
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_8")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, half4,      4,  dequantize_f16_t4>;
 
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_2")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q8_0, 32, dequantize_q8_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_3")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q8_0, 32, dequantize_q8_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_4")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q8_0, 32, dequantize_q8_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_5")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q8_0, 32, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_6")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<6, block_q8_0, 32, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_7")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<7, block_q8_0, 32, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_8")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, block_q8_0, 32, dequantize_q8_0_t4>;
 
 template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_1")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<1, ds4_dense_block_q4_0, 32,  dequantize_dense_q4_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_2")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, ds4_dense_block_q4_0, 32,  dequantize_dense_q4_0_t4>;
@@ -1896,6 +1902,9 @@ template [[host_name("kernel_mul_mv_ext_q8_0_pair_swiglu_f32_r1_2")]] kernel mul
 template [[host_name("kernel_mul_mv_ext_q8_0_pair_swiglu_f32_r1_3")]] kernel mul_mv_ext_q8_0_pair_swiglu_f32_t kernel_mul_mv_ext_q8_0_pair_swiglu_f32_disp<3>;
 template [[host_name("kernel_mul_mv_ext_q8_0_pair_swiglu_f32_r1_4")]] kernel mul_mv_ext_q8_0_pair_swiglu_f32_t kernel_mul_mv_ext_q8_0_pair_swiglu_f32_disp<4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_pair_swiglu_f32_r1_5")]] kernel mul_mv_ext_q8_0_pair_swiglu_f32_t kernel_mul_mv_ext_q8_0_pair_swiglu_f32_disp<5>;
+template [[host_name("kernel_mul_mv_ext_q8_0_pair_swiglu_f32_r1_6")]] kernel mul_mv_ext_q8_0_pair_swiglu_f32_t kernel_mul_mv_ext_q8_0_pair_swiglu_f32_disp<6>;
+template [[host_name("kernel_mul_mv_ext_q8_0_pair_swiglu_f32_r1_7")]] kernel mul_mv_ext_q8_0_pair_swiglu_f32_t kernel_mul_mv_ext_q8_0_pair_swiglu_f32_disp<7>;
+template [[host_name("kernel_mul_mv_ext_q8_0_pair_swiglu_f32_r1_8")]] kernel mul_mv_ext_q8_0_pair_swiglu_f32_t kernel_mul_mv_ext_q8_0_pair_swiglu_f32_disp<8>;
 
 constant bool FC_mul_mm_bc_inp [[function_constant(FC_MUL_MM + 0)]];
 constant bool FC_mul_mm_bc_out [[function_constant(FC_MUL_MM + 1)]];

--- a/metal/dsv4_hc.metal
+++ b/metal/dsv4_hc.metal
@@ -1321,7 +1321,13 @@ kernel void kernel_dsv4_hc_rms_norm_mix_f16_cluster2(
     }
 }
 
-kernel void kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm(
+// COMB_TGS selects how the 16 comb rows spread over producer groups: 4 keeps
+// the shipped cluster2 packing (groups 2..5, both clusters live); 8 gives
+// every comb group one live NR0=2 cluster (groups 2..9, grid 6 -> 10).
+// Groups 0/1 and every per-row lane traversal, reduce tree and epilogue are
+// identical in both shapes, so outputs are bit-identical across COMB_TGS.
+template<short COMB_TGS>
+void kernel_dsv4_hc_producer_pre_norm_impl(
         constant ds4_metal_args_hc_norm_mix & args,
         constant ds4_metal_args_dsv4_hc_split_weighted_sum_norm & split_args,
         device const char  * x,
@@ -1334,10 +1340,10 @@ kernel void kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm(
         device const char  * norm_weight,
         device       char  * norm_dst,
         device atomic_uint * completion,
-        threadgroup  char  * shmem [[threadgroup(0)]],
-        uint3  tgpig [[threadgroup_position_in_grid]],
-        ushort tiisg [[thread_index_in_simdgroup]],
-        ushort sgitg [[simdgroup_index_in_threadgroup]]) {
+        threadgroup  char  * shmem,
+        uint3  tgpig,
+        ushort tiisg,
+        ushort sgitg) {
     constexpr short NSG_CLUSTER = 8;
     constexpr short NCLUSTER = 2;
     constexpr short NSG_TOTAL = NSG_CLUSTER * NCLUSTER;
@@ -1380,7 +1386,11 @@ kernel void kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm(
     const short cluster = sgitg / NSG_CLUSTER;
     const short local_sg = sgitg - cluster*NSG_CLUSTER;
     const int nb = args.n/NB;
-    const int r0 = (int)tgpig.x*(NCLUSTER*NR0) + cluster*NR0;
+    const bool cluster_active =
+        COMB_TGS == 4 || tgpig.x < 2 || cluster == 0;
+    const int r0 = (COMB_TGS == 4 || tgpig.x < 2)
+        ? (int)tgpig.x*(NCLUSTER*NR0) + cluster*NR0
+        : 2*(NCLUSTER*NR0) + ((int)tgpig.x - 2)*NR0;
 
     device const half4 *ax4[NR0];
     FOR_UNROLL (short row = 0; row < NR0; ++row) {
@@ -1392,7 +1402,7 @@ kernel void kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm(
     const short ix = tiisg/(NW/NF);
     const short il = tiisg%(NW/NF);
     const int ib0 = local_sg*NF + ix;
-    for (int ib = ib0; ib < nb; ib += NSG_CLUSTER*NF) {
+    for (int ib = ib0; cluster_active && ib < nb; ib += NSG_CLUSTER*NF) {
         float4 yl4[NF4];
         FOR_UNROLL (short i = 0; i < NF4; ++i) {
             yl4[i] = x4[(ib*NB + il*NF)/4 + i]*scale;
@@ -1429,7 +1439,7 @@ kernel void kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm(
     if (local_sg == 0) {
         FOR_UNROLL (short row = 0; row < NR0; ++row) {
             const float tot = simd_sum(cluster_shmem[row][tiisg]);
-            if (tiisg == 0 && r0 + row < args.out_dim) {
+            if (tiisg == 0 && cluster_active && r0 + row < args.out_dim) {
                 mixes_f32[r0 + row] = tot;
             }
         }
@@ -1528,7 +1538,7 @@ kernel void kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm(
 
     const uint old = atomic_fetch_add_explicit(
         completion, 1u, memory_order_relaxed);
-    if (old + 1u != 4u) {
+    if (old + 1u != (uint)COMB_TGS) {
         return;
     }
     atomic_thread_fence(mem_flags::mem_device,
@@ -1541,4 +1551,39 @@ kernel void kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm(
                         memory_order_seq_cst,
                         thread_scope_device);
     atomic_store_explicit(completion, 0u, memory_order_relaxed);
+}
+
+#define DS4_HC_PRODUCER_PRE_NORM_PARAMS \
+        constant ds4_metal_args_hc_norm_mix & args, \
+        constant ds4_metal_args_dsv4_hc_split_weighted_sum_norm & split_args, \
+        device const char  * x, \
+        device const char  * weight, \
+        device       char  * dst, \
+        device const float * hc_scale, \
+        device const float * hc_base, \
+        device       char  * split, \
+        device       char  * collapse_dst, \
+        device const char  * norm_weight, \
+        device       char  * norm_dst, \
+        device atomic_uint * completion, \
+        threadgroup  char  * shmem [[threadgroup(0)]], \
+        uint3  tgpig [[threadgroup_position_in_grid]], \
+        ushort tiisg [[thread_index_in_simdgroup]], \
+        ushort sgitg [[simdgroup_index_in_threadgroup]]
+
+#define DS4_HC_PRODUCER_PRE_NORM_ARGS \
+        args, split_args, x, weight, dst, hc_scale, hc_base, split, \
+        collapse_dst, norm_weight, norm_dst, completion, shmem, tgpig, \
+        tiisg, sgitg
+
+[[host_name("kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm")]]
+kernel void kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm(
+        DS4_HC_PRODUCER_PRE_NORM_PARAMS) {
+    kernel_dsv4_hc_producer_pre_norm_impl<4>(DS4_HC_PRODUCER_PRE_NORM_ARGS);
+}
+
+[[host_name("kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm_spread")]]
+kernel void kernel_dsv4_hc_rms_norm_mix_f16_cluster2_pre_norm_spread(
+        DS4_HC_PRODUCER_PRE_NORM_PARAMS) {
+    kernel_dsv4_hc_producer_pre_norm_impl<8>(DS4_HC_PRODUCER_PRE_NORM_ARGS);
 }

--- a/metal/dsv4_kv.metal
+++ b/metal/dsv4_kv.metal
@@ -430,30 +430,29 @@ kernel void kernel_dsv4_compressor_exact_softmax_product_ratio4(
     (void)softmax_scratch;
 }
 
-// Exact one-dispatch ratio-4 decode pool. This specializes the three-dispatch
-// pack -> exact softmax/product -> sum_rows chain above without changing any
-// floating-point operation or reduction topology. The normalized softmax and
-// product are still materialized and volatile-reloaded through device memory.
-// The two simd_sum calls in the final reduction execute under an eight-lane
-// active mask, exactly matching kernel_sum_rows_f32_f32's original TG8.
-kernel void kernel_dsv4_compressor_exact_pool_ratio4_decode_ggml(
-        constant ds4_metal_args_dsv4_compressor_pack_ratio4 & args,
+// Shared body of the exact ratio-4 decode pool below: one state column per
+// 32-lane cohort. Extracted so the batch-path fused kernel in dsv4_rope.metal
+// (kernel_dsv4_comp_rows_update_f32) runs the same source per column with its
+// own simdgroup playing the standalone kernel's 32-thread threadgroup. All
+// simd_max/simd_sum active-lane masks, the volatile device store/reload
+// boundaries, and the eight-lane sum_rows topology are preserved verbatim.
+// `sum_scratch` must be a 32-float threadgroup region private to the calling
+// cohort; the threadgroup barriers inside are a superset of the standalone
+// kernel's (they span the whole calling threadgroup) which only strengthens
+// ordering and changes no arithmetic.
+static void ds4_dsv4_compressor_exact_pool_ratio4_col(
         device const float * state_kv,
         device const float * state_score,
         device       float * softmax,
         device       float * product,
         device       float * dst,
-        threadgroup  float * sum_scratch [[threadgroup(0)]],
-        uint col [[threadgroup_position_in_grid]],
-        uint tid [[thread_position_in_threadgroup]]) {
-    if (col >= args.head_dim || args.n_comp != 1u ||
-        args.n_threads != 32u) {
-        return;
-    }
-
-    const uint64_t state_row_stride = 2ull * args.head_dim;
-    const float scale = (float)args.replay;
-    const float zero = (float)(args.n_comp - 1u);
+        threadgroup  float * sum_scratch,
+        uint head_dim,
+        float scale,
+        float zero,
+        uint col,
+        uint tid) {
+    const uint64_t state_row_stride = 2ull * head_dim;
 
     // Match the packed float4 ownership: lane 0 owns rows 0..3 and lane 1
     // rows 4..7. The gather itself is an integer-addressed bit-preserving load.
@@ -463,7 +462,7 @@ kernel void kernel_dsv4_compressor_exact_pool_ratio4_decode_ggml(
         for (uint j = 0u; j < 4u; ++j) {
             const uint row = row0 + j;
             const uint64_t src = (uint64_t)row * state_row_stride +
-                                 (row >= 4u ? args.head_dim : 0u) + col;
+                                 (row >= 4u ? head_dim : 0u) + col;
             score_values[j] = state_score[src];
         }
     }
@@ -506,7 +505,7 @@ kernel void kernel_dsv4_compressor_exact_pool_ratio4_decode_ggml(
     if (tid < 4u) {
         for (uint i0 = tid; i0 < 8u; i0 += 4u) {
             const uint64_t src = (uint64_t)i0 * state_row_stride +
-                                 (i0 >= 4u ? args.head_dim : 0u) + col;
+                                 (i0 >= 4u ? head_dim : 0u) + col;
             float value = state_kv[src];
             value *= reloaded_softmax[i0];
             product_row[i0] = value;
@@ -539,6 +538,40 @@ kernel void kernel_dsv4_compressor_exact_pool_ratio4_decode_ggml(
             dst[col] = row_sum;
         }
     }
+}
+
+// Exact one-dispatch ratio-4 decode pool. This specializes the three-dispatch
+// pack -> exact softmax/product -> sum_rows chain above without changing any
+// floating-point operation or reduction topology. The normalized softmax and
+// product are still materialized and volatile-reloaded through device memory.
+// The two simd_sum calls in the final reduction execute under an eight-lane
+// active mask, exactly matching kernel_sum_rows_f32_f32's original TG8.
+kernel void kernel_dsv4_compressor_exact_pool_ratio4_decode_ggml(
+        constant ds4_metal_args_dsv4_compressor_pack_ratio4 & args,
+        device const float * state_kv,
+        device const float * state_score,
+        device       float * softmax,
+        device       float * product,
+        device       float * dst,
+        threadgroup  float * sum_scratch [[threadgroup(0)]],
+        uint col [[threadgroup_position_in_grid]],
+        uint tid [[thread_position_in_threadgroup]]) {
+    if (col >= args.head_dim || args.n_comp != 1u ||
+        args.n_threads != 32u) {
+        return;
+    }
+
+    ds4_dsv4_compressor_exact_pool_ratio4_col(state_kv,
+                                              state_score,
+                                              softmax,
+                                              product,
+                                              dst,
+                                              sum_scratch,
+                                              args.head_dim,
+                                              (float)args.replay,
+                                              (float)(args.n_comp - 1u),
+                                              col,
+                                              tid);
 }
 
 // Ratio-4 compression keeps two 4-row halves of recurrent state. After an

--- a/metal/dsv4_misc.metal
+++ b/metal/dsv4_misc.metal
@@ -6714,3 +6714,111 @@ kernel void kernel_dsv4_softmax_pool_ratio4_direct(
 
     dst[ic * args.head_dim + id] = acc/sum;
 }
+
+// DSpark draft proposal: fused markov bias + argmax over one base-logits
+// row. Stage one dequants the rank<=256 markov state from the previous
+// token's Q8 row and grid-strides the vocab keeping one best pair per
+// threadgroup; stage two folds the partials into the packed
+// (monotonic-value, ~index) key the session consumes. Ties resolve to the
+// smaller index, matching the CPU argmax.
+kernel void kernel_dspark_markov_argmax_stage1_f32(
+        device const float *logits      [[buffer(0)]],
+        device const uchar *w1_row      [[buffer(1)]],
+        device const uchar *w2          [[buffer(2)]],
+        device float2      *partials    [[buffer(3)]],
+        constant uint      &vocab       [[buffer(4)]],
+        constant uint      &rank_blocks [[buffer(5)]],
+        uint tgid [[threadgroup_position_in_grid]],
+        uint tid  [[thread_position_in_threadgroup]],
+        uint ntg  [[threadgroups_per_grid]],
+        uint nth  [[threads_per_threadgroup]]) {
+    threadgroup float state[256];
+    if (tid < rank_blocks * 32u) {
+        const uint b = tid >> 5, k = tid & 31u;
+        device const uchar *blk = w1_row + (ulong)b * 34u;
+        const float d = float(*(device const half *)blk);
+        state[tid] = d * float(((device const char *)(blk + 2))[k]);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float best_v = -INFINITY;
+    uint best_i = 0u;
+    for (uint i = tgid * nth + tid; i < vocab; i += ntg * nth) {
+        device const uchar *row = w2 + (ulong)i * rank_blocks * 34u;
+        float acc = 0.0f;
+        for (uint b = 0; b < rank_blocks; b++) {
+            device const uchar *blk = row + (ulong)b * 34u;
+            const float d = float(*(device const half *)blk);
+            device const char *q = (device const char *)(blk + 2);
+            float s = 0.0f;
+            FOR_UNROLL (uint k = 0; k < 32u; k++) {
+                s += float(q[k]) * state[b * 32u + k];
+            }
+            acc += d * s;
+        }
+        const float v = logits[i] + acc;
+        if (v > best_v || (v == best_v && i < best_i)) {
+            best_v = v;
+            best_i = i;
+        }
+    }
+
+    threadgroup float vals[256];
+    threadgroup uint  idxs[256];
+    vals[tid] = best_v;
+    idxs[tid] = best_i;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint stride = nth >> 1; stride > 0u; stride >>= 1u) {
+        if (tid < stride) {
+            const float ov = vals[tid + stride];
+            const uint  oi = idxs[tid + stride];
+            if (ov > vals[tid] || (ov == vals[tid] && oi < idxs[tid])) {
+                vals[tid] = ov;
+                idxs[tid] = oi;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (tid == 0u) {
+        partials[tgid] = float2(vals[0], as_type<float>(idxs[0]));
+    }
+}
+
+kernel void kernel_dspark_markov_argmax_stage2_f32(
+        device const float2 *partials [[buffer(0)]],
+        device ulong        *out_key  [[buffer(1)]],
+        constant uint       &count    [[buffer(2)]],
+        uint tid [[thread_position_in_threadgroup]],
+        uint nth [[threads_per_threadgroup]]) {
+    threadgroup float vals[128];
+    threadgroup uint  idxs[128];
+    float best_v = -INFINITY;
+    uint best_i = 0u;
+    for (uint i = tid; i < count; i += nth) {
+        const float v = partials[i].x;
+        const uint ix = as_type<uint>(partials[i].y);
+        if (v > best_v || (v == best_v && ix < best_i)) {
+            best_v = v;
+            best_i = ix;
+        }
+    }
+    vals[tid] = best_v;
+    idxs[tid] = best_i;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint stride = nth >> 1; stride > 0u; stride >>= 1u) {
+        if (tid < stride) {
+            const float ov = vals[tid + stride];
+            const uint  oi = idxs[tid + stride];
+            if (ov > vals[tid] || (ov == vals[tid] && oi < idxs[tid])) {
+                vals[tid] = ov;
+                idxs[tid] = oi;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (tid == 0u) {
+        const uint f = as_type<uint>(vals[0]);
+        const uint fkey = (f & 0x80000000u) ? ~f : (f | 0x80000000u);
+        out_key[0] = ((ulong)fkey << 32) | (ulong)(~idxs[0] & 0xffffffffu);
+    }
+}

--- a/metal/dsv4_rope.metal
+++ b/metal/dsv4_rope.metal
@@ -828,6 +828,417 @@ kernel void kernel_dsv4_comp_row_finalize_f32(
     }
 }
 
+struct ds4_metal_args_dsv4_comp_rows_update {
+    ds4_metal_args_dsv4_rope_affine_pair rope;
+    float    rms_eps;
+    uint32_t head_dim;         /* 512 (attention) or 128 (indexer)          */
+    uint32_t width;            /* state/batch row width: coff * head_dim    */
+    uint32_t ratio;            /* 4 or 128                                  */
+    uint32_t pos0;
+    uint32_t n_tokens;
+    uint32_t row_stride;       /* batch kv/score row stride in floats       */
+    uint32_t ape_type;         /* 0 = F32, 1 = F16                          */
+    uint32_t comp_row0;        /* first cache row this call appends         */
+    uint32_t cache_row_stride; /* cache row stride in elements              */
+    uint32_t out_f16;          /* 1: finalize in work row + commit to half  */
+    uint32_t quant_mode;       /* 0 = FP8 E4M3 tail, 1 = Hadamard+FP4       */
+    uint32_t capture_slots;    /* speculative prefix slots to snapshot      */
+    uint32_t state_rows;       /* coff * ratio (8 or 128)                   */
+};
+
+/* Batch-path sibling of the decode finalize fusion above.  The speculative
+ * verify path (n_tokens 2..6) and unaligned prefill chunks used to run a host
+ * loop per token: one store dispatch, and on every ratio-th token a pool +
+ * norm + rope + quantize + commit + shift chain plus two prefix-capture blits.
+ * This kernel replays that whole per-layer loop in ONE single-threadgroup
+ * dispatch.  One threadgroup because every token depends on the state the
+ * previous token wrote (the compressor is a recurrence): sequencing inside one
+ * threadgroup with device barriers is the only way to keep the chain on-GPU
+ * without a dispatch per step.
+ *
+ * Each phase reproduces its standalone kernel bit-exactly:
+ *  - store:  kernel_dsv4_compressor_store_one (elementwise, one lane per col).
+ *  - pool r4:  ds4_dsv4_compressor_exact_pool_ratio4_col, the exact body the
+ *    standalone exact-pool kernel runs, one column per simdgroup; its device
+ *    volatile softmax/product round-trips through the SAME host scratch
+ *    buffers, so the compiler cannot keep the normalized softmax in registers
+ *    and the dispatch-boundary store/load semantics are preserved.
+ *  - pool r128:  the GGML soft_max_f32_4(ne00=128, nth=32) -> mul ->
+ *    sum_rows(nth=128) chain, one score column per simdgroup for the softmax
+ *    and eight 128-thread cohorts for the sum_rows two-stage simd_sum tree.
+ *    The transpose staging copy of the fallback is a bit-preserving load and
+ *    is replaced by direct gathers; softmax and product still materialize in
+ *    device scratch with volatile reloads at each former dispatch boundary.
+ *  - norm/rope/fp8/commit/qat:  verbatim kernel_dsv4_comp_row_finalize_f32
+ *    phases (same virtual widths; threads outside a phase's width still
+ *    execute every barrier so barriers stay uniform); the rope tail uses the
+ *    shared noinline helper with comp_pos = pos + 1 - ratio.
+ *  - shift:  kernel_dsv4_ratio4_shift_f32 (elementwise row move).
+ *  - capture:  elementwise copy of both state tensors into prefix slot t,
+ *    replacing the two per-token blit encoders.
+ * All loop bounds derive from args (no arrays sized by n_tokens), so the same
+ * kernel serves verify chunks and long unaligned prefill chunks alike. */
+[[max_total_threads_per_threadgroup(1024)]]
+kernel void kernel_dsv4_comp_rows_update_f32(
+        constant ds4_metal_args_dsv4_comp_rows_update & args [[buffer(0)]],
+        device const float * batch_kv     [[buffer(1)]],
+        device const float * batch_sc     [[buffer(2)]],
+        device const char  * ape          [[buffer(3)]],
+        device       float * state_kv     [[buffer(4)]],
+        device       float * state_score  [[buffer(5)]],
+        device const float * norm_w       [[buffer(6)]],
+        device       float * pool_softmax [[buffer(7)]],
+        device       float * pool_product [[buffer(8)]],
+        device       float * work         [[buffer(9)]],
+        device       half  * cache_f16    [[buffer(10)]],
+        device       float * prefix_kv    [[buffer(11)]],
+        device       float * prefix_score [[buffer(12)]],
+        threadgroup  float * shmem        [[threadgroup(0)]],
+        uint  tiitg [[thread_index_in_threadgroup]],
+        ushort tiisg [[thread_index_in_simdgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]]) {
+    const uint nth = 1024u;
+    if (args.head_dim == 0u || args.width == 0u || args.ratio == 0u ||
+        (args.head_dim & 31u) != 0u) {
+        return;
+    }
+
+    uint emit_index = 0u;
+    for (uint t = 0u; t < args.n_tokens; ++t) {
+        const uint pos = args.pos0 + t;
+        const uint pos_mod = pos % args.ratio;
+        const bool emit = ((pos + 1u) % args.ratio) == 0u;
+
+        /* ---- store: verbatim kernel_dsv4_compressor_store_one ---- */
+        {
+            const uint dst_row = args.ratio == 4u ? args.ratio + pos_mod
+                                                  : pos_mod;
+            device const float * kv_row =
+                batch_kv + (uint64_t)t * args.row_stride;
+            device const float * sc_row =
+                batch_sc + (uint64_t)t * args.row_stride;
+            for (uint gid = tiitg; gid < args.width; gid += nth) {
+                const uint dst = dst_row * args.width + gid;
+                const uint ape_i = pos_mod * args.width + gid;
+                float ape_v;
+                if (args.ape_type == 1u) {
+                    ape_v = (float)(((device const half *)ape)[ape_i]);
+                } else {
+                    ape_v = ((device const float *)ape)[ape_i];
+                }
+                state_kv[dst] = kv_row[gid];
+                state_score[dst] = sc_row[gid] + ape_v;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_device);
+
+        if (emit) {
+            device float * row = args.out_f16 != 0u
+                ? work
+                : work + (uint64_t)(args.comp_row0 + emit_index) *
+                         args.cache_row_stride;
+
+            /* ---- pool ---- */
+            if (args.ratio == 4u) {
+                /* One state column per simdgroup: each 32-lane simdgroup
+                 * replays the standalone exact-pool kernel's 32-thread
+                 * threadgroup, with a private 32-float scratch slice. */
+                for (uint base = 0u; base < args.head_dim; base += 32u) {
+                    ds4_dsv4_compressor_exact_pool_ratio4_col(
+                            state_kv,
+                            state_score,
+                            pool_softmax,
+                            pool_product,
+                            row,
+                            shmem + (uint)sgitg * 32u,
+                            args.head_dim,
+                            /* host dispatches replay=1, n_comp=1 */
+                            1.0f,
+                            0.0f,
+                            base + (uint)sgitg,
+                            (uint)tiisg);
+                }
+            } else {
+                /* Ratio-128 pool: the fallback runs the generic GGML chain on
+                 * a [head_dim][128] transposed scratch.  Reproduce each of its
+                 * three dispatches. */
+                const uint n_rows = args.ratio; /* 128 */
+                /* (a) kernel_soft_max_f32_4(ne00=128, nth=32): one scratch row
+                 * (= one state column) per simdgroup, one float4 per lane.
+                 * No mask/sink sources, scale 1.0 -- keep the literal
+                 * `x*scale + (float4)(0.0f)` arithmetic of the kernel. */
+                const float sm_scale = 1.0f;
+                for (uint base = 0u; base < args.head_dim; base += 32u) {
+                    const uint col = base + (uint)sgitg;
+                    float4 score4;
+                    for (uint j = 0u; j < 4u; ++j) {
+                        score4[j] = state_score[
+                            (uint64_t)(4u * (uint)tiisg + j) * args.width + col];
+                    }
+                    device float4 * pdst4 = (device float4 *)
+                        (pool_softmax + (uint64_t)col * n_rows);
+
+                    float4 lmax4 = -INFINITY;
+                    for (int i00 = (int)tiisg; i00 < (int)(n_rows / 4u);
+                         i00 += 32) {
+                        lmax4 = fmax(lmax4, score4 * sm_scale +
+                                            (float4)(0.0f));
+                    }
+                    const float lmax =
+                        MAX(MAX(lmax4[0], lmax4[1]), MAX(lmax4[2], lmax4[3]));
+                    const float max_val = simd_max(lmax);
+
+                    float4 lsum4 = 0.0f;
+                    for (int i00 = (int)tiisg; i00 < (int)(n_rows / 4u);
+                         i00 += 32) {
+                        const float4 exp_score4 =
+                            exp((score4 * sm_scale + (float4)(0.0f)) - max_val);
+                        lsum4 += exp_score4;
+                        pdst4[i00] = exp_score4;
+                    }
+                    const float lsum =
+                        lsum4[0] + lsum4[1] + lsum4[2] + lsum4[3];
+                    threadgroup_barrier(mem_flags::mem_none);
+                    const float sum = simd_sum(lsum);
+                    const float inv_sum = 1.0f / sum;
+                    for (int i00 = (int)tiisg; i00 < (int)(n_rows / 4u);
+                         i00 += 32) {
+                        pdst4[i00] *= inv_sum;
+                    }
+                }
+                threadgroup_barrier(mem_flags::mem_device);
+                /* (b) elementwise multiply into the product scratch.  The
+                 * fallback's mul reads the softmax from device after its own
+                 * dispatch boundary: reload through volatile.  The KV operand
+                 * was a bit-preserving transpose copy; gather it directly. */
+                {
+                    device volatile const float * reloaded_softmax =
+                        (device volatile const float *)pool_softmax;
+                    const uint total = args.head_dim * n_rows;
+                    for (uint idx = tiitg; idx < total; idx += nth) {
+                        const uint d = idx / n_rows;
+                        const uint r = idx % n_rows;
+                        float value = state_kv[(uint64_t)r * args.width + d];
+                        value *= reloaded_softmax[idx];
+                        pool_product[idx] = value;
+                    }
+                }
+                threadgroup_barrier(mem_flags::mem_device);
+                /* (c) kernel_sum_rows_f32_f32(ne00=128, nth=128): eight
+                 * 128-thread cohorts (four simdgroups each) replay the
+                 * two-stage simd_sum tree with a private 32-float scratch. */
+                {
+                    device volatile const float * reloaded_product =
+                        (device volatile const float *)pool_product;
+                    const uint cohort = tiitg >> 7u;      /* 0..7  */
+                    const uint ltid = tiitg & 127u;       /* 0..127 */
+                    const uint lsg = (uint)sgitg & 3u;    /* 0..3  */
+                    threadgroup float * sh = shmem + cohort * 32u;
+                    for (uint base = 0u; base < args.head_dim; base += 8u) {
+                        const uint d = base + cohort;
+                        /* Each pass reuses the cohort scratch that simdgroups
+                         * 1..3 of the cohort read at the end of the previous
+                         * pass; the standalone kernel had one dispatch per
+                         * row, so this ordering came for free there. */
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+                        if (lsg == 0u) {
+                            sh[tiisg] = 0.0f;
+                        }
+                        float sumf = 0.0f;
+                        sumf += reloaded_product[(uint64_t)d * n_rows + ltid];
+                        sumf = simd_sum(sumf);
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+                        if (tiisg == 0) {
+                            sh[lsg] = sumf;
+                        }
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+                        sumf = sh[tiisg];
+                        sumf = simd_sum(sumf);
+                        if (ltid == 0u) {
+                            row[d] = sumf;
+                        }
+                    }
+                }
+            }
+            threadgroup_barrier(mem_flags::mem_device);
+
+            /* ---- norm: verbatim comp_row_finalize phases ---- */
+            if (args.head_dim == 512u) {
+                device float4 * y4 = (device float4 *)row;
+                device const float4 * x4 = (device const float4 *)row;
+                device const float4 * w4 = (device const float4 *)norm_w;
+                if (sgitg == 0) {
+                    shmem[tiisg] = 0.0f;
+                }
+                float sumf = 0.0f;
+                if (tiitg < 128) {
+                    sumf = dot(x4[tiitg], x4[tiitg]);
+                }
+                sumf = simd_sum(sumf);
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                if (tiitg < 128 && tiisg == 0) {
+                    shmem[sgitg] = sumf;
+                }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                float total = 0.0f;
+                if (tiitg < 128) {
+                    total = simd_sum(shmem[tiisg]);
+                }
+                const float mean  = total / 512.0f;
+                const float scale = 1.0f/sqrt(mean + args.rms_eps);
+                if (tiitg < 128) {
+                    y4[tiitg] = (x4[tiitg]*scale)*w4[tiitg];
+                }
+            } else {
+                device float4 * y4 = (device float4 *)row;
+                device const float4 * x4 = (device const float4 *)row;
+                device const float4 * w4 = (device const float4 *)norm_w;
+                if (sgitg == 0) {
+                    shmem[tiisg] = 0.0f;
+                }
+                float sumf = 0.0f;
+                if (tiitg < 32) {
+                    sumf = dot(x4[tiitg], x4[tiitg]);
+                }
+                sumf = simd_sum(sumf);
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                if (tiisg == 0) {
+                    shmem[sgitg] = sumf;
+                }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                float total = 0.0f;
+                if (tiitg < 32) {
+                    total = simd_sum(shmem[tiisg]);
+                }
+                const float mean  = total / 128.0f;
+                const float scale = 1.0f/sqrt(mean + args.rms_eps);
+                if (tiitg < 32) {
+                    y4[tiitg] = (x4[tiitg]*scale)*w4[tiitg];
+                }
+            }
+            threadgroup_barrier(mem_flags::mem_device);
+
+            /* ---- rope: shared noinline helper, comp_pos per emit ---- */
+            ds4_rope_tail_pair_affine_row(args.rope,
+                                          (device const char *)row,
+                                          (device char *)row,
+                                          (int)args.head_dim - args.rope.n_dims,
+                                          pos + 1u - args.ratio,
+                                          tiitg,
+                                          64u);
+            threadgroup_barrier(mem_flags::mem_device);
+
+            /* ---- quantize ---- */
+            if (args.quant_mode == 0u) {
+                /* FP8 E4M3 round-trip on [0, head_dim - n_rot); the host gate
+                 * guarantees a multiple of 64 so every block is full. */
+                const int n_nope = (int)args.head_dim - args.rope.n_dims;
+                for (int off = 0; off < n_nope; off += 64) {
+                    float v = 0.0f;
+                    if (tiitg < 64) {
+                        v = row[off + tiitg];
+                        shmem[tiitg] = abs(v);
+                    }
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                    for (uint stride = 32; stride > 0; stride >>= 1) {
+                        if (tiitg < stride) {
+                            shmem[tiitg] = max(shmem[tiitg],
+                                               shmem[tiitg + stride]);
+                        }
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+                    }
+                    const float amax = max(shmem[0], 1.0e-4f);
+                    const float scale = exp2(ceil(log2(amax / 448.0f)));
+                    if (tiitg < 64) {
+                        const float q = dsv4_e4m3fn_dequant(
+                            clamp(v / scale, -448.0f, 448.0f)) * scale;
+                        row[off + tiitg] = q;
+                    }
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                }
+            } else {
+                /* Hadamard + FP4: verbatim indexer QAT phase (128 lanes). */
+                threadgroup float *vals = shmem;
+                threadgroup float *absbuf = shmem + 128;
+                if (tiitg < 128) {
+                    vals[tiitg] = row[tiitg];
+                }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                for (uint stride = 1u; stride < 128u; stride <<= 1u) {
+                    if (tiitg < 128 && (tiitg & stride) == 0u) {
+                        const uint base = (tiitg & ~(2u * stride - 1u)) +
+                                          (tiitg & (stride - 1u));
+                        const float a = vals[base];
+                        const float b = vals[base + stride];
+                        vals[base] = a + b;
+                        vals[base + stride] = a - b;
+                    }
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                }
+                float v = 0.0f;
+                if (tiitg < 128) {
+                    v = vals[tiitg] * 0.08838834764831845f;
+                    absbuf[tiitg] = abs(v);
+                }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                const uint block = tiitg >> 5u;
+                const uint lane = tiitg & 31u;
+                const uint block_base = block * 32u;
+                for (uint stride = 16u; stride > 0u; stride >>= 1u) {
+                    if (tiitg < 128 && lane < stride) {
+                        absbuf[block_base + lane] =
+                            max(absbuf[block_base + lane],
+                                absbuf[block_base + lane + stride]);
+                    }
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                }
+                if (tiitg < 128) {
+                    const float amax = max(absbuf[block_base],
+                                           7.052966104933725e-38f);
+                    const float scale = exp2(ceil(log2(amax / 6.0f)));
+                    row[tiitg] = dsv4_e2m1fn_dequant(
+                        clamp(v / scale, -6.0f, 6.0f)) * scale;
+                }
+            }
+            threadgroup_barrier(mem_flags::mem_device);
+
+            /* ---- commit: per-element f32->f16 (value-wise exact) ---- */
+            if (args.out_f16 != 0u && tiitg < 128 && args.head_dim == 512u) {
+                device const float4 * x4 = (device const float4 *)row;
+                device half4 * o4 = (device half4 *)
+                    (cache_f16 + (uint64_t)(args.comp_row0 + emit_index) *
+                                 args.cache_row_stride);
+                o4[tiitg] = half4(x4[tiitg]);
+            }
+
+            /* ---- shift: verbatim kernel_dsv4_ratio4_shift_f32 ---- */
+            if (args.ratio == 4u) {
+                const uint n0 = 4u * args.width;
+                for (uint gid = tiitg; gid < n0; gid += nth) {
+                    state_kv[gid] = state_kv[n0 + gid];
+                    state_score[gid] = state_score[n0 + gid];
+                }
+            }
+            emit_index++;
+        }
+        threadgroup_barrier(mem_flags::mem_device);
+
+        /* ---- speculative prefix capture (replaces the two blits) ---- */
+        if (args.capture_slots != 0u && t + 1u < args.n_tokens &&
+            t < args.capture_slots) {
+            const uint64_t n = (uint64_t)args.state_rows * args.width;
+            device float * dkv = prefix_kv + (uint64_t)t * n;
+            device float * dsc = prefix_score + (uint64_t)t * n;
+            for (uint64_t i = tiitg; i < n; i += nth) {
+                dkv[i] = state_kv[i];
+                dsc[i] = state_score[i];
+            }
+            /* The next token's store overwrites the state these reads use. */
+            threadgroup_barrier(mem_flags::mem_device);
+        }
+    }
+}
+
 // Host-visible packed FlashAttention + exact inverse-RoPE decode kernel.
 kernel void kernel_dsv4_flash_attn_vec_packed32_reduce_rope_f16_dk512_dv512(
         constant ds4_metal_args_flash_attn_ext_vec & args [[buffer(0)]],

--- a/metal/moe.metal
+++ b/metal/moe.metal
@@ -8941,7 +8941,13 @@ kernel void kernel_mul_mm_id_mpp(
         + args.nb10*iy);
 
     auto tA = tensor(sa, dextents<int32_t, 2>(NK, NR0));
-    auto tB = tensor(sb, dextents<int32_t, 2>(NR1, NK));
+    /* The staged B tile stores element (n, k) at sb[n*NK + k]: dim0 is K
+     * (stride 1), dim1 is N (stride NK) — the same convention as tA above.
+     * The historical (NR1, NK) extents order only described it correctly
+     * because NR1 == NK == 32; spell it (NK, NR1) so narrower future
+     * instantiations keep the true layout. Identical extents and strides
+     * while NR1 == 32. */
+    auto tB = tensor(sb, dextents<int32_t, 2>(NK, NR1));
 
     matmul2d<
         matmul2d_descriptor(NR1, NR0, NK, false, true, false,

--- a/speed-bench/ngram_similarity.py
+++ b/speed-bench/ngram_similarity.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Workload self-similarity probe for speculative-decoding triage.
+
+For each input file, runs an online n-gram predictor (orders 1..3) over the
+stream and reports its hit rate: at each position the predictor proposes the
+most frequent continuation of the current context seen so far, then learns the
+actual one. High hit rates flag self-similar streams (code, structured output)
+where draft acceptance is likely to be high; low rates flag prose-like streams.
+
+This is a workload characterization aid, NOT a bound on learned-draft
+acceptance (a trained draft can beat stream self-similarity). Units are words
+(whitespace-split) by default, or bytes with --bytes; real tokenizer streams
+can be fed later via files with one token id per line and --ids.
+
+Standard library only, like the other speed-bench tools.
+"""
+import argparse
+import sys
+from collections import defaultdict, Counter
+
+
+def stream_units(path, mode):
+    data = open(path, 'rb').read()
+    if mode == 'bytes':
+        return list(data)
+    if mode == 'ids':
+        return [int(x) for x in data.split()]
+    return data.decode('utf-8', 'replace').split()
+
+
+def hit_rate(units, order, warmup):
+    model = defaultdict(Counter)
+    hits = 0
+    scored = 0
+    ctx = tuple()
+    for i, u in enumerate(units):
+        if len(ctx) == order:
+            c = model.get(ctx)
+            if i >= warmup and c:
+                pred = max(c.items(), key=lambda kv: kv[1])[0]
+                hits += pred == u
+                scored += 1
+            model[ctx][u] += 1
+        ctx = (ctx + (u,))[-order:] if order else tuple()
+    return hits / scored if scored else 0.0, scored
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('files', nargs='+')
+    ap.add_argument('--bytes', action='store_true', help='byte units instead of words')
+    ap.add_argument('--ids', action='store_true', help='inputs are one token id per line')
+    ap.add_argument('--orders', default='1,2,3')
+    ap.add_argument('--warmup', type=int, default=256,
+                    help='positions before scoring starts (default 256)')
+    args = ap.parse_args()
+    mode = 'bytes' if args.bytes else 'ids' if args.ids else 'words'
+    orders = [int(x) for x in args.orders.split(',')]
+    print(f'unit={mode} warmup={args.warmup}')
+    header = f'{"file":40} {"units":>9} ' + ' '.join(f'{"o"+str(o):>7}' for o in orders)
+    print(header)
+    for path in args.files:
+        units = stream_units(path, mode)
+        cells = []
+        for o in orders:
+            r, n = hit_rate(units, o, args.warmup)
+            cells.append(f'{r*100:6.1f}%')
+        name = path if len(path) <= 40 else '...' + path[-37:]
+        print(f'{name:40} {len(units):9} ' + ' '.join(cells))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -1213,6 +1213,382 @@ static void test_metal_f16_compressor_pair_state_store_exact(void) {
         512, 128, 255, 1, 43, false);
 }
 
+/* Bit-exact check for the fused batch-path compressor rows update
+ * (ds4_gpu_dsv4_comp_rows_update_tensor): replays the exact per-token wrapper
+ * chain the ds4.c fallback loop issues (compressor update with the decode
+ * pool, per-emit FP8/QAT quantize, F16 commit for the attention layout, and
+ * the speculative prefix state capture copies) on one buffer set, runs the
+ * single fused dispatch on an identical second set, and compares every output
+ * buffer bit for bit. */
+static void test_metal_comp_rows_update_exact_case(
+        uint32_t head_dim,
+        uint32_t ratio,
+        uint32_t pos0,
+        uint32_t n_tokens,
+        uint32_t ape_type,
+        int      out_f16,
+        uint32_t capture_slots,
+        uint32_t seed) {
+    const uint32_t coff = ratio == 4u ? 2u : 1u;
+    const uint32_t width = coff * head_dim;
+    const uint32_t state_rows = coff * ratio;
+    const uint32_t n_rot = 64u;
+    const int quant_mode = out_f16 ? 0 : 1;
+    const uint32_t n_emit = (pos0 + n_tokens) / ratio - pos0 / ratio;
+    const uint32_t comp_row0 = pos0 / ratio;
+    const uint32_t cache_rows = comp_row0 + n_emit + 1u;
+    const uint32_t capture_eff =
+        capture_slots < n_tokens - 1u ? capture_slots : n_tokens - 1u;
+    const uint32_t n_ctx_orig = (seed & 1u) ? 4096u : 0u;
+    const float ext_factor = (seed & 1u) ? 1.0f : 0.0f;
+    const float attn_factor = (seed & 1u) ? 1.03f : 1.0f;
+
+    const uint64_t page = (uint64_t)getpagesize();
+    const uint64_t ape_elem_bytes = ape_type == 1u ? 2u : 4u;
+    const uint64_t ape_bytes = (uint64_t)ratio * width * ape_elem_bytes;
+    const uint64_t norm_offset = test_round_up_u64(ape_bytes, page);
+    const uint64_t model_bytes = test_round_up_u64(
+        norm_offset + (uint64_t)head_dim * sizeof(float), page);
+
+    const uint64_t batch_count = (uint64_t)n_tokens * width;
+    const uint64_t batch_bytes = batch_count * sizeof(float);
+    const uint64_t state_count = (uint64_t)state_rows * width;
+    const uint64_t state_bytes = state_count * sizeof(float);
+    const uint64_t cache_elem = out_f16 ? sizeof(uint16_t) : sizeof(float);
+    const uint64_t cache_count = (uint64_t)cache_rows * head_dim;
+    const uint64_t cache_bytes = cache_count * cache_elem;
+    const uint64_t stage_bytes = (uint64_t)head_dim * sizeof(float);
+    const uint64_t prefix_count =
+        (uint64_t)(capture_eff ? capture_eff : 1u) * state_count;
+    const uint64_t prefix_bytes = prefix_count * sizeof(float);
+
+    void *model_raw = NULL;
+    TEST_ASSERT(posix_memalign(&model_raw, (size_t)page,
+                               (size_t)model_bytes) == 0);
+    ds4_gpu_tensor *batch_kv = ds4_gpu_tensor_alloc(batch_bytes);
+    ds4_gpu_tensor *batch_sc = ds4_gpu_tensor_alloc(batch_bytes);
+    ds4_gpu_tensor *ref_state_kv = ds4_gpu_tensor_alloc(state_bytes);
+    ds4_gpu_tensor *ref_state_sc = ds4_gpu_tensor_alloc(state_bytes);
+    ds4_gpu_tensor *fus_state_kv = ds4_gpu_tensor_alloc(state_bytes);
+    ds4_gpu_tensor *fus_state_sc = ds4_gpu_tensor_alloc(state_bytes);
+    ds4_gpu_tensor *ref_stage = ds4_gpu_tensor_alloc(stage_bytes);
+    ds4_gpu_tensor *fus_stage = ds4_gpu_tensor_alloc(stage_bytes);
+    ds4_gpu_tensor *ref_cache = ds4_gpu_tensor_alloc(cache_bytes);
+    ds4_gpu_tensor *fus_cache = ds4_gpu_tensor_alloc(cache_bytes);
+    ds4_gpu_tensor *ref_prefix_kv = ds4_gpu_tensor_alloc(prefix_bytes);
+    ds4_gpu_tensor *ref_prefix_sc = ds4_gpu_tensor_alloc(prefix_bytes);
+    ds4_gpu_tensor *fus_prefix_kv = ds4_gpu_tensor_alloc(prefix_bytes);
+    ds4_gpu_tensor *fus_prefix_sc = ds4_gpu_tensor_alloc(prefix_bytes);
+
+    float *host_a = malloc((size_t)batch_bytes);
+    float *host_b = malloc((size_t)batch_bytes);
+    float *ref_state_host = malloc((size_t)state_bytes);
+    float *fus_state_host = malloc((size_t)state_bytes);
+    uint8_t *ref_cache_host = malloc((size_t)cache_bytes);
+    uint8_t *fus_cache_host = malloc((size_t)cache_bytes);
+    float *ref_prefix_host = malloc((size_t)prefix_bytes);
+    float *fus_prefix_host = malloc((size_t)prefix_bytes);
+    float *ref_stage_host = malloc((size_t)stage_bytes);
+    float *fus_stage_host = malloc((size_t)stage_bytes);
+
+    const bool allocated = model_raw && batch_kv && batch_sc &&
+        ref_state_kv && ref_state_sc && fus_state_kv && fus_state_sc &&
+        ref_stage && fus_stage && ref_cache && fus_cache &&
+        ref_prefix_kv && ref_prefix_sc && fus_prefix_kv && fus_prefix_sc &&
+        host_a && host_b && ref_state_host && fus_state_host &&
+        ref_cache_host && fus_cache_host && ref_prefix_host &&
+        fus_prefix_host && ref_stage_host && fus_stage_host;
+    TEST_ASSERT(allocated);
+
+    size_t state_kv_mm = 0, state_sc_mm = 0, cache_mm = 0;
+    size_t prefix_kv_mm = 0, prefix_sc_mm = 0, stage_mm = 0;
+
+    if (allocated) {
+        memset(model_raw, 0, (size_t)model_bytes);
+        if (ape_type == 1u) {
+            uint16_t *ape = (uint16_t *)model_raw;
+            for (uint64_t i = 0; i < (uint64_t)ratio * width; i++) {
+                const int value = (int)((i * 13u + (i ^ (i >> 3u)) * 7u +
+                                         seed * 17u) % 61u) - 30;
+                ape[i] = test_float_to_f16((float)value / 80.0f);
+            }
+        } else {
+            float *ape = (float *)model_raw;
+            for (uint64_t i = 0; i < (uint64_t)ratio * width; i++) {
+                const int value = (int)((i * 13u + (i ^ (i >> 3u)) * 7u +
+                                         seed * 17u) % 61u) - 30;
+                ape[i] = (float)value / 80.0f;
+            }
+        }
+        float *norm = (float *)((uint8_t *)model_raw + norm_offset);
+        for (uint32_t i = 0; i < head_dim; i++) {
+            norm[i] = 0.75f + (float)((i * 7u + seed * 3u) % 23u) / 64.0f;
+        }
+
+        for (uint64_t i = 0; i < batch_count; i++) {
+            const int kv_value =
+                (int)((i * 29u + (i ^ (i >> 4u)) * 9u + seed * 11u) % 127u) -
+                63;
+            const int sc_value =
+                (int)((i * 23u + (i ^ (i >> 5u)) * 13u + seed * 7u) % 113u) -
+                56;
+            host_a[i] = (float)kv_value / 88.0f;
+            host_b[i] = (float)sc_value / 96.0f;
+        }
+        TEST_ASSERT(ds4_gpu_tensor_write(batch_kv, 0, host_a,
+                                         batch_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_write(batch_sc, 0, host_b,
+                                         batch_bytes) != 0);
+
+        for (uint64_t i = 0; i < state_count; i++) {
+            const int kv_value = (int)((i * 5u + seed * 13u) % 97u) - 48;
+            ref_state_host[i] = (float)kv_value / 64.0f;
+        }
+        TEST_ASSERT(ds4_gpu_tensor_write(ref_state_kv, 0, ref_state_host,
+                                         state_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_write(fus_state_kv, 0, ref_state_host,
+                                         state_bytes) != 0);
+        for (uint64_t i = 0; i < state_count; i++) {
+            const int sc_value = (int)((i * 7u + seed * 5u) % 101u) - 50;
+            ref_state_host[i] = (float)sc_value / 72.0f;
+        }
+        TEST_ASSERT(ds4_gpu_tensor_write(ref_state_sc, 0, ref_state_host,
+                                         state_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_write(fus_state_sc, 0, ref_state_host,
+                                         state_bytes) != 0);
+
+        for (uint64_t i = 0; i < cache_bytes; i++) {
+            ref_cache_host[i] = (uint8_t)(0xA5u ^ (i & 0xffu));
+        }
+        TEST_ASSERT(ds4_gpu_tensor_write(ref_cache, 0, ref_cache_host,
+                                         cache_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_write(fus_cache, 0, ref_cache_host,
+                                         cache_bytes) != 0);
+        for (uint32_t i = 0; i < head_dim; i++) {
+            const uint32_t poison = 0x7fc02001u + (i & 0x3ffu);
+            memcpy(ref_stage_host + i, &poison, sizeof(poison));
+        }
+        TEST_ASSERT(ds4_gpu_tensor_write(ref_stage, 0, ref_stage_host,
+                                         stage_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_write(fus_stage, 0, ref_stage_host,
+                                         stage_bytes) != 0);
+        for (uint64_t i = 0; i < prefix_count; i++) {
+            const uint32_t poison = 0x7fc03001u + (uint32_t)(i & 0x3ffu);
+            memcpy(ref_prefix_host + i, &poison, sizeof(poison));
+        }
+        TEST_ASSERT(ds4_gpu_tensor_write(ref_prefix_kv, 0, ref_prefix_host,
+                                         prefix_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_write(ref_prefix_sc, 0, ref_prefix_host,
+                                         prefix_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_write(fus_prefix_kv, 0, ref_prefix_host,
+                                         prefix_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_write(fus_prefix_sc, 0, ref_prefix_host,
+                                         prefix_bytes) != 0);
+
+        TEST_ASSERT(ds4_gpu_set_model_map(model_raw, model_bytes) != 0);
+        ds4_gpu_set_quality(false);
+
+        /* Reference: the exact wrapper chain of the ds4.c fallback loop. */
+        uint32_t comp_row = comp_row0;
+        for (uint32_t t = 0; t < n_tokens; t++) {
+            const uint32_t pos = pos0 + t;
+            const bool emit = ((pos + 1u) % ratio) == 0u;
+            ds4_gpu_tensor *kv_view = ds4_gpu_tensor_view(
+                batch_kv, (uint64_t)t * width * sizeof(float),
+                (uint64_t)width * sizeof(float));
+            ds4_gpu_tensor *sc_view = ds4_gpu_tensor_view(
+                batch_sc, (uint64_t)t * width * sizeof(float),
+                (uint64_t)width * sizeof(float));
+            TEST_ASSERT(kv_view && sc_view);
+            TEST_ASSERT(ds4_gpu_compressor_update_tensor(
+                            kv_view, sc_view, ref_state_kv, ref_state_sc,
+                            out_f16 ? ref_stage : ref_cache,
+                            model_raw, model_bytes, 0, ape_type,
+                            norm_offset, 0, head_dim, ratio, pos,
+                            out_f16 ? 0u : comp_row,
+                            n_rot, n_ctx_orig,
+                            10000.0f, 1.0f, ext_factor, attn_factor,
+                            32.0f, 1.0f, 1.0e-6f,
+                            false, true, false) != 0);
+            if (emit) {
+                ds4_gpu_tensor *row_view = out_f16
+                    ? ds4_gpu_tensor_view(ref_stage, 0, stage_bytes)
+                    : ds4_gpu_tensor_view(
+                          ref_cache,
+                          (uint64_t)comp_row * head_dim * sizeof(float),
+                          (uint64_t)head_dim * sizeof(float));
+                TEST_ASSERT(row_view != NULL);
+                if (quant_mode == 0) {
+                    TEST_ASSERT(ds4_gpu_dsv4_fp8_kv_quantize_tensor(
+                                    row_view, 1, head_dim, n_rot) != 0);
+                } else {
+                    TEST_ASSERT(ds4_gpu_dsv4_indexer_qat_tensor(
+                                    row_view, 1, head_dim) != 0);
+                }
+                ds4_gpu_tensor_free(row_view);
+                if (out_f16) {
+                    TEST_ASSERT(ds4_gpu_tensor_copy_f32_to_f16(
+                                    ref_cache,
+                                    (uint64_t)comp_row * head_dim *
+                                        sizeof(uint16_t),
+                                    ref_stage, 0, head_dim) != 0);
+                }
+                comp_row++;
+            }
+            if (t + 1u < n_tokens && t < capture_eff) {
+                /* ds4_gpu_tensor_copy encodes onto the command batch the
+                 * runtime graph keeps open; open one for the two blits. */
+                TEST_ASSERT(ds4_gpu_begin_commands() != 0);
+                TEST_ASSERT(ds4_gpu_tensor_copy(
+                                ref_prefix_kv, (uint64_t)t * state_bytes,
+                                ref_state_kv, 0, state_bytes) != 0);
+                TEST_ASSERT(ds4_gpu_tensor_copy(
+                                ref_prefix_sc, (uint64_t)t * state_bytes,
+                                ref_state_sc, 0, state_bytes) != 0);
+                TEST_ASSERT(ds4_gpu_end_commands() != 0);
+            }
+            ds4_gpu_tensor_free(sc_view);
+            ds4_gpu_tensor_free(kv_view);
+        }
+
+        /* Fused: one dispatch. */
+        TEST_ASSERT(ds4_gpu_dsv4_comp_rows_update_tensor(
+                        batch_kv, batch_sc, width,
+                        fus_state_kv, fus_state_sc,
+                        out_f16 ? fus_stage : NULL,
+                        fus_cache, comp_row0,
+                        (uint64_t)head_dim * cache_elem,
+                        out_f16, quant_mode,
+                        capture_eff ? fus_prefix_kv : NULL,
+                        capture_eff ? fus_prefix_sc : NULL,
+                        capture_slots,
+                        model_raw, model_bytes, 0, ape_type, norm_offset,
+                        head_dim, ratio, pos0, n_tokens, n_rot, n_ctx_orig,
+                        10000.0f, 1.0f, ext_factor, attn_factor,
+                        32.0f, 1.0f, 1.0e-6f) == 1);
+
+        TEST_ASSERT(ds4_gpu_tensor_read(ref_state_kv, 0, ref_state_host,
+                                        state_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_read(fus_state_kv, 0, fus_state_host,
+                                        state_bytes) != 0);
+        for (uint64_t i = 0; i < state_count; i++) {
+            if (memcmp(ref_state_host + i, fus_state_host + i,
+                       sizeof(float)) != 0) state_kv_mm++;
+        }
+        TEST_ASSERT(ds4_gpu_tensor_read(ref_state_sc, 0, ref_state_host,
+                                        state_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_read(fus_state_sc, 0, fus_state_host,
+                                        state_bytes) != 0);
+        for (uint64_t i = 0; i < state_count; i++) {
+            if (memcmp(ref_state_host + i, fus_state_host + i,
+                       sizeof(float)) != 0) state_sc_mm++;
+        }
+        TEST_ASSERT(ds4_gpu_tensor_read(ref_cache, 0, ref_cache_host,
+                                        cache_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_read(fus_cache, 0, fus_cache_host,
+                                        cache_bytes) != 0);
+        for (uint64_t i = 0; i < cache_count; i++) {
+            if (memcmp(ref_cache_host + i * cache_elem,
+                       fus_cache_host + i * cache_elem,
+                       (size_t)cache_elem) != 0) cache_mm++;
+        }
+        TEST_ASSERT(ds4_gpu_tensor_read(ref_stage, 0, ref_stage_host,
+                                        stage_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_read(fus_stage, 0, fus_stage_host,
+                                        stage_bytes) != 0);
+        if (out_f16) {
+            for (uint32_t i = 0; i < head_dim; i++) {
+                if (memcmp(ref_stage_host + i, fus_stage_host + i,
+                           sizeof(float)) != 0) stage_mm++;
+            }
+        }
+        TEST_ASSERT(ds4_gpu_tensor_read(ref_prefix_kv, 0, ref_prefix_host,
+                                        prefix_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_read(fus_prefix_kv, 0, fus_prefix_host,
+                                        prefix_bytes) != 0);
+        for (uint64_t i = 0; i < prefix_count; i++) {
+            if (memcmp(ref_prefix_host + i, fus_prefix_host + i,
+                       sizeof(float)) != 0) prefix_kv_mm++;
+        }
+        TEST_ASSERT(ds4_gpu_tensor_read(ref_prefix_sc, 0, ref_prefix_host,
+                                        prefix_bytes) != 0);
+        TEST_ASSERT(ds4_gpu_tensor_read(fus_prefix_sc, 0, fus_prefix_host,
+                                        prefix_bytes) != 0);
+        for (uint64_t i = 0; i < prefix_count; i++) {
+            if (memcmp(ref_prefix_host + i, fus_prefix_host + i,
+                       sizeof(float)) != 0) prefix_sc_mm++;
+        }
+    }
+
+    fprintf(stderr,
+            "ds4-test: comp rows update exact head_dim=%u ratio=%u pos0=%u "
+            "n_tokens=%u n_emit=%u ape=%s out=%s capture=%u "
+            "mm state=%zu/%zu cache=%zu stage=%zu prefix=%zu/%zu\n",
+            head_dim, ratio, pos0, n_tokens, n_emit,
+            ape_type == 1u ? "f16" : "f32",
+            out_f16 ? "f16" : "f32", capture_eff,
+            state_kv_mm, state_sc_mm, cache_mm, stage_mm,
+            prefix_kv_mm, prefix_sc_mm);
+    TEST_ASSERT(state_kv_mm == 0);
+    TEST_ASSERT(state_sc_mm == 0);
+    TEST_ASSERT(cache_mm == 0);
+    TEST_ASSERT(stage_mm == 0);
+    TEST_ASSERT(prefix_kv_mm == 0);
+    TEST_ASSERT(prefix_sc_mm == 0);
+
+    free(fus_stage_host);
+    free(ref_stage_host);
+    free(fus_prefix_host);
+    free(ref_prefix_host);
+    free(fus_cache_host);
+    free(ref_cache_host);
+    free(fus_state_host);
+    free(ref_state_host);
+    free(host_b);
+    free(host_a);
+    ds4_gpu_tensor_free(fus_prefix_sc);
+    ds4_gpu_tensor_free(fus_prefix_kv);
+    ds4_gpu_tensor_free(ref_prefix_sc);
+    ds4_gpu_tensor_free(ref_prefix_kv);
+    ds4_gpu_tensor_free(fus_cache);
+    ds4_gpu_tensor_free(ref_cache);
+    ds4_gpu_tensor_free(fus_stage);
+    ds4_gpu_tensor_free(ref_stage);
+    ds4_gpu_tensor_free(fus_state_sc);
+    ds4_gpu_tensor_free(fus_state_kv);
+    ds4_gpu_tensor_free(ref_state_sc);
+    ds4_gpu_tensor_free(ref_state_kv);
+    ds4_gpu_tensor_free(batch_sc);
+    ds4_gpu_tensor_free(batch_kv);
+    free(model_raw);
+}
+
+static void test_metal_comp_rows_update_exact(void) {
+    /* Speculative-verify shapes: n_tokens 2..6 crossed with every ratio-4
+     * phase of pos0, for the attention (512, F16 commit, FP8 tail) and
+     * indexer (128, in-place F32, Hadamard+FP4) compressors.  Emits per
+     * chunk range over 0, 1, and 2. */
+    uint32_t seed = 51u;
+    for (uint32_t n_tokens = 2u; n_tokens <= 6u; n_tokens++) {
+        for (uint32_t rem = 0u; rem < 4u; rem++) {
+            const uint32_t pos0 = 8u + rem;
+            test_metal_comp_rows_update_exact_case(
+                512, 4, pos0, n_tokens, rem & 1u, 1, 4, seed++);
+            test_metal_comp_rows_update_exact_case(
+                128, 4, pos0, n_tokens, (rem >> 1u) & 1u, 0, 4, seed++);
+        }
+    }
+    /* Ratio-128 layers reach the same host loop with the generic pool
+     * chain: cover no-emit, mid-chunk emit, last-token emit, and
+     * first-token emit, plus a capture-disabled chunk. */
+    test_metal_comp_rows_update_exact_case(512, 128, 120, 6, 0, 1, 4, 91);
+    test_metal_comp_rows_update_exact_case(512, 128, 124, 6, 1, 1, 4, 92);
+    test_metal_comp_rows_update_exact_case(512, 128, 126, 2, 0, 1, 4, 93);
+    test_metal_comp_rows_update_exact_case(512, 128, 255, 3, 1, 1, 4, 94);
+    test_metal_comp_rows_update_exact_case(512, 128, 124, 6, 0, 1, 0, 95);
+    test_metal_comp_rows_update_exact_case(512, 4, 10, 5, 0, 1, 0, 96);
+}
+
 static void test_metal_compressor_ape_add_exact_case(
         uint32_t head_dim,
         uint32_t ratio,
@@ -4552,6 +4928,7 @@ static void test_metal_kernel_group(void) {
     test_metal_q8_0_decode_pair_exact();
 #if defined(__APPLE__)
     test_metal_f16_compressor_pair_state_store_exact();
+    test_metal_comp_rows_update_exact();
     test_metal_compressor_ape_add_exact();
     test_metal_compressor_ratio4_pack_exact();
     test_metal_compressor_ratio4_replay_pack_exact();


### PR DESCRIPTION
Three commits, measured on M5 Max 40-core / 128 GB with the ds4f-q2 model. The default (non-speculative) decode path stays bit-exact throughout: every change was gated by an abort-on-diff A/B harness comparing full-vocabulary logit frontiers, and the official bench keeps the canonical frontier hash (prefill 786-788 t/s, steady decode 45.50-45.58 t/s).

## dspark: fold the first token's forward into the verify batch

With `--dspark`, each accept/miss cycle previously paid a standalone target forward for the first token before the verify batch. This folds that forward into the verify dispatch as row 0 (the DFlash protocol shape), so one batched pass covers first token + verification. The fold is self-regulating: it re-arms only on a full accept; any partial accept or miss falls back to the standalone path, which resynchronizes draft conditioning.

Also in this commit, all opt-in via env:
- `DS4_DSPARK_CONFIDENCE_GRID` — per-position draft confidence thresholds (best: `0.55,0.6,0.65`)
- `DS4_DSPARK_SCHEDULER_BACKOFF` — adaptive selectivity + regime pauses on consecutive miss streaks
- `DS4_DSPARK_MARGIN_GATE` — skip proposing when the target's top1-top2 logit margin says it is hesitating (the draft has no chance there); applied at the standalone site only
- r1 6/7/8 row-count instantiations for the ext matvec (the 6-row verify blocks sat on a 2x dense-relu cliff)

With `DS4_DSPARK_FOLD=1 DS4_DSPARK_CONFIDENCE_GRID=0.55,0.6,0.65 DS4_DSPARK_SCHEDULER_BACKOFF=1 DS4_DSPARK_MARGIN_GATE=1` (temp 0, `-n 512`), against plain decode on the same channel:

| channel | plain | dspark | delta |
|---|---|---|---|
| self-similar payload | 46.2 t/s | 62.8 t/s | +36% |
| codegen (red-black tree) | 46.8 t/s | 48.2 t/s | +2.9% |
| prose | 44.8 t/s | 46.6 t/s | +4.0% |

No channel regresses — the margin gate is what turned prose from a loss into a gain (the speculative path only works its genuinely predictable spans, at ~87% acceptance). The speculative flow is deterministic run-to-run.

## metal: fix staged B-tile tensor extents in the mm_id mpp kernel

Latent-bug fix, also submitted standalone as #777 (kept as its own commit here so either merge order works): the `tB` extents were declared transposed and only accidentally correct because `NR1 == NK == 32`. Bit-identical today; required for any future `NR1 != NK` instantiation.

## metal: two M5 decode encoder/occupancy wins, both bit-exact

- **HC producer spread**: one live NR0=2 cluster per comb threadgroup instead of packing both clusters on groups 2..5, raising the producer grid from 6 to 10 threadgroups. Identical per-row math, bit-identical outputs; ~+0.12% decode on M5 Max. Default on M5-class GPUs, kill switch `DS4_METAL_DISABLE_M5_HC_SPREAD`.
- **FFN island into HC expand**: publish the parallel-FFN join outputs with a memory barrier inside the still-open concurrent encoder so the HC expansion dispatch lands there too, saving one encoder transition per layer. Kill switch `DS4_METAL_DISABLE_M5_FFN_ISLAND_INTO_HC`.

`make test` passes, `--metal-kernels` green, ROCm/CUDA paths untouched apart from the already-merged DSpark support hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)