### PR TITLE
cuda: keep the support model map from evicting the primary (enables single-GPU DSpark)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -57983,12 +57983,16 @@ static int ds4_engine_open_internal(ds4_engine **out,
         const bool support_model_runtime_ready =
             e->mtp_ready ||
             (e->support_kind == DS4_SUPPORT_DSPARK && e->dspark);
+        /* The support model rides a SECONDARY mapping: the primary
+         * set_model_map path is single-model and would release the main
+         * model's cached ranges + dequant caches and unregister its host
+         * mapping, poisoning every later main-weight resolution. */
         if (support_model_runtime_ready &&
-            !ds4_gpu_set_model_map_range(e->mtp_model.map,
-                                           e->mtp_model.size,
-                                           e->mtp_model.tensor_data_pos,
-                                           e->mtp_model.size - e->mtp_model.tensor_data_pos,
-                                           e->mtp_model.max_tensor_bytes))
+            !ds4_gpu_set_secondary_model_map(e->mtp_model.map,
+                                             e->mtp_model.size,
+                                             e->mtp_model.tensor_data_pos,
+                                             e->mtp_model.size - e->mtp_model.tensor_data_pos,
+                                             e->mtp_model.max_tensor_bytes))
         {
             fprintf(stderr,
                     "ds4: %s failed to map support model views; aborting startup. "

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -89,6 +89,13 @@ static const void *g_model_host_base;
 static const char *g_model_device_base;
 static uint64_t g_model_registered_size;
 static int g_model_registered;
+/* Secondary model map (the --mtp support GGUF). Registered ALONGSIDE the
+ * primary: a second model must never evict the primary's ranges, dequant
+ * caches, or host registration the way ds4_gpu_set_model_map does. */
+static const void *g_secondary_host_base;
+static const char *g_secondary_device_base;
+static uint64_t g_secondary_size;
+static int g_secondary_registered;
 static thread_local bool g_glm_mtp_verify_mode;
 static int g_model_device_owned;
 static int g_model_range_mapping_supported = 1;
@@ -697,11 +704,18 @@ static int cuda_attention_score_buffer_fits(uint32_t n_comp) {
 
 static const char *cuda_model_ptr(const void *model_map, uint64_t offset) {
     if (model_map == g_model_host_base && g_model_device_base) return g_model_device_base + offset;
+    if (model_map == g_secondary_host_base && g_secondary_device_base) {
+        return g_secondary_device_base + offset;
+    }
     return (const char *)model_map + offset;
 }
 
 static const char *cuda_model_range_ptr(const void *model_map, uint64_t offset, uint64_t bytes, const char *what) {
     if (bytes == 0) return cuda_model_ptr(model_map, offset);
+    if (model_map == g_secondary_host_base && g_secondary_device_base &&
+        bytes <= g_secondary_size && offset <= g_secondary_size - bytes) {
+        return g_secondary_device_base + offset;
+    }
     if (g_model_device_owned || g_model_registered) return cuda_model_ptr(model_map, offset);
     if (g_model_hmm_direct &&
         getenv("DS4_CUDA_WEIGHT_CACHE") == NULL &&
@@ -1307,6 +1321,10 @@ static const char *cuda_resolve_weight_ptr(const void *model_map,
 
 static int cuda_model_range_is_cached(const void *model_map, uint64_t offset, uint64_t bytes) {
     if (bytes == 0) return 1;
+    if (model_map == g_secondary_host_base && g_secondary_device_base &&
+        bytes <= g_secondary_size && offset <= g_secondary_size - bytes) {
+        return 1;
+    }
     if (g_model_device_owned || g_model_registered) return 1;
 
     const uint64_t end = offset + bytes;
@@ -2887,6 +2905,13 @@ extern "C" void ds4_gpu_cleanup(void) {
     if (g_model_registered && g_model_host_base) {
         (void)cudaHostUnregister((void *)g_model_host_base);
     }
+    if (g_secondary_registered && g_secondary_host_base) {
+        (void)cudaHostUnregister((void *)g_secondary_host_base);
+    }
+    g_secondary_host_base = NULL;
+    g_secondary_device_base = NULL;
+    g_secondary_size = 0;
+    g_secondary_registered = 0;
     g_model_host_base = NULL;
     g_model_device_base = NULL;
     g_model_registered_size = 0;
@@ -3783,6 +3808,52 @@ extern "C" int ds4_gpu_set_model_map_range(const void *model_map, uint64_t model
         !cuda_model_copy_chunked(model_map, model_size, map_offset, map_size)) {
         (void)cuda_model_prefetch_range(model_map, model_size, map_offset, map_size);
     }
+    return 1;
+}
+
+/* Map a SECOND model (the --mtp support GGUF) next to the primary. The
+ * primary setters above are single-model by design: they release every
+ * cached range, free the dequant caches, and unregister the previous host
+ * mapping before taking over the bookkeeping. Routing the support model
+ * through them therefore destroys the primary model's device residency,
+ * and every later primary-weight resolution degrades to a raw unpinned
+ * host pointer (illegal address under the sm_121 TMA matmul kernels).
+ * This entry point touches none of the primary state. */
+extern "C" int ds4_gpu_set_secondary_model_map(const void *model_map, uint64_t model_size, uint64_t map_offset, uint64_t map_size, uint64_t max_tensor_bytes) {
+    (void)map_offset;
+    (void)map_size;
+    (void)max_tensor_bytes;
+    if (!model_map || model_size == 0) return 0;
+    if (g_secondary_host_base == model_map && g_secondary_size == model_size) return 1;
+    if (g_secondary_registered && g_secondary_host_base) {
+        (void)cudaHostUnregister((void *)g_secondary_host_base);
+    }
+    g_secondary_registered = 0;
+    g_secondary_device_base = NULL;
+    g_secondary_host_base = model_map;
+    g_secondary_size = model_size;
+    cudaError_t err = cudaHostRegister((void *)model_map, (size_t)model_size,
+                                       cudaHostRegisterMapped | cudaHostRegisterReadOnly);
+    if (err == cudaSuccess) {
+        void *dev = NULL;
+        err = cudaHostGetDevicePointer(&dev, (void *)model_map, 0);
+        if (err == cudaSuccess && dev) {
+            g_secondary_device_base = (const char *)dev;
+            g_secondary_registered = 1;
+            fprintf(stderr,
+                    "ds4: CUDA (no-copy) registered %.2f GiB secondary model mapping\n",
+                    (double)model_size / 1073741824.0);
+            return 1;
+        }
+        (void)cudaHostUnregister((void *)model_map);
+    }
+    (void)cudaGetLastError();
+    /* Unified-memory fallback: the raw host pointer is device-accessible on
+     * HMM-capable parts; kernels read the mmap directly, just unpinned. */
+    g_secondary_device_base = (const char *)model_map;
+    fprintf(stderr,
+            "ds4: CUDA secondary model mapping unregistered (HMM direct, %.2f GiB)\n",
+            (double)model_size / 1073741824.0);
     return 1;
 }
 

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -118,6 +118,7 @@ int ds4_gpu_build_derived_artifacts(const void *model_map, uint64_t model_size,
 int ds4_gpu_model_range_replaced(const void *model_map, uint64_t offset,
                                  uint64_t bytes);
 int ds4_gpu_set_model_map_range(const void *model_map, uint64_t model_size, uint64_t map_offset, uint64_t map_size, uint64_t max_tensor_bytes);
+int ds4_gpu_set_secondary_model_map(const void *model_map, uint64_t model_size, uint64_t map_offset, uint64_t map_size, uint64_t max_tensor_bytes);
 int ds4_gpu_set_model_map_spans(const void *model_map, uint64_t model_size, const uint64_t *offsets, const uint64_t *sizes, uint32_t count, uint64_t max_tensor_bytes);
 int ds4_gpu_cache_model_range(const void *model_map, uint64_t model_size, uint64_t offset, uint64_t bytes, const char *label);
 int ds4_gpu_cache_q8_f16_range(const void *model_map, uint64_t model_size, uint64_t offset, uint64_t bytes, uint64_t in_dim, uint64_t out_dim, const char *label);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -11363,6 +11363,15 @@ int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size) {
     return ds4_gpu_set_model_map_range(model_map, model_size, 0, model_size, 0);
 }
 
+/* Secondary (support-model) mapping. Metal's view table already holds views
+ * for multiple model_map bases side by side, so the existing range path is
+ * the correct behavior here; the dedicated entry point exists because the
+ * CUDA backend's model-map bookkeeping is single-model and needs a separate
+ * registration to keep a second model from evicting the first. */
+int ds4_gpu_set_secondary_model_map(const void *model_map, uint64_t model_size, uint64_t map_offset, uint64_t map_size, uint64_t max_tensor_bytes) {
+    return ds4_gpu_set_model_map_range(model_map, model_size, map_offset, map_size, max_tensor_bytes);
+}
+
 int ds4_gpu_set_model_fd(int fd) {
     g_model_fd = fd;
     return 1;


### PR DESCRIPTION
## Problem

`--dspark` has never worked on a single CUDA GPU. On a GB10 (sm_121) it fails at
engine open or at first prefill, in two apparent ways that turn out to be one bug:

1. Load time: `dequant_q8_0_to_f16_kernel` reads ~79 GB out of bounds while the
   Q8 preload caches main-model tensors (compute-sanitizer: the faulting base is
   the support GGUF's 5.99 GB allocation plus a main-model offset).
2. First prefill/warmup: `ds4: cuBLAS f16 rms-fold matmul failed: status 14`
   right after "DSpark target-hidden capture enabled", then an illegal-access
   cascade.

## Root cause

The CUDA model-map bookkeeping is a single-model singleton. When the engine maps
the `--mtp` support GGUF through `ds4_gpu_set_model_map_range` /
`ds4_gpu_register_model_map_no_copy`, the setter releases every cached
main-model range (`cuda_model_range_release_all`), frees the Q8 F16/F32 dequant
caches, host-unregisters the primary mapping, and repoints
`g_model_host_base` at the support model. Every later main-model weight
resolution then falls through `cuda_model_ptr` to a raw, unpinned host mmap
pointer, which the sm_121 TMA matmul kernels fault on.

Two-GPU DSpark never hit this because the multi-tier path places support
weights per tier (`engine_install_dspark_support_cache`) and does not rely on
the singleton. Metal never hit it because `ds4_metal.m` keeps a view table that
holds multiple model_map bases side by side.

## Fix

Add a secondary model-map registration that coexists with the primary instead
of evicting it:

- `ds4_cuda.cu`: `ds4_gpu_set_secondary_model_map()` host-registers the support
  mapping (`cudaHostRegisterMapped | ReadOnly`) with its own bookkeeping and a
  raw-pointer HMM fallback; `cuda_model_ptr`, `cuda_model_range_ptr` (bounds
  checked), and `cuda_model_range_is_cached` learn to resolve through it;
  cleanup unregisters it.
- `ds4.c`: the support model maps through the secondary entry point instead of
  the primary setter.
- `ds4_metal.m`: passthrough to `ds4_gpu_set_model_map_range` (the view table
  already handles multiple maps; behavior unchanged).
- ROCm compiles the same translation unit as CUDA and inherits the fix.

No change to any decode/verify path; the multi-GPU flow is untouched (the
single-tier map site is only reached when the multi-tier branch is not taken).

## Results (GB10, CUDA, single GPU)

Model: DeepSeek-V4-Flash IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8 (0731 imatrix build),
support GGUF: DeepSeek-V4-Flash-DSpark-support-0731. Greedy, `--nothink`,
`-c 8192 -n 256`, code prompt, `DS4_CUDA_Q8_NO_ALIGNED=1` (separate,
pre-existing sm_121 alignment issue, applies identically to both runs).

| mode              | generation |
|-------------------|-----------|
| `--dspark-strict` | 21.33 / 21.30 t/s (two runs) |
| `--dspark`        | 27.06 / 27.20 / 27.08 t/s (three runs) |

+27%, accept_rate 91.1%, avg 3.87 of block 5 per drafted cycle
(`DS4_DSPARK_STATS=1`), and the DSpark output was byte-identical to the strict
run in every pairing. Longer generations (`-n 512`) hold accept at 88% but
draft fewer cycles (no_draft rises); separate observation, not part of this
change. Disabling the scheduler makes things worse (75.8% accept); the default
heuristic behaves correctly.

## Commands run

```
make ds4
DS4_CUDA_Q8_NO_ALIGNED=1 ./ds4 --cuda -m <2bit-moe-mix>.gguf \
  --mtp DeepSeek-V4-Flash-DSpark-support-0731.gguf \
  --dspark --nothink --temp 0 -c 8192 -n 256 -p "<code prompt>"
```

(and the same with `--dspark-strict` for the control)

## Regression tests

- `./ds4_test --server`: OK.
- `./ds4_test --logprob-vectors` (2-bit reference quant above): the three short
  vectors pass; the two long vectors (`long_memory_archive`, `long_code_audit`)
  fail 16 assertions. Control: an unmodified `origin/main` worktree fails the
  same 16 assertions identically, with and without `DS4_CUDA_Q8_NO_ALIGNED=1`,
  so this is pre-existing on this quant/hardware and unrelated to the change
  (which is also inert in that test: no `--mtp` model is loaded, so the
  secondary map is never registered and every added branch compares against a
  NULL base). Full `make test` with the default model exceeds GB10 memory on
  this box.
- Strongest receipt for the changed path: the DSpark and strict runs above
  produce byte-identical output in paired runs, exercising the secondary-map
  resolution end to end.

