### PR TITLE
metal: lightning-indexer-organized DS4 indexer scorer (llt)

### DIFF
--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -17402,8 +17402,16 @@ int ds4_gpu_indexer_score_one_tensor(
         }
 
         if (n_head == 64 && head_dim == 128) {
-            id<MTLComputePipelineState> direct_pipeline =
-                ds4_gpu_hot_pipeline(g_dsv4_indexer_score_one_direct_pipeline,
+            /* Same lightning-indexer organization for decode: one kernel,
+             * causal masking off (n_tokens==1).
+             * DS4_METAL_DISABLE_INDEXER_LLT rolls back (A/B control). */
+            const bool score_llt =
+                getenv("DS4_METAL_DISABLE_INDEXER_LLT") == NULL;
+            const bool score_nsg4 = getenv("DS4_METAL_INDEXER_LLT_NSG4") != NULL;
+            id<MTLComputePipelineState> direct_pipeline = score_llt
+                ? ds4_gpu_get_pipeline(score_nsg4 ? "kernel_dsv4_indexer_scores_llt_nsg4"
+                                                  : "kernel_dsv4_indexer_scores_llt")
+                : ds4_gpu_hot_pipeline(g_dsv4_indexer_score_one_direct_pipeline,
                                         "kernel_dsv4_indexer_score_one_direct");
             if (!direct_pipeline) return 0;
 
@@ -17432,9 +17440,21 @@ int ds4_gpu_indexer_score_one_tensor(
             [enc setBuffer:wbuf offset:ds4_gpu_tensor_offset(weights) atIndex:2];
             [enc setBuffer:compbuf offset:ds4_gpu_tensor_offset(index_comp) atIndex:3];
             [enc setBuffer:scorebuf offset:ds4_gpu_tensor_offset(scores) atIndex:4];
-            [enc setThreadgroupMemoryLength:(128u + 4u) * sizeof(float) atIndex:0];
-            [enc dispatchThreadgroups:MTLSizeMake(n_comp, 1, 1)
-                 threadsPerThreadgroup:MTLSizeMake(32, 4, 1)];
+            if (score_llt && score_nsg4) {
+                [enc setThreadgroupMemoryLength:(32u*128u + 8u*128u) * sizeof(uint16_t) +
+                                                (8u + 256u) * sizeof(float) atIndex:0];
+                [enc dispatchThreadgroups:MTLSizeMake(((NSUInteger)n_comp + 31u) / 32u, 1, 1)
+                     threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+            } else if (score_llt) {
+                [enc setThreadgroupMemoryLength:(64u*128u + 8u*128u) * sizeof(uint16_t) +
+                                                (8u + 512u) * sizeof(float) atIndex:0];
+                [enc dispatchThreadgroups:MTLSizeMake(((NSUInteger)n_comp + 63u) / 64u, 1, 1)
+                     threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+            } else {
+                [enc setThreadgroupMemoryLength:(128u + 4u) * sizeof(float) atIndex:0];
+                [enc dispatchThreadgroups:MTLSizeMake(n_comp, 1, 1)
+                     threadsPerThreadgroup:MTLSizeMake(32, 4, 1)];
+            }
             ds4_gpu_end_compute_encoder(cb, enc);
 
             if (!ds4_gpu_finish_command_buffer(cb, owned, "indexer direct score")) return 0;
@@ -17555,10 +17575,24 @@ static int ds4_gpu_indexer_scores_batch_tensor(
          * those paths keep the older direct/tiled score kernels.
          */
         const bool use_nax = ds4_gpu_mpp_available() && n_tokens >= 16u;
+        /* Lightning-indexer-organized scorer (ported from llama.cpp) is the
+         * default pre-M5/NAX schedule; DS4_METAL_DISABLE_INDEXER_LLT rolls
+         * back to the tiled kernel (A/B control). */
+        const bool use_llt = !use_nax && !g_quality_mode &&
+            getenv("DS4_METAL_DISABLE_INDEXER_LLT") == NULL;
+        const char *llt_nb = getenv("DS4_METAL_INDEXER_LLT_NBPTG");
+        const char *llt_name =
+            (llt_nb && llt_nb[0] == '3' && llt_nb[1] == '2' && llt_nb[2] == '\0') ? "kernel_dsv4_indexer_scores_llt32" :
+            (llt_nb && llt_nb[0] == '1' && llt_nb[1] == '6' && llt_nb[2] == '\0') ? "kernel_dsv4_indexer_scores_llt16" :
+            "kernel_dsv4_indexer_scores_llt";
+        if (getenv("DS4_METAL_INDEXER_LLT_NSG4") != NULL) {
+            llt_name = "kernel_dsv4_indexer_scores_llt_nsg4";
+        }
         id<MTLComputePipelineState> pipeline = ds4_gpu_get_pipeline(
             use_nax ? "kernel_dsv4_indexer_scores_nax" :
             (g_quality_mode ? "kernel_dsv4_indexer_scores_tiled_f32"
-                            : "kernel_dsv4_indexer_scores_tiled"));
+                            : (use_llt ? llt_name
+                                       : "kernel_dsv4_indexer_scores_tiled")));
         if (!pipeline) return 0;
 
         ds4_gpu_dsv4_indexer_scores_fused_args args = {
@@ -17606,7 +17640,7 @@ static int ds4_gpu_indexer_scores_batch_tensor(
                                                   ((NSUInteger)n_tokens + 7u) / 8u,
                                                   1)
                  threadsPerThreadgroup:MTLSizeMake(32, 4, 1)];
-        } else {
+        } else if (!use_llt) {
             const NSUInteger q_shared = 8u * 128u;
             const NSUInteger k_shared = 32u * 128u;
             const NSUInteger dot_shared = 8u * 32u;
@@ -17616,6 +17650,22 @@ static int ds4_gpu_indexer_scores_batch_tensor(
                                                   ((NSUInteger)n_tokens + 7u) / 8u,
                                                   1)
                  threadsPerThreadgroup:MTLSizeMake(32, 4, 1)];
+        } else if (getenv("DS4_METAL_INDEXER_LLT_NSG4") != NULL) {
+            /* NSG=4: sk[32x128]half + sq[8x128]half + sw[8] + sqk[256] f32 */
+            [enc setThreadgroupMemoryLength:(32u*128u + 8u*128u) * sizeof(uint16_t) +
+                                            (8u + 256u) * sizeof(float) atIndex:0];
+            [enc dispatchThreadgroups:MTLSizeMake(((NSUInteger)n_comp + 31u) / 32u,
+                                                  ((NSUInteger)n_tokens + 7u) / 8u,
+                                                  1)
+                 threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+        } else {
+            /* sk[NKxDK]half + sq[NHPTGxDK]half + sw[NHPTG] + sqk[512] f32 */
+            [enc setThreadgroupMemoryLength:(64u*128u + 8u*128u) * sizeof(uint16_t) +
+                                            (8u + 512u) * sizeof(float) atIndex:0];
+            [enc dispatchThreadgroups:MTLSizeMake(((NSUInteger)n_comp + 63u) / 64u,
+                                                  ((NSUInteger)n_tokens + 7u) / 8u,
+                                                  1)
+                 threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
         }
         ds4_gpu_end_compute_encoder(cb, enc);
 

--- a/metal/dsv4_misc.metal
+++ b/metal/dsv4_misc.metal
@@ -6314,6 +6314,144 @@ kernel void kernel_dsv4_indexer_scores_tiled(
     }
 }
 
+/* DS4 ratio-4 indexer score builder, lightning-indexer organization
+ * (ported from llama.cpp's Metal kernel_lightning_indexer):
+ *
+ * Each 256-thread threadgroup owns NK=64 compressed rows.  Those rows are
+ * staged to threadgroup memory once and transposed into per-simdgroup
+ * register matrices (mk) ONCE; the whole head loop then reuses
+ * register-resident K instead of re-reading threadgroup K per head (the
+ * structural tax in kernel_dsv4_indexer_scores_tiled* and
+ * kernel_dsv4_indexer_score_one_direct).  Heads are processed in
+ * NHPTG=8-head tiles (Q staged per tile, head weights pre-scaled), with
+ * one score register per key accumulated over all tiles and a single
+ * store per key.  Prefill iterates NBPTG=8 tokens inside the kernel
+ * against the same resident K; decode passes n_tokens=1.
+ *
+ * Per-cell math is preserved: f32 rows staged to half, 8x8 simdgroup
+ * matrix steps over depth 128 in ascending order, relu then w*scale per
+ * head in ascending head order, and ds4's causal (-inf) epilogue for
+ * multi-token (prefill) calls / all-rows pass-through for decode. */
+template <int NBPTG, int T_NSG>
+kernel void kernel_dsv4_indexer_scores_llt_impl(
+        constant ds4_metal_args_dsv4_indexer_scores_fused & args,
+        device const char *q,
+        device const char *weights,
+        device const char *index_comp,
+        device       char *scores,
+        threadgroup float *sharedf [[threadgroup(0)]],
+        uint2  tgpig [[threadgroup_position_in_grid]],
+        ushort tiitg [[thread_index_in_threadgroup]],
+        ushort tiisg [[thread_index_in_simdgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]]) {
+    constexpr uint DK     = 128;   // indexer key depth
+    constexpr uint NH     = 64;    // indexer heads
+    constexpr uint NHPTG  = 8;     // heads per tile
+    constexpr uint NKPSG  = 8;     // keys per simdgroup
+    constexpr uint NSG    = T_NSG; // simdgroups per threadgroup
+    constexpr uint NK     = NKPSG*NSG;   // keys per threadgroup
+    constexpr uint NTG    = 32*NSG;      // threads per threadgroup
+    constexpr uint DK8    = DK/8;
+
+    if (args.n_head != NH || args.head_dim != DK) return;
+    const bool causal = args.n_tokens > 1u;
+
+    threadgroup half  *sk  = (threadgroup half *)sharedf;        // [NK][DK]
+    threadgroup half  *sq  = sk + NK*DK;                         // [NHPTG][DK]
+    threadgroup float *sw  = sharedf + (NK*DK + NHPTG*DK)/2;     // [NHPTG]
+    threadgroup float *sqk = sw + NHPTG;                         // [NSG*NHPTG*NKPSG]
+
+    const uint i_kv_0 = tgpig.x * NK;
+
+    // Stage this threadgroup's K rows once (f32 device -> half, edges zeroed).
+    for (uint i = tiitg; i < NK*DK; i += NTG) {
+        const uint ik = i / DK;
+        const uint d  = i - ik*DK;
+        const uint comp = i_kv_0 + ik;
+        half v = half(0.0h);
+        if (comp < args.n_comp) {
+            device const float *row = (device const float *)(index_comp +
+                (uint64_t)comp * args.index_row_stride);
+            v = half(row[d]);
+        }
+        sk[i] = v;
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // K tile of this simdgroup transposed into registers: [DK][NKPSG].
+    simdgroup_half8x8 mk[DK8];
+    for (uint i = 0; i < DK8; i++) {
+        simdgroup_load(mk[i], sk + (uint)sgitg*NKPSG*DK + 8*i, DK, 0, true);
+    }
+
+    const uint i_kv = i_kv_0 + (uint)sgitg*NKPSG;   // first key of this simdgroup
+    const uint i_batch_0 = tgpig.y * NBPTG;
+    const uint n_batch = min((uint)NBPTG, args.n_tokens - i_batch_0);
+    threadgroup float *pqk = sqk + (uint)sgitg*NHPTG*NKPSG;
+
+    for (uint ib = 0; ib < n_batch; ib++) {
+        const uint i_batch = i_batch_0 + ib;
+        device const char *pq = q + (uint64_t)i_batch * args.q_token_stride;
+        device const float *pw = (device const float *)(weights +
+            (uint64_t)i_batch * args.weights_token_stride);
+
+        float score = 0.0f;
+
+        for (uint i_head = 0; i_head < NH; i_head += NHPTG) {
+            // Stage Q for this head tile: [NHPTG][DK] half.
+            for (uint i = tiitg; i < NHPTG*DK; i += NTG) {
+                const uint ih = i / DK;
+                const uint d  = i - ih*DK;
+                device const float *qh = (device const float *)(pq +
+                    (uint64_t)(i_head + ih) * args.q_head_stride);
+                sq[i] = half(qh[d]);
+            }
+            if (tiitg < NHPTG) {
+                sw[tiitg] = pw[i_head + tiitg] * args.scale;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            simdgroup_float8x8 mqk = make_filled_simdgroup_matrix<float, 8>(0.0f);
+            for (uint i = 0; i < DK8; i++) {
+                simdgroup_half8x8 mq;
+                simdgroup_load(mq, sq + 8*i, DK, 0, false);
+                simdgroup_multiply_accumulate(mqk, mq, mk[i], mqk);
+            }
+            simdgroup_store(mqk, pqk, NKPSG, 0, false);
+            simdgroup_barrier(mem_flags::mem_threadgroup);
+
+            // One lane per key: ReLU, pre-scaled head weight, accumulate
+            // over this head tile (ascending head order across tiles).
+            if (tiisg < NKPSG) {
+                for (uint ih = 0; ih < NHPTG; ih++) {
+                    score += max(pqk[ih*NKPSG + tiisg], 0.0f) * sw[ih];
+                }
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+
+        if (tiisg < NKPSG) {
+            const uint comp = i_kv + tiisg;
+            if (comp < args.n_comp) {
+                const uint visible = causal ?
+                    min((args.pos0 + i_batch + 1u) / args.ratio, args.n_comp)
+                    : args.n_comp;
+                device float *dst = (device float *)(scores +
+                    (uint64_t)i_batch * args.score_token_stride) + comp;
+                *dst = comp < visible ? score : -INFINITY;
+            }
+        }
+    }
+}
+
+typedef decltype(kernel_dsv4_indexer_scores_llt_impl<1,1>) kernel_dsv4_llt_t;
+/* Default NBPTG=8; 16 and 32 trade grid occupancy for amortized K staging. */
+template [[host_name("kernel_dsv4_indexer_scores_llt")]]   kernel kernel_dsv4_llt_t kernel_dsv4_indexer_scores_llt_impl<8, 8>;
+template [[host_name("kernel_dsv4_indexer_scores_llt16")]] kernel kernel_dsv4_llt_t kernel_dsv4_indexer_scores_llt_impl<16, 8>;
+template [[host_name("kernel_dsv4_indexer_scores_llt32")]] kernel kernel_dsv4_llt_t kernel_dsv4_indexer_scores_llt_impl<32, 8>;
+template [[host_name("kernel_dsv4_indexer_scores_llt_nsg4")]] kernel kernel_dsv4_llt_t kernel_dsv4_indexer_scores_llt_impl<8, 4>;
+
 #ifdef DS4_METAL_HAS_TENSOR
 // Retained full-512 prefill indexer score path.  This is the part of sparse
 // compressed attention that maps cleanly to TensorOps: a regular token by


### PR DESCRIPTION
Ports llama.cpp's Metal kernel_lightning_indexer organization to ds4's ratio-4 (CSA) indexer score stage on pre-M5/non-NAX paths, replacing both the prefill tiled kernels and the decode direct score kernel.

Structure: each 256-thread threadgroup owns 64 compressed rows, staged once and transposed into per-simdgroup REGISTER matrices; the 64-head loop then reuses register-resident K instead of re-reading threadgroup K per head. Heads are processed in 8-head tiles (single Q stage + pre-scaled head weights, 2 barriers per tile vs 3 per head); prefill iterates 8 tokens per kernel pass against resident K; decode runs the same kernel with n_tokens=1. Per-cell math preserved (f32->half staged rows, ascending depth-8 simdgroup matrix steps, relu then w*scale per head ascending, ds4 causal -inf epilogue for prefill / all-rows for decode).

Measured on Apple M3 Ultra 512 GB, DeepSeek V4 Flash resident, ctx frontier probes over HTTP + ds4-bench + variant benches:

* decode bit-exact vs kernel_dsv4_indexer_score_one_direct: metal_decode_schedule_bench --candidate-env DS4_METAL_DISABLE_INDEXER_LLT --include-selection: exact_rows=529, exact_floats=68389120, exact_selected_ids=528
* decode @117.6k ctx: 39.3 -> 42.2 / 41.5 t/s (+6-7%, two replicates)
* short-ctx decode 48.0 t/s, prefill cold @117.6k 405 t/s: parity
* prefill score stage @29.4k rows: parity vs scores_tiled (dual-head / wide-tile / NSG4 alternate organizations were also measured and revert for net-negative; knobs preserved below)

Env knobs: DS4_METAL_DISABLE_INDEXER_LLT (rollback, variant-bench control), DS4_METAL_INDEXER_LLT_NBPTG=16|32 (token batch per pass, measured flat), DS4_METAL_INDEXER_LLT_NSG4 (4-simdgroup / 2-TG-per-core variant, measured prefill-negative/decode-slightly-positive, off).