### PR TITLE
agent+server: recover when a tool-call marker is truncated by the token budget

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -1909,6 +1909,37 @@ static void agent_dsml_feed(agent_dsml_parser *p, const char *s, size_t n) {
     }
 }
 
+/* agent_dsml_feed()'s AGENT_DSML_SEARCH branch only transitions to
+ * AGENT_DSML_STRUCTURAL once search_tail's tail matches the COMPLETE start
+ * marker. If generation is cut off (token budget exhausted) while the model
+ * is a few bytes into emitting that marker, the parser is left stuck in
+ * AGENT_DSML_SEARCH forever -- indistinguishable, to the caller, from the
+ * model simply never attempting a tool call at all.  That silence is what
+ * made ds4-chat look unusable: the turn ends with no tool executed and no
+ * error, so nothing tells the user (or an orchestrating caller) that a read
+ * was attempted and lost.
+ *
+ * This checks whether the tail of search_tail is itself a genuine (possibly
+ * whole-buffer) PREFIX of the marker, so a caller that knows generation
+ * stopped on the token budget can treat it the same as the already-handled
+ * AGENT_DSML_STRUCTURAL/AGENT_DSML_PARAM_VALUE truncation case instead of
+ * silently discarding the turn. A single leading "<" matches every marker
+ * and both DSML and GLM syntaxes start with "<", so this is a deliberate
+ * over-match: the cost of a false positive is one extra model-visible
+ * "your tool call was cut short, retry" turn -- the same recovery already
+ * used for a genuinely unclosed call -- not a wrong answer. */
+static bool agent_dsml_search_tail_is_partial_start(const agent_dsml_parser *p) {
+    if (!p || !p->search_len) return false;
+    const char *start = p->syntax == AGENT_TOOL_SYNTAX_GLM ?
+        "<tool_call>" : "<｜DSML｜tool_calls>";
+    size_t start_len = strlen(start);
+    size_t max_k = start_len - 1 < p->search_len ? start_len - 1 : p->search_len;
+    for (size_t k = 1; k <= max_k; k++) {
+        if (!memcmp(p->search_tail + p->search_len - k, start, k)) return true;
+    }
+    return false;
+}
+
 /* ============================================================================
  * Assistant Markdown Rendering
  * ============================================================================
@@ -6720,6 +6751,63 @@ static char *agent_test_stream_capture(agent_tool_syntax syntax,
     return agent_tail_capture_take(&tail, NULL);
 }
 
+static void test_agent_dsml_search_tail_is_partial_start(void) {
+    /* The exact failure this session reproduced: budget runs out one byte
+     * into the DSML marker, parser never leaves AGENT_DSML_SEARCH. */
+    {
+        agent_dsml_parser p = { .syntax = AGENT_TOOL_SYNTAX_DSML, .state = AGENT_DSML_SEARCH };
+        const char *text = "The file contains one line.\n\n<";
+        agent_dsml_feed(&p, text, strlen(text));
+        AGENT_TEST_ASSERT(p.state == AGENT_DSML_SEARCH);
+        AGENT_TEST_ASSERT(agent_dsml_search_tail_is_partial_start(&p));
+        agent_dsml_parser_free(&p);
+    }
+
+    /* Cut a few bytes further into the marker, still short of the full
+     * "<｜DSML｜tool_calls>" match that would flip the parser to STRUCTURAL. */
+    {
+        agent_dsml_parser p = { .syntax = AGENT_TOOL_SYNTAX_DSML, .state = AGENT_DSML_SEARCH };
+        const char *text = "thinking done\n\n<｜DSML｜tool";
+        agent_dsml_feed(&p, text, strlen(text));
+        AGENT_TEST_ASSERT(p.state == AGENT_DSML_SEARCH);
+        AGENT_TEST_ASSERT(agent_dsml_search_tail_is_partial_start(&p));
+        agent_dsml_parser_free(&p);
+    }
+
+    /* GLM syntax, its own single marker. */
+    {
+        agent_dsml_parser p = { .syntax = AGENT_TOOL_SYNTAX_GLM, .state = AGENT_DSML_SEARCH };
+        const char *text = "ok\n\n<tool_ca";
+        agent_dsml_feed(&p, text, strlen(text));
+        AGENT_TEST_ASSERT(p.state == AGENT_DSML_SEARCH);
+        AGENT_TEST_ASSERT(agent_dsml_search_tail_is_partial_start(&p));
+        agent_dsml_parser_free(&p);
+    }
+
+    /* A complete marker flips state to STRUCTURAL before this function would
+     * ever be consulted by the caller (state != AGENT_DSML_SEARCH guards
+     * every call site) -- confirm that transition still happens on its own. */
+    {
+        agent_dsml_parser p = { .syntax = AGENT_TOOL_SYNTAX_GLM, .state = AGENT_DSML_SEARCH };
+        const char *text = "go\n\n<tool_call>";
+        agent_dsml_feed(&p, text, strlen(text));
+        AGENT_TEST_ASSERT(p.state == AGENT_DSML_STRUCTURAL);
+        agent_dsml_parser_free(&p);
+    }
+
+    /* Ordinary prose with no marker-prefix bytes at the tail: not flagged. */
+    {
+        agent_dsml_parser p = { .syntax = AGENT_TOOL_SYNTAX_DSML, .state = AGENT_DSML_SEARCH };
+        const char *text = "questa e' la risposta finale.";
+        agent_dsml_feed(&p, text, strlen(text));
+        AGENT_TEST_ASSERT(p.state == AGENT_DSML_SEARCH);
+        AGENT_TEST_ASSERT(!agent_dsml_search_tail_is_partial_start(&p));
+        agent_dsml_parser_free(&p);
+    }
+
+    AGENT_TEST_ASSERT(!agent_dsml_search_tail_is_partial_start(NULL));
+}
+
 static void test_agent_glm_tool_parser_single_arg(void) {
     const char *text =
         "prose before <tool_call>list"
@@ -7074,6 +7162,7 @@ static void ds4_agent_unit_tests_run(void) {
     test_agent_glm_template_policy();
     test_agent_edit_upto_prompt_is_opt_in();
     test_agent_glm_tools_prompt_is_native();
+    test_agent_dsml_search_tail_is_partial_start();
     test_agent_glm_tool_parser_single_arg();
     test_agent_glm_tool_parser_chunked_multi_arg();
     test_agent_glm_tool_parser_streams_param_state();
@@ -8776,6 +8865,20 @@ static int worker_run_turn(agent_worker *w, const char *user_text) {
                    (dsml.state == AGENT_DSML_STRUCTURAL ||
                     dsml.state == AGENT_DSML_PARAM_VALUE))
         {
+            malformed_tool = true;
+            snprintf(dsml.error, sizeof(dsml.error),
+                     tool_syntax == AGENT_TOOL_SYNTAX_GLM ?
+                     "incomplete GLM tool call" :
+                     "incomplete DSML tool call");
+        } else if (!got_tool && !malformed_tool && !early_tool_error &&
+                   !interrupted && dsml.state == AGENT_DSML_SEARCH &&
+                   generated >= max_tokens &&
+                   agent_dsml_search_tail_is_partial_start(&dsml))
+        {
+            /* Budget ran out before the marker itself finished (e.g. cut
+             * after just "<"), so agent_dsml_feed() never left SEARCH state
+             * to notice.  Same recoverable-truncation treatment as the
+             * STRUCTURAL/PARAM_VALUE case above, not silence. */
             malformed_tool = true;
             snprintf(dsml.error, sizeof(dsml.error),
                      tool_syntax == AGENT_TOOL_SYNTAX_GLM ?

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -4610,6 +4610,33 @@ static const char *find_any_tool_end(const char *s) {
     return best;
 }
 
+/* find_any_tool_start() only matches a COMPLETE start marker, so it misses
+ * generation cut off (finish=length) mid-way through emitting the marker
+ * itself (e.g. the budget runs out right after "<" or "<｜DSML｜tool").  That
+ * gap left such fragments to fall through to ordinary content, silently
+ * showing the user a garbage partial tag instead of retrying the call.  This
+ * checks whether the tail of the buffer is a (possibly empty-suffix, non-
+ * empty) prefix of one of the known start markers, so callers can route a
+ * truncated-mid-marker generation into the same saw_tool_start recovery path
+ * used for "start seen, end missing". Caller must also require finish ==
+ * "length": a naturally stopped turn ending in "<" is real prose, not a cut
+ * tool call. */
+static bool text_tail_is_partial_tool_start(const char *text, size_t len) {
+    if (!text || !len) return false;
+    const char *markers[] = {
+        DS4_TOOL_CALLS_START, DS4_TOOL_CALLS_START_SHORT,
+        "<tool_calls>", "<tool_call>",
+    };
+    for (size_t m = 0; m < sizeof(markers)/sizeof(markers[0]); m++) {
+        size_t mlen = strlen(markers[m]);
+        size_t max_k = mlen - 1 < len ? mlen - 1 : len;
+        for (size_t k = 1; k <= max_k; k++) {
+            if (!memcmp(text + len - k, markers[m], k)) return true;
+        }
+    }
+    return false;
+}
+
 static void observe_tool_markers(const char *scan, bool *saw_start,
                                  bool *saw_end, bool *orphan_end) {
     if (!scan) return;
@@ -11901,6 +11928,19 @@ decode_again:
         snprintf(err, sizeof(err), "shutdown requested");
     }
 
+    /* saw_tool_start only latches on a COMPLETE start marker (observe_tool_
+     * markers -> find_any_tool_start).  When the token budget runs out before
+     * the marker itself finishes emitting (e.g. text ends in a bare "<"), the
+     * turn looks like ordinary short content instead of a truncated tool
+     * call, and is shown to the user as-is with no recovery.  finish=="length"
+     * plus a partial marker in the tail is the same signal, just caught one
+     * marker-byte earlier; fold it into saw_tool_start so it takes the same
+     * repair-or-retry path below. */
+    if (!saw_tool_start && !saw_tool_end && !strcmp(finish, "length") &&
+        text_tail_is_partial_tool_start(text.ptr, text.len)) {
+        saw_tool_start = true;
+    }
+
     if (j->req.kind == REQ_CHAT && j->req.has_tools &&
         saw_tool_start && !saw_tool_end && strcmp(finish, "error") != 0)
     {
@@ -15562,6 +15602,55 @@ static void test_dsml_repair_produces_parseable_calls(void) {
     buf_free(&repaired);
 }
 
+static void test_text_tail_is_partial_tool_start(void) {
+    /* The exact failure this session reproduced: budget runs out one byte
+     * into the DSML marker. */
+    const char *one_char = "The file contains one line.\n\n<";
+    TEST_ASSERT(text_tail_is_partial_tool_start(one_char, strlen(one_char)));
+
+    /* Cut off a few bytes into the full marker (still short of a complete
+     * DS4_TOOL_CALLS_START match, which find_any_tool_start would catch). */
+    char partial_marker[256];
+    snprintf(partial_marker, sizeof(partial_marker), "thinking done\n\n%.*s",
+             (int)(strlen(DS4_TOOL_CALLS_START) - 2), DS4_TOOL_CALLS_START);
+    TEST_ASSERT(text_tail_is_partial_tool_start(partial_marker, strlen(partial_marker)));
+
+    /* Short-form marker prefix. */
+    char short_marker[256];
+    snprintf(short_marker, sizeof(short_marker), "ok\n\n%.*s",
+             (int)(strlen(DS4_TOOL_CALLS_START_SHORT) - 3), DS4_TOOL_CALLS_START_SHORT);
+    TEST_ASSERT(text_tail_is_partial_tool_start(short_marker, strlen(short_marker)));
+
+    /* Plain-XML style prefix. */
+    const char *xml_prefix = "let me call it\n\n<tool_cal";
+    TEST_ASSERT(text_tail_is_partial_tool_start(xml_prefix, strlen(xml_prefix)));
+
+    /* A COMPLETE marker is find_any_tool_start's job, not this one: only
+     * k < strlen(marker) is checked, so a marker sitting exactly at the tail
+     * with nothing truncated after it is NOT flagged here (the caller only
+     * consults this function when saw_tool_start is already false, so the
+     * two never need to agree on the same text). */
+    const char *complete = "go\n\n" DS4_TOOL_CALLS_START;
+    TEST_ASSERT(!text_tail_is_partial_tool_start(complete, strlen(complete)));
+
+    /* A lone trailing "<" IS flagged (every marker starts with it) even
+     * though it can, rarely, be ordinary prose truncated mid-comparison
+     * ("se a<b" cut after "a<"). Accepted false-positive: the guard at the
+     * call site only fires on finish=="length" with tools enabled, and the
+     * cost is one extra model-visible "your tool call was cut off, retry"
+     * turn, the same recovery already used for a genuinely unclosed call. */
+    const char *ambiguous = "controlla se a<";
+    TEST_ASSERT(text_tail_is_partial_tool_start(ambiguous, strlen(ambiguous)));
+
+    /* Prose ending in a character no marker starts with must NOT be
+     * flagged. */
+    const char *plain = "questa e' la risposta finale.";
+    TEST_ASSERT(!text_tail_is_partial_tool_start(plain, strlen(plain)));
+
+    TEST_ASSERT(!text_tail_is_partial_tool_start("", 0));
+    TEST_ASSERT(!text_tail_is_partial_tool_start(NULL, 0));
+}
+
 static void test_tool_parse_failure_returns_recoverable_finish(void) {
     const char *generated =
         "trying a tool\n\n"
@@ -18361,6 +18450,7 @@ static void ds4_server_unit_tests_run(void) {
     test_parse_glm_tool_call_message();
     test_dsml_parser_recovers_loose_nested_parameters();
     test_dsml_repair_produces_parseable_calls();
+    test_text_tail_is_partial_tool_start();
     test_tool_parse_failure_returns_recoverable_finish();
     test_invalid_dsml_tool_error_suffix_includes_system_prompt();
     test_invalid_glm_tool_error_suffix();


### PR DESCRIPTION
## Problem

When the token budget runs out right as the model starts emitting the
tool-call start marker (DSML or GLM), the agent/server parser is left
stuck mid-marker. The turn ends with no tool executed and no error: the
truncated marker fragment (as short as a single `<`) is shown to the
caller as if it were the actual answer.

This is distinct from the already-handled "marker started, never closed"
case (`AGENT_DSML_STRUCTURAL`/`AGENT_DSML_PARAM_VALUE` on the agent side,
`saw_tool_start && !saw_tool_end` on the server side): both of those
require a *complete* start marker to have matched first. A cutoff before
the marker itself finishes emitting is invisible to that detection and
falls through silently.

Reproduced deterministically with `--trace` and a small `-n` on a single
tool-triggering prompt: `</think>` closes correctly, then generation stops
one byte into the DSML marker (trace shows `<think>` ... `</think>` ...
`\n\n` ... a lone `<`, then the budget is exhausted).

## Fix

- `ds4_agent.c`: `agent_dsml_search_tail_is_partial_start()` checks whether
  the tail of the still-buffered search window (`search_tail`/`search_len`,
  already maintained by `agent_dsml_feed()`'s `AGENT_DSML_SEARCH` state) is
  itself a genuine prefix of the syntax's start marker. When generation
  stopped on the token budget (`generated >= max_tokens`) and this holds,
  the turn is folded into the same `malformed_tool` recovery path already
  used for the STRUCTURAL/PARAM_VALUE case (model-visible tool error +
  automatic retry), instead of ending in silence.
- `ds4_server.c`: same failure family in the standalone HTTP server's
  independent parser (`parse_deepseek_generated_message_ex`, no code
  shared with the agent). `text_tail_is_partial_tool_start()` is the
  analogous check, wired into the existing `saw_tool_start`/repair path.

A single leading `<` matches the prefix check trivially (every marker
starts with it), which is a deliberate over-match: the guard only fires
when `finish == "length"` (budget exhaustion, not a natural stop), and the
cost of a false positive is one extra "your tool call was cut short, retry"
turn -- the same recovery path already in place for the unclosed-marker
case, not a wrong answer.

## Testing

Two new pure-function unit tests, no model required:
- `ds4_test`: `test_text_tail_is_partial_tool_start`
- `ds4_agent_test`: `test_agent_dsml_search_tail_is_partial_start`

Both full suites pass (`./ds4_test --server`, `./ds4_agent_test`).

Verified live on Metal with the real model: a forced repro (`-n 25`,
single file-read request) no longer leaks a truncated marker as content
(now retries with a model-visible tool error); a normal-budget multi-file
agentic task still completes cleanly with no regression.
