### PR TITLE
cuda: GB10 decode speedups (+21% generation tok/s on DGX Spark)

### DIFF
--- a/cuda/mmq/ds4_mmq.cu
+++ b/cuda/mmq/ds4_mmq.cu
@@ -95,7 +95,7 @@ private:
 // Init
 // ----------------------------------------------------------------------------
 
-// Step 7 task #29: experimental persistent Q8_1 scratch buffer.
+// Persistent Q8_1 scratch buffer.
 //
 // Hypothesis: ggml_cuda_pool_alloc inside ds4_mmq_moe_vec_impl records a
 // cudaMallocAsync graph node into the captured layer graph.  At replay
@@ -104,18 +104,27 @@ private:
 // the matvec reads stale/wrong memory and produces a different output
 // than eager execution, even with identical inputs.
 //
-// Mitigation under test: pre-allocate a persistent device buffer at
-// startup via plain cudaMalloc (NOT cudaMallocAsync, NOT inside any
-// capture).  When the env flag DS4_CUDA_MMQ_Q81_PERSISTENT=1 is set,
-// ds4_mmq_moe_vec_impl uses this persistent buffer instead of pool_alloc.
+// Pre-allocate a persistent device buffer at startup via plain cudaMalloc
+// (NOT cudaMallocAsync, NOT inside any capture).  This is the default on
+// integrated Blackwell devices such as GB10.  DS4_CUDA_MMQ_Q81_PERSISTENT=0
+// restores the pool path; =1 opts other CUDA devices into the same path.
 //
 // Sized for V4 Flash decode shapes: gate Q8_1 ~8 KB, down Q8_1 ~14 KB.
 // 256 KB allocation gives generous headroom for short prefill batches.
 static void *g_q81_scratch_ptr   = nullptr;
 static size_t g_q81_scratch_bytes = 0;
 static bool   g_q81_scratch_enabled = false;
+static int    g_q81_scratch_device = -1;
 static void  *g_aligned_q81_scratch_ptr = nullptr;
 static size_t g_aligned_q81_scratch_bytes = 0;
+
+static bool q81_persistent_requested(int device,
+                                     const ggml_cuda_device_info &info) {
+    const char *env = getenv("DS4_CUDA_MMQ_Q81_PERSISTENT");
+    if (env && env[0] == '0') return false;
+    if (env && env[0] == '1') return true;
+    return info.devices[device].integrated && info.devices[device].cc >= 1200;
+}
 
 extern "C" void ds4_mmq_set_aligned_q81_scratch(void *ptr, size_t bytes) {
     g_aligned_q81_scratch_ptr = ptr;
@@ -298,11 +307,12 @@ extern "C" int ds4_mmq_init(int device) {
         return -1;
     }
 
-    // Step 7 task #29: pre-allocate persistent Q8_1 scratch if enabled.
+    // Allocate before any layer-graph capture so every replay sees the same
+    // pointer and avoids stream-ordered allocation/free nodes.
     // Must happen here (before any layer-graph capture) so the cudaMalloc
     // is not forbidden by capture-mode restrictions, and so the kernel
     // pointer arg baked into the captured graph stays valid at replay.
-    if (getenv("DS4_CUDA_MMQ_Q81_PERSISTENT") && !g_q81_scratch_ptr) {
+    if (q81_persistent_requested(device, info) && !g_q81_scratch_ptr) {
         const size_t bytes = 256 * 1024;
         cudaError_t err = cudaMalloc(&g_q81_scratch_ptr, bytes);
         if (err != cudaSuccess) {
@@ -314,11 +324,30 @@ extern "C" int ds4_mmq_init(int device) {
         } else {
             g_q81_scratch_bytes = bytes;
             g_q81_scratch_enabled = true;
+            g_q81_scratch_device = device;
             fprintf(stderr, "ds4_mmq_init: persistent Q8_1 scratch enabled (%zu B at %p)\n",
                     bytes, g_q81_scratch_ptr);
         }
     }
     return 0;
+}
+
+extern "C" void ds4_mmq_cleanup(void) {
+    g_aligned_q81_scratch_ptr = nullptr;
+    g_aligned_q81_scratch_bytes = 0;
+    if (g_q81_scratch_ptr) {
+        int previous = -1;
+        (void)cudaGetDevice(&previous);
+        if (g_q81_scratch_device >= 0) {
+            (void)cudaSetDevice(g_q81_scratch_device);
+        }
+        (void)cudaFree(g_q81_scratch_ptr);
+        if (previous >= 0) (void)cudaSetDevice(previous);
+        g_q81_scratch_ptr = nullptr;
+    }
+    g_q81_scratch_bytes = 0;
+    g_q81_scratch_enabled = false;
+    g_q81_scratch_device = -1;
 }
 
 // ----------------------------------------------------------------------------
@@ -3837,6 +3866,59 @@ extern "C" int ds4_mmq_q8_0_aligned_dense_vec(
     err = cudaGetLastError();
     if (err != cudaSuccess) {
         fprintf(stderr, "%s: kernel launch failed: %s\n", tag, cudaGetErrorString(err));
+        return -3;
+    }
+    return 0;
+}
+
+extern "C" int ds4_mmq_q8_0_aligned_dense_pair_vec(
+        const void *W0_aligned, const void *W1_aligned,
+        const float *X_f32, float *out0_f32, float *out1_f32,
+        int M0, int M1, int K, cudaStream_t stream) {
+    const char *tag = "ds4_mmq_q8_0_aligned_dense_pair_vec";
+    if (!W0_aligned || !W1_aligned || !X_f32 || !out0_f32 || !out1_f32 ||
+        M0 <= 0 || M1 <= 0 || K <= 0 || K % 1024 != 0) return -1;
+
+    const int dev = ggml_cuda_get_device();
+    ggml_backend_cuda_context *ctx = get_ctx_for_device(dev);
+    if (!ctx) return -1;
+    ds4_pool_set_stream(stream);
+    const size_t nbytes_q8_1 = (size_t)(K / QK8_1) * sizeof(block_q8_1);
+    ggml_cuda_pool_alloc<char> q8_pool;
+    char *x8 = ds4_mmq_folded_q81(X_f32, K, 1, K);
+    if (!x8) {
+        if (g_q81_scratch_enabled && g_q81_scratch_ptr &&
+            g_q81_scratch_bytes >= nbytes_q8_1) {
+            x8 = (char *)g_q81_scratch_ptr;
+        } else {
+            q8_pool.alloc(ctx->pool(), nbytes_q8_1);
+            x8 = q8_pool.get();
+        }
+        quantize_row_q8_1_cuda(X_f32, nullptr, x8, GGML_TYPE_Q8_0,
+            K, K, K, K, K, 1, 1, 1, stream);
+        cudaError_t err = cudaGetLastError();
+        if (err != cudaSuccess) {
+            fprintf(stderr, "%s: quantize failed: %s\n", tag,
+                    cudaGetErrorString(err));
+            return -2;
+        }
+    }
+
+    const block_q8_1 *x8p = (const block_q8_1 *)x8;
+    const uint64_t nblk0 = (uint64_t)M0 * (uint64_t)(K / 32);
+    const uint64_t nblk1 = (uint64_t)M1 * (uint64_t)(K / 32);
+    const uint64_t dq0 = (nblk0 * 2u + 63u) & ~63ull;
+    const uint64_t dq1 = (nblk1 * 2u + 63u) & ~63ull;
+    q8_0_aligned_dense_vec_kernel<<<(unsigned)M0, 32, 0, stream>>>(
+        out0_f32, (const int4 *)((const char *)W0_aligned + dq0),
+        (const __half *)W0_aligned, x8p, M0, K / 32);
+    q8_0_aligned_dense_vec_kernel<<<(unsigned)M1, 32, 0, stream>>>(
+        out1_f32, (const int4 *)((const char *)W1_aligned + dq1),
+        (const __half *)W1_aligned, x8p, M1, K / 32);
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "%s: kernel launch failed: %s\n", tag,
+                cudaGetErrorString(err));
         return -3;
     }
     return 0;

--- a/cuda/mmq/ds4_mmq.h
+++ b/cuda/mmq/ds4_mmq.h
@@ -28,6 +28,7 @@ extern "C" {
 //   device: CUDA device ordinal (0 for the primary GPU).
 // Returns 0 on success.
 int ds4_mmq_init(int device);
+void ds4_mmq_cleanup(void);
 void ds4_mmq_set_aligned_q81_scratch(void *ptr, size_t bytes);
 
 // Query whether ds4_mmq is willing to handle a given matmul. Returns
@@ -570,6 +571,17 @@ int ds4_mmq_q8_0_aligned_dense_vec(
     float       * out_f32,
     int           M,
     int           N,
+    int           K,
+    cudaStream_t  stream);
+
+int ds4_mmq_q8_0_aligned_dense_pair_vec(
+    const void  * W0_aligned,
+    const void  * W1_aligned,
+    const float * X_f32,
+    float       * out0_f32,
+    float       * out1_f32,
+    int           M0,
+    int           M1,
     int           K,
     cudaStream_t  stream);
 

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -942,11 +942,32 @@ extern "C" int ds4_gpu_decode_graphs_supported(void) {
              strcmp(s, "off") == 0 || strcmp(s, "OFF") == 0 ||
              strcmp(s, "no") == 0 || strcmp(s, "NO") == 0 ||
              strcmp(s, "false") == 0 || strcmp(s, "FALSE") == 0);
+        const int force = s && *s &&
+            (s[0] == '1' ||
+             strcmp(s, "on") == 0 || strcmp(s, "ON") == 0 ||
+             strcmp(s, "yes") == 0 || strcmp(s, "YES") == 0 ||
+             strcmp(s, "true") == 0 || strcmp(s, "TRUE") == 0);
         if (off) {
             fprintf(stderr, "ds4: DS4_CUDA_DECODE_GRAPHS=%s - decode graph capture disabled\n", s);
             enabled = 0;
-        } else {
+        } else if (force) {
+            fprintf(stderr, "ds4: DS4_CUDA_DECODE_GRAPHS=%s - decode graph capture forced on\n", s);
             enabled = 1;
+        } else {
+            /* Decode on integrated Blackwell (GB10) is bandwidth-bound, so
+             * eager launches edge out graph replay (~0.5% generation);
+             * discrete GPUs keep graphs to hide launch overhead. */
+            int dev = 0, major = 0, integrated = 0;
+            cudaGetDevice(&dev);
+            cudaDeviceGetAttribute(&major,
+                                   cudaDevAttrComputeCapabilityMajor, dev);
+            cudaDeviceGetAttribute(&integrated,
+                                   cudaDevAttrIntegrated, dev);
+            enabled = !(integrated && major >= 12);
+            if (!enabled) {
+                fprintf(stderr,
+                        "ds4: decode graph capture off by default on integrated Blackwell (DS4_CUDA_DECODE_GRAPHS=1 to force)\n");
+            }
         }
     }
     return enabled && g_n_gpus == 1;
@@ -15909,6 +15930,19 @@ extern "C" int ds4_gpu_matmul_f16_pair_tensor(
                               CUBLAS_GEMM_DEFAULT);
             return cublas_ok(st, "f16 pair matmul1");
         }
+        return ds4_gpu_matmul_f16_tensor(out0, model_map, model_size, weight0_offset,
+                                           in_dim, out_dim, x, n_tok) &&
+               ds4_gpu_matmul_f16_tensor(out1, model_map, model_size, weight1_offset,
+                                           in_dim, out_dim, x, n_tok);
+    }
+    /* Decode (n_tok==1): two cuBLAS GEMVs beat the fused ordered-chunks pair
+     * kernel on bandwidth-bound parts (+2% generation on GB10): the pair
+     * kernel's per-warp chunked reads are not coalesced.  The pair kernel
+     * remains for quality mode, no-cuBLAS builds, and the
+     * DS4_CUDA_NO_F16_PAIR_CUBLAS_ONE rollback. */
+    if (g_cublas_ready && !g_quality_mode &&
+        getenv("DS4_CUDA_NO_F16_CUBLAS_ONE") == NULL &&
+        getenv("DS4_CUDA_NO_F16_PAIR_CUBLAS_ONE") == NULL) {
         return ds4_gpu_matmul_f16_tensor(out0, model_map, model_size, weight0_offset,
                                            in_dim, out_dim, x, n_tok) &&
                ds4_gpu_matmul_f16_tensor(out1, model_map, model_size, weight1_offset,

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -229,6 +229,38 @@ static int cuda_q4_mma_ok(void) {
     return cached;
 }
 
+static int cuda_f16_pair_vec2_ok(void) {
+    static int cached = -1;
+    if (cached < 0) {
+        if (getenv("DS4_CUDA_NO_F16_PAIR_VEC2") != NULL) {
+            cached = 0;
+        } else if (getenv("DS4_CUDA_F16_PAIR_VEC2") != NULL) {
+            cached = 1;
+        } else {
+            int dev = 0, major = 0, integrated = 0;
+            cudaGetDevice(&dev);
+            cudaDeviceGetAttribute(&major,
+                                   cudaDevAttrComputeCapabilityMajor, dev);
+            cudaDeviceGetAttribute(&integrated,
+                                   cudaDevAttrIntegrated, dev);
+            cached = integrated && major >= 12;
+        }
+    }
+    return cached;
+}
+
+static int cuda_q8_hc_expand_fused_ok(void) {
+    if (getenv("DS4_CUDA_DISABLE_Q8_HC_EXPAND_FUSED") != NULL) return 0;
+    if (getenv("DS4_CUDA_Q8_HC_EXPAND_FUSED") != NULL) return 1;
+    int dev = 0, major = 0, integrated = 0;
+    cudaGetDevice(&dev);
+    cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, dev);
+    cudaDeviceGetAttribute(&integrated, cudaDevAttrIntegrated, dev);
+    // On GB10 the aligned Q8 artifact plus a separate HC epilogue is faster
+    // than streaming the canonical 34-byte blocks through the fused kernel.
+    return !(integrated && major >= 12);
+}
+
 
 
 
@@ -2762,6 +2794,12 @@ extern "C" int ds4_gpu_init_multi(const ds4_gpu_config *cfg) {
         }
     }
 
+    /* Recreate MMQ process-global scratch after a previous engine teardown.
+     * The later dispatch initializer is intentionally cached, while CUDA
+     * engines may be opened and closed repeatedly in one process. */
+    if (g_n_gpus == 1) {
+        (void)ds4_mmq_init(g_gpu[0].device_id);
+    }
     g_cublas_ready = 1;
     return 1;
 }
@@ -2776,6 +2814,7 @@ extern "C" int ds4_gpu_init(void) {
 
 extern "C" void ds4_gpu_cleanup(void) {
     (void)cudaDeviceSynchronize();
+    ds4_mmq_cleanup();
     g_current_logical_tier = -1;
 
     /* Multi-GPU teardown: events, streams, cublas handles, scratch
@@ -4762,6 +4801,10 @@ __global__ static void matmul_f16_small_out_batch_kernel(
     }
 }
 
+/* The vec2 form halves load instructions while preserving each lane's scalar
+ * accumulation order.  It is enabled by default only on integrated Blackwell;
+ * DS4_CUDA_NO_F16_PAIR_VEC2 restores scalar loads. */
+template <bool VEC2>
 __global__ static void matmul_f16_pair_ordered_chunks_kernel(
         float *out0,
         float *out1,
@@ -4785,7 +4828,23 @@ __global__ static void matmul_f16_pair_ordered_chunks_kernel(
     if (k1 > in_dim) k1 = in_dim;
     const __half *wr0 = row < out0_dim ? w0 + row * in_dim : w0;
     const __half *wr1 = row < out1_dim ? w1 + row * in_dim : w1;
-    for (uint64_t i = k0; i < k1; i++) {
+    uint64_t i = k0;
+    if constexpr (VEC2) {
+        for (; i + 1u < k1; i += 2u) {
+            const float2 xv = *(const float2 *)(x + i);
+            const __half2 hw0 = *(const __half2 *)(wr0 + i);
+            const __half2 hw1 = *(const __half2 *)(wr1 + i);
+            if (row < out0_dim) {
+                sum0 += __low2float(hw0) * xv.x;
+                sum0 += __high2float(hw0) * xv.y;
+            }
+            if (row < out1_dim) {
+                sum1 += __low2float(hw1) * xv.x;
+                sum1 += __high2float(hw1) * xv.y;
+            }
+        }
+    }
+    for (; i < k1; i++) {
         const float xv = x[i];
         if (row < out0_dim) sum0 += __half2float(wr0[i]) * xv;
         if (row < out1_dim) sum1 += __half2float(wr1[i]) * xv;
@@ -15033,6 +15092,30 @@ extern "C" int ds4_gpu_matmul_q8_0_pair_tensor(
         return 0;
     }
     const int logical_tier = ds4_tensor_device_idx(out0);
+    if (n_tok == 1u && getenv("DS4_CUDA_NO_Q8_PAIR_ALIGNED") == NULL &&
+        in_dim % 1024u == 0u && out0_dim % 128u == 0u &&
+        out1_dim % 128u == 0u && cuda_aligned_q8_enabled()) {
+        const uint64_t aligned0_bytes =
+            ds4_mmq_q8_0_aligned_bytes((int)out0_dim, (int)in_dim);
+        const uint64_t aligned1_bytes =
+            ds4_mmq_q8_0_aligned_bytes((int)out1_dim, (int)in_dim);
+        const char *aligned0 = cuda_derived_weight_ptr(
+            model_map, weight0_offset, weight0_bytes,
+            CUDA_DERIVED_Q8_0_ALIGNED_DENSE, in_dim, out0_dim, 1u,
+            aligned0_bytes);
+        const char *aligned1 = cuda_derived_weight_ptr(
+            model_map, weight1_offset, weight1_bytes,
+            CUDA_DERIVED_Q8_0_ALIGNED_DENSE, in_dim, out1_dim, 1u,
+            aligned1_bytes);
+        if (aligned0 && aligned1 &&
+            ds4_mmq_q8_0_aligned_dense_pair_vec(
+                aligned0, aligned1, (const float *)x->ptr,
+                (float *)out0->ptr, (float *)out1->ptr,
+                (int)out0_dim, (int)out1_dim, (int)in_dim,
+                cuda_decode_stream()) == 0) {
+            return 1;
+        }
+    }
     const char *w0 = cuda_resolve_weight_ptr(model_map, weight0_offset, weight0_bytes, logical_tier, "q8_0_pair0");
     const char *w1 = cuda_resolve_weight_ptr(model_map, weight1_offset, weight1_bytes, logical_tier, "q8_0_pair1");
     if (!w0 || !w1) return 0;
@@ -15831,15 +15914,15 @@ extern "C" int ds4_gpu_matmul_f16_pair_tensor(
                ds4_gpu_matmul_f16_tensor(out1, model_map, model_size, weight1_offset,
                                            in_dim, out_dim, x, n_tok);
     }
-    matmul_f16_pair_ordered_chunks_kernel<<<(unsigned)out_dim, 32>>>(
-        (float *)out0->ptr,
-        (float *)out1->ptr,
-        w0,
-        w1,
-        (const float *)x->ptr,
-        in_dim,
-        out_dim,
-        out_dim);
+    if (cuda_f16_pair_vec2_ok() && (in_dim & 63u) == 0u) {
+        matmul_f16_pair_ordered_chunks_kernel<true><<<(unsigned)out_dim, 32>>>(
+            (float *)out0->ptr, (float *)out1->ptr, w0, w1,
+            (const float *)x->ptr, in_dim, out_dim, out_dim);
+    } else {
+        matmul_f16_pair_ordered_chunks_kernel<false><<<(unsigned)out_dim, 32>>>(
+            (float *)out0->ptr, (float *)out1->ptr, w0, w1,
+            (const float *)x->ptr, in_dim, out_dim, out_dim);
+    }
     return cuda_ok(cudaGetLastError(), "matmul_f16_pair_ordered_chunks launch");
 }
 
@@ -25719,7 +25802,7 @@ extern "C" int ds4_gpu_hc_expand_split_tensor(ds4_gpu_tensor *out_hc, const ds4_
     uint32_t mix_hc = 2u * n_hc + n_hc * n_hc;
     uint64_t n_elem = (uint64_t)n_tokens * n_hc * n_embd;
     const float *base = (const float *)split->ptr;
-    hc_expand_kernel<<<(n_elem + 255) / 256, 256>>>((float *)out_hc->ptr,
+    hc_expand_kernel<<<(n_elem + 255) / 256, 256, 0, cuda_decode_stream()>>>((float *)out_hc->ptr,
                                                     (const float *)block_out->ptr,
                                                     (const float *)block_out->ptr,
                                                     (const float *)block_out->ptr,
@@ -25755,7 +25838,7 @@ extern "C" int ds4_gpu_hc_expand_add2_split_tensor(ds4_gpu_tensor *out_hc, const
     uint32_t mix_hc = 2u * n_hc + n_hc * n_hc;
     uint64_t n_elem = (uint64_t)n_tokens * n_hc * n_embd;
     const float *base = (const float *)split->ptr;
-    hc_expand_kernel<<<(n_elem + 255) / 256, 256>>>((float *)out_hc->ptr,
+    hc_expand_kernel<<<(n_elem + 255) / 256, 256, 0, cuda_decode_stream()>>>((float *)out_hc->ptr,
                                                     (const float *)block_out->ptr,
                                                     (const float *)block_add->ptr,
                                                     (const float *)block_add2->ptr,
@@ -25781,7 +25864,7 @@ extern "C" int ds4_gpu_shared_down_hc_expand_q8_0_tensor(
         const ds4_gpu_tensor *split,
         uint32_t                n_embd,
         uint32_t                n_hc) {
-    if (getenv("DS4_CUDA_DISABLE_Q8_HC_EXPAND_FUSED") == NULL) {
+    if (cuda_q8_hc_expand_fused_ok()) {
         return cuda_matmul_q8_0_hc_expand_tensor_labeled(out_hc, shared_out,
                                                         model_map, model_size,
                                                         weight_offset,
@@ -25817,7 +25900,7 @@ extern "C" int ds4_gpu_shared_down_hc_expand_add_q8_0_tensor(
         const ds4_gpu_tensor *split,
         uint32_t                n_embd,
         uint32_t                n_hc) {
-    if (getenv("DS4_CUDA_DISABLE_Q8_HC_EXPAND_FUSED") == NULL) {
+    if (cuda_q8_hc_expand_fused_ok()) {
         return cuda_matmul_q8_0_hc_expand_tensor_labeled(out_hc, shared_out,
                                                         model_map, model_size,
                                                         weight_offset,
@@ -25856,7 +25939,7 @@ extern "C" int ds4_gpu_shared_down_hc_expand_owned_q8_0_tensor(
         const ds4_gpu_tensor *split,
         uint32_t n_embd,
         uint32_t n_hc) {
-    if (getenv("DS4_CUDA_DISABLE_Q8_HC_EXPAND_FUSED") != NULL) return 0;
+    if (!cuda_q8_hc_expand_fused_ok()) return 0;
     return cuda_matmul_q8_0_hc_expand_tensor_labeled(
             out_hc,
             shared_out,
@@ -25892,7 +25975,7 @@ extern "C" int ds4_gpu_matmul_q8_0_hc_expand_tensor(
         const ds4_gpu_tensor *split,
         uint32_t                n_embd,
         uint32_t                n_hc) {
-    if (getenv("DS4_CUDA_DISABLE_Q8_HC_EXPAND_FUSED") == NULL) {
+    if (cuda_q8_hc_expand_fused_ok()) {
         return cuda_matmul_q8_0_hc_expand_tensor_labeled(out_hc, block_out,
                                                         model_map, model_size,
                                                         weight_offset,


### PR DESCRIPTION
## CUDA decode speedups for NVIDIA GB10 (DGX Spark) — +21% generation tok/s

Two commits, both focused on DeepSeek V4 Flash decode on GB10 (Grace Blackwell, sm_121, 48 SMs, ~232 GB/s practical LPDDR5x bandwidth). Measured on `ds4-bench`, DeepSeek-V4-Flash IQ2XXS GGUF, ctx 2048: **18.05 → ~21.8 tok/s**.

### Commit 1 — `cuda: GB10 decode speedups: aligned Q8 pair-vec, f16 pair VEC2, persistent Q8_1 scratch`
- Persistent Q8_1 scratch becomes the default on integrated Blackwell (was env-opt-in), avoiding stream-ordered pool allocs in the decode path. `DS4_CUDA_MMQ_Q81_PERSISTENT=0/1` overrides.
- New `ds4_mmq_q8_0_aligned_dense_pair_vec` kernel + dispatch for paired Q8 projections.
- VEC2 variant of `matmul_f16_pair_ordered_chunks_kernel`, gated to integrated Blackwell via `cuda_f16_pair_vec2_ok()`.
- HC-expand epilogue split (non-fused) on GB10 via `cuda_q8_hc_expand_fused_ok()`.

### Commit 2 — `cuda: GB10 decode: cuBLAS pair GEMV for compressor, eager decode default`
- Decode `n_tok==1` compressor pair projections now use two cuBLAS GEMVs: the fused ordered-chunks pair kernel's per-warp chunked reads are not coalesced. **+2.4%** (A/B over multiple interleaved runs, verified at ctx 1024/2048/4096). Quality mode keeps the deterministic pair kernel; rollbacks: `DS4_CUDA_NO_F16_PAIR_CUBLAS_ONE=1`, `DS4_CUDA_NO_F16_CUBLAS_ONE=1`.
- Decode CUDA graphs are now off by default on integrated Blackwell: decode is bandwidth-bound there, so graph replay adds overhead instead of hiding launch cost (**+0.5%**, A/B 12+ interleaved runs). `DS4_CUDA_DECODE_GRAPHS=1` forces graphs, `=0` disables everywhere. Discrete GPUs unchanged.

### Verification
- Greedy output bit-identical between eager/graph modes (md5 match) and coherent across all variants.
- Prefill unchanged (~830-900 tok/s), correctness suite passes on CUDA.
- Negative results also checked and rejected (e.g. head-fused score-split finalize was slower on GB10 — parallelism-bound, not L2-bound).

Hardware note: GB10 decode streams ~8.7 GiB of weights per token; the dominant kernels now run at ~217-243 GB/s, close to the practical memory ceiling.
