### PR TITLE
mtp: verify draft>=2 exactly by default, not with the batch verifier (#750)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -66207,26 +66207,29 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
     }
 
     /*
-     * Metal normally benefits from the tiny-batch verifier: it checks two
-     * target positions in one layer-major pass and commits prefix-1 directly
-     * on a partial accept. Like the rest of the non-quality Metal path, it may
-     * pick a different greedy token when batched reductions perturb nearly
-     * tied logits.
-     *
-     * ROCm is different. Its DeepSeek one-token graph uses the prequantized Q8
-     * decode kernels, while the generic N=2 batch graph uses full-F32
-     * activations and loses the paired and HC-expand decode fusions. Running
-     * the exact two-row verifier reuses those Q8 kernels and is faster.
-     * DS4_MTP_BATCH_VERIFY remains an explicit diagnostic rollback to the
-     * generic batch verifier.
+     * The tiny-batch verifier checks several target positions in one
+     * layer-major pass and commits prefix-1 directly on a partial accept, but
+     * its batched reductions can pick a different greedy token than
+     * autoregressive decode when logits are nearly tied.  At MTP draft depth
+     * >= 2 that divergence is not always benign: a perturbed row can make the
+     * committed next-token logits argmax to <｜begin▁of▁sentence｜>, injecting
+     * BOS into the output and cascading into self-restart garbage (issue #750).
+     * MTP is a drafter, not a sampler, so the target stream must stay
+     * bit-identical to ordinary decode.  Make the exact verifier the default on
+     * every backend: the fused two-row verifier for depth 2, and exact
+     * sequential decode of the drafts for depth > 2 (the same kernel the clean
+     * depth-1 path uses).  ROCm gains speed from the exact path too (it reuses
+     * the prequantized Q8 decode kernels that the generic batch graph drops).
+     * DS4_MTP_BATCH_VERIFY opts back into the fast approximate batch verifier
+     * for diagnostics.
      */
-#ifdef DS4_ROCM_BUILD
     const bool prefer_decode2_exact = true;
-#else
-    const bool prefer_decode2_exact = false;
-#endif
     const bool use_decode2_exact =
         draft_n == 2 &&
+        (strict_mtp || prefer_decode2_exact) &&
+        getenv("DS4_MTP_BATCH_VERIFY") == NULL;
+    const bool use_exact_sequential =
+        draft_n > 2 &&
         (strict_mtp || prefer_decode2_exact) &&
         getenv("DS4_MTP_BATCH_VERIFY") == NULL;
     if (use_decode2_exact) {
@@ -66318,7 +66321,51 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
         }
     }
 
-    if (!use_decode2_exact)
+    if (use_exact_sequential) {
+        /*
+         * Depth > 2 has no fused exact verifier, so verify the drafts the same
+         * way the clean depth-1 path emits tokens: decode each proposed token
+         * with the exact raw-SWA kernel and accept the next draft only when it
+         * equals the exact greedy argmax.  This commits accepted tokens as it
+         * goes and stops at the first divergence, so no snapshot/rollback is
+         * needed, and the emitted stream is bit-identical to ordinary decode.
+         */
+        float *row_logits = xmalloc((size_t)DS4_N_VOCAB * sizeof(row_logits[0]));
+        const int start = s->checkpoint.len;
+        int committed = 0;
+        bool ok = true;
+        for (int i = 0; i < draft_n && ok && n_accept < accepted_cap; i++) {
+            ok = metal_graph_eval_token_raw_swa(&s->graph,
+                                                &e->model,
+                                                &e->weights,
+                                                drafts[i],
+                                                (uint32_t)(start + i),
+                                                row_logits);
+            if (!ok) break;
+            token_vec_push(&s->checkpoint, drafts[i]);
+            committed++;
+            accepted[n_accept++] = drafts[i];
+            if (drafts[i] == eos_token) break;
+            if (i + 1 < draft_n &&
+                sample_argmax(row_logits, DS4_N_VOCAB) != drafts[i + 1]) break;
+        }
+        if (!ok) {
+            s->checkpoint.len = start;
+            free(row_logits);
+            snprintf(err, errlen, "%s decode failed", ds4_backend_name(e->backend));
+            s->checkpoint_valid = false;
+            return -1;
+        }
+        memcpy(s->logits, row_logits, (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
+        s->checkpoint_valid = true;
+        s->mtp_draft_valid = false;
+        DS4_MTP_KEEP_ACCEPTED(committed);
+        ds4_session_dspark_capture_note_checkpoint(s);
+        free(row_logits);
+        return n_accept;
+    }
+
+    if (!use_decode2_exact && !use_exact_sequential)
     {
         ds4_spec_frontier frontier;
         memset(&frontier, 0, sizeof(frontier));


### PR DESCRIPTION
Fixes #750. Credit to @eisbaw for the report and the CUDA/GB10 root-cause analysis; this lands the same fix and adds Metal verification.

## Problem

At MTP draft depth ≥ 2 without `--quality`, `ds4_session_eval_speculative_argmax()` verifies the drafted suffix with the fast batched verifier (`metal_graph_verify_suffix_tops`) and commits its per-row logits directly. The exact verifier's own comment already warns why that is unsafe:

> The generic batch prefill path is fast, but it is not a safe substitute for autoregressive decode: small row-wise differences in HC/MoE/output kernels are enough to flip future greedy tokens.

At depth ≥ 2 that divergence reaches the output. On a partial accept the committed next-token logits are read from a batched row whose argmax can be `<｜begin▁of▁sentence｜>`, so the next emitted token is BOS and the stream cascades into self-restart garbage (`We need<｜begin▁of▁sentence｜># The sky is<｜begin▁of▁sentence｜># …`). `--mtp-draft 1` is clean because it never uses the batched verifier.

## Fix

MTP is a drafter, not a sampler — the target stream must stay bit-identical to ordinary decode. Make the exact verifier the default on every backend (previously the default only under `--quality`, or unconditionally on ROCm):

- **depth 2** → the existing fused `metal_graph_verify_decode2_exact` (`prefer_decode2_exact` is now `true` everywhere instead of `#ifdef DS4_ROCM_BUILD`).
- **depth > 2** → a new exact-sequential path: decode each draft with the exact raw-SWA kernel (the same one the clean depth-1 path and the existing margin-skip/exact-replay paths use) and accept the next draft only when it equals the exact greedy argmax. It commits accepted tokens as it goes and stops at the first divergence, so no snapshot/rollback is needed.

`DS4_MTP_BATCH_VERIFY` still opts back into the fast approximate verifier for diagnostics. ROCm behaviour is unchanged (it already preferred exact).

## Verification (M5 Max, Metal, DeepSeek-V4-Flash-IQ2XXS 0731 + MTP-Q4K drafter, greedy)

Same prompt, `--temp 0`, output SHA:

| run | sha1[:12] |
|---|---|
| `--mtp-draft 1` (ordinary decode) | `31d301a62138` |
| `--mtp-draft 2 --quality` (exact) | `31d301a62138` |
| **`--mtp-draft 2` (old default, batched)** | **`d12cfa6f2788`** ← diverges |
| `--mtp-draft 2` (this PR) | `31d301a62138` ✓ |
| `--mtp-draft 4` (this PR) | `31d301a62138` ✓ |

So depth-2 and depth-4 are now byte-identical to depth-1 and to `--quality`, where the old default diverged. This is the invariant `tests/ds4_test.c:test_mtp_verify_depth` documents ("commits autoregressive-identical tokens at draft depth > 2"); it passes on the exact default and (as its own comment notes) catches the batched path's large argmax gap on divergence-prone models. Warning-free `make ds4` / `ds4_test` build; `./ds4_test --server` green.

The BOS injection itself is the catastrophic tail of a broader divergence (the batched verifier flips ~2–3% of greedy tokens on open-ended prompts, mostly benignly); the bit-exact comparison above surfaces it deterministically.

## Throughput is a non-issue

On this machine MTP already runs *below* ordinary decode, so the batched verifier's small speed edge was speed spent producing wrong output:

| path | generation |
|---|---|
| `--mtp-draft 1` (ordinary) | 45.9 t/s |
| `--mtp-draft 2` batched (old default) | 42.7 t/s |
| `--mtp-draft 2` exact (this PR) | 39.7 t/s |

Consistent with `QA_BEFORE_RELEASES.md` ("MTP gives no single-token speedup on ds4-server").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
