### PR TITLE
Metal: per-stream command-queue overlap for batched session decode (~1.7x measured)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -62185,8 +62185,12 @@ static int ds4_sessions_eval_batch_metal(
     }
     bool native_shared = false;
     bool native_qkv = false;
+    /* SSD streaming's expert-cache slabs are process-global mutable state,
+     * so concurrently executing streams must not share them: keep streaming
+     * configurations on the single-queue path. */
     const bool stream_overlap =
         overlap_all_deepseek && !e->tp.active && !mirror && count > 1 &&
+        !e->ssd_streaming &&
         getenv("DS4_METAL_NO_STREAM_OVERLAP") == NULL;
     bool ok = true;
     if (stream_overlap) {

--- a/ds4.c
+++ b/ds4.c
@@ -49333,6 +49333,9 @@ struct ds4_session {
     void *cancel_ud;
     uint32_t prefill_cap;
     int ctx_size;
+    int stream_id;
+    int pending_token;
+    bool pending_eval;
     bool checkpoint_valid;
     bool mtp_draft_valid;
     bool greedy_splitkv_anchor_valid;
@@ -61668,6 +61671,80 @@ static int ds4_session_eval_probe_tp(ds4_session *s, int token, bool probe_mtp,
     return rc;
 }
 
+void ds4_session_set_stream(ds4_session *s, int stream_id) {
+    if (s) s->stream_id = stream_id;
+}
+
+/* Async decode pair for multi-stream generation: _begin encodes and commits
+ * one token's decode pass on the session's own GPU stream without waiting;
+ * _end waits for that stream, reads logits, and commits the token to the
+ * session timeline.  Callers interleave other sessions' _begin calls in
+ * between; independent per-stream queues let the GPU overlap them.  Metal
+ * encoding must stay serialized by the caller (one thread, or a lock around
+ * _begin). */
+int ds4_session_eval_begin(ds4_session *s, int token, char *err, size_t errlen) {
+    if (!s) return -1;
+#ifdef DS4_NO_GPU
+    (void)token; snprintf(err, errlen, "GPU support is not compiled in");
+    return -1;
+#else
+    if (s->distributed || ds4_session_is_cpu(s) || !s->checkpoint_valid) {
+        return ds4_session_eval(s, token, err, errlen);   /* sync fallback */
+    }
+    int room = s->ctx_size - s->checkpoint.len;
+    if (room <= 1) { snprintf(err, errlen, "context is full"); return -1; }
+    ds4_engine *e = s->engine;
+    ds4_gpu_set_stream(s->stream_id);
+    if (ds4_gpu_begin_commands() == 0) {
+        snprintf(err, errlen, "%s begin failed", ds4_backend_name(e->backend));
+        return -1;
+    }
+    if (!metal_graph_encode_token_raw_swa(&s->graph, &e->model, &e->weights,
+                                          token, (uint32_t)s->checkpoint.len,
+                                          true, false)) {
+        (void)ds4_gpu_synchronize();
+        snprintf(err, errlen, "%s decode encode failed", ds4_backend_name(e->backend));
+        s->checkpoint_valid = false;
+        return -1;
+    }
+    if (ds4_gpu_end_commands_async() == 0) {
+        snprintf(err, errlen, "%s commit failed", ds4_backend_name(e->backend));
+        s->checkpoint_valid = false;
+        return -1;
+    }
+    s->pending_token = token;
+    s->pending_eval = true;
+    return 0;
+#endif
+}
+
+int ds4_session_eval_end(ds4_session *s, char *err, size_t errlen) {
+    if (!s) return -1;
+#ifdef DS4_NO_GPU
+    snprintf(err, errlen, "GPU support is not compiled in");
+    return -1;
+#else
+    if (!s->pending_eval) return 0;
+    s->pending_eval = false;
+    ds4_engine *e = s->engine;
+    if (ds4_gpu_wait_stream(s->stream_id) == 0) {
+        snprintf(err, errlen, "%s stream wait failed", ds4_backend_name(e->backend));
+        s->checkpoint_valid = false;
+        return -1;
+    }
+    if (ds4_gpu_tensor_read(metal_graph_logits(&s->graph), 0, s->logits,
+                            (uint64_t)DS4_N_VOCAB * sizeof(s->logits[0])) == 0) {
+        snprintf(err, errlen, "%s logits readback failed", ds4_backend_name(e->backend));
+        s->checkpoint_valid = false;
+        return -1;
+    }
+    token_vec_push(&s->checkpoint, s->pending_token);
+    s->mtp_draft_valid = false;
+    s->checkpoint_valid = true;
+    return 0;
+#endif
+}
+
 int ds4_session_eval(ds4_session *s, int token, char *err, size_t errlen) {
     bool probe_mtp = true;
 #ifndef DS4_NO_GPU
@@ -62095,10 +62172,51 @@ static int ds4_sessions_eval_batch_metal(
 #if defined(__APPLE__)
     if (e->tp.active) ds4_gpu_tp_set_session_batch_mode(1);
 #endif
-    bool ok = ds4_gpu_begin_commands() != 0;
-    const bool native_shared = ok &&
+    /* Per-session GPU-stream overlap: encode each DeepSeek session's decode
+     * pass on its own command queue and let the GPU overlap the latency-bound
+     * chains.  Measured ~2x aggregate over one-queue encoding at 4-8 sessions
+     * when the model buffers opt out of hazard tracking
+     * (DS4_METAL_MODEL_UNTRACKED=1), which otherwise serializes the queues.
+     * The fused native session batch stays preferred where supported; GLM and
+     * tensor-parallel sessions keep the single-queue path. */
+    bool overlap_all_deepseek = true;
+    for (int i = 0; i < count; i++) {
+        if (ds4_session_is_glm(items[i].session)) { overlap_all_deepseek = false; break; }
+    }
+    bool native_shared = false;
+    bool native_qkv = false;
+    const bool stream_overlap =
+        overlap_all_deepseek && !e->tp.active && !mirror && count > 1 &&
+        getenv("DS4_METAL_NO_STREAM_OVERLAP") == NULL;
+    bool ok = true;
+    if (stream_overlap) {
+        int started = 0;
+        for (int i = 0; ok && i < count; i++) {
+            ds4_session *s = items[i].session;
+            ds4_gpu_set_stream(i % 8);
+            ok = ds4_gpu_begin_commands() != 0;
+            if (ok) ok = metal_graph_encode_token_raw_swa(&s->graph,
+                                                          &e->model,
+                                                          &e->weights,
+                                                          items[i].token,
+                                                          (uint32_t)s->checkpoint.len,
+                                                          true,
+                                                          false);
+            if (ok) ok = ds4_gpu_end_commands_async() != 0;
+            if (ok) started = i + 1;
+        }
+        const int waited = started < count ? started : count;
+        const int n_streams = waited < 8 ? waited : 8;
+        for (int i = 0; i < n_streams; i++) {
+            if (ds4_gpu_wait_stream(i) == 0) ok = false;
+        }
+        ds4_gpu_set_stream(0);
+        if (!ok) (void)ds4_gpu_synchronize();
+    } else {
+    ok = ds4_gpu_begin_commands() != 0;
+    native_shared = ok &&
         metal_graph_native_session_batch_shared_supported(items, count, e);
-    const bool native_qkv = native_shared &&
+    native_qkv = native_shared &&
         metal_graph_native_session_batch_qkv_supported(items, count, e);
     if (native_shared) {
         ok = metal_graph_encode_native_session_batch_shared(
@@ -62130,6 +62248,7 @@ static int ds4_sessions_eval_batch_metal(
     }
     if (ok) ok = ds4_gpu_end_commands() != 0;
     else (void)ds4_gpu_synchronize();
+    }
 #if defined(__APPLE__)
     if (e->tp.active) ds4_gpu_tp_set_session_batch_mode(0);
     if (ok && e->tp.active && ds4_gpu_tp_failed()) {

--- a/ds4.h
+++ b/ds4.h
@@ -385,6 +385,9 @@ int ds4_session_set_logits(ds4_session *s, const float *logits, int n);
  * used by the TP worker right after session create (no-op on CPU/GLM). */
 void ds4_session_gpu_warmup(ds4_session *s);
 int ds4_session_eval(ds4_session *s, int token, char *err, size_t errlen);
+void ds4_session_set_stream(ds4_session *s, int stream_id);
+int ds4_session_eval_begin(ds4_session *s, int token, char *err, size_t errlen);
+int ds4_session_eval_end(ds4_session *s, char *err, size_t errlen);
 
 typedef struct {
     ds4_session *session;

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -108,6 +108,10 @@ int ds4_gpu_tensor_read_after_selected_event(const ds4_gpu_tensor *tensor,
                                              const char *label);
 #endif
 int ds4_gpu_end_commands(void);
+int ds4_gpu_end_commands_async(void);
+int ds4_gpu_wait_stream(int idx);
+void ds4_gpu_set_stream(int idx);
+int ds4_gpu_current_stream(void);
 int ds4_gpu_synchronize(void);
 
 int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -48,7 +48,11 @@ enum {
 @class DS4MetalQ4ExpertTable;
 
 static id<MTLDevice> g_device;
+#define DS4_GPU_MAX_STREAMS 8
+static _Thread_local int g_ds4_stream = 0;
 static id<MTLCommandQueue> g_queue;
+static id<MTLCommandQueue> g_stream_queues[DS4_GPU_MAX_STREAMS];
+static id<MTLCommandBuffer> g_stream_last_cb[DS4_GPU_MAX_STREAMS];
 static id<MTLLibrary> g_library;
 static id<MTLCommandBuffer> g_batch_cb;
 static id<MTLComputeCommandEncoder> g_batch_enc;
@@ -298,7 +302,7 @@ static uint32_t g_decode_pipeline_fast_cache_entries;
 static NSMutableDictionary<NSString *, id<MTLBuffer>> *g_model_buffer_cache;
 static NSMutableDictionary<NSString *, DS4MetalQ4ExpertTable *> *g_q4_expert_table_cache;
 static NSMutableDictionary<NSString *, id> *g_q4_expert_layer_residency_cache;
-static NSMutableArray<id<MTLBuffer>> *g_transient_buffers;
+static NSMutableArray<id<MTLBuffer>> *g_transient_buffers[DS4_GPU_MAX_STREAMS];
 static id g_model_residency_set;
 
 typedef struct {
@@ -330,36 +334,36 @@ enum {
 static ds4_gpu_zero_prefix_prefill_mask_cache_entry
     g_zero_prefix_prefill_mask_cache[DS4_GPU_PREFILL_MASK_CACHE_SLOTS];
 static void ds4_gpu_invalidate_zero_prefix_prefill_block_maps(void);
-static id<MTLBuffer> g_flash_attn_mask_buffer;
-static id<MTLBuffer> g_flash_attn_zero_mask_buffer;
-static id<MTLBuffer> g_flash_attn_pad_buffer;
-static id<MTLBuffer> g_flash_attn_tmp_buffer;
-static id<MTLBuffer> g_flash_attn_blk_buffer;
-static id<MTLBuffer> g_flash_attn_ring_buffer;
-static id<MTLBuffer> g_flash_attn_kv_buffer;
-static id<MTLBuffer> g_glm_flash_attn_mask_buffer;
-static id<MTLBuffer> g_compressor_pool_kv_buffer;
-static id<MTLBuffer> g_compressor_pool_score_buffer;
-static id<MTLBuffer> g_compressor_pool_score_cont_buffer;
-static id<MTLBuffer> g_compressor_pool_softmax_buffer;
-static id<MTLBuffer> g_compressor_pool_product_buffer;
-static id<MTLBuffer> g_compressor_store_ape_buffer;
-static id<MTLBuffer> g_compressor_store_score_buffer;
-static id<MTLBuffer> g_embed_rows_buffer;
-static id<MTLBuffer> g_router_selection_buffer;
-static id<MTLBuffer> g_router_weight_sum_buffer;
-static id<MTLBuffer> g_indexer_head_scores_buffer;
-static id<MTLBuffer> g_indexer_topk_buffer;
-static id<MTLBuffer> g_indexed_topk_buffer;
-static id<MTLBuffer> g_f16_round_scratch_buffer;
-static id<MTLBuffer> g_raw_store_round_buffer;
-static id<MTLBuffer> g_moe_gate_scratch_buffer;
-static id<MTLBuffer> g_moe_down_scratch_buffer;
-static id<MTLBuffer> g_moe_id_map_buffer;
-static id<MTLBuffer> g_moe_q4_gate_slots_buffer;
-static id<MTLBuffer> g_moe_q4_up_slots_buffer;
-static id<MTLBuffer> g_moe_q4_down_slots_buffer;
-static id<MTLBuffer> g_attn_out_group_ids_buffer;
+static id<MTLBuffer> g_flash_attn_mask_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_flash_attn_zero_mask_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_flash_attn_pad_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_flash_attn_tmp_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_flash_attn_blk_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_flash_attn_ring_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_flash_attn_kv_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_glm_flash_attn_mask_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_compressor_pool_kv_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_compressor_pool_score_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_compressor_pool_score_cont_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_compressor_pool_softmax_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_compressor_pool_product_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_compressor_store_ape_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_compressor_store_score_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_embed_rows_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_router_selection_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_router_weight_sum_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_indexer_head_scores_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_indexer_topk_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_indexed_topk_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_f16_round_scratch_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_raw_store_round_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_moe_gate_scratch_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_moe_down_scratch_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_moe_id_map_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_moe_q4_gate_slots_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_moe_q4_up_slots_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_moe_q4_down_slots_buffer[DS4_GPU_MAX_STREAMS];
+static id<MTLBuffer> g_attn_out_group_ids_buffer[DS4_GPU_MAX_STREAMS];
 static int g_model_fd = -1;
 static const void *g_model_map_ptr;
 static uint64_t g_model_map_size;
@@ -520,40 +524,40 @@ static int ds4_gpu_stream_expert_cache_on_service_thread(void) {
     return g_stream_expert_service_thread_set &&
            pthread_equal(pthread_self(), g_stream_expert_service_thread);
 }
-static NSUInteger g_flash_attn_mask_bytes;
-static NSUInteger g_flash_attn_zero_mask_bytes;
-static NSUInteger g_flash_attn_pad_bytes;
-static NSUInteger g_flash_attn_tmp_bytes;
-static NSUInteger g_flash_attn_blk_bytes;
-static NSUInteger g_flash_attn_ring_bytes;
-static NSUInteger g_flash_attn_kv_bytes;
-static NSUInteger g_glm_flash_attn_mask_bytes;
+static NSUInteger g_flash_attn_mask_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_flash_attn_zero_mask_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_flash_attn_pad_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_flash_attn_tmp_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_flash_attn_blk_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_flash_attn_ring_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_flash_attn_kv_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_glm_flash_attn_mask_bytes[DS4_GPU_MAX_STREAMS];
 static uint32_t g_glm_flash_attn_mask_pos0;
 static uint32_t g_glm_flash_attn_mask_tokens;
 static uint32_t g_glm_flash_attn_mask_cache_len;
 static int g_glm_flash_attn_mask_valid;
-static NSUInteger g_compressor_pool_kv_bytes;
-static NSUInteger g_compressor_pool_score_bytes;
-static NSUInteger g_compressor_pool_score_cont_bytes;
-static NSUInteger g_compressor_pool_softmax_bytes;
-static NSUInteger g_compressor_pool_product_bytes;
-static NSUInteger g_compressor_store_ape_bytes;
-static NSUInteger g_compressor_store_score_bytes;
-static NSUInteger g_embed_rows_bytes;
-static NSUInteger g_router_selection_bytes;
-static NSUInteger g_router_weight_sum_bytes;
-static NSUInteger g_indexer_head_scores_bytes;
-static NSUInteger g_indexer_topk_bytes;
-static NSUInteger g_indexed_topk_bytes;
-static NSUInteger g_f16_round_scratch_bytes;
-static NSUInteger g_raw_store_round_bytes;
-static NSUInteger g_moe_gate_scratch_bytes;
-static NSUInteger g_moe_down_scratch_bytes;
-static NSUInteger g_moe_id_map_bytes;
-static NSUInteger g_moe_q4_gate_slots_bytes;
-static NSUInteger g_moe_q4_up_slots_bytes;
-static NSUInteger g_moe_q4_down_slots_bytes;
-static NSUInteger g_attn_out_group_ids_bytes;
+static NSUInteger g_compressor_pool_kv_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_compressor_pool_score_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_compressor_pool_score_cont_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_compressor_pool_softmax_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_compressor_pool_product_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_compressor_store_ape_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_compressor_store_score_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_embed_rows_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_router_selection_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_router_weight_sum_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_indexer_head_scores_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_indexer_topk_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_indexed_topk_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_f16_round_scratch_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_raw_store_round_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_moe_gate_scratch_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_moe_down_scratch_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_moe_id_map_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_moe_q4_gate_slots_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_moe_q4_up_slots_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_moe_q4_down_slots_bytes[DS4_GPU_MAX_STREAMS];
+static NSUInteger g_attn_out_group_ids_bytes[DS4_GPU_MAX_STREAMS];
 static int g_initialized;
 static int g_quality_mode;
 static int g_mpp_invalid_env_reported;
@@ -947,6 +951,34 @@ static NSUInteger ds4_gpu_tensor_offset(const ds4_gpu_tensor *tensor) {
 }
 
 static id<MTLCommandBuffer> ds4_gpu_new_command_buffer(void);
+
+/* Multi-stream decode overlap: each stream has its own command queue and its
+ * own set of the lazily-grown scratch buffers above (indexed by the
+ * thread-local g_ds4_stream), so independently executing decode streams never
+ * share mutable GPU state and the GPU can overlap their latency-bound kernel
+ * chains.  Pair with DS4_METAL_MODEL_UNTRACKED=1 so hazard tracking on the
+ * shared read-only model buffers does not serialize the queues. */
+void ds4_gpu_set_stream(int idx) {
+    if (idx < 0) idx = 0;
+    if (idx >= DS4_GPU_MAX_STREAMS) idx = DS4_GPU_MAX_STREAMS - 1;
+    g_ds4_stream = idx;
+}
+
+int ds4_gpu_current_stream(void) { return g_ds4_stream; }
+
+static id<MTLCommandQueue> ds4_gpu_active_queue(void) {
+    if (g_ds4_stream == 0) return g_queue;
+    if (!g_stream_queues[g_ds4_stream]) {
+        id<MTLCommandQueue> q = [g_device newCommandQueue];
+        if (q && g_model_residency_set &&
+            [q respondsToSelector:@selector(addResidencySet:)]) {
+            [q addResidencySet:g_model_residency_set];
+        }
+        g_stream_queues[g_ds4_stream] = q;
+    }
+    return g_stream_queues[g_ds4_stream] ? g_stream_queues[g_ds4_stream] : g_queue;
+}
+
 static void ds4_gpu_stream_expert_cache_note_owned_created(void);
 
 static id<MTLCommandBuffer> ds4_gpu_command_buffer(int *owned) {
@@ -1027,9 +1059,9 @@ static id<MTLCommandBuffer> ds4_gpu_new_command_buffer(void) {
         initialized = 1;
     }
     if (use_unretained) {
-        return [g_queue commandBufferWithUnretainedReferences];
+        return [ds4_gpu_active_queue() commandBufferWithUnretainedReferences];
     }
-    return [g_queue commandBuffer];
+    return [ds4_gpu_active_queue() commandBuffer];
 }
 
 static uint64_t ds4_gpu_exact_view_cache_limit_bytes(void) {
@@ -1209,7 +1241,7 @@ static int ds4_gpu_finish_command_buffer(id<MTLCommandBuffer> cb, int owned, con
         ds4_gpu_invalidate_zero_prefix_prefill_block_maps();
     }
     ds4_gpu_stream_expert_cache_note_owned_completed();
-    [g_transient_buffers removeAllObjects];
+    [g_transient_buffers[g_ds4_stream] removeAllObjects];
     ds4_gpu_model_buffer_cache_maybe_evict(label);
     return ok;
 }
@@ -1281,19 +1313,19 @@ static int ds4_gpu_ensure_scratch_buffer(
 static int ds4_gpu_ensure_zero_attention_mask(NSUInteger bytes) {
     const NSUInteger capacity = 8192u * sizeof(uint16_t);
     if (bytes > capacity) return 0;
-    if (g_flash_attn_zero_mask_buffer &&
-        g_flash_attn_zero_mask_bytes >= capacity) {
+    if (g_flash_attn_zero_mask_buffer[g_ds4_stream] &&
+        g_flash_attn_zero_mask_bytes[g_ds4_stream] >= capacity) {
         return 1;
     }
-    if (!ds4_gpu_ensure_scratch_buffer(&g_flash_attn_zero_mask_buffer,
-                                         &g_flash_attn_zero_mask_bytes,
+    if (!ds4_gpu_ensure_scratch_buffer(&g_flash_attn_zero_mask_buffer[g_ds4_stream],
+                                         &g_flash_attn_zero_mask_bytes[g_ds4_stream],
                                          capacity,
                                          "ds4_flash_attn_zero_mask")) {
         return 0;
     }
-    void *contents = [g_flash_attn_zero_mask_buffer contents];
+    void *contents = [g_flash_attn_zero_mask_buffer[g_ds4_stream] contents];
     if (!contents) return 0;
-    memset(contents, 0, g_flash_attn_zero_mask_bytes);
+    memset(contents, 0, g_flash_attn_zero_mask_bytes[g_ds4_stream]);
     return 1;
 }
 
@@ -2003,7 +2035,7 @@ static id<MTLBuffer> ds4_gpu_new_transient_buffer(NSUInteger bytes, const char *
      * A local ObjC strong variable is not enough when the encoder function
      * returns before the caller commits the command buffer.
      */
-    [g_transient_buffers addObject:buffer];
+    [g_transient_buffers[g_ds4_stream] addObject:buffer];
     return buffer;
 }
 
@@ -2072,8 +2104,8 @@ ds4_gpu_get_zero_prefix_prefill_mask_cache(
     /* A replaced entry may still be referenced by an uncommitted or in-flight
      * command buffer. Keep its resources alive with the other batch-scoped
      * buffers until command completion instead of mutating or releasing them. */
-    if (entry->mask) [g_transient_buffers addObject:entry->mask];
-    if (entry->blk) [g_transient_buffers addObject:entry->blk];
+    if (entry->mask) [g_transient_buffers[g_ds4_stream] addObject:entry->mask];
+    if (entry->blk) [g_transient_buffers[g_ds4_stream] addObject:entry->blk];
 
     entry->mask = mask;
     entry->blk = blk;
@@ -3878,37 +3910,37 @@ void ds4_gpu_print_memory_report(const char *label) {
         if (entry->blk) cached_prefill_blk_bytes += entry->blk_bytes;
     }
     const uint64_t scratch =
-        (uint64_t)g_flash_attn_mask_bytes +
-        (uint64_t)g_flash_attn_zero_mask_bytes +
+        (uint64_t)g_flash_attn_mask_bytes[g_ds4_stream] +
+        (uint64_t)g_flash_attn_zero_mask_bytes[g_ds4_stream] +
         cached_prefill_mask_bytes +
-        (uint64_t)g_flash_attn_pad_bytes +
-        (uint64_t)g_flash_attn_tmp_bytes +
-        (uint64_t)g_flash_attn_blk_bytes +
+        (uint64_t)g_flash_attn_pad_bytes[g_ds4_stream] +
+        (uint64_t)g_flash_attn_tmp_bytes[g_ds4_stream] +
+        (uint64_t)g_flash_attn_blk_bytes[g_ds4_stream] +
         cached_prefill_blk_bytes +
-        (uint64_t)g_flash_attn_ring_bytes +
-        (uint64_t)g_flash_attn_kv_bytes +
-        (uint64_t)g_glm_flash_attn_mask_bytes +
-        (uint64_t)g_compressor_pool_kv_bytes +
-        (uint64_t)g_compressor_pool_score_bytes +
-        (uint64_t)g_compressor_pool_score_cont_bytes +
-        (uint64_t)g_compressor_pool_softmax_bytes +
-        (uint64_t)g_compressor_pool_product_bytes +
-        (uint64_t)g_compressor_store_ape_bytes +
-        (uint64_t)g_compressor_store_score_bytes +
-        (uint64_t)g_embed_rows_bytes +
-        (uint64_t)g_router_selection_bytes +
-        (uint64_t)g_router_weight_sum_bytes +
-        (uint64_t)g_indexer_head_scores_bytes +
-        (uint64_t)g_indexer_topk_bytes +
-        (uint64_t)g_indexed_topk_bytes +
-        (uint64_t)g_f16_round_scratch_bytes +
-        (uint64_t)g_raw_store_round_bytes +
-        (uint64_t)g_moe_gate_scratch_bytes +
-        (uint64_t)g_moe_down_scratch_bytes +
-        (uint64_t)g_moe_id_map_bytes +
-        (uint64_t)g_moe_q4_gate_slots_bytes +
-        (uint64_t)g_moe_q4_up_slots_bytes +
-        (uint64_t)g_moe_q4_down_slots_bytes;
+        (uint64_t)g_flash_attn_ring_bytes[g_ds4_stream] +
+        (uint64_t)g_flash_attn_kv_bytes[g_ds4_stream] +
+        (uint64_t)g_glm_flash_attn_mask_bytes[g_ds4_stream] +
+        (uint64_t)g_compressor_pool_kv_bytes[g_ds4_stream] +
+        (uint64_t)g_compressor_pool_score_bytes[g_ds4_stream] +
+        (uint64_t)g_compressor_pool_score_cont_bytes[g_ds4_stream] +
+        (uint64_t)g_compressor_pool_softmax_bytes[g_ds4_stream] +
+        (uint64_t)g_compressor_pool_product_bytes[g_ds4_stream] +
+        (uint64_t)g_compressor_store_ape_bytes[g_ds4_stream] +
+        (uint64_t)g_compressor_store_score_bytes[g_ds4_stream] +
+        (uint64_t)g_embed_rows_bytes[g_ds4_stream] +
+        (uint64_t)g_router_selection_bytes[g_ds4_stream] +
+        (uint64_t)g_router_weight_sum_bytes[g_ds4_stream] +
+        (uint64_t)g_indexer_head_scores_bytes[g_ds4_stream] +
+        (uint64_t)g_indexer_topk_bytes[g_ds4_stream] +
+        (uint64_t)g_indexed_topk_bytes[g_ds4_stream] +
+        (uint64_t)g_f16_round_scratch_bytes[g_ds4_stream] +
+        (uint64_t)g_raw_store_round_bytes[g_ds4_stream] +
+        (uint64_t)g_moe_gate_scratch_bytes[g_ds4_stream] +
+        (uint64_t)g_moe_down_scratch_bytes[g_ds4_stream] +
+        (uint64_t)g_moe_id_map_bytes[g_ds4_stream] +
+        (uint64_t)g_moe_q4_gate_slots_bytes[g_ds4_stream] +
+        (uint64_t)g_moe_q4_up_slots_bytes[g_ds4_stream] +
+        (uint64_t)g_moe_q4_down_slots_bytes[g_ds4_stream];
 
     pthread_mutex_lock(&g_tensor_mu);
     const uint64_t tensor_live_snap = g_tensor_alloc_live_bytes;
@@ -4162,37 +4194,37 @@ void ds4_gpu_print_memory_report(const char *label) {
     fprintf(stderr,
             "ds4:   scratch %.2f MiB (flash mask %.2f, pad %.2f, tmp %.2f, blk %.2f, ring %.2f, kv %.2f, compressor %.2f, router %.2f, indexer %.2f, moe %.2f, f16 %.2f, raw-store %.2f)\n",
             ds4_gpu_mib(scratch),
-            ds4_gpu_mib((uint64_t)g_flash_attn_mask_bytes +
-                        (uint64_t)g_glm_flash_attn_mask_bytes +
-                        (uint64_t)g_flash_attn_zero_mask_bytes +
+            ds4_gpu_mib((uint64_t)g_flash_attn_mask_bytes[g_ds4_stream] +
+                        (uint64_t)g_glm_flash_attn_mask_bytes[g_ds4_stream] +
+                        (uint64_t)g_flash_attn_zero_mask_bytes[g_ds4_stream] +
                         cached_prefill_mask_bytes),
-            ds4_gpu_mib((uint64_t)g_flash_attn_pad_bytes),
-            ds4_gpu_mib((uint64_t)g_flash_attn_tmp_bytes),
-            ds4_gpu_mib((uint64_t)g_flash_attn_blk_bytes +
+            ds4_gpu_mib((uint64_t)g_flash_attn_pad_bytes[g_ds4_stream]),
+            ds4_gpu_mib((uint64_t)g_flash_attn_tmp_bytes[g_ds4_stream]),
+            ds4_gpu_mib((uint64_t)g_flash_attn_blk_bytes[g_ds4_stream] +
                         cached_prefill_blk_bytes),
-            ds4_gpu_mib((uint64_t)g_flash_attn_ring_bytes),
-            ds4_gpu_mib((uint64_t)g_flash_attn_kv_bytes),
-            ds4_gpu_mib((uint64_t)g_compressor_pool_kv_bytes +
-                          (uint64_t)g_compressor_pool_score_bytes +
-                          (uint64_t)g_compressor_pool_score_cont_bytes +
-                          (uint64_t)g_compressor_pool_softmax_bytes +
-                          (uint64_t)g_compressor_pool_product_bytes +
-                          (uint64_t)g_compressor_store_ape_bytes +
-                          (uint64_t)g_compressor_store_score_bytes +
-                          (uint64_t)g_embed_rows_bytes),
-            ds4_gpu_mib((uint64_t)g_router_selection_bytes +
-                          (uint64_t)g_router_weight_sum_bytes),
-            ds4_gpu_mib((uint64_t)g_indexer_head_scores_bytes +
-                          (uint64_t)g_indexer_topk_bytes +
-                          (uint64_t)g_indexed_topk_bytes),
-            ds4_gpu_mib((uint64_t)g_moe_gate_scratch_bytes +
-                          (uint64_t)g_moe_down_scratch_bytes +
-                          (uint64_t)g_moe_id_map_bytes +
-                          (uint64_t)g_moe_q4_gate_slots_bytes +
-                          (uint64_t)g_moe_q4_up_slots_bytes +
-                          (uint64_t)g_moe_q4_down_slots_bytes),
-            ds4_gpu_mib((uint64_t)g_f16_round_scratch_bytes),
-            ds4_gpu_mib((uint64_t)g_raw_store_round_bytes));
+            ds4_gpu_mib((uint64_t)g_flash_attn_ring_bytes[g_ds4_stream]),
+            ds4_gpu_mib((uint64_t)g_flash_attn_kv_bytes[g_ds4_stream]),
+            ds4_gpu_mib((uint64_t)g_compressor_pool_kv_bytes[g_ds4_stream] +
+                          (uint64_t)g_compressor_pool_score_bytes[g_ds4_stream] +
+                          (uint64_t)g_compressor_pool_score_cont_bytes[g_ds4_stream] +
+                          (uint64_t)g_compressor_pool_softmax_bytes[g_ds4_stream] +
+                          (uint64_t)g_compressor_pool_product_bytes[g_ds4_stream] +
+                          (uint64_t)g_compressor_store_ape_bytes[g_ds4_stream] +
+                          (uint64_t)g_compressor_store_score_bytes[g_ds4_stream] +
+                          (uint64_t)g_embed_rows_bytes[g_ds4_stream]),
+            ds4_gpu_mib((uint64_t)g_router_selection_bytes[g_ds4_stream] +
+                          (uint64_t)g_router_weight_sum_bytes[g_ds4_stream]),
+            ds4_gpu_mib((uint64_t)g_indexer_head_scores_bytes[g_ds4_stream] +
+                          (uint64_t)g_indexer_topk_bytes[g_ds4_stream] +
+                          (uint64_t)g_indexed_topk_bytes[g_ds4_stream]),
+            ds4_gpu_mib((uint64_t)g_moe_gate_scratch_bytes[g_ds4_stream] +
+                          (uint64_t)g_moe_down_scratch_bytes[g_ds4_stream] +
+                          (uint64_t)g_moe_id_map_bytes[g_ds4_stream] +
+                          (uint64_t)g_moe_q4_gate_slots_bytes[g_ds4_stream] +
+                          (uint64_t)g_moe_q4_up_slots_bytes[g_ds4_stream] +
+                          (uint64_t)g_moe_q4_down_slots_bytes[g_ds4_stream]),
+            ds4_gpu_mib((uint64_t)g_f16_round_scratch_bytes[g_ds4_stream]),
+            ds4_gpu_mib((uint64_t)g_raw_store_round_bytes[g_ds4_stream]));
     if (color) fputs(reset, stderr);
 }
 
@@ -6373,15 +6405,17 @@ int ds4_gpu_init(void) {
         g_pipeline_cache = [NSMutableDictionary dictionary];
         g_dsv4_completion_cache = [NSCache new];
         g_dsv4_completion_cache.countLimit = 256u;
-        g_transient_buffers = [NSMutableArray array];
+        for (int si = 0; si < DS4_GPU_MAX_STREAMS; si++) {
+            g_transient_buffers[si] = [NSMutableArray array];
+        }
         g_pending_cbs = [NSMutableArray array];
         if (!g_model_buffer_cache || !g_q4_expert_table_cache ||
             !g_q4_expert_layer_residency_cache ||
             !g_pipeline_cache || !g_dsv4_completion_cache ||
-            !g_transient_buffers || !g_pending_cbs) {
+            !g_transient_buffers[0] || !g_pending_cbs) {
             fprintf(stderr, "ds4: Metal bookkeeping allocation failed\n");
             g_pending_cbs = nil;
-            g_transient_buffers = nil;
+            g_transient_buffers[g_ds4_stream] = nil;
             g_dsv4_completion_cache = nil;
             g_pipeline_cache = nil;
             g_q4_expert_layer_residency_cache = nil;
@@ -9007,7 +9041,7 @@ int ds4_gpu_flush_commands(void) {
     if (g_batch_cb) ds4_gpu_stream_expert_cache_note_batch_created();
     if (!g_batch_cb) {
         (void)ds4_gpu_wait_pending_command_buffers("command batch");
-        [g_transient_buffers removeAllObjects];
+        [g_transient_buffers[g_ds4_stream] removeAllObjects];
         return 0;
     }
     return 1;
@@ -9382,7 +9416,7 @@ int ds4_gpu_commit_and_wait_selected_readback(uint64_t event_value, const char *
         if (!signaled) {
             fprintf(stderr, "ds4: timeout waiting for Metal shared event in %s\n", what);
             (void)ds4_gpu_wait_pending_command_buffers(what);
-            [g_transient_buffers removeAllObjects];
+            [g_transient_buffers[g_ds4_stream] removeAllObjects];
             return 0;
         }
         if (cb.status == MTLCommandBufferStatusError) {
@@ -9390,7 +9424,7 @@ int ds4_gpu_commit_and_wait_selected_readback(uint64_t event_value, const char *
                     what,
                     [[cb.error localizedDescription] UTF8String]);
             (void)ds4_gpu_wait_pending_command_buffers(what);
-            [g_transient_buffers removeAllObjects];
+            [g_transient_buffers[g_ds4_stream] removeAllObjects];
             return 0;
         }
 
@@ -9399,7 +9433,7 @@ int ds4_gpu_commit_and_wait_selected_readback(uint64_t event_value, const char *
         if (g_batch_cb) ds4_gpu_stream_expert_cache_note_batch_created();
         if (!g_batch_cb) {
             (void)ds4_gpu_wait_pending_command_buffers(what);
-            [g_transient_buffers removeAllObjects];
+            [g_transient_buffers[g_ds4_stream] removeAllObjects];
             return 0;
         }
         return 1;
@@ -10031,7 +10065,7 @@ static int ds4_gpu_signal_batch_and_wait_event(const char *label) {
             fprintf(stderr, "ds4: timeout waiting for Metal shared event in %s\n",
                     label ? label : "selected-id readback");
             (void)ds4_gpu_wait_pending_command_buffers(label ? label : "selected-id readback");
-            [g_transient_buffers removeAllObjects];
+            [g_transient_buffers[g_ds4_stream] removeAllObjects];
             return 0;
         }
         if (cb.status == MTLCommandBufferStatusError) {
@@ -10039,7 +10073,7 @@ static int ds4_gpu_signal_batch_and_wait_event(const char *label) {
                     label ? label : "selected-id readback",
                     [[cb.error localizedDescription] UTF8String]);
             (void)ds4_gpu_wait_pending_command_buffers(label ? label : "selected-id readback");
-            [g_transient_buffers removeAllObjects];
+            [g_transient_buffers[g_ds4_stream] removeAllObjects];
             return 0;
         }
 
@@ -10048,7 +10082,7 @@ static int ds4_gpu_signal_batch_and_wait_event(const char *label) {
         if (g_batch_cb) ds4_gpu_stream_expert_cache_note_batch_created();
         if (!g_batch_cb) {
             (void)ds4_gpu_wait_pending_command_buffers(label ? label : "selected-id readback");
-            [g_transient_buffers removeAllObjects];
+            [g_transient_buffers[g_ds4_stream] removeAllObjects];
             return 0;
         }
         return 1;
@@ -10062,6 +10096,30 @@ static int ds4_gpu_signal_batch_and_wait_event(const char *label) {
         }
         return ds4_gpu_begin_commands();
     }
+}
+
+int ds4_gpu_end_commands_async(void) {
+    if (!g_batch_cb) return 0;
+    ds4_gpu_close_batch_encoder();
+    id<MTLCommandBuffer> cb = g_batch_cb;
+    g_batch_cb = nil;
+    [cb commit];
+    g_stream_last_cb[g_ds4_stream] = cb;
+    return 1;
+}
+
+int ds4_gpu_wait_stream(int idx) {
+    if (idx < 0 || idx >= DS4_GPU_MAX_STREAMS) return 0;
+    id<MTLCommandBuffer> cb = g_stream_last_cb[idx];
+    if (!cb) return 1;
+    g_stream_last_cb[idx] = nil;
+    [cb waitUntilCompleted];
+    if (cb.status == MTLCommandBufferStatusError) {
+        fprintf(stderr, "ds4: Metal stream %d command batch failed: %s\n",
+                idx, cb.error ? cb.error.localizedDescription.UTF8String : "unknown");
+        return 0;
+    }
+    return 1;
 }
 
 int ds4_gpu_end_commands(void) {
@@ -10129,7 +10187,7 @@ int ds4_gpu_synchronize(void) {
     ds4_gpu_parallel_ffn_reset_state(YES);
     if ([g_pending_cbs count] != 0) {
         int ok = ds4_gpu_wait_pending_command_buffers("synchronize");
-        [g_transient_buffers removeAllObjects];
+        [g_transient_buffers[g_ds4_stream] removeAllObjects];
         ds4_gpu_model_buffer_cache_maybe_evict("synchronize");
         return ok;
     }
@@ -10162,7 +10220,7 @@ void ds4_gpu_cleanup(void) {
         }
         g_selected_readback_event = nil;
         g_selected_readback_event_value = 0;
-        [g_transient_buffers removeAllObjects];
+        [g_transient_buffers[g_ds4_stream] removeAllObjects];
         ds4_gpu_stream_expert_pread_pool_shutdown();
         ds4_gpu_stream_expert_cache_clear_all(1);
         for (uint32_t layer = 0; layer < DS4_METAL_STREAM_EXPERT_CACHE_MAX_LAYER; layer++) {
@@ -10378,38 +10436,38 @@ void ds4_gpu_cleanup(void) {
         g_glm_q6_k_down_f32_pipeline = nil;
         g_dsv4_router_weights_batch_pipeline = nil;
         g_dsv4_hc_expand4_pipeline = nil;
-        g_flash_attn_mask_buffer = nil;
-        g_flash_attn_zero_mask_buffer = nil;
-        g_flash_attn_pad_buffer = nil;
-        g_flash_attn_tmp_buffer = nil;
-        g_flash_attn_blk_buffer = nil;
+        g_flash_attn_mask_buffer[g_ds4_stream] = nil;
+        g_flash_attn_zero_mask_buffer[g_ds4_stream] = nil;
+        g_flash_attn_pad_buffer[g_ds4_stream] = nil;
+        g_flash_attn_tmp_buffer[g_ds4_stream] = nil;
+        g_flash_attn_blk_buffer[g_ds4_stream] = nil;
         ds4_gpu_clear_zero_prefix_prefill_mask_cache();
-        g_flash_attn_ring_buffer = nil;
-        g_flash_attn_kv_buffer = nil;
-        g_glm_flash_attn_mask_buffer = nil;
-        g_compressor_pool_kv_buffer = nil;
-        g_compressor_pool_score_buffer = nil;
-        g_compressor_pool_score_cont_buffer = nil;
-        g_compressor_pool_softmax_buffer = nil;
-        g_compressor_pool_product_buffer = nil;
-        g_compressor_store_ape_buffer = nil;
-        g_compressor_store_score_buffer = nil;
-        g_embed_rows_buffer = nil;
-        g_router_selection_buffer = nil;
-        g_router_weight_sum_buffer = nil;
-        g_indexer_head_scores_buffer = nil;
-        g_indexer_topk_buffer = nil;
-        g_indexed_topk_buffer = nil;
+        g_flash_attn_ring_buffer[g_ds4_stream] = nil;
+        g_flash_attn_kv_buffer[g_ds4_stream] = nil;
+        g_glm_flash_attn_mask_buffer[g_ds4_stream] = nil;
+        g_compressor_pool_kv_buffer[g_ds4_stream] = nil;
+        g_compressor_pool_score_buffer[g_ds4_stream] = nil;
+        g_compressor_pool_score_cont_buffer[g_ds4_stream] = nil;
+        g_compressor_pool_softmax_buffer[g_ds4_stream] = nil;
+        g_compressor_pool_product_buffer[g_ds4_stream] = nil;
+        g_compressor_store_ape_buffer[g_ds4_stream] = nil;
+        g_compressor_store_score_buffer[g_ds4_stream] = nil;
+        g_embed_rows_buffer[g_ds4_stream] = nil;
+        g_router_selection_buffer[g_ds4_stream] = nil;
+        g_router_weight_sum_buffer[g_ds4_stream] = nil;
+        g_indexer_head_scores_buffer[g_ds4_stream] = nil;
+        g_indexer_topk_buffer[g_ds4_stream] = nil;
+        g_indexed_topk_buffer[g_ds4_stream] = nil;
         g_stream_expert_validate_status_buffer = nil;
-        g_f16_round_scratch_buffer = nil;
-        g_raw_store_round_buffer = nil;
-        g_moe_gate_scratch_buffer = nil;
-        g_moe_down_scratch_buffer = nil;
-        g_moe_id_map_buffer = nil;
-        g_moe_q4_gate_slots_buffer = nil;
-        g_moe_q4_up_slots_buffer = nil;
-        g_moe_q4_down_slots_buffer = nil;
-        g_attn_out_group_ids_buffer = nil;
+        g_f16_round_scratch_buffer[g_ds4_stream] = nil;
+        g_raw_store_round_buffer[g_ds4_stream] = nil;
+        g_moe_gate_scratch_buffer[g_ds4_stream] = nil;
+        g_moe_down_scratch_buffer[g_ds4_stream] = nil;
+        g_moe_id_map_buffer[g_ds4_stream] = nil;
+        g_moe_q4_gate_slots_buffer[g_ds4_stream] = nil;
+        g_moe_q4_up_slots_buffer[g_ds4_stream] = nil;
+        g_moe_q4_down_slots_buffer[g_ds4_stream] = nil;
+        g_attn_out_group_ids_buffer[g_ds4_stream] = nil;
         g_model_fd = -1;
         g_model_map_ptr = NULL;
         g_model_map_size = 0;
@@ -10417,40 +10475,40 @@ void ds4_gpu_cleanup(void) {
         g_model_mapped_size = 0;
         g_model_mapped_max_tensor_bytes = 0;
         ds4_gpu_tensor_tracking_reset();
-        g_flash_attn_mask_bytes = 0;
-        g_flash_attn_zero_mask_bytes = 0;
-        g_flash_attn_pad_bytes = 0;
-        g_flash_attn_tmp_bytes = 0;
-        g_flash_attn_blk_bytes = 0;
-        g_flash_attn_ring_bytes = 0;
-        g_flash_attn_kv_bytes = 0;
-        g_glm_flash_attn_mask_bytes = 0;
+        g_flash_attn_mask_bytes[g_ds4_stream] = 0;
+        g_flash_attn_zero_mask_bytes[g_ds4_stream] = 0;
+        g_flash_attn_pad_bytes[g_ds4_stream] = 0;
+        g_flash_attn_tmp_bytes[g_ds4_stream] = 0;
+        g_flash_attn_blk_bytes[g_ds4_stream] = 0;
+        g_flash_attn_ring_bytes[g_ds4_stream] = 0;
+        g_flash_attn_kv_bytes[g_ds4_stream] = 0;
+        g_glm_flash_attn_mask_bytes[g_ds4_stream] = 0;
         g_glm_flash_attn_mask_valid = 0;
         g_glm_flash_attn_mask_pos0 = 0;
         g_glm_flash_attn_mask_tokens = 0;
         g_glm_flash_attn_mask_cache_len = 0;
-        g_compressor_pool_kv_bytes = 0;
-        g_compressor_pool_score_bytes = 0;
-        g_compressor_pool_score_cont_bytes = 0;
-        g_compressor_pool_softmax_bytes = 0;
-        g_compressor_pool_product_bytes = 0;
-        g_compressor_store_ape_bytes = 0;
-        g_compressor_store_score_bytes = 0;
-        g_embed_rows_bytes = 0;
-        g_router_selection_bytes = 0;
-        g_router_weight_sum_bytes = 0;
-        g_indexer_head_scores_bytes = 0;
-        g_indexer_topk_bytes = 0;
-        g_indexed_topk_bytes = 0;
-        g_f16_round_scratch_bytes = 0;
-        g_raw_store_round_bytes = 0;
-        g_moe_gate_scratch_bytes = 0;
-        g_moe_down_scratch_bytes = 0;
-        g_moe_id_map_bytes = 0;
-        g_moe_q4_gate_slots_bytes = 0;
-        g_moe_q4_up_slots_bytes = 0;
-        g_moe_q4_down_slots_bytes = 0;
-        g_attn_out_group_ids_bytes = 0;
+        g_compressor_pool_kv_bytes[g_ds4_stream] = 0;
+        g_compressor_pool_score_bytes[g_ds4_stream] = 0;
+        g_compressor_pool_score_cont_bytes[g_ds4_stream] = 0;
+        g_compressor_pool_softmax_bytes[g_ds4_stream] = 0;
+        g_compressor_pool_product_bytes[g_ds4_stream] = 0;
+        g_compressor_store_ape_bytes[g_ds4_stream] = 0;
+        g_compressor_store_score_bytes[g_ds4_stream] = 0;
+        g_embed_rows_bytes[g_ds4_stream] = 0;
+        g_router_selection_bytes[g_ds4_stream] = 0;
+        g_router_weight_sum_bytes[g_ds4_stream] = 0;
+        g_indexer_head_scores_bytes[g_ds4_stream] = 0;
+        g_indexer_topk_bytes[g_ds4_stream] = 0;
+        g_indexed_topk_bytes[g_ds4_stream] = 0;
+        g_f16_round_scratch_bytes[g_ds4_stream] = 0;
+        g_raw_store_round_bytes[g_ds4_stream] = 0;
+        g_moe_gate_scratch_bytes[g_ds4_stream] = 0;
+        g_moe_down_scratch_bytes[g_ds4_stream] = 0;
+        g_moe_id_map_bytes[g_ds4_stream] = 0;
+        g_moe_q4_gate_slots_bytes[g_ds4_stream] = 0;
+        g_moe_q4_up_slots_bytes[g_ds4_stream] = 0;
+        g_moe_q4_down_slots_bytes[g_ds4_stream] = 0;
+        g_attn_out_group_ids_bytes[g_ds4_stream] = 0;
         g_model_wrap_count = 0;
         g_model_wrap_bytes = 0;
         g_model_wrap_max_bytes = 0;
@@ -10467,7 +10525,7 @@ void ds4_gpu_cleanup(void) {
         g_q4_expert_table_cache = nil;
         [g_model_buffer_cache removeAllObjects];
         g_model_buffer_cache = nil;
-        g_transient_buffers = nil;
+        g_transient_buffers[g_ds4_stream] = nil;
         g_pending_cbs = nil;
         g_library = nil;
         g_queue = nil;
@@ -11097,8 +11155,8 @@ int ds4_gpu_embed_token_hc_tensor(
         if (!wbuf) return 0;
 
         const NSUInteger row_bytes = (NSUInteger)n_embd * sizeof(float);
-        if (!ds4_gpu_ensure_scratch_buffer(&g_embed_rows_buffer,
-                                             &g_embed_rows_bytes,
+        if (!ds4_gpu_ensure_scratch_buffer(&g_embed_rows_buffer[g_ds4_stream],
+                                             &g_embed_rows_bytes[g_ds4_stream],
                                              row_bytes,
                                              "ds4_embed_rows")) {
             return 0;
@@ -11135,13 +11193,13 @@ int ds4_gpu_embed_token_hc_tensor(
         [enc setBytes:&args length:sizeof(args) atIndex:0];
         [enc setBuffer:wbuf offset:(NSUInteger)inner_offset atIndex:1];
         [enc setBytes:&token_i32 length:sizeof(token_i32) atIndex:2];
-        [enc setBuffer:g_embed_rows_buffer offset:0 atIndex:3];
+        [enc setBuffer:g_embed_rows_buffer[g_ds4_stream] offset:0 atIndex:3];
         [enc dispatchThreadgroups:MTLSizeMake(nw0, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(nth, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
 
         if (!ds4_gpu_encode_repeat_hc_embedding(cb,
-                                                  g_embed_rows_buffer,
+                                                  g_embed_rows_buffer[g_ds4_stream],
                                                   0,
                                                   outbuf,
                                                   ds4_gpu_tensor_offset(out_hc),
@@ -11200,8 +11258,8 @@ int ds4_gpu_embed_tokens_hc_tensor(
         if (!wbuf) return 0;
 
         const NSUInteger rows_bytes = (NSUInteger)n_tokens * n_embd * sizeof(float);
-        if (!ds4_gpu_ensure_scratch_buffer(&g_embed_rows_buffer,
-                                             &g_embed_rows_bytes,
+        if (!ds4_gpu_ensure_scratch_buffer(&g_embed_rows_buffer[g_ds4_stream],
+                                             &g_embed_rows_bytes[g_ds4_stream],
                                              rows_bytes,
                                              "ds4_embed_rows")) {
             return 0;
@@ -11216,13 +11274,13 @@ int ds4_gpu_embed_tokens_hc_tensor(
                                            (NSUInteger)inner_offset,
                                            tokbuf,
                                            ds4_gpu_tensor_offset(tokens),
-                                           g_embed_rows_buffer,
+                                           g_embed_rows_buffer[g_ds4_stream],
                                            0,
                                            n_vocab,
                                            n_tokens,
                                            n_embd) ||
             !ds4_gpu_encode_repeat_hc_embedding(cb,
-                                                  g_embed_rows_buffer,
+                                                  g_embed_rows_buffer[g_ds4_stream],
                                                   0,
                                                   outbuf,
                                                   ds4_gpu_tensor_offset(out_hc),
@@ -11464,7 +11522,7 @@ static id<MTLBuffer> ds4_gpu_wrap_model_exact_range_impl(
     const bool transient_view = lifetime == DS4_GPU_EXACT_VIEW_TRANSIENT;
     if (!model_map || !g_device ||
         (cache_view && !g_model_buffer_cache) ||
-        (transient_view && !g_transient_buffers) ||
+        (transient_view && !g_transient_buffers[g_ds4_stream]) ||
         model_size == 0 || offset > model_size || len > model_size - offset) {
         fprintf(stderr, "ds4: Metal exact model range is outside the mapped model\n");
         return nil;
@@ -11526,7 +11584,7 @@ static id<MTLBuffer> ds4_gpu_wrap_model_exact_range_impl(
             [g_model_buffer_cache setObject:buffer forKey:key];
             ds4_gpu_model_buffer_cache_note_insert(view_bytes);
         } else if (transient_view) {
-            [g_transient_buffers addObject:buffer];
+            [g_transient_buffers[g_ds4_stream] addObject:buffer];
         }
     }
 
@@ -17442,8 +17500,8 @@ int ds4_gpu_indexer_score_one_tensor(
         }
 
         const uint64_t head_score_bytes = (uint64_t)n_comp * n_head * sizeof(float);
-        if (!ds4_gpu_ensure_scratch_buffer(&g_indexer_head_scores_buffer,
-                                             &g_indexer_head_scores_bytes,
+        if (!ds4_gpu_ensure_scratch_buffer(&g_indexer_head_scores_buffer[g_ds4_stream],
+                                             &g_indexer_head_scores_bytes[g_ds4_stream],
                                              (NSUInteger)head_score_bytes,
                                              "ds4_indexer_head_scores")) {
             return 0;
@@ -17484,7 +17542,7 @@ int ds4_gpu_indexer_score_one_tensor(
         [enc setBytes:&dot_args length:sizeof(dot_args) atIndex:0];
         [enc setBuffer:compbuf offset:ds4_gpu_tensor_offset(index_comp) atIndex:1];
         [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:2];
-        [enc setBuffer:g_indexer_head_scores_buffer offset:0 atIndex:3];
+        [enc setBuffer:g_indexer_head_scores_buffer[g_ds4_stream] offset:0 atIndex:3];
         if (dot_dispatch.smem) {
             [enc setThreadgroupMemoryLength:dot_dispatch.smem atIndex:0];
         }
@@ -17497,7 +17555,7 @@ int ds4_gpu_indexer_score_one_tensor(
         enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:g_dsv4_indexer_weighted_sum_pipeline];
         [enc setBytes:&sum_args length:sizeof(sum_args) atIndex:0];
-        [enc setBuffer:g_indexer_head_scores_buffer offset:0 atIndex:1];
+        [enc setBuffer:g_indexer_head_scores_buffer[g_ds4_stream] offset:0 atIndex:1];
         [enc setBuffer:wbuf offset:ds4_gpu_tensor_offset(weights) atIndex:2];
         [enc setBuffer:scorebuf offset:ds4_gpu_tensor_offset(scores) atIndex:3];
         [enc dispatchThreadgroups:MTLSizeMake(((NSUInteger)n_comp + 255u) / 256u, 1, 1)
@@ -17711,8 +17769,8 @@ int ds4_gpu_indexer_topk_tensor(
         const bool one_pass = npr <= 1;
         const uint64_t scratch_bytes = one_pass ? scratch_row_bytes * n_tokens :
             2u * scratch_row_bytes * n_tokens;
-        if (!ds4_gpu_ensure_scratch_buffer(&g_indexer_topk_buffer,
-                                             &g_indexer_topk_bytes,
+        if (!ds4_gpu_ensure_scratch_buffer(&g_indexer_topk_buffer[g_ds4_stream],
+                                             &g_indexer_topk_bytes[g_ds4_stream],
                                              (NSUInteger)scratch_bytes,
                                              "ds4_indexer_topk")) {
             return 0;
@@ -17747,7 +17805,7 @@ int ds4_gpu_indexer_topk_tensor(
         [enc setComputePipelineState:g_argsort_f32_i32_desc_pipeline];
         [enc setBytes:&args length:sizeof(args) atIndex:0];
         [enc setBuffer:scorebuf offset:ds4_gpu_tensor_offset(scores) atIndex:1];
-        [enc setBuffer:one_pass ? selbuf : g_indexer_topk_buffer
+        [enc setBuffer:one_pass ? selbuf : g_indexer_topk_buffer[g_ds4_stream]
               offset:one_pass ? ds4_gpu_tensor_offset(selected) : cur_off
              atIndex:2];
         [enc setThreadgroupMemoryLength:smem atIndex:0];
@@ -17785,8 +17843,8 @@ int ds4_gpu_indexer_topk_tensor(
             [enc setComputePipelineState:g_argsort_merge_f32_i32_desc_pipeline];
             [enc setBytes:&merge_args length:sizeof(merge_args) atIndex:0];
             [enc setBuffer:scorebuf offset:ds4_gpu_tensor_offset(scores) atIndex:1];
-            [enc setBuffer:g_indexer_topk_buffer offset:cur_off atIndex:2];
-            [enc setBuffer:final_merge ? selbuf : g_indexer_topk_buffer
+            [enc setBuffer:g_indexer_topk_buffer[g_ds4_stream] offset:cur_off atIndex:2];
+            [enc setBuffer:final_merge ? selbuf : g_indexer_topk_buffer[g_ds4_stream]
                   offset:final_merge ? ds4_gpu_tensor_offset(selected) : next_off
                  atIndex:3];
             [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)nm * n_tokens, 1, 1)
@@ -19133,7 +19191,7 @@ int ds4_gpu_router_project_select_fused_tensor(
             [g_dsv4_completion_cache setObject:completion
                                         forKey:completion_key];
         }
-        [g_transient_buffers addObject:completion];
+        [g_transient_buffers[g_ds4_stream] addObject:completion];
         ds4_gpu_f16_matvec_args rargs =
             ds4_gpu_make_f16_mv_args(in_dim, n_expert);
         rargs.nr0 = 2;
@@ -21478,12 +21536,12 @@ static int ds4_gpu_encode_f16_round_copy_for_raw_store(
         fprintf(stderr, "ds4: Metal raw KV store received undersized source buffer\n");
         return 0;
     }
-    if (!ds4_gpu_ensure_scratch_buffer(&g_f16_round_scratch_buffer,
-                                         &g_f16_round_scratch_bytes,
+    if (!ds4_gpu_ensure_scratch_buffer(&g_f16_round_scratch_buffer[g_ds4_stream],
+                                         &g_f16_round_scratch_bytes[g_ds4_stream],
                                          (NSUInteger)n * sizeof(uint16_t),
                                          "ds4_f16_round_scratch") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_raw_store_round_buffer,
-                                         &g_raw_store_round_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_raw_store_round_buffer[g_ds4_stream],
+                                         &g_raw_store_round_bytes[g_ds4_stream],
                                          (NSUInteger)n * sizeof(float),
                                          "ds4_raw_store_round")) {
         return 0;
@@ -21492,15 +21550,15 @@ static int ds4_gpu_encode_f16_round_copy_for_raw_store(
     if (!ds4_gpu_encode_cpy_f32_f16_1d(cb,
                                          srcbuf,
                                          ds4_gpu_tensor_offset(src),
-                                         g_f16_round_scratch_buffer,
+                                         g_f16_round_scratch_buffer[g_ds4_stream],
                                          0,
                                          n)) {
         return 0;
     }
     return ds4_gpu_encode_cpy_f16_f32_1d(cb,
-                                           g_f16_round_scratch_buffer,
+                                           g_f16_round_scratch_buffer[g_ds4_stream],
                                            0,
-                                           g_raw_store_round_buffer,
+                                           g_raw_store_round_buffer[g_ds4_stream],
                                            0,
                                            n);
 }
@@ -21623,7 +21681,7 @@ int ds4_gpu_store_raw_kv_tensor(
         const int32_t row_i32 = (int32_t)row;
         if (!ds4_gpu_encode_f16_round_copy_for_raw_store(cb, kv, head_dim) ||
             !ds4_gpu_encode_set_rows_f32_i32(cb, raw_cache,
-                                               g_raw_store_round_buffer,
+                                               g_raw_store_round_buffer[g_ds4_stream],
                                                0,
                                                &row_i32,
                                                1,
@@ -21827,7 +21885,7 @@ int ds4_gpu_store_raw_kv_batch_tensor(
         const int ok = n <= UINT32_MAX &&
             ds4_gpu_encode_f16_round_copy_for_raw_store(cb, kv, (uint32_t)n) &&
             ds4_gpu_encode_set_rows_f32_i32(cb, raw_cache,
-                                               g_raw_store_round_buffer,
+                                               g_raw_store_round_buffer[g_ds4_stream],
                                                0,
                                                rows,
                                                n_tokens,
@@ -21901,8 +21959,8 @@ static int ds4_gpu_encode_compressor_score_with_ape(
     }
 
     const NSUInteger scratch_bytes = (NSUInteger)total_elems * sizeof(float);
-    if (!ds4_gpu_ensure_scratch_buffer(&g_compressor_store_ape_buffer,
-                                         &g_compressor_store_ape_bytes,
+    if (!ds4_gpu_ensure_scratch_buffer(&g_compressor_store_ape_buffer[g_ds4_stream],
+                                         &g_compressor_store_ape_bytes[g_ds4_stream],
                                          scratch_bytes,
                                          "ds4_compressor_store_ape")) {
         return 0;
@@ -21922,14 +21980,14 @@ static int ds4_gpu_encode_compressor_score_with_ape(
             ok = ds4_gpu_encode_cpy_f16_f32_1d(cb,
                                                  apebuf,
                                                  src_off,
-                                                 g_compressor_store_ape_buffer,
+                                                 g_compressor_store_ape_buffer[g_ds4_stream],
                                                  dst_off,
                                                  seg_elems);
         } else {
             ok = ds4_gpu_encode_cpy_f32_f32_1d(cb,
                                                  apebuf,
                                                  src_off,
-                                                 g_compressor_store_ape_buffer,
+                                                 g_compressor_store_ape_buffer[g_ds4_stream],
                                                  dst_off,
                                                  seg_elems);
         }
@@ -21941,7 +21999,7 @@ static int ds4_gpu_encode_compressor_score_with_ape(
     return ds4_gpu_encode_add_f32_1d(cb,
                                        score_src,
                                        score_src_offset,
-                                       g_compressor_store_ape_buffer,
+                                       g_compressor_store_ape_buffer[g_ds4_stream],
                                        0,
                                        score_dst,
                                        score_dst_offset,
@@ -21971,8 +22029,8 @@ static int ds4_gpu_encode_compressor_set_rows_projected(
     }
 
     const NSUInteger score_scratch_bytes = (NSUInteger)n_rows * width * sizeof(float);
-    if (!ds4_gpu_ensure_scratch_buffer(&g_compressor_store_score_buffer,
-                                         &g_compressor_store_score_bytes,
+    if (!ds4_gpu_ensure_scratch_buffer(&g_compressor_store_score_buffer[g_ds4_stream],
+                                         &g_compressor_store_score_bytes[g_ds4_stream],
                                          score_scratch_bytes,
                                          "ds4_compressor_store_score")) {
         return 0;
@@ -21981,7 +22039,7 @@ static int ds4_gpu_encode_compressor_set_rows_projected(
     return ds4_gpu_encode_compressor_score_with_ape(cb,
                                                       scorebuf,
                                                       score_offset,
-                                                      g_compressor_store_score_buffer,
+                                                      g_compressor_store_score_buffer[g_ds4_stream],
                                                       0,
                                                       apebuf,
                                                       ape_offset,
@@ -22000,7 +22058,7 @@ static int ds4_gpu_encode_compressor_set_rows_projected(
                                              width) &&
            ds4_gpu_encode_set_rows_f32_i32(cb,
                                              state_score,
-                                             g_compressor_store_score_buffer,
+                                             g_compressor_store_score_buffer[g_ds4_stream],
                                              0,
                                              rows,
                                              n_rows,
@@ -22136,12 +22194,12 @@ int ds4_gpu_compressor_store_batch_tensor(
         }
         const uint32_t total_elems = (uint32_t)total_elems64;
         const NSUInteger scratch_bytes = (NSUInteger)total_elems * sizeof(float);
-        if (!ds4_gpu_ensure_scratch_buffer(&g_compressor_store_ape_buffer,
-                                             &g_compressor_store_ape_bytes,
+        if (!ds4_gpu_ensure_scratch_buffer(&g_compressor_store_ape_buffer[g_ds4_stream],
+                                             &g_compressor_store_ape_bytes[g_ds4_stream],
                                              scratch_bytes,
                                              "ds4_compressor_store_ape") ||
-            !ds4_gpu_ensure_scratch_buffer(&g_compressor_store_score_buffer,
-                                             &g_compressor_store_score_bytes,
+            !ds4_gpu_ensure_scratch_buffer(&g_compressor_store_score_buffer[g_ds4_stream],
+                                             &g_compressor_store_score_bytes[g_ds4_stream],
                                              scratch_bytes,
                                              "ds4_compressor_store_score")) {
             return 0;
@@ -22182,14 +22240,14 @@ int ds4_gpu_compressor_store_batch_tensor(
                 ok = ds4_gpu_encode_cpy_f16_f32_1d(cb,
                                                      apebuf,
                                                      src_off,
-                                                     g_compressor_store_ape_buffer,
+                                                     g_compressor_store_ape_buffer[g_ds4_stream],
                                                      dst_off,
                                                      seg_elems);
             } else {
                 ok = ds4_gpu_encode_cpy_f32_f32_1d(cb,
                                                      apebuf,
                                                      src_off,
-                                                     g_compressor_store_ape_buffer,
+                                                     g_compressor_store_ape_buffer[g_ds4_stream],
                                                      dst_off,
                                                      seg_elems);
             }
@@ -22201,9 +22259,9 @@ int ds4_gpu_compressor_store_batch_tensor(
             ok = ds4_gpu_encode_add_f32_1d(cb,
                                              scbuf,
                                              ds4_gpu_tensor_offset(sc),
-                                             g_compressor_store_ape_buffer,
+                                             g_compressor_store_ape_buffer[g_ds4_stream],
                                              0,
-                                             g_compressor_store_score_buffer,
+                                             g_compressor_store_score_buffer[g_ds4_stream],
                                              0,
                                              total_elems);
         }
@@ -22220,7 +22278,7 @@ int ds4_gpu_compressor_store_batch_tensor(
         if (ok) {
             ok = ds4_gpu_encode_set_rows_f32_i32(cb,
                                                    state_score,
-                                                   g_compressor_store_score_buffer,
+                                                   g_compressor_store_score_buffer[g_ds4_stream],
                                                    0,
                                                    rows,
                                                    n_tokens,
@@ -22353,16 +22411,16 @@ static int ds4_gpu_ensure_compressor_pool_ggml_scratch(
     const NSUInteger pack_bytes =
         (NSUInteger)pack_elems * sizeof(float);
     return
-        ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_product_buffer,
-                                       &g_compressor_pool_product_bytes,
+        ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_product_buffer[g_ds4_stream],
+                                       &g_compressor_pool_product_bytes[g_ds4_stream],
                                        pack_bytes,
                                        "ds4_compressor_pool_product") &&
-        ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_score_cont_buffer,
-                                       &g_compressor_pool_score_cont_bytes,
+        ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_score_cont_buffer[g_ds4_stream],
+                                       &g_compressor_pool_score_cont_bytes[g_ds4_stream],
                                        pack_bytes,
                                        "ds4_compressor_pool_score_cont") &&
-        ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_softmax_buffer,
-                                       &g_compressor_pool_softmax_bytes,
+        ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_softmax_buffer[g_ds4_stream],
+                                       &g_compressor_pool_softmax_bytes[g_ds4_stream],
                                        pack_bytes,
                                        "ds4_compressor_pool_softmax");
 }
@@ -22407,7 +22465,7 @@ static int ds4_gpu_encode_dsv4_softmax_pool_one_comp_ggml_reduce(
             float poison;
             memcpy(&poison, &poison_bits, sizeof(poison));
             if (!ds4_gpu_encode_fill_f32_rows(cb,
-                                                 g_compressor_pool_softmax_buffer,
+                                                 g_compressor_pool_softmax_buffer[g_ds4_stream],
                                                  0,
                                                  n_rows,
                                                  head_dim,
@@ -22425,16 +22483,16 @@ static int ds4_gpu_encode_dsv4_softmax_pool_one_comp_ggml_reduce(
         id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:exact_reduction_fusion_pipeline];
         [enc setBytes:&args length:sizeof(args) atIndex:0];
-        [enc setBuffer:g_compressor_pool_product_buffer offset:0 atIndex:1];
-        [enc setBuffer:g_compressor_pool_score_cont_buffer offset:0 atIndex:2];
-        [enc setBuffer:g_compressor_pool_softmax_buffer offset:0 atIndex:3];
-        [enc setBuffer:g_compressor_pool_product_buffer offset:0 atIndex:4];
+        [enc setBuffer:g_compressor_pool_product_buffer[g_ds4_stream] offset:0 atIndex:1];
+        [enc setBuffer:g_compressor_pool_score_cont_buffer[g_ds4_stream] offset:0 atIndex:2];
+        [enc setBuffer:g_compressor_pool_softmax_buffer[g_ds4_stream] offset:0 atIndex:3];
+        [enc setBuffer:g_compressor_pool_product_buffer[g_ds4_stream] offset:0 atIndex:4];
         [enc setThreadgroupMemoryLength:32u * sizeof(float) atIndex:0];
         [enc dispatchThreadgroups:MTLSizeMake(head_dim, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
         return ds4_gpu_encode_sum_rows_f32(cb,
-                                             g_compressor_pool_product_buffer,
+                                             g_compressor_pool_product_buffer[g_ds4_stream],
                                              0,
                                              outbuf,
                                              ds4_gpu_tensor_offset(out),
@@ -22451,9 +22509,9 @@ static int ds4_gpu_encode_dsv4_softmax_pool_one_comp_ggml_reduce(
         ds4_gpu_make_bin_contiguous_3d_args(n_rows, head_dim, 1);
     return
         ds4_gpu_encode_softmax_f32_contiguous(cb,
-                                                g_compressor_pool_score_cont_buffer,
+                                                g_compressor_pool_score_cont_buffer[g_ds4_stream],
                                                 0,
-                                                g_compressor_pool_softmax_buffer,
+                                                g_compressor_pool_softmax_buffer[g_ds4_stream],
                                                 0,
                                                 n_rows,
                                                 head_dim,
@@ -22461,14 +22519,14 @@ static int ds4_gpu_encode_dsv4_softmax_pool_one_comp_ggml_reduce(
         ds4_gpu_encode_bin_f32_rows(cb,
                                       g_mul_pipeline,
                                       &mul_args,
-                                      g_compressor_pool_product_buffer,
+                                      g_compressor_pool_product_buffer[g_ds4_stream],
                                       0,
-                                      g_compressor_pool_softmax_buffer,
+                                      g_compressor_pool_softmax_buffer[g_ds4_stream],
                                       0,
-                                      g_compressor_pool_product_buffer,
+                                      g_compressor_pool_product_buffer[g_ds4_stream],
                                       0) &&
         ds4_gpu_encode_sum_rows_f32(cb,
-                                      g_compressor_pool_product_buffer,
+                                      g_compressor_pool_product_buffer[g_ds4_stream],
                                       0,
                                       outbuf,
                                       ds4_gpu_tensor_offset(out),
@@ -22508,7 +22566,7 @@ static int ds4_gpu_encode_dsv4_softmax_pool_one_comp_ggml(
         ds4_gpu_encode_cpy_f32_f32_3d_src_strided(cb,
                                                     kvbuf,
                                                     kv_offset,
-                                                    g_compressor_pool_product_buffer,
+                                                    g_compressor_pool_product_buffer[g_ds4_stream],
                                                     0,
                                                     n_rows,
                                                     head_dim,
@@ -22521,7 +22579,7 @@ static int ds4_gpu_encode_dsv4_softmax_pool_one_comp_ggml(
         ds4_gpu_encode_cpy_f32_f32_3d_src_strided(cb,
                                                     scorebuf,
                                                     score_offset,
-                                                    g_compressor_pool_score_cont_buffer,
+                                                    g_compressor_pool_score_cont_buffer[g_ds4_stream],
                                                     0,
                                                     n_rows,
                                                     head_dim,
@@ -22801,7 +22859,7 @@ static int ds4_gpu_encode_compressor_pack_ratio4(
         uint32_t             n_comp,
         bool                 replay) {
     if (!cb || !kvbuf || !scorebuf || !statekvbuf || !statescbuf ||
-        !g_compressor_pool_kv_buffer || !g_compressor_pool_score_buffer ||
+        !g_compressor_pool_kv_buffer[g_ds4_stream] || !g_compressor_pool_score_buffer[g_ds4_stream] ||
         head_dim == 0 || n_comp == 0 || head_dim > UINT32_MAX / 2u) {
         return 0;
     }
@@ -22834,8 +22892,8 @@ static int ds4_gpu_encode_compressor_pack_ratio4(
     [enc setBuffer:scorebuf offset:score_offset atIndex:2];
     [enc setBuffer:statekvbuf offset:state_kv_offset atIndex:3];
     [enc setBuffer:statescbuf offset:state_score_offset atIndex:4];
-    [enc setBuffer:g_compressor_pool_kv_buffer offset:0 atIndex:5];
-    [enc setBuffer:g_compressor_pool_score_buffer offset:0 atIndex:6];
+    [enc setBuffer:g_compressor_pool_kv_buffer[g_ds4_stream] offset:0 atIndex:5];
+    [enc setBuffer:g_compressor_pool_score_buffer[g_ds4_stream] offset:0 atIndex:6];
     [enc dispatchThreadgroups:MTLSizeMake(n_comp, 8u, 1)
          threadsPerThreadgroup:MTLSizeMake(nth, 1, 1)];
     ds4_gpu_end_compute_encoder(cb, enc);
@@ -22883,7 +22941,7 @@ static int ds4_gpu_encode_compressor_ratio4_decode_pack_ggml(
                 float poison;
                 memcpy(&poison, &poison_bits, sizeof(poison));
                 if (!ds4_gpu_encode_fill_f32_rows(cb,
-                                                   g_compressor_pool_softmax_buffer,
+                                                   g_compressor_pool_softmax_buffer[g_ds4_stream],
                                                    0,
                                                    8u,
                                                    head_dim,
@@ -22902,8 +22960,8 @@ static int ds4_gpu_encode_compressor_ratio4_decode_pack_ggml(
             [enc setBytes:&args length:sizeof(args) atIndex:0];
             [enc setBuffer:statekvbuf offset:state_kv_offset atIndex:1];
             [enc setBuffer:statescbuf offset:state_score_offset atIndex:2];
-            [enc setBuffer:g_compressor_pool_softmax_buffer offset:0 atIndex:3];
-            [enc setBuffer:g_compressor_pool_product_buffer offset:0 atIndex:4];
+            [enc setBuffer:g_compressor_pool_softmax_buffer[g_ds4_stream] offset:0 atIndex:3];
+            [enc setBuffer:g_compressor_pool_product_buffer[g_ds4_stream] offset:0 atIndex:4];
             [enc setBuffer:outbuf offset:out_offset atIndex:5];
             [enc setThreadgroupMemoryLength:32u * sizeof(float) atIndex:0];
             [enc dispatchThreadgroups:MTLSizeMake(head_dim, 1, 1)
@@ -22937,8 +22995,8 @@ static int ds4_gpu_encode_compressor_ratio4_decode_pack_ggml(
     [enc setBytes:&args length:sizeof(args) atIndex:0];
     [enc setBuffer:statekvbuf offset:state_kv_offset atIndex:1];
     [enc setBuffer:statescbuf offset:state_score_offset atIndex:2];
-    [enc setBuffer:g_compressor_pool_product_buffer offset:0 atIndex:3];
-    [enc setBuffer:g_compressor_pool_score_cont_buffer offset:0 atIndex:4];
+    [enc setBuffer:g_compressor_pool_product_buffer[g_ds4_stream] offset:0 atIndex:3];
+    [enc setBuffer:g_compressor_pool_score_cont_buffer[g_ds4_stream] offset:0 atIndex:4];
     [enc dispatchThreadgroups:MTLSizeMake(8u, 1, 1)
          threadsPerThreadgroup:MTLSizeMake(nth, 1, 1)];
     ds4_gpu_end_compute_encoder(cb, enc);
@@ -23006,12 +23064,12 @@ static int ds4_gpu_encode_compressor_pool(
     }
 
     const NSUInteger packed_bytes = (NSUInteger)8u * head_dim * sizeof(float);
-    if (!ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_kv_buffer,
-                                         &g_compressor_pool_kv_bytes,
+    if (!ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_kv_buffer[g_ds4_stream],
+                                         &g_compressor_pool_kv_bytes[g_ds4_stream],
                                          packed_bytes,
                                          "ds4_compressor_pool_kv") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_score_buffer,
-                                         &g_compressor_pool_score_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_score_buffer[g_ds4_stream],
+                                         &g_compressor_pool_score_bytes[g_ds4_stream],
                                          packed_bytes,
                                          "ds4_compressor_pool_score")) {
         return 0;
@@ -23030,7 +23088,7 @@ static int ds4_gpu_encode_compressor_pool(
                                           ds4_gpu_tensor_offset(state_kv) + curr_offset,
                                           4,
                                           state_row_stride,
-                                          g_compressor_pool_kv_buffer,
+                                          g_compressor_pool_kv_buffer[g_ds4_stream],
                                           0,
                                           head_dim,
                                           pool_row_stride) ||
@@ -23043,7 +23101,7 @@ static int ds4_gpu_encode_compressor_pool(
                                           ds4_gpu_tensor_offset(state_score) + curr_offset,
                                           4,
                                           state_row_stride,
-                                          g_compressor_pool_score_buffer,
+                                          g_compressor_pool_score_buffer[g_ds4_stream],
                                           0,
                                           head_dim,
                                           pool_row_stride)) {
@@ -23052,12 +23110,12 @@ static int ds4_gpu_encode_compressor_pool(
 
     return ds4_gpu_encode_dsv4_softmax_pool(cb,
                                               out,
-                                              g_compressor_pool_kv_buffer,
+                                              g_compressor_pool_kv_buffer[g_ds4_stream],
                                               0,
                                               pool_row_stride,
                                               sizeof(float),
                                               packed_bytes,
-                                              g_compressor_pool_score_buffer,
+                                              g_compressor_pool_score_buffer[g_ds4_stream],
                                               0,
                                               pool_row_stride,
                                               sizeof(float),
@@ -23263,8 +23321,8 @@ int ds4_gpu_compressor_prefill_tensor(
 
         if (ok && n_comp != 0) {
             const NSUInteger score_bytes = (NSUInteger)cutoff * width * sizeof(float);
-            if (!ds4_gpu_ensure_scratch_buffer(&g_compressor_store_score_buffer,
-                                                 &g_compressor_store_score_bytes,
+            if (!ds4_gpu_ensure_scratch_buffer(&g_compressor_store_score_buffer[g_ds4_stream],
+                                                 &g_compressor_store_score_bytes[g_ds4_stream],
                                                  score_bytes,
                                                  "ds4_compressor_store_score")) {
                 ok = 0;
@@ -23273,7 +23331,7 @@ int ds4_gpu_compressor_prefill_tensor(
                 ok = ds4_gpu_encode_compressor_score_with_ape(cb,
                                                                  scbuf,
                                                                  ds4_gpu_tensor_offset(sc),
-                                                                 g_compressor_store_score_buffer,
+                                                                 g_compressor_store_score_buffer[g_ds4_stream],
                                                                  0,
                                                                  apebuf,
                                                                  (NSUInteger)ape_inner,
@@ -23304,12 +23362,12 @@ int ds4_gpu_compressor_prefill_tensor(
                     direct_pool_mode > 0 && !direct_pool_overlap;
                 const NSUInteger pack_bytes = (NSUInteger)n_comp * 8u * head_dim * sizeof(float);
                 if (ok && !use_direct_pool &&
-                    (!ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_kv_buffer,
-                                                      &g_compressor_pool_kv_bytes,
+                    (!ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_kv_buffer[g_ds4_stream],
+                                                      &g_compressor_pool_kv_bytes[g_ds4_stream],
                                                       pack_bytes,
                                                       "ds4_compressor_pool_kv") ||
-                     !ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_score_buffer,
-                                                      &g_compressor_pool_score_bytes,
+                     !ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_score_buffer[g_ds4_stream],
+                                                      &g_compressor_pool_score_bytes[g_ds4_stream],
                                                       pack_bytes,
                                                       "ds4_compressor_pool_score"))) {
                     ok = 0;
@@ -23324,7 +23382,7 @@ int ds4_gpu_compressor_prefill_tensor(
                         comp_cache,
                         kvbuf,
                         ds4_gpu_tensor_offset(kv),
-                        g_compressor_store_score_buffer,
+                        g_compressor_store_score_buffer[g_ds4_stream],
                         0,
                         statekvbuf,
                         ds4_gpu_tensor_offset(state_kv),
@@ -23339,7 +23397,7 @@ int ds4_gpu_compressor_prefill_tensor(
                         cb,
                         kvbuf,
                         ds4_gpu_tensor_offset(kv),
-                        g_compressor_store_score_buffer,
+                        g_compressor_store_score_buffer[g_ds4_stream],
                         0,
                         statekvbuf,
                         ds4_gpu_tensor_offset(state_kv),
@@ -23351,13 +23409,13 @@ int ds4_gpu_compressor_prefill_tensor(
                 }
                 if (ok && !use_direct_pool && !use_pack_fusion) {
                     ok = ds4_gpu_encode_fill_f32_rows(cb,
-                                                        g_compressor_pool_kv_buffer,
+                                                        g_compressor_pool_kv_buffer[g_ds4_stream],
                                                         0,
                                                         head_dim,
                                                         8u * n_comp,
                                                         0.0f) &&
                          ds4_gpu_encode_fill_f32_rows(cb,
-                                                        g_compressor_pool_score_buffer,
+                                                        g_compressor_pool_score_buffer[g_ds4_stream],
                                                         0,
                                                         head_dim,
                                                         8u * n_comp,
@@ -23372,7 +23430,7 @@ int ds4_gpu_compressor_prefill_tensor(
                                                          kvbuf,
                                                          ds4_gpu_tensor_offset(kv) +
                                                                  (NSUInteger)head_dim * sizeof(float),
-                                                         g_compressor_pool_kv_buffer,
+                                                         g_compressor_pool_kv_buffer[g_ds4_stream],
                                                          (NSUInteger)4u * head_dim * sizeof(float),
                                                          head_dim,
                                                          ratio,
@@ -23382,9 +23440,9 @@ int ds4_gpu_compressor_prefill_tensor(
                                                          dst_row_stride,
                                                          dst_plane_stride) &&
                          ds4_gpu_encode_cpy_f32_f32_3d(cb,
-                                                         g_compressor_store_score_buffer,
+                                                         g_compressor_store_score_buffer[g_ds4_stream],
                                                          (NSUInteger)head_dim * sizeof(float),
-                                                         g_compressor_pool_score_buffer,
+                                                         g_compressor_pool_score_buffer[g_ds4_stream],
                                                          (NSUInteger)4u * head_dim * sizeof(float),
                                                          head_dim,
                                                          ratio,
@@ -23402,7 +23460,7 @@ int ds4_gpu_compressor_prefill_tensor(
                     ok = ds4_gpu_encode_cpy_f32_f32_3d(cb,
                                                          kvbuf,
                                                          ds4_gpu_tensor_offset(kv),
-                                                         g_compressor_pool_kv_buffer,
+                                                         g_compressor_pool_kv_buffer[g_ds4_stream],
                                                          dst_plane_stride,
                                                          head_dim,
                                                          ratio,
@@ -23412,9 +23470,9 @@ int ds4_gpu_compressor_prefill_tensor(
                                                          dst_row_stride,
                                                          dst_plane_stride) &&
                          ds4_gpu_encode_cpy_f32_f32_3d(cb,
-                                                         g_compressor_store_score_buffer,
+                                                         g_compressor_store_score_buffer[g_ds4_stream],
                                                          0,
-                                                         g_compressor_pool_score_buffer,
+                                                         g_compressor_pool_score_buffer[g_ds4_stream],
                                                          dst_plane_stride,
                                                          head_dim,
                                                          ratio,
@@ -23427,12 +23485,12 @@ int ds4_gpu_compressor_prefill_tensor(
                 if (ok && !use_direct_pool) {
                     ok = ds4_gpu_encode_dsv4_softmax_pool(cb,
                                                             comp_cache,
-                                                            g_compressor_pool_kv_buffer,
+                                                            g_compressor_pool_kv_buffer[g_ds4_stream],
                                                             0,
                                                             (uint64_t)head_dim * sizeof(float),
                                                             sizeof(float),
                                                             8ull * head_dim * sizeof(float),
-                                                            g_compressor_pool_score_buffer,
+                                                            g_compressor_pool_score_buffer[g_ds4_stream],
                                                             0,
                                                             (uint64_t)head_dim * sizeof(float),
                                                             sizeof(float),
@@ -23450,7 +23508,7 @@ int ds4_gpu_compressor_prefill_tensor(
                                                         row_stride,
                                                         sizeof(float),
                                                         (uint64_t)ratio * row_stride,
-                                                        g_compressor_store_score_buffer,
+                                                        g_compressor_store_score_buffer[g_ds4_stream],
                                                         0,
                                                         row_stride,
                                                         sizeof(float),
@@ -23613,17 +23671,17 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
                  direct_state_bytes));
         const bool use_direct_pool =
             direct_pool_mode > 0 && !direct_pool_overlap;
-        if (ok && (!ds4_gpu_ensure_scratch_buffer(&g_compressor_store_score_buffer,
-                                                    &g_compressor_store_score_bytes,
+        if (ok && (!ds4_gpu_ensure_scratch_buffer(&g_compressor_store_score_buffer[g_ds4_stream],
+                                                    &g_compressor_store_score_bytes[g_ds4_stream],
                                                     score_bytes,
                                                     "ds4_compressor_store_score") ||
                    (!use_direct_pool &&
-                    (!ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_kv_buffer,
-                                                     &g_compressor_pool_kv_bytes,
+                    (!ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_kv_buffer[g_ds4_stream],
+                                                     &g_compressor_pool_kv_bytes[g_ds4_stream],
                                                      pack_bytes,
                                                      "ds4_compressor_pool_kv") ||
-                     !ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_score_buffer,
-                                                     &g_compressor_pool_score_bytes,
+                     !ds4_gpu_ensure_scratch_buffer(&g_compressor_pool_score_buffer[g_ds4_stream],
+                                                     &g_compressor_pool_score_bytes[g_ds4_stream],
                                                      pack_bytes,
                                                      "ds4_compressor_pool_score"))))) {
             ok = 0;
@@ -23633,7 +23691,7 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
             ok = ds4_gpu_encode_compressor_score_with_ape(cb,
                                                             scbuf,
                                                             ds4_gpu_tensor_offset(sc),
-                                                            g_compressor_store_score_buffer,
+                                                            g_compressor_store_score_buffer[g_ds4_stream],
                                                             0,
                                                             apebuf,
                                                             (NSUInteger)ape_inner,
@@ -23661,7 +23719,7 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
                 comp_cache,
                 kvbuf,
                 ds4_gpu_tensor_offset(kv),
-                g_compressor_store_score_buffer,
+                g_compressor_store_score_buffer[g_ds4_stream],
                 0,
                 statekvbuf,
                 state_off,
@@ -23677,7 +23735,7 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
                 cb,
                 kvbuf,
                 ds4_gpu_tensor_offset(kv),
-                g_compressor_store_score_buffer,
+                g_compressor_store_score_buffer[g_ds4_stream],
                 0,
                 statekvbuf,
                 state_off,
@@ -23690,13 +23748,13 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
 
         if (ok && !use_direct_pool && !use_pack_fusion) {
             ok = ds4_gpu_encode_fill_f32_rows(cb,
-                                                g_compressor_pool_kv_buffer,
+                                                g_compressor_pool_kv_buffer[g_ds4_stream],
                                                 0,
                                                 head_dim,
                                                 8u * n_comp,
                                                 0.0f) &&
                  ds4_gpu_encode_fill_f32_rows(cb,
-                                                g_compressor_pool_score_buffer,
+                                                g_compressor_pool_score_buffer[g_ds4_stream],
                                                 0,
                                                 head_dim,
                                                 8u * n_comp,
@@ -23713,7 +23771,7 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
             ok = ds4_gpu_encode_cpy_f32_f32_3d(cb,
                                                  statekvbuf,
                                                  state_off,
-                                                 g_compressor_pool_kv_buffer,
+                                                 g_compressor_pool_kv_buffer[g_ds4_stream],
                                                  0,
                                                  head_dim,
                                                  ratio,
@@ -23725,7 +23783,7 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
                  ds4_gpu_encode_cpy_f32_f32_3d(cb,
                                                  statescbuf,
                                                  state_score_off,
-                                                 g_compressor_pool_score_buffer,
+                                                 g_compressor_pool_score_buffer[g_ds4_stream],
                                                  0,
                                                  head_dim,
                                                  ratio,
@@ -23740,7 +23798,7 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
                                                  kvbuf,
                                                  ds4_gpu_tensor_offset(kv) +
                                                          (NSUInteger)head_dim * sizeof(float),
-                                                 g_compressor_pool_kv_buffer,
+                                                 g_compressor_pool_kv_buffer[g_ds4_stream],
                                                  (NSUInteger)4u * head_dim * sizeof(float),
                                                  head_dim,
                                                  ratio,
@@ -23750,9 +23808,9 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
                                                  dst_row_stride,
                                                  dst_plane_stride) &&
                  ds4_gpu_encode_cpy_f32_f32_3d(cb,
-                                                 g_compressor_store_score_buffer,
+                                                 g_compressor_store_score_buffer[g_ds4_stream],
                                                  (NSUInteger)head_dim * sizeof(float),
-                                                 g_compressor_pool_score_buffer,
+                                                 g_compressor_pool_score_buffer[g_ds4_stream],
                                                  (NSUInteger)4u * head_dim * sizeof(float),
                                                  head_dim,
                                                  ratio,
@@ -23766,7 +23824,7 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
             ok = ds4_gpu_encode_cpy_f32_f32_3d(cb,
                                                  kvbuf,
                                                  ds4_gpu_tensor_offset(kv),
-                                                 g_compressor_pool_kv_buffer,
+                                                 g_compressor_pool_kv_buffer[g_ds4_stream],
                                                  dst_plane_stride,
                                                  head_dim,
                                                  ratio,
@@ -23776,9 +23834,9 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
                                                  dst_row_stride,
                                                  dst_plane_stride) &&
                  ds4_gpu_encode_cpy_f32_f32_3d(cb,
-                                                 g_compressor_store_score_buffer,
+                                                 g_compressor_store_score_buffer[g_ds4_stream],
                                                  0,
-                                                 g_compressor_pool_score_buffer,
+                                                 g_compressor_pool_score_buffer[g_ds4_stream],
                                                  dst_plane_stride,
                                                  head_dim,
                                                  ratio,
@@ -23791,12 +23849,12 @@ int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
         if (ok && !use_direct_pool) {
             ok = ds4_gpu_encode_dsv4_softmax_pool(cb,
                                                     comp_cache,
-                                                    g_compressor_pool_kv_buffer,
+                                                    g_compressor_pool_kv_buffer[g_ds4_stream],
                                                     0,
                                                     dst_row_stride,
                                                     sizeof(float),
                                                     dst_plane_stride,
-                                                    g_compressor_pool_score_buffer,
+                                                    g_compressor_pool_score_buffer[g_ds4_stream],
                                                     0,
                                                     dst_row_stride,
                                                     sizeof(float),
@@ -24244,13 +24302,13 @@ int ds4_gpu_attention_output_q8_batch_tensor(
                     return 0;
                 }
             } else {
-                if (!ds4_gpu_ensure_scratch_buffer(&g_attn_out_group_ids_buffer,
-                                                     &g_attn_out_group_ids_bytes,
+                if (!ds4_gpu_ensure_scratch_buffer(&g_attn_out_group_ids_buffer[g_ds4_stream],
+                                                     &g_attn_out_group_ids_bytes[g_ds4_stream],
                                                      ids_bytes,
                                                      "ds4_attention_output_group_ids")) {
                     return 0;
                 }
-                group_ids_buffer = g_attn_out_group_ids_buffer;
+                group_ids_buffer = g_attn_out_group_ids_buffer[g_ds4_stream];
             }
             int32_t *ids = (int32_t *)[group_ids_buffer contents];
             for (uint32_t t = 0; t < n_tokens; t++) {
@@ -24350,11 +24408,11 @@ int ds4_gpu_attention_output_q8_batch_tensor(
                         if (getenv("DS4_METAL_DISABLE_ATTN_OUT_IDS_CACHE") != NULL) {
                             group_ids_buffer =
                                 ds4_gpu_new_transient_buffer(ids_bytes, "attention output group ids");
-                        } else if (ds4_gpu_ensure_scratch_buffer(&g_attn_out_group_ids_buffer,
-                                                                   &g_attn_out_group_ids_bytes,
+                        } else if (ds4_gpu_ensure_scratch_buffer(&g_attn_out_group_ids_buffer[g_ds4_stream],
+                                                                   &g_attn_out_group_ids_bytes[g_ds4_stream],
                                                                    ids_bytes,
                                                                    "ds4_attention_output_group_ids")) {
-                            group_ids_buffer = g_attn_out_group_ids_buffer;
+                            group_ids_buffer = g_attn_out_group_ids_buffer[g_ds4_stream];
                         }
                         if (group_ids_buffer) {
                             int32_t *ids = (int32_t *)[group_ids_buffer contents];
@@ -24612,11 +24670,11 @@ int ds4_gpu_attention_output_q4_K_batch_tensor(
             if (getenv("DS4_METAL_DISABLE_ATTN_OUT_IDS_CACHE") != NULL) {
                 group_ids_buffer =
                     ds4_gpu_new_transient_buffer(ids_bytes, "attention output Q4 group ids");
-            } else if (ds4_gpu_ensure_scratch_buffer(&g_attn_out_group_ids_buffer,
-                                                     &g_attn_out_group_ids_bytes,
+            } else if (ds4_gpu_ensure_scratch_buffer(&g_attn_out_group_ids_buffer[g_ds4_stream],
+                                                     &g_attn_out_group_ids_bytes[g_ds4_stream],
                                                      ids_bytes,
                                                      "ds4_attention_output_group_ids")) {
-                group_ids_buffer = g_attn_out_group_ids_buffer;
+                group_ids_buffer = g_attn_out_group_ids_buffer[g_ds4_stream];
             }
             if (!group_ids_buffer) return 0;
 
@@ -25983,23 +26041,23 @@ static int ds4_gpu_encode_flash_attention_raw_heads(
     id<MTLBuffer> mask_buffer = nil;
     if (use_persistent_zero_mask &&
         ds4_gpu_ensure_zero_attention_mask(mask_bytes)) {
-        mask_buffer = g_flash_attn_zero_mask_buffer;
+        mask_buffer = g_flash_attn_zero_mask_buffer[g_ds4_stream];
     } else {
         mask_buffer =
             ds4_gpu_new_transient_buffer(mask_bytes, "ds4_flash_attn_mask");
         if (mask_buffer) memset([mask_buffer contents], 0, mask_bytes);
     }
     if (!mask_buffer ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer,
-                                         &g_flash_attn_kv_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer[g_ds4_stream],
+                                         &g_flash_attn_kv_bytes[g_ds4_stream],
                                          kv_bytes,
                                          "ds4_flash_attn_kv_f16") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer,
-                                         &g_flash_attn_pad_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer[g_ds4_stream],
+                                         &g_flash_attn_pad_bytes[g_ds4_stream],
                                          pad_bytes,
                                          "ds4_flash_attn_pad") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_tmp_buffer,
-                                         &g_flash_attn_tmp_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_tmp_buffer[g_ds4_stream],
+                                         &g_flash_attn_tmp_bytes[g_ds4_stream],
                                          tmp_bytes,
                                          "ds4_flash_attn_tmp")) {
         return 0;
@@ -26028,7 +26086,7 @@ static int ds4_gpu_encode_flash_attention_raw_heads(
                                               raw_start,
                                               n_raw,
                                               head_dim,
-                                              g_flash_attn_kv_buffer,
+                                              g_flash_attn_kv_buffer[g_ds4_stream],
                                               0)) {
         return 0;
     }
@@ -26055,10 +26113,10 @@ static int ds4_gpu_encode_flash_attention_raw_heads(
         id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:pad_pipeline];
         [enc setBytes:&pad_args length:sizeof(pad_args) atIndex:0];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:1];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:1];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
         [enc setBuffer:mask_buffer offset:0 atIndex:3];
-        [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:4];
+        [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:4];
         [enc dispatchThreadgroups:MTLSizeMake(ncpsg, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
@@ -26108,12 +26166,12 @@ static int ds4_gpu_encode_flash_attention_raw_heads(
     [enc setComputePipelineState:vec_pipeline];
     [enc setBytes:&vec_args length:sizeof(vec_args) atIndex:0];
     [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:3];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:3];
     [enc setBuffer:mask_buffer offset:0 atIndex:4];
     [enc setBuffer:sinks_buf offset:sinks_offset atIndex:5];
-    [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:6];
-    [enc setBuffer:g_flash_attn_tmp_buffer offset:0 atIndex:7];
+    [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:6];
+    [enc setBuffer:g_flash_attn_tmp_buffer[g_ds4_stream] offset:0 atIndex:7];
     [enc setThreadgroupMemoryLength:shared_bytes atIndex:0];
     [enc dispatchThreadgroups:MTLSizeMake(1, n_head, nwg)
          threadsPerThreadgroup:MTLSizeMake(32, nsg, 1)];
@@ -26125,7 +26183,7 @@ static int ds4_gpu_encode_flash_attention_raw_heads(
     enc = ds4_gpu_compute_encoder(cb);
     [enc setComputePipelineState:reduce_pipeline];
     [enc setBytes:&reduce_args length:sizeof(reduce_args) atIndex:0];
-    [enc setBuffer:g_flash_attn_tmp_buffer offset:0 atIndex:1];
+    [enc setBuffer:g_flash_attn_tmp_buffer[g_ds4_stream] offset:0 atIndex:1];
     [enc setBuffer:headsbuf offset:ds4_gpu_tensor_offset(heads) atIndex:2];
     [enc dispatchThreadgroups:MTLSizeMake(nrows, 1, 1)
          threadsPerThreadgroup:MTLSizeMake(32u * nwg, 1, 1)];
@@ -26177,27 +26235,27 @@ static id<MTLBuffer> ds4_gpu_glm_prefill_mask_buffer(
         NSUInteger mask_bytes) {
     const int same_shape =
         g_glm_flash_attn_mask_valid &&
-        g_glm_flash_attn_mask_buffer &&
-        g_glm_flash_attn_mask_bytes >= mask_bytes &&
+        g_glm_flash_attn_mask_buffer[g_ds4_stream] &&
+        g_glm_flash_attn_mask_bytes[g_ds4_stream] >= mask_bytes &&
         g_glm_flash_attn_mask_pos0 == pos0 &&
         g_glm_flash_attn_mask_tokens == n_tokens &&
         g_glm_flash_attn_mask_cache_len == cache_len;
-    if (same_shape) return g_glm_flash_attn_mask_buffer;
+    if (same_shape) return g_glm_flash_attn_mask_buffer[g_ds4_stream];
 
-    if (g_glm_flash_attn_mask_buffer) {
-        [g_transient_buffers addObject:g_glm_flash_attn_mask_buffer];
-        g_glm_flash_attn_mask_buffer = nil;
+    if (g_glm_flash_attn_mask_buffer[g_ds4_stream]) {
+        [g_transient_buffers[g_ds4_stream] addObject:g_glm_flash_attn_mask_buffer[g_ds4_stream]];
+        g_glm_flash_attn_mask_buffer[g_ds4_stream] = nil;
     }
-    g_glm_flash_attn_mask_bytes = 0;
+    g_glm_flash_attn_mask_bytes[g_ds4_stream] = 0;
     g_glm_flash_attn_mask_valid = 0;
-    if (!ds4_gpu_ensure_scratch_buffer(&g_glm_flash_attn_mask_buffer,
-                                        &g_glm_flash_attn_mask_bytes,
+    if (!ds4_gpu_ensure_scratch_buffer(&g_glm_flash_attn_mask_buffer[g_ds4_stream],
+                                        &g_glm_flash_attn_mask_bytes[g_ds4_stream],
                                         mask_bytes,
                                         "ds4_glm_flash_attn_mask")) {
         return nil;
     }
 
-    ds4_gpu_fill_glm_prefill_mask((uint16_t *)[g_glm_flash_attn_mask_buffer contents],
+    ds4_gpu_fill_glm_prefill_mask((uint16_t *)[g_glm_flash_attn_mask_buffer[g_ds4_stream] contents],
                                   pos0,
                                   n_tokens,
                                   cache_len);
@@ -26205,7 +26263,7 @@ static id<MTLBuffer> ds4_gpu_glm_prefill_mask_buffer(
     g_glm_flash_attn_mask_tokens = n_tokens;
     g_glm_flash_attn_mask_cache_len = cache_len;
     g_glm_flash_attn_mask_valid = 1;
-    return g_glm_flash_attn_mask_buffer;
+    return g_glm_flash_attn_mask_buffer[g_ds4_stream];
 }
 
 static void ds4_gpu_fill_raw_decode_batch_mask(
@@ -26392,24 +26450,24 @@ static int ds4_gpu_encode_flash_attention_prefill_static_mixed_heads_nonvec_long
         mask_cache->valid = true;
     }
     if (!mask_buffer ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer,
-                                         &g_flash_attn_kv_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer[g_ds4_stream],
+                                         &g_flash_attn_kv_bytes[g_ds4_stream],
                                          kv_bytes,
                                          "ds4_flash_attn_kv_f16") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer,
-                                         &g_flash_attn_pad_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer[g_ds4_stream],
+                                         &g_flash_attn_pad_bytes[g_ds4_stream],
                                          pad_bytes,
                                          "ds4_flash_attn_pad") ||
         (!mask_cache &&
-         !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_blk_buffer,
-                                          &g_flash_attn_blk_bytes,
+         !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_blk_buffer[g_ds4_stream],
+                                          &g_flash_attn_blk_bytes[g_ds4_stream],
                                           blk_bytes,
                                           "ds4_flash_attn_blk"))) {
         return 0;
     }
     id<MTLBuffer> blk_buffer = mask_cache
         ? mask_cache->blk
-        : g_flash_attn_blk_buffer;
+        : g_flash_attn_blk_buffer[g_ds4_stream];
 
     const bool flash_stage_profile =
         getenv("DS4_METAL_FLASH_ATTN_STAGE_PROFILE") != NULL && g_batch_cb != nil;
@@ -26438,7 +26496,7 @@ static int ds4_gpu_encode_flash_attention_prefill_static_mixed_heads_nonvec_long
     if (!ds4_gpu_encode_cpy_f32_f16_1d(cb,
                                          rawbuf,
                                          ds4_gpu_tensor_offset(raw_kv),
-                                         g_flash_attn_kv_buffer,
+                                         g_flash_attn_kv_buffer[g_ds4_stream],
                                          0,
                                          n_tokens * head_dim)) {
         return 0;
@@ -26449,7 +26507,7 @@ static int ds4_gpu_encode_flash_attention_prefill_static_mixed_heads_nonvec_long
                                        compbuf,
                                        ds4_gpu_tensor_offset(comp_kv),
                                        comp_kv_f16 != 0,
-                                       g_flash_attn_kv_buffer,
+                                       g_flash_attn_kv_buffer[g_ds4_stream],
                                        (NSUInteger)n_tokens * row_bytes_f16,
                                        n_comp * head_dim)) {
         return 0;
@@ -26521,10 +26579,10 @@ static int ds4_gpu_encode_flash_attention_prefill_static_mixed_heads_nonvec_long
         id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:pad_pipeline];
         [enc setBytes:&pad_args length:sizeof(pad_args) atIndex:0];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:1];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:1];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
         [enc setBuffer:mask_buffer offset:0 atIndex:3];
-        [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:4];
+        [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:4];
         [enc dispatchThreadgroups:MTLSizeMake(ncpsg, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
@@ -26600,11 +26658,11 @@ static int ds4_gpu_encode_flash_attention_prefill_static_mixed_heads_nonvec_long
     [enc setComputePipelineState:attn_pipeline];
     [enc setBytes:&args length:sizeof(args) atIndex:0];
     [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:3];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:3];
     [enc setBuffer:mask_buffer offset:0 atIndex:4];
     [enc setBuffer:sinks_buf offset:sinks_offset atIndex:5];
-    [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:6];
+    [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:6];
     [enc setBuffer:blk_buffer offset:0 atIndex:7];
     [enc setBuffer:headsbuf offset:ds4_gpu_tensor_offset(heads) atIndex:8];
     [enc setThreadgroupMemoryLength:shared_bytes atIndex:0];
@@ -26679,16 +26737,16 @@ static int ds4_gpu_encode_flash_attention_prefill_static_mixed_heads_vec(
     id<MTLBuffer> mask_buffer =
         ds4_gpu_new_transient_buffer(mask_bytes, "ds4_flash_attn_mask");
     if (!mask_buffer ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer,
-                                         &g_flash_attn_kv_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer[g_ds4_stream],
+                                         &g_flash_attn_kv_bytes[g_ds4_stream],
                                          kv_bytes,
                                          "ds4_flash_attn_kv") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer,
-                                         &g_flash_attn_pad_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer[g_ds4_stream],
+                                         &g_flash_attn_pad_bytes[g_ds4_stream],
                                          pad_bytes,
                                          "ds4_flash_attn_pad") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_tmp_buffer,
-                                         &g_flash_attn_tmp_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_tmp_buffer[g_ds4_stream],
+                                         &g_flash_attn_tmp_bytes[g_ds4_stream],
                                          tmp_bytes,
                                          "ds4_flash_attn_tmp")) {
         return 0;
@@ -26721,7 +26779,7 @@ static int ds4_gpu_encode_flash_attention_prefill_static_mixed_heads_vec(
     if (!ds4_gpu_encode_cpy_f32_f16_1d(cb,
                                          rawbuf,
                                          ds4_gpu_tensor_offset(raw_kv),
-                                         g_flash_attn_kv_buffer,
+                                         g_flash_attn_kv_buffer[g_ds4_stream],
                                          0,
                                          n_tokens * head_dim)) {
         return 0;
@@ -26732,7 +26790,7 @@ static int ds4_gpu_encode_flash_attention_prefill_static_mixed_heads_vec(
                                            compbuf,
                                            ds4_gpu_tensor_offset(comp_kv),
                                            comp_kv_f16 != 0,
-                                           g_flash_attn_kv_buffer,
+                                           g_flash_attn_kv_buffer[g_ds4_stream],
                                            (NSUInteger)n_tokens * row_bytes_f16,
                                            n_comp * head_dim)) {
             return 0;
@@ -26803,10 +26861,10 @@ static int ds4_gpu_encode_flash_attention_prefill_static_mixed_heads_vec(
         enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:pad_pipeline];
         [enc setBytes:&pad_args length:sizeof(pad_args) atIndex:0];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:1];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:1];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
         [enc setBuffer:mask_buffer offset:0 atIndex:3];
-        [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:4];
+        [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:4];
         [enc dispatchThreadgroups:MTLSizeMake(ncpsg, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
@@ -26857,12 +26915,12 @@ static int ds4_gpu_encode_flash_attention_prefill_static_mixed_heads_vec(
     [enc setComputePipelineState:vec_pipeline];
     [enc setBytes:&vec_args length:sizeof(vec_args) atIndex:0];
     [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:3];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:3];
     [enc setBuffer:mask_buffer offset:0 atIndex:4];
     [enc setBuffer:sinks_buf offset:sinks_offset atIndex:5];
-    [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:6];
-    [enc setBuffer:g_flash_attn_tmp_buffer offset:0 atIndex:7];
+    [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:6];
+    [enc setBuffer:g_flash_attn_tmp_buffer[g_ds4_stream] offset:0 atIndex:7];
     [enc setThreadgroupMemoryLength:shared_bytes atIndex:0];
     [enc dispatchThreadgroups:MTLSizeMake(n_tokens, n_head, nwg)
          threadsPerThreadgroup:MTLSizeMake(32, nsg, 1)];
@@ -26875,7 +26933,7 @@ static int ds4_gpu_encode_flash_attention_prefill_static_mixed_heads_vec(
     enc = ds4_gpu_compute_encoder(cb);
     [enc setComputePipelineState:reduce_pipeline];
     [enc setBytes:&reduce_args length:sizeof(reduce_args) atIndex:0];
-    [enc setBuffer:g_flash_attn_tmp_buffer offset:0 atIndex:1];
+    [enc setBuffer:g_flash_attn_tmp_buffer[g_ds4_stream] offset:0 atIndex:1];
     [enc setBuffer:headsbuf offset:ds4_gpu_tensor_offset(heads) atIndex:2];
     [enc dispatchThreadgroups:MTLSizeMake(nrows, 1, 1)
          threadsPerThreadgroup:MTLSizeMake(32u * nwg, 1, 1)];
@@ -27024,24 +27082,24 @@ static int ds4_gpu_encode_flash_attention_prefill_raw_heads_nonvec(
         mask_cache->valid = true;
     }
     if (!mask_buffer ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer,
-                                         &g_flash_attn_kv_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer[g_ds4_stream],
+                                         &g_flash_attn_kv_bytes[g_ds4_stream],
                                          kv_bytes,
                                          "ds4_flash_attn_kv_f16") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer,
-                                         &g_flash_attn_pad_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer[g_ds4_stream],
+                                         &g_flash_attn_pad_bytes[g_ds4_stream],
                                          pad_bytes,
                                          "ds4_flash_attn_pad") ||
         (!mask_cache &&
-         !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_blk_buffer,
-                                          &g_flash_attn_blk_bytes,
+         !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_blk_buffer[g_ds4_stream],
+                                          &g_flash_attn_blk_bytes[g_ds4_stream],
                                           blk_bytes,
                                           "ds4_flash_attn_blk"))) {
         return 0;
     }
     id<MTLBuffer> blk_buffer = mask_cache
         ? mask_cache->blk
-        : g_flash_attn_blk_buffer;
+        : g_flash_attn_blk_buffer[g_ds4_stream];
 
     const bool flash_stage_profile =
         getenv("DS4_METAL_FLASH_ATTN_STAGE_PROFILE") != NULL && g_batch_cb != nil;
@@ -27091,7 +27149,7 @@ static int ds4_gpu_encode_flash_attention_prefill_raw_heads_nonvec(
     if (!ds4_gpu_encode_cpy_f32_f16_1d(cb,
                                          rawbuf,
                                          ds4_gpu_tensor_offset(raw_kv),
-                                         g_flash_attn_kv_buffer,
+                                         g_flash_attn_kv_buffer[g_ds4_stream],
                                          0,
                                          n_kv * head_dim)) {
         return 0;
@@ -27120,10 +27178,10 @@ static int ds4_gpu_encode_flash_attention_prefill_raw_heads_nonvec(
         id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:pad_pipeline];
         [enc setBytes:&pad_args length:sizeof(pad_args) atIndex:0];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:1];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:1];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
         [enc setBuffer:mask_buffer offset:0 atIndex:3];
-        [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:4];
+        [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:4];
         [enc dispatchThreadgroups:MTLSizeMake(ncpsg, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
@@ -27199,11 +27257,11 @@ static int ds4_gpu_encode_flash_attention_prefill_raw_heads_nonvec(
     [enc setComputePipelineState:attn_pipeline];
     [enc setBytes:&args length:sizeof(args) atIndex:0];
     [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:3];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:3];
     [enc setBuffer:mask_buffer offset:0 atIndex:4];
     [enc setBuffer:sinks_buf offset:sinks_offset atIndex:5];
-    [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:6];
+    [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:6];
     [enc setBuffer:blk_buffer offset:0 atIndex:7];
     [enc setBuffer:headsbuf offset:ds4_gpu_tensor_offset(heads) atIndex:8];
     [enc setThreadgroupMemoryLength:shared_bytes atIndex:0];
@@ -27282,16 +27340,16 @@ static int ds4_gpu_encode_flash_attention_prefill_raw_heads(
     id<MTLBuffer> mask_buffer =
         ds4_gpu_new_transient_buffer(mask_bytes, "ds4_flash_attn_mask");
     if (!mask_buffer ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer,
-                                         &g_flash_attn_pad_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer[g_ds4_stream],
+                                         &g_flash_attn_pad_bytes[g_ds4_stream],
                                          pad_bytes,
                                          "ds4_flash_attn_pad") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer,
-                                         &g_flash_attn_kv_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer[g_ds4_stream],
+                                         &g_flash_attn_kv_bytes[g_ds4_stream],
                                          kv_f16_bytes,
                                          "ds4_flash_attn_kv_f16") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_tmp_buffer,
-                                         &g_flash_attn_tmp_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_tmp_buffer[g_ds4_stream],
+                                         &g_flash_attn_tmp_bytes[g_ds4_stream],
                                          tmp_bytes,
                                          "ds4_flash_attn_tmp")) {
         return 0;
@@ -27344,7 +27402,7 @@ static int ds4_gpu_encode_flash_attention_prefill_raw_heads(
     if (!ds4_gpu_encode_cpy_f32_f16_1d(cb,
                                          rawbuf,
                                          ds4_gpu_tensor_offset(raw_kv),
-                                         g_flash_attn_kv_buffer,
+                                         g_flash_attn_kv_buffer[g_ds4_stream],
                                          kv_f16_offset,
                                          n_tokens * head_dim)) {
         return 0;
@@ -27373,10 +27431,10 @@ static int ds4_gpu_encode_flash_attention_prefill_raw_heads(
         id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:pad_pipeline];
         [enc setBytes:&pad_args length:sizeof(pad_args) atIndex:0];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:kv_f16_offset atIndex:1];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:kv_f16_offset atIndex:2];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:kv_f16_offset atIndex:1];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:kv_f16_offset atIndex:2];
         [enc setBuffer:mask_buffer offset:0 atIndex:3];
-        [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:4];
+        [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:4];
         [enc dispatchThreadgroups:MTLSizeMake(ncpsg, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
@@ -27427,12 +27485,12 @@ static int ds4_gpu_encode_flash_attention_prefill_raw_heads(
     [enc setComputePipelineState:vec_pipeline];
     [enc setBytes:&vec_args length:sizeof(vec_args) atIndex:0];
     [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:kv_f16_offset atIndex:2];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:kv_f16_offset atIndex:3];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:kv_f16_offset atIndex:2];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:kv_f16_offset atIndex:3];
     [enc setBuffer:mask_buffer offset:0 atIndex:4];
     [enc setBuffer:sinks_buf offset:sinks_offset atIndex:5];
-    [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:6];
-    [enc setBuffer:g_flash_attn_tmp_buffer offset:0 atIndex:7];
+    [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:6];
+    [enc setBuffer:g_flash_attn_tmp_buffer[g_ds4_stream] offset:0 atIndex:7];
     [enc setThreadgroupMemoryLength:shared_bytes atIndex:0];
     [enc dispatchThreadgroups:MTLSizeMake(n_tokens, n_head, nwg)
          threadsPerThreadgroup:MTLSizeMake(32, nsg, 1)];
@@ -27445,7 +27503,7 @@ static int ds4_gpu_encode_flash_attention_prefill_raw_heads(
     enc = ds4_gpu_compute_encoder(cb);
     [enc setComputePipelineState:reduce_pipeline];
     [enc setBytes:&reduce_args length:sizeof(reduce_args) atIndex:0];
-    [enc setBuffer:g_flash_attn_tmp_buffer offset:0 atIndex:1];
+    [enc setBuffer:g_flash_attn_tmp_buffer[g_ds4_stream] offset:0 atIndex:1];
     [enc setBuffer:headsbuf offset:ds4_gpu_tensor_offset(heads) atIndex:2];
     [enc dispatchThreadgroups:MTLSizeMake(nrows, 1, 1)
          threadsPerThreadgroup:MTLSizeMake(32u * nwg, 1, 1)];
@@ -27538,27 +27596,27 @@ static int ds4_gpu_encode_flash_attention_gathered_heads(
 
     if (!(use_persistent_zero_mask
               ? ds4_gpu_ensure_zero_attention_mask(mask_bytes)
-              : ds4_gpu_ensure_scratch_buffer(&g_flash_attn_mask_buffer,
-                                                &g_flash_attn_mask_bytes,
+              : ds4_gpu_ensure_scratch_buffer(&g_flash_attn_mask_buffer[g_ds4_stream],
+                                                &g_flash_attn_mask_bytes[g_ds4_stream],
                                                 mask_bytes,
                                                 "ds4_flash_attn_mask")) ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer,
-                                         &g_flash_attn_kv_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer[g_ds4_stream],
+                                         &g_flash_attn_kv_bytes[g_ds4_stream],
                                          kv_bytes,
                                          "ds4_flash_attn_kv") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer,
-                                         &g_flash_attn_pad_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer[g_ds4_stream],
+                                         &g_flash_attn_pad_bytes[g_ds4_stream],
                                          pad_bytes,
                                          "ds4_flash_attn_pad") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_tmp_buffer,
-                                         &g_flash_attn_tmp_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_tmp_buffer[g_ds4_stream],
+                                         &g_flash_attn_tmp_bytes[g_ds4_stream],
                                          tmp_bytes,
                                          "ds4_flash_attn_tmp")) {
         return 0;
     }
     id<MTLBuffer> flash_mask_buffer = use_persistent_zero_mask
-        ? g_flash_attn_zero_mask_buffer
-        : g_flash_attn_mask_buffer;
+        ? g_flash_attn_zero_mask_buffer[g_ds4_stream]
+        : g_flash_attn_mask_buffer[g_ds4_stream];
 
     const bool has_kvpad = (n_keys % ncpsg) != 0;
     const bool use_shared_kvpad =
@@ -27642,11 +27700,11 @@ static int ds4_gpu_encode_flash_attention_gathered_heads(
             comp_kv_f16 != 0,
             n_comp,
             head_dim,
-            g_flash_attn_kv_buffer,
+            g_flash_attn_kv_buffer[g_ds4_stream],
             0,
             flash_mask_buffer,
             0,
-            g_flash_attn_pad_buffer,
+            g_flash_attn_pad_buffer[g_ds4_stream],
             0,
             has_kvpad,
             use_shared_kvpad,
@@ -27682,10 +27740,10 @@ static int ds4_gpu_encode_flash_attention_gathered_heads(
         id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:pad_pipeline];
         [enc setBytes:&pad_args length:sizeof(pad_args) atIndex:0];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:1];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:1];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
         [enc setBuffer:flash_mask_buffer offset:0 atIndex:3];
-        [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:4];
+        [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:4];
         [enc dispatchThreadgroups:MTLSizeMake(ncpsg, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
@@ -27736,11 +27794,11 @@ static int ds4_gpu_encode_flash_attention_gathered_heads(
         [packed_enc setComputePipelineState:packed_pipeline];
         [packed_enc setBytes:&vec_args length:sizeof(vec_args) atIndex:0];
         [packed_enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
-        [packed_enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
-        [packed_enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:3];
+        [packed_enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
+        [packed_enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:3];
         [packed_enc setBuffer:flash_mask_buffer offset:0 atIndex:4];
         [packed_enc setBuffer:sinks_buf offset:sinks_offset atIndex:5];
-        [packed_enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:6];
+        [packed_enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:6];
         [packed_enc setBuffer:headsbuf
                         offset:ds4_gpu_tensor_offset(heads) atIndex:7];
         [packed_enc setBytes:&g_decode_attn_rope_args
@@ -27758,12 +27816,12 @@ static int ds4_gpu_encode_flash_attention_gathered_heads(
     [enc setComputePipelineState:vec_pipeline];
     [enc setBytes:&vec_args length:sizeof(vec_args) atIndex:0];
     [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:3];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:3];
     [enc setBuffer:flash_mask_buffer offset:0 atIndex:4];
     [enc setBuffer:sinks_buf offset:sinks_offset atIndex:5];
-    [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:6];
-    [enc setBuffer:g_flash_attn_tmp_buffer offset:0 atIndex:7];
+    [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:6];
+    [enc setBuffer:g_flash_attn_tmp_buffer[g_ds4_stream] offset:0 atIndex:7];
     [enc setThreadgroupMemoryLength:shared_bytes atIndex:0];
     [enc dispatchThreadgroups:MTLSizeMake(1, n_head, nwg)
          threadsPerThreadgroup:MTLSizeMake(32, nsg, 1)];
@@ -27786,7 +27844,7 @@ static int ds4_gpu_encode_flash_attention_gathered_heads(
     enc = ds4_gpu_compute_encoder(cb);
     [enc setComputePipelineState:reduce_pso];
     [enc setBytes:&reduce_args length:sizeof(reduce_args) atIndex:0];
-    [enc setBuffer:g_flash_attn_tmp_buffer offset:0 atIndex:1];
+    [enc setBuffer:g_flash_attn_tmp_buffer[g_ds4_stream] offset:0 atIndex:1];
     [enc setBuffer:headsbuf offset:ds4_gpu_tensor_offset(heads) atIndex:2];
     if (fuse_rope) {
         [enc setBytes:&g_decode_attn_rope_args
@@ -27852,16 +27910,16 @@ static int ds4_gpu_encode_flash_attention_decode_raw_batch_heads(
     id<MTLBuffer> mask_buffer =
         ds4_gpu_new_transient_buffer(mask_bytes, "ds4_flash_attn_mask");
     if (!mask_buffer ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer,
-                                         &g_flash_attn_kv_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer[g_ds4_stream],
+                                         &g_flash_attn_kv_bytes[g_ds4_stream],
                                          kv_bytes,
                                          "ds4_flash_attn_kv_f16") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer,
-                                         &g_flash_attn_pad_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer[g_ds4_stream],
+                                         &g_flash_attn_pad_bytes[g_ds4_stream],
                                          pad_bytes,
                                          "ds4_flash_attn_pad") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_blk_buffer,
-                                         &g_flash_attn_blk_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_blk_buffer[g_ds4_stream],
+                                         &g_flash_attn_blk_bytes[g_ds4_stream],
                                          blk_bytes,
                                          "ds4_flash_attn_blk")) {
         return 0;
@@ -27874,7 +27932,7 @@ static int ds4_gpu_encode_flash_attention_decode_raw_batch_heads(
                                               raw_start,
                                               n_raw,
                                               head_dim,
-                                              g_flash_attn_kv_buffer,
+                                              g_flash_attn_kv_buffer[g_ds4_stream],
                                               0)) {
         return 0;
     }
@@ -27926,10 +27984,10 @@ static int ds4_gpu_encode_flash_attention_decode_raw_batch_heads(
         id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:pad_pipeline];
         [enc setBytes:&pad_args length:sizeof(pad_args) atIndex:0];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:1];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:1];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
         [enc setBuffer:mask_buffer offset:0 atIndex:3];
-        [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:4];
+        [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:4];
         [enc dispatchThreadgroups:MTLSizeMake(ncpsg, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
@@ -27950,7 +28008,7 @@ static int ds4_gpu_encode_flash_attention_decode_raw_batch_heads(
     [enc setComputePipelineState:blk_pipeline];
     [enc setBytes:&blk_args length:sizeof(blk_args) atIndex:0];
     [enc setBuffer:mask_buffer offset:0 atIndex:1];
-    [enc setBuffer:g_flash_attn_blk_buffer offset:0 atIndex:2];
+    [enc setBuffer:g_flash_attn_blk_buffer[g_ds4_stream] offset:0 atIndex:2];
     [enc dispatchThreadgroups:MTLSizeMake(nblk0, nblk1, 1)
          threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
     ds4_gpu_end_compute_encoder(cb, enc);
@@ -27999,12 +28057,12 @@ static int ds4_gpu_encode_flash_attention_decode_raw_batch_heads(
     [enc setComputePipelineState:attn_pipeline];
     [enc setBytes:&args length:sizeof(args) atIndex:0];
     [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:3];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:3];
     [enc setBuffer:mask_buffer offset:0 atIndex:4];
     [enc setBuffer:sinks_buf offset:sinks_offset atIndex:5];
-    [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:6];
-    [enc setBuffer:g_flash_attn_blk_buffer offset:0 atIndex:7];
+    [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:6];
+    [enc setBuffer:g_flash_attn_blk_buffer[g_ds4_stream] offset:0 atIndex:7];
     [enc setBuffer:headsbuf offset:ds4_gpu_tensor_offset(heads) atIndex:8];
     [enc setThreadgroupMemoryLength:shared_bytes atIndex:0];
     [enc dispatchThreadgroups:MTLSizeMake(nblk1, n_head, 1)
@@ -28098,16 +28156,16 @@ static int ds4_gpu_encode_flash_attention_decode_mixed_batch_heads(
     id<MTLBuffer> mask_buffer =
         ds4_gpu_new_transient_buffer(mask_bytes, "ds4_flash_attn_mask");
     if (!mask_buffer ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer,
-                                         &g_flash_attn_kv_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer[g_ds4_stream],
+                                         &g_flash_attn_kv_bytes[g_ds4_stream],
                                          kv_bytes,
                                          "ds4_flash_attn_kv_f16") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer,
-                                         &g_flash_attn_pad_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer[g_ds4_stream],
+                                         &g_flash_attn_pad_bytes[g_ds4_stream],
                                          pad_bytes,
                                          "ds4_flash_attn_pad") ||
-        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_blk_buffer,
-                                         &g_flash_attn_blk_bytes,
+        !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_blk_buffer[g_ds4_stream],
+                                         &g_flash_attn_blk_bytes[g_ds4_stream],
                                          blk_bytes,
                                          "ds4_flash_attn_blk")) {
         return 0;
@@ -28120,13 +28178,13 @@ static int ds4_gpu_encode_flash_attention_decode_mixed_batch_heads(
                                               raw_start,
                                               n_raw,
                                               head_dim,
-                                              g_flash_attn_kv_buffer,
+                                              g_flash_attn_kv_buffer[g_ds4_stream],
                                               0) ||
         !ds4_gpu_encode_copy_to_f16_1d(cb,
                                        compbuf,
                                        ds4_gpu_tensor_offset(comp_kv),
                                        comp_kv_f16 != 0,
-                                       g_flash_attn_kv_buffer,
+                                       g_flash_attn_kv_buffer[g_ds4_stream],
                                        (NSUInteger)n_raw * row_bytes_f16,
                                        n_comp * head_dim)) {
         return 0;
@@ -28190,10 +28248,10 @@ static int ds4_gpu_encode_flash_attention_decode_mixed_batch_heads(
         id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:pad_pipeline];
         [enc setBytes:&pad_args length:sizeof(pad_args) atIndex:0];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:1];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:1];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
         [enc setBuffer:mask_buffer offset:0 atIndex:3];
-        [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:4];
+        [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:4];
         [enc dispatchThreadgroups:MTLSizeMake(ncpsg, 1, 1)
              threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
@@ -28214,7 +28272,7 @@ static int ds4_gpu_encode_flash_attention_decode_mixed_batch_heads(
     [enc setComputePipelineState:blk_pipeline];
     [enc setBytes:&blk_args length:sizeof(blk_args) atIndex:0];
     [enc setBuffer:mask_buffer offset:0 atIndex:1];
-    [enc setBuffer:g_flash_attn_blk_buffer offset:0 atIndex:2];
+    [enc setBuffer:g_flash_attn_blk_buffer[g_ds4_stream] offset:0 atIndex:2];
     [enc dispatchThreadgroups:MTLSizeMake(nblk0, nblk1, 1)
          threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
     ds4_gpu_end_compute_encoder(cb, enc);
@@ -28263,12 +28321,12 @@ static int ds4_gpu_encode_flash_attention_decode_mixed_batch_heads(
     [enc setComputePipelineState:attn_pipeline];
     [enc setBytes:&args length:sizeof(args) atIndex:0];
     [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:2];
-    [enc setBuffer:g_flash_attn_kv_buffer offset:0 atIndex:3];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:2];
+    [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:0 atIndex:3];
     [enc setBuffer:mask_buffer offset:0 atIndex:4];
     [enc setBuffer:sinks_buf offset:sinks_offset atIndex:5];
-    [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:6];
-    [enc setBuffer:g_flash_attn_blk_buffer offset:0 atIndex:7];
+    [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:6];
+    [enc setBuffer:g_flash_attn_blk_buffer[g_ds4_stream] offset:0 atIndex:7];
     [enc setBuffer:headsbuf offset:ds4_gpu_tensor_offset(heads) atIndex:8];
     [enc setThreadgroupMemoryLength:shared_bytes atIndex:0];
     [enc dispatchThreadgroups:MTLSizeMake(nblk1, n_head, 1)
@@ -28663,8 +28721,8 @@ int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
          */
         const bool skip_decode_sort = !g_quality_mode && decode_one_token;
         if (!skip_decode_sort &&
-            !ds4_gpu_ensure_scratch_buffer(&g_indexed_topk_buffer,
-                                             &g_indexed_topk_bytes,
+            !ds4_gpu_ensure_scratch_buffer(&g_indexed_topk_buffer[g_ds4_stream],
+                                             &g_indexed_topk_bytes[g_ds4_stream],
                                              (NSUInteger)topk_bytes,
                                              "ds4_indexed_topk_sorted")) {
             return 0;
@@ -28713,7 +28771,7 @@ int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
             [enc setComputePipelineState:sort_pipeline];
             [enc setBytes:&sort_args length:sizeof(sort_args) atIndex:0];
             [enc setBuffer:topkbuf offset:ds4_gpu_tensor_offset(topk) atIndex:1];
-            [enc setBuffer:g_indexed_topk_buffer offset:0 atIndex:2];
+            [enc setBuffer:g_indexed_topk_buffer[g_ds4_stream] offset:0 atIndex:2];
             [enc setThreadgroupMemoryLength:(NSUInteger)top_k * sizeof(int32_t) atIndex:0];
             [enc dispatchThreadgroups:MTLSizeMake(n_tokens, 1, 1)
                  threadsPerThreadgroup:MTLSizeMake(top_k, 1, 1)];
@@ -28728,8 +28786,8 @@ int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
                 nrows * decode_splits * 2u * sizeof(float);
             if (partial_bytes > NSUIntegerMax - stats_bytes ||
                 !ds4_gpu_ensure_scratch_buffer(
-                    &g_flash_attn_tmp_buffer,
-                    &g_flash_attn_tmp_bytes,
+                    &g_flash_attn_tmp_buffer[g_ds4_stream],
+                    &g_flash_attn_tmp_bytes[g_ds4_stream],
                     (NSUInteger)(partial_bytes + stats_bytes),
                     "ds4_dsv4_indexed_attention_split_tmp")) {
                 return 0;
@@ -28741,10 +28799,10 @@ int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
             [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
             [enc setBuffer:rawbuf offset:ds4_gpu_tensor_offset(raw_kv) atIndex:2];
             [enc setBuffer:compbuf offset:ds4_gpu_tensor_offset(comp_kv) atIndex:3];
-            [enc setBuffer:skip_decode_sort ? topkbuf : g_indexed_topk_buffer
+            [enc setBuffer:skip_decode_sort ? topkbuf : g_indexed_topk_buffer[g_ds4_stream]
                   offset:skip_decode_sort ? ds4_gpu_tensor_offset(topk) : 0
                  atIndex:4];
-            [enc setBuffer:g_flash_attn_tmp_buffer offset:0 atIndex:5];
+            [enc setBuffer:g_flash_attn_tmp_buffer[g_ds4_stream] offset:0 atIndex:5];
             [enc setThreadgroupMemoryLength:16u * 128u * sizeof(uint16_t) * 4u
                                     atIndex:0];
             [enc dispatchThreadgroups:
@@ -28757,7 +28815,7 @@ int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
             enc = ds4_gpu_compute_encoder(cb);
             [enc setComputePipelineState:split_reduce_pipeline];
             [enc setBytes:&attn_args length:sizeof(attn_args) atIndex:0];
-            [enc setBuffer:g_flash_attn_tmp_buffer offset:0 atIndex:1];
+            [enc setBuffer:g_flash_attn_tmp_buffer[g_ds4_stream] offset:0 atIndex:1];
             [enc setBuffer:sinks_buf offset:(NSUInteger)sinks_inner atIndex:2];
             [enc setBuffer:headsbuf offset:ds4_gpu_tensor_offset(heads) atIndex:3];
             [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)nrows, 1, 1)
@@ -28770,7 +28828,7 @@ int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
             [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
             [enc setBuffer:rawbuf offset:ds4_gpu_tensor_offset(raw_kv) atIndex:2];
             [enc setBuffer:compbuf offset:ds4_gpu_tensor_offset(comp_kv) atIndex:3];
-            [enc setBuffer:skip_decode_sort ? topkbuf : g_indexed_topk_buffer
+            [enc setBuffer:skip_decode_sort ? topkbuf : g_indexed_topk_buffer[g_ds4_stream]
                   offset:skip_decode_sort ? ds4_gpu_tensor_offset(topk) : 0
                  atIndex:4];
             [enc setBuffer:sinks_buf offset:(NSUInteger)sinks_inner atIndex:5];
@@ -31123,8 +31181,8 @@ static int ds4_gpu_encode_mul_mm_id_map(
     }
     const NSUInteger total_bytes =
         work_offset + 8u + (NSUInteger)work_cap * work_item_bytes;
-    if (!ds4_gpu_ensure_scratch_buffer(&g_moe_id_map_buffer,
-                                         &g_moe_id_map_bytes,
+    if (!ds4_gpu_ensure_scratch_buffer(&g_moe_id_map_buffer[g_ds4_stream],
+                                         &g_moe_id_map_bytes[g_ds4_stream],
                                          total_bytes,
                                          "ds4_moe_id_map")) {
         return 0;
@@ -31134,9 +31192,9 @@ static int ds4_gpu_encode_mul_mm_id_map(
     [enc setComputePipelineState:map_pipeline];
     [enc setBytes:map_args length:sizeof(*map_args) atIndex:0];
     [enc setBuffer:ids offset:ids_off atIndex:1];
-    [enc setBuffer:g_moe_id_map_buffer offset:0 atIndex:2];
-    [enc setBuffer:g_moe_id_map_buffer offset:tpe_bytes atIndex:3];
-    [enc setBuffer:g_moe_id_map_buffer offset:work_offset atIndex:4];
+    [enc setBuffer:g_moe_id_map_buffer[g_ds4_stream] offset:0 atIndex:2];
+    [enc setBuffer:g_moe_id_map_buffer[g_ds4_stream] offset:tpe_bytes atIndex:3];
+    [enc setBuffer:g_moe_id_map_buffer[g_ds4_stream] offset:work_offset atIndex:4];
     [enc setThreadgroupMemoryLength:(NSUInteger)mm_args->ne02 * (NSUInteger)mm_args->ne20 * sizeof(uint16_t) atIndex:0];
     [enc dispatchThreadgroups:MTLSizeMake(1, 1, 1)
          threadsPerThreadgroup:MTLSizeMake((NSUInteger)mm_args->ne02, 1, 1)];
@@ -31156,7 +31214,7 @@ static int ds4_gpu_encode_mul_mm_id_mapped_tile(
         NSUInteger                  dst_off,
         NSUInteger                  threadgroup_bytes) {
     if (!cb || !mm_pipeline || !mm_args || !src0 || !src1 || !dst ||
-        !g_moe_id_map_buffer ||
+        !g_moe_id_map_buffer[g_ds4_stream] ||
         mm_args->ne00 <= 0 || mm_args->ne0 <= 0 ||
         mm_args->ne20 <= 0 || mm_args->ne21 <= 0 || mm_args->ne02 <= 0) {
         return 0;
@@ -31185,7 +31243,7 @@ static int ds4_gpu_encode_mul_mm_id_mapped_tile(
         work_offset > NSUIntegerMax - 8u ||
         (NSUInteger)work_cap >
             (NSUIntegerMax - work_offset - 8u) / work_item_bytes ||
-        g_moe_id_map_bytes <
+        g_moe_id_map_bytes[g_ds4_stream] <
             work_offset + 8u + (NSUInteger)work_cap * work_item_bytes) {
         return 0;
     }
@@ -31195,10 +31253,10 @@ static int ds4_gpu_encode_mul_mm_id_mapped_tile(
     [enc setBytes:mm_args length:sizeof(*mm_args) atIndex:0];
     [enc setBuffer:src0 offset:src0_off atIndex:1];
     [enc setBuffer:src1 offset:src1_off atIndex:2];
-    [enc setBuffer:g_moe_id_map_buffer offset:0 atIndex:3];
-    [enc setBuffer:g_moe_id_map_buffer offset:tpe_bytes atIndex:4];
+    [enc setBuffer:g_moe_id_map_buffer[g_ds4_stream] offset:0 atIndex:3];
+    [enc setBuffer:g_moe_id_map_buffer[g_ds4_stream] offset:tpe_bytes atIndex:4];
     [enc setBuffer:dst offset:dst_off atIndex:5];
-    [enc setBuffer:g_moe_id_map_buffer offset:work_offset atIndex:6];
+    [enc setBuffer:g_moe_id_map_buffer[g_ds4_stream] offset:work_offset atIndex:6];
     if (use_resource_hints) {
         [enc useResource:src0 usage:MTLResourceUsageRead];
     }
@@ -31226,7 +31284,7 @@ static int ds4_gpu_encode_mul_mm_id_addr_mapped_tile(
         uint32_t                    resource_kind,
         id<MTLBuffer>               overflow_resource) {
     if (!cb || !mm_pipeline || !mm_args || !src0_addrs || !src1 || !dst ||
-        !g_moe_id_map_buffer ||
+        !g_moe_id_map_buffer[g_ds4_stream] ||
         mm_args->ne00 <= 0 || mm_args->ne0 <= 0 ||
         mm_args->ne20 <= 0 || mm_args->ne21 <= 0 || mm_args->ne02 <= 0) {
         return 0;
@@ -31237,7 +31295,7 @@ static int ds4_gpu_encode_mul_mm_id_addr_mapped_tile(
     const NSUInteger hids_bytes =
         (NSUInteger)mm_args->ne02 * (NSUInteger)mm_args->ne21 * sizeof(int32_t);
     if (tpe_bytes > NSUIntegerMax - hids_bytes ||
-        g_moe_id_map_bytes < tpe_bytes + hids_bytes) {
+        g_moe_id_map_bytes[g_ds4_stream] < tpe_bytes + hids_bytes) {
         return 0;
     }
 
@@ -31246,8 +31304,8 @@ static int ds4_gpu_encode_mul_mm_id_addr_mapped_tile(
     [enc setBytes:mm_args length:sizeof(*mm_args) atIndex:0];
     [enc setBuffer:src0_addrs offset:0 atIndex:1];
     [enc setBuffer:src1 offset:src1_off atIndex:2];
-    [enc setBuffer:g_moe_id_map_buffer offset:0 atIndex:3];
-    [enc setBuffer:g_moe_id_map_buffer offset:tpe_bytes atIndex:4];
+    [enc setBuffer:g_moe_id_map_buffer[g_ds4_stream] offset:0 atIndex:3];
+    [enc setBuffer:g_moe_id_map_buffer[g_ds4_stream] offset:tpe_bytes atIndex:4];
     [enc setBuffer:dst offset:dst_off atIndex:5];
     [enc useResource:src0_addrs usage:MTLResourceUsageRead];
     for (uint32_t i = 0; resources && i < resource_count; i++) {
@@ -31289,7 +31347,7 @@ static int ds4_gpu_encode_mul_mm_id_iq2_pair_swiglu_f16(
         NSUInteger                  weights_off) {
     if (!cb || !pipeline || !mm_args || !act_args ||
         !gate_src0 || !up_src0 || !src1 || !mid || !weights ||
-        !g_moe_id_map_buffer ||
+        !g_moe_id_map_buffer[g_ds4_stream] ||
         mm_args->ne00 <= 0 || mm_args->ne0 <= 0 ||
         mm_args->ne20 <= 0 || mm_args->ne21 <= 0 || mm_args->ne02 <= 0) {
         return 0;
@@ -31310,7 +31368,7 @@ static int ds4_gpu_encode_mul_mm_id_iq2_pair_swiglu_f16(
         work_offset > NSUIntegerMax - 8u ||
         (NSUInteger)work_cap >
             (NSUIntegerMax - work_offset - 8u) / work_item_bytes ||
-        g_moe_id_map_bytes <
+        g_moe_id_map_bytes[g_ds4_stream] <
             work_offset + 8u + (NSUInteger)work_cap * work_item_bytes) {
         return 0;
     }
@@ -31322,11 +31380,11 @@ static int ds4_gpu_encode_mul_mm_id_iq2_pair_swiglu_f16(
     [enc setBuffer:gate_src0 offset:gate_src0_off atIndex:2];
     [enc setBuffer:up_src0 offset:up_src0_off atIndex:3];
     [enc setBuffer:src1 offset:src1_off atIndex:4];
-    [enc setBuffer:g_moe_id_map_buffer offset:0 atIndex:5];
-    [enc setBuffer:g_moe_id_map_buffer offset:tpe_bytes atIndex:6];
+    [enc setBuffer:g_moe_id_map_buffer[g_ds4_stream] offset:0 atIndex:5];
+    [enc setBuffer:g_moe_id_map_buffer[g_ds4_stream] offset:tpe_bytes atIndex:6];
     [enc setBuffer:mid offset:mid_off atIndex:7];
     [enc setBuffer:weights offset:weights_off atIndex:8];
-    [enc setBuffer:g_moe_id_map_buffer offset:work_offset atIndex:9];
+    [enc setBuffer:g_moe_id_map_buffer[g_ds4_stream] offset:work_offset atIndex:9];
     const NSUInteger tile_m = compact_tile ? 32u : 64u;
     [enc setThreadgroupMemoryLength:compact_tile ? 8192u : 16384u atIndex:0];
     [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)work_cap,
@@ -32062,8 +32120,8 @@ static int ds4_gpu_encode_router_select(
 
         if (has_bias) {
             if (!biasbuf ||
-                !ds4_gpu_ensure_scratch_buffer(&g_router_selection_buffer,
-                                                 &g_router_selection_bytes,
+                !ds4_gpu_ensure_scratch_buffer(&g_router_selection_buffer[g_ds4_stream],
+                                                 &g_router_selection_bytes[g_ds4_stream],
                                                  probs_bytes,
                                                  "ds4_router_selection")) {
                 return 0;
@@ -32077,12 +32135,12 @@ static int ds4_gpu_encode_router_select(
                                                probs_off,
                                                biasbuf,
                                                bias_off,
-                                               g_router_selection_buffer,
+                                               g_router_selection_buffer[g_ds4_stream],
                                                0);
             if (!ok) return 0;
 
             selection_view = [DS4MetalTensor new];
-            selection_view.buffer = g_router_selection_buffer;
+            selection_view.buffer = g_router_selection_buffer[g_ds4_stream];
             selection_view.offset = 0;
             selection_view.bytes = probs_bytes;
             selection_view.owner = 0;
@@ -32131,8 +32189,8 @@ static int ds4_gpu_encode_router_select(
     }
 
     const NSUInteger sum_bytes = (NSUInteger)n_tokens * sizeof(float);
-    if (!ds4_gpu_ensure_scratch_buffer(&g_router_weight_sum_buffer,
-                                         &g_router_weight_sum_bytes,
+    if (!ds4_gpu_ensure_scratch_buffer(&g_router_weight_sum_buffer[g_ds4_stream],
+                                         &g_router_weight_sum_bytes[g_ds4_stream],
                                          sum_bytes,
                                          "ds4_router_weight_sum")) {
         return 0;
@@ -32151,15 +32209,15 @@ static int ds4_gpu_encode_router_select(
          ds4_gpu_encode_sum_rows_f32(cb,
                                        weightsbuf,
                                        weights_off,
-                                       g_router_weight_sum_buffer,
+                                       g_router_weight_sum_buffer[g_ds4_stream],
                                        0,
                                        n_expert_used,
                                        n_tokens) &&
          ds4_gpu_encode_unary_f32_rows(cb,
                                          g_unary_clamp_pipeline,
-                                         g_router_weight_sum_buffer,
+                                         g_router_weight_sum_buffer[g_ds4_stream],
                                          0,
-                                         g_router_weight_sum_buffer,
+                                         g_router_weight_sum_buffer[g_ds4_stream],
                                          0,
                                          1,
                                          n_tokens,
@@ -32177,7 +32235,7 @@ static int ds4_gpu_encode_router_select(
                                        &div_args,
                                        weightsbuf,
                                        weights_off,
-                                       g_router_weight_sum_buffer,
+                                       g_router_weight_sum_buffer[g_ds4_stream],
                                        0,
                                        weightsbuf,
                                        weights_off);
@@ -32896,8 +32954,8 @@ int ds4_gpu_glm_build_kv_cache_flash_tensor(
         const NSUInteger value_f16_bytes =
             (NSUInteger)n_tokens * (NSUInteger)n_head * v_row_bytes_f16;
         const NSUInteger kv_f16_bytes = key_f16_bytes + value_f16_bytes;
-        if (!ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer,
-                                           &g_flash_attn_kv_bytes,
+        if (!ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer[g_ds4_stream],
+                                           &g_flash_attn_kv_bytes[g_ds4_stream],
                                            kv_f16_bytes,
                                            "ds4_glm_flash_attn_kv_f16")) {
             return 0;
@@ -32941,8 +32999,8 @@ int ds4_gpu_glm_build_kv_cache_flash_tensor(
         [enc setBuffer:vbuf offset:ds4_gpu_tensor_offset(value) atIndex:3];
         [enc setBuffer:keybuf offset:ds4_gpu_tensor_offset(key_cache) atIndex:4];
         [enc setBuffer:valbuf offset:ds4_gpu_tensor_offset(value_cache) atIndex:5];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:key_f16_offset atIndex:6];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:value_f16_offset atIndex:7];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:key_f16_offset atIndex:6];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:value_f16_offset atIndex:7];
         [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)n_tokens, (NSUInteger)n_head, 1)
              threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
@@ -33030,22 +33088,22 @@ static int ds4_gpu_glm_attention_flash_tensor_impl(
             ds4_gpu_glm_prefill_mask_buffer(pos0, n_tokens, cache_len, mask_bytes);
         if (!mask_buffer) return 0;
         if (kv_pre_staged) {
-            if (!g_flash_attn_kv_buffer || g_flash_attn_kv_bytes < kv_f16_bytes) {
+            if (!g_flash_attn_kv_buffer[g_ds4_stream] || g_flash_attn_kv_bytes[g_ds4_stream] < kv_f16_bytes) {
                 fprintf(stderr, "ds4: GLM staged FlashAttention KV scratch is missing\n");
                 return 0;
             }
-        } else if (!ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer,
-                                                  &g_flash_attn_kv_bytes,
+        } else if (!ds4_gpu_ensure_scratch_buffer(&g_flash_attn_kv_buffer[g_ds4_stream],
+                                                  &g_flash_attn_kv_bytes[g_ds4_stream],
                                                   kv_f16_bytes,
                                                   "ds4_glm_flash_attn_kv_f16")) {
             return 0;
         }
-        if (!ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer,
-                                             &g_flash_attn_pad_bytes,
+        if (!ds4_gpu_ensure_scratch_buffer(&g_flash_attn_pad_buffer[g_ds4_stream],
+                                             &g_flash_attn_pad_bytes[g_ds4_stream],
                                              pad_bytes,
                                              "ds4_glm_flash_attn_pad") ||
-            !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_blk_buffer,
-                                             &g_flash_attn_blk_bytes,
+            !ds4_gpu_ensure_scratch_buffer(&g_flash_attn_blk_buffer[g_ds4_stream],
+                                             &g_flash_attn_blk_bytes[g_ds4_stream],
                                              blk_bytes,
                                              "ds4_glm_flash_attn_blk")) {
             return 0;
@@ -33075,7 +33133,7 @@ static int ds4_gpu_glm_attention_flash_tensor_impl(
                 (ds4_gpu_encode_cpy_f16_f16_3d(cb,
                                                keybuf,
                                                ds4_gpu_tensor_offset(key_cache),
-                                               g_flash_attn_kv_buffer,
+                                               g_flash_attn_kv_buffer[g_ds4_stream],
                                                key_f16_offset,
                                                qk_dim,
                                                cache_len,
@@ -33087,7 +33145,7 @@ static int ds4_gpu_glm_attention_flash_tensor_impl(
                  ds4_gpu_encode_cpy_f16_f16_3d(cb,
                                                valbuf,
                                                ds4_gpu_tensor_offset(value_cache),
-                                               g_flash_attn_kv_buffer,
+                                               g_flash_attn_kv_buffer[g_ds4_stream],
                                                value_f16_offset,
                                                value_dim,
                                                cache_len,
@@ -33099,7 +33157,7 @@ static int ds4_gpu_glm_attention_flash_tensor_impl(
                 (ds4_gpu_encode_cpy_f32_f16_3d(cb,
                                                keybuf,
                                                ds4_gpu_tensor_offset(key_cache),
-                                               g_flash_attn_kv_buffer,
+                                               g_flash_attn_kv_buffer[g_ds4_stream],
                                                key_f16_offset,
                                                qk_dim,
                                                cache_len,
@@ -33111,7 +33169,7 @@ static int ds4_gpu_glm_attention_flash_tensor_impl(
                  ds4_gpu_encode_cpy_f32_f16_3d(cb,
                                                valbuf,
                                                ds4_gpu_tensor_offset(value_cache),
-                                               g_flash_attn_kv_buffer,
+                                               g_flash_attn_kv_buffer[g_ds4_stream],
                                                value_f16_offset,
                                                value_dim,
                                                cache_len,
@@ -33147,10 +33205,10 @@ static int ds4_gpu_glm_attention_flash_tensor_impl(
             id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
             [enc setComputePipelineState:pad_pipeline];
             [enc setBytes:&pad_args length:sizeof(pad_args) atIndex:0];
-            [enc setBuffer:g_flash_attn_kv_buffer offset:key_f16_offset atIndex:1];
-            [enc setBuffer:g_flash_attn_kv_buffer offset:value_f16_offset atIndex:2];
+            [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:key_f16_offset atIndex:1];
+            [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:value_f16_offset atIndex:2];
             [enc setBuffer:mask_buffer offset:0 atIndex:3];
-            [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:4];
+            [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:4];
             [enc dispatchThreadgroups:MTLSizeMake(ncpsg, n_head, 1)
                  threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
             ds4_gpu_end_compute_encoder(cb, enc);
@@ -33171,7 +33229,7 @@ static int ds4_gpu_glm_attention_flash_tensor_impl(
         [enc setComputePipelineState:blk_pipeline];
         [enc setBytes:&blk_args length:sizeof(blk_args) atIndex:0];
         [enc setBuffer:mask_buffer offset:0 atIndex:1];
-        [enc setBuffer:g_flash_attn_blk_buffer offset:0 atIndex:2];
+        [enc setBuffer:g_flash_attn_blk_buffer[g_ds4_stream] offset:0 atIndex:2];
         [enc dispatchThreadgroups:MTLSizeMake(nblk0, nblk1, 1)
              threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
         ds4_gpu_end_compute_encoder(cb, enc);
@@ -33220,12 +33278,12 @@ static int ds4_gpu_glm_attention_flash_tensor_impl(
         [enc setComputePipelineState:attn_pipeline];
         [enc setBytes:&args length:sizeof(args) atIndex:0];
         [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:key_f16_offset atIndex:2];
-        [enc setBuffer:g_flash_attn_kv_buffer offset:value_f16_offset atIndex:3];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:key_f16_offset atIndex:2];
+        [enc setBuffer:g_flash_attn_kv_buffer[g_ds4_stream] offset:value_f16_offset atIndex:3];
         [enc setBuffer:mask_buffer offset:0 atIndex:4];
         [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:5];
-        [enc setBuffer:g_flash_attn_pad_buffer offset:0 atIndex:6];
-        [enc setBuffer:g_flash_attn_blk_buffer offset:0 atIndex:7];
+        [enc setBuffer:g_flash_attn_pad_buffer[g_ds4_stream] offset:0 atIndex:6];
+        [enc setBuffer:g_flash_attn_blk_buffer[g_ds4_stream] offset:0 atIndex:7];
         [enc setBuffer:headsbuf offset:ds4_gpu_tensor_offset(heads) atIndex:8];
         [enc setThreadgroupMemoryLength:shared_bytes atIndex:0];
         [enc dispatchThreadgroups:MTLSizeMake(nblk1, n_head, 1)
@@ -36422,15 +36480,15 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_tensor(
             fprintf(stderr, "ds4: Metal GLM grouped routed MoE received undersized activation buffers\n");
             return 0;
         }
-        if (!ds4_gpu_ensure_scratch_buffer(&g_moe_gate_scratch_buffer,
-                                           &g_moe_gate_scratch_bytes,
+        if (!ds4_gpu_ensure_scratch_buffer(&g_moe_gate_scratch_buffer[g_ds4_stream],
+                                           &g_moe_gate_scratch_bytes[g_ds4_stream],
                                            (NSUInteger)(gate_scratch_bytes * 2ull),
                                            "ds4_glm_moe_gate_up_scratch")) {
             return 0;
         }
         if (n_expert > 1 &&
-            !ds4_gpu_ensure_scratch_buffer(&g_moe_down_scratch_buffer,
-                                           &g_moe_down_scratch_bytes,
+            !ds4_gpu_ensure_scratch_buffer(&g_moe_down_scratch_buffer[g_ds4_stream],
+                                           &g_moe_down_scratch_bytes[g_ds4_stream],
                                            (NSUInteger)down_scratch_bytes,
                                            "ds4_glm_moe_down_scratch")) {
             return 0;
@@ -36547,7 +36605,7 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_tensor(
                                                        (NSUInteger)gate_inner,
                                                        xbuf,
                                                        ds4_gpu_tensor_offset(x),
-                                                       g_moe_gate_scratch_buffer,
+                                                       g_moe_gate_scratch_buffer[g_ds4_stream],
                                                        0,
                                                        mm_id_threadgroup_bytes);
         }
@@ -36560,16 +36618,16 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_tensor(
                                                        (NSUInteger)up_inner,
                                                        xbuf,
                                                        ds4_gpu_tensor_offset(x),
-                                                       g_moe_gate_scratch_buffer,
+                                                       g_moe_gate_scratch_buffer[g_ds4_stream],
                                                        (NSUInteger)gate_scratch_bytes,
                                                        mm_id_threadgroup_bytes);
         }
         DS4_METAL_PROFILE_GLM_GROUPED_MOE_STAGE("up");
         if (ok) {
             ok = ds4_gpu_encode_moe_swiglu_weight(cb,
-                                                   g_moe_gate_scratch_buffer,
+                                                   g_moe_gate_scratch_buffer[g_ds4_stream],
                                                    0,
-                                                   g_moe_gate_scratch_buffer,
+                                                   g_moe_gate_scratch_buffer[g_ds4_stream],
                                                    (NSUInteger)gate_scratch_bytes,
                                                    midbuf,
                                                    ds4_gpu_tensor_offset(mid),
@@ -36582,7 +36640,7 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_tensor(
         }
         DS4_METAL_PROFILE_GLM_GROUPED_MOE_STAGE("activation_weight");
 
-        id<MTLBuffer> down_dst = n_expert == 1 ? outbuf : g_moe_down_scratch_buffer;
+        id<MTLBuffer> down_dst = n_expert == 1 ? outbuf : g_moe_down_scratch_buffer[g_ds4_stream];
         NSUInteger down_dst_off = n_expert == 1 ? ds4_gpu_tensor_offset(out) : 0;
         if (ok) {
             ok = ds4_gpu_encode_mul_mm_id_mapped_tile(cb,
@@ -36711,15 +36769,15 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_addr_tensor(
             fprintf(stderr, "ds4: Metal GLM grouped-address routed MoE received undersized activation buffers\n");
             return 0;
         }
-        if (!ds4_gpu_ensure_scratch_buffer(&g_moe_gate_scratch_buffer,
-                                           &g_moe_gate_scratch_bytes,
+        if (!ds4_gpu_ensure_scratch_buffer(&g_moe_gate_scratch_buffer[g_ds4_stream],
+                                           &g_moe_gate_scratch_bytes[g_ds4_stream],
                                            (NSUInteger)(gate_scratch_bytes * 2ull),
                                            "ds4_glm_moe_gate_up_scratch")) {
             return 0;
         }
         if (n_expert > 1 &&
-            !ds4_gpu_ensure_scratch_buffer(&g_moe_down_scratch_buffer,
-                                           &g_moe_down_scratch_bytes,
+            !ds4_gpu_ensure_scratch_buffer(&g_moe_down_scratch_buffer[g_ds4_stream],
+                                           &g_moe_down_scratch_bytes[g_ds4_stream],
                                            (NSUInteger)down_scratch_bytes,
                                            "ds4_glm_moe_down_scratch")) {
             return 0;
@@ -36819,7 +36877,7 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_addr_tensor(
                                                            gate_addrs,
                                                            xbuf,
                                                            ds4_gpu_tensor_offset(x),
-                                                           g_moe_gate_scratch_buffer,
+                                                           g_moe_gate_scratch_buffer[g_ds4_stream],
                                                            0,
                                                            mm_id_threadgroup_bytes,
                                                            resources,
@@ -36835,7 +36893,7 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_addr_tensor(
                                                            up_addrs,
                                                            xbuf,
                                                            ds4_gpu_tensor_offset(x),
-                                                           g_moe_gate_scratch_buffer,
+                                                           g_moe_gate_scratch_buffer[g_ds4_stream],
                                                            (NSUInteger)gate_scratch_bytes,
                                                            mm_id_threadgroup_bytes,
                                                            resources,
@@ -36846,9 +36904,9 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_addr_tensor(
         DS4_METAL_PROFILE_GLM_GROUPED_ADDR_MOE_STAGE("up");
         if (ok) {
             ok = ds4_gpu_encode_moe_swiglu_weight(cb,
-                                                   g_moe_gate_scratch_buffer,
+                                                   g_moe_gate_scratch_buffer[g_ds4_stream],
                                                    0,
-                                                   g_moe_gate_scratch_buffer,
+                                                   g_moe_gate_scratch_buffer[g_ds4_stream],
                                                    (NSUInteger)gate_scratch_bytes,
                                                    midbuf,
                                                    ds4_gpu_tensor_offset(mid),
@@ -36861,7 +36919,7 @@ static int ds4_gpu_glm_routed_moe_batch_grouped_addr_tensor(
         }
         DS4_METAL_PROFILE_GLM_GROUPED_ADDR_MOE_STAGE("activation_weight");
 
-        id<MTLBuffer> down_dst = n_expert == 1 ? outbuf : g_moe_down_scratch_buffer;
+        id<MTLBuffer> down_dst = n_expert == 1 ? outbuf : g_moe_down_scratch_buffer[g_ds4_stream];
         NSUInteger down_dst_off = n_expert == 1 ? ds4_gpu_tensor_offset(out) : 0;
         if (ok) {
             ok = ds4_gpu_encode_mul_mm_id_addr_mapped_tile(cb,
@@ -37900,8 +37958,8 @@ int ds4_gpu_routed_moe_one_tensor(
         const uint32_t pair_rows = n_tokens * n_expert;
         const uint64_t down_scratch_bytes = (uint64_t)pair_rows * out_dim * sizeof(float);
         if ((n_expert > 1 && !expertsbuf &&
-             !ds4_gpu_ensure_scratch_buffer(&g_moe_down_scratch_buffer,
-                                              &g_moe_down_scratch_bytes,
+             !ds4_gpu_ensure_scratch_buffer(&g_moe_down_scratch_buffer[g_ds4_stream],
+                                              &g_moe_down_scratch_bytes[g_ds4_stream],
                                               (NSUInteger)down_scratch_bytes,
                                               "ds4_moe_down_scratch"))) {
             if (getenv("DS4_GLM_TP_DEBUG")) fprintf(stderr, "ds4: routed_moe_one silent return at line %d\n", 32148);
@@ -38573,25 +38631,25 @@ int ds4_gpu_routed_moe_one_tensor(
                 }
                 const NSUInteger gate_slots_bytes = (NSUInteger)(6ull * gate_expert_bytes);
                 const NSUInteger down_slots_bytes = (NSUInteger)(6ull * down_expert_bytes);
-                if (!ds4_gpu_ensure_scratch_buffer(&g_moe_q4_gate_slots_buffer,
-                                                    &g_moe_q4_gate_slots_bytes,
+                if (!ds4_gpu_ensure_scratch_buffer(&g_moe_q4_gate_slots_buffer[g_ds4_stream],
+                                                    &g_moe_q4_gate_slots_bytes[g_ds4_stream],
                                                     gate_slots_bytes,
                                                     "ds4_moe_q4_gate_slots") ||
-                    !ds4_gpu_ensure_scratch_buffer(&g_moe_q4_up_slots_buffer,
-                                                    &g_moe_q4_up_slots_bytes,
+                    !ds4_gpu_ensure_scratch_buffer(&g_moe_q4_up_slots_buffer[g_ds4_stream],
+                                                    &g_moe_q4_up_slots_bytes[g_ds4_stream],
                                                     gate_slots_bytes,
                                                     "ds4_moe_q4_up_slots") ||
-                    !ds4_gpu_ensure_scratch_buffer(&g_moe_q4_down_slots_buffer,
-                                                    &g_moe_q4_down_slots_bytes,
+                    !ds4_gpu_ensure_scratch_buffer(&g_moe_q4_down_slots_buffer[g_ds4_stream],
+                                                    &g_moe_q4_down_slots_bytes[g_ds4_stream],
                                                     down_slots_bytes,
                                                     "ds4_moe_q4_down_slots")) {
                     if (getenv("DS4_GLM_TP_DEBUG")) fprintf(stderr, "ds4: routed_moe_one silent return at line %d\n", 32670);
                     return 0;
                 }
                 for (uint32_t i = 0; i < 6; i++) {
-                    gate_slot_bufs[i] = g_moe_q4_gate_slots_buffer;
-                    up_slot_bufs[i] = g_moe_q4_up_slots_buffer;
-                    down_slot_bufs[i] = g_moe_q4_down_slots_buffer;
+                    gate_slot_bufs[i] = g_moe_q4_gate_slots_buffer[g_ds4_stream];
+                    up_slot_bufs[i] = g_moe_q4_up_slots_buffer[g_ds4_stream];
+                    down_slot_bufs[i] = g_moe_q4_down_slots_buffer[g_ds4_stream];
                     gate_slot_offsets[i] = (NSUInteger)((uint64_t)i * gate_expert_bytes);
                     up_slot_offsets[i] = (NSUInteger)((uint64_t)i * gate_expert_bytes);
                     down_slot_offsets[i] = (NSUInteger)((uint64_t)i * down_expert_bytes);
@@ -39343,7 +39401,7 @@ int ds4_gpu_routed_moe_one_tensor(
                                                   gate_group6_offsets,
                                                   selectedbuf,
                                                   ds4_gpu_tensor_offset(selected),
-                                                  g_moe_q4_gate_slots_buffer,
+                                                  g_moe_q4_gate_slots_buffer[g_ds4_stream],
                                                   0) &&
                  ds4_gpu_encode_q4_gather_slots6(cb,
                                                   g_moe_q4_gather_slots6_pipeline,
@@ -39352,7 +39410,7 @@ int ds4_gpu_routed_moe_one_tensor(
                                                   up_group6_offsets,
                                                   selectedbuf,
                                                   ds4_gpu_tensor_offset(selected),
-                                                  g_moe_q4_up_slots_buffer,
+                                                  g_moe_q4_up_slots_buffer[g_ds4_stream],
                                                   0) &&
                  ds4_gpu_encode_q4_gather_slots6(cb,
                                                   g_moe_q4_gather_slots6_pipeline,
@@ -39361,7 +39419,7 @@ int ds4_gpu_routed_moe_one_tensor(
                                                   down_group6_offsets,
                                                   selectedbuf,
                                                   ds4_gpu_tensor_offset(selected),
-                                                  g_moe_q4_down_slots_buffer,
+                                                  g_moe_q4_down_slots_buffer[g_ds4_stream],
                                                   0);
         }
         if (use_q4_gather_slots) {
@@ -40063,7 +40121,7 @@ int ds4_gpu_routed_moe_one_tensor(
             ok = ds4_gpu_parallel_q8_matvec_encode_pending(cb, midbuf) != 0;
         }
 
-        id<MTLBuffer> down_dst = n_expert == 1 ? outbuf : (expertsbuf ? expertsbuf : g_moe_down_scratch_buffer);
+        id<MTLBuffer> down_dst = n_expert == 1 ? outbuf : (expertsbuf ? expertsbuf : g_moe_down_scratch_buffer[g_ds4_stream]);
         NSUInteger down_dst_off = n_expert == 1 ? ds4_gpu_tensor_offset(out) :
             (expertsbuf ? ds4_gpu_tensor_offset(experts) : 0);
         if (ok && stream_expert_split_completed) {
@@ -41005,8 +41063,8 @@ int ds4_gpu_routed_moe_batch_tensor(
         } else if (use_iq2_batch_selected_addr) {
             if (n_expert > 1 && (!expertsbuf ||
                 ds4_gpu_tensor_bytes(experts) < down_scratch_bytes)) {
-                if (!ds4_gpu_ensure_scratch_buffer(&g_moe_down_scratch_buffer,
-                                                   &g_moe_down_scratch_bytes,
+                if (!ds4_gpu_ensure_scratch_buffer(&g_moe_down_scratch_buffer[g_ds4_stream],
+                                                   &g_moe_down_scratch_bytes[g_ds4_stream],
                                                    (NSUInteger)down_scratch_bytes,
                                                    "ds4_moe_down_scratch")) {
                     ds4_gpu_stream_expert_cache_clear_layer(layer_index);
@@ -41016,8 +41074,8 @@ int ds4_gpu_routed_moe_batch_tensor(
         } else {
             if (n_expert > 1 && (!expertsbuf ||
                 ds4_gpu_tensor_bytes(experts) < down_scratch_bytes)) {
-                if (!ds4_gpu_ensure_scratch_buffer(&g_moe_down_scratch_buffer,
-                                                   &g_moe_down_scratch_bytes,
+                if (!ds4_gpu_ensure_scratch_buffer(&g_moe_down_scratch_buffer[g_ds4_stream],
+                                                   &g_moe_down_scratch_bytes[g_ds4_stream],
                                                    (NSUInteger)down_scratch_bytes,
                                                    "ds4_moe_down_scratch")) {
                     return 0;
@@ -41490,7 +41548,7 @@ int ds4_gpu_routed_moe_batch_tensor(
         }
         DS4_METAL_PROFILE_MOE_STAGE("activation_weight");
 
-        id<MTLBuffer> down_dst = n_expert == 1 ? outbuf : (expertsbuf ? expertsbuf : g_moe_down_scratch_buffer);
+        id<MTLBuffer> down_dst = n_expert == 1 ? outbuf : (expertsbuf ? expertsbuf : g_moe_down_scratch_buffer[g_ds4_stream]);
         NSUInteger down_dst_off = n_expert == 1 ? ds4_gpu_tensor_offset(out) :
             (expertsbuf ? ds4_gpu_tensor_offset(experts) : 0);
         if (ok) {
@@ -42306,7 +42364,7 @@ int ds4_gpu_hc_rms_norm_mix_split_norm_f16_tensor(
             g_dsv4_hc_producer_last_mix_offset = mix_offset;
             g_dsv4_hc_producer_last_completion = completion;
         }
-        [g_transient_buffers addObject:completion];
+        [g_transient_buffers[g_ds4_stream] addObject:completion];
 
         ds4_gpu_hc_norm_mix_args mix_args = {
             .n = (int32_t)n,


### PR DESCRIPTION
## What

When `ds4_sessions_eval_batch` receives an all-DeepSeek, non-TP decode batch, encode each session's decode pass on **its own Metal command queue** and commit without waiting, then collect all streams. Independent queues let the GPU overlap the latency-bound per-token kernel chains that a single serial queue executes back-to-back.

Mechanics:
- thread-local stream index (`ds4_gpu_set_stream`), lazily created per-stream queues (each gets the model residency set);
- the lazily-grown scratch buffers (`g_*_buffer/_bytes`, transient pool) become per-stream sets so concurrently executing streams never share mutable GPU state — this is the bulk of the diff and is mechanical;
- `ds4_gpu_end_commands_async` / `ds4_gpu_wait_stream`, plus a public `ds4_session_eval_begin/_end` pair for library/CLI callers;
- CPU-side encoding stays single-threaded; only GPU execution overlaps.

Best paired with `DS4_METAL_MODEL_UNTRACKED=1`: hazard tracking on the two shared model buffers otherwise serializes the queues (measured +63% from that flag alone under multi-stream).

## Why

Batch-1 decode on Apple silicon is latency-bound, not bandwidth-bound: an M3 Ultra (2x cores, 1.5x bandwidth of an M5 Max) decodes only ~7% faster. A microbenchmark of dependent skinny-kernel chains shows 4 queues overlap at ~2.3x aggregate on M5 Max. This PR converts that idle capacity into multi-session throughput.

## Measured

M5 Max 128GB, DeepSeek V4 Flash IQ2XXS, inside `ds4-server --batched-session 8` (machine concurrently running an unrelated PyTorch training job, so absolute numbers are depressed; ratios are same-conditions):

| decode path | ms per token per session |
|---|---|
| solo request (count=1) | 116 |
| existing native Metal session batch | ~110/row (count 2-3) |
| **this PR, count=8** | **68.5/row (~1.7x)** |

CLI validation on the same machine: at temperature 0, N concurrent streams produce byte-identical output to solo runs (verified N=4, with and without the untracked flag).

## Scope / fallbacks

- GLM sessions, tensor-parallel, and mirror mode keep the existing single-queue path untouched.
- `DS4_METAL_NO_STREAM_OVERLAP=1` restores current behavior entirely.
- Currently overlap takes precedence over the native fused session batch when both apply; happy to flip that default or gate per-backend if you prefer — under our measurements the native path was ~110ms/row while overlap was ~68ms/row, but that deserves confirmation on an uncontended machine and on CUDA-era hardware it may differ.

## Caveats

- Tested on one machine (M5 Max), under GPU contention; would value numbers from an idle M3 Ultra / M4 Max.
- Waiting only the last committed buffer per queue relies on per-queue FIFO completion; capped at 8 streams.
- In the spirit of the project's README: this was built with strong AI assistance (Claude), with measurements driving every step. Full diagnostic trail (dispatch census, per-stage decode budget, queue-overlap microbenchmarks) available if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194nbHLo3afzCgw1QW3zpTX