### PR TITLE
ds4-server: add --idle-timeout to free GPU and engine while idle

### DIFF
--- a/ds4_help.c
+++ b/ds4_help.c
@@ -331,10 +331,12 @@ static void print_server_api(FILE *fp, const help_colors *c) {
     opt(fp, c, "--host HOST", "Bind address. Default: 127.0.0.1");
     opt(fp, c, "--port N", "Bind port. Default: 8000");
     opt(fp, c, "--cors", "Add Access-Control-Allow-* headers for browser JS clients.");
+    opt(fp, c, "--idle-timeout N", "Free GPU and engine after N idle seconds, reloading on the next request. 0 disables. Default: 0");
     opt(fp, c, "--trace FILE", "Write prompts, cache decisions, output, and tool calls.");
     opt(fp, c, "--batched-session N", "Keep N resident sessions and batch decode-ready requests.");
     opt(fp, c, "--mixed-prefill-quantum N", "Prefill chunk while generations are active. Default: 128");
     para(fp, c, "Endpoints: /v1/chat/completions, /v1/responses, /v1/completions, and /v1/messages.");
+    para(fp, c, "With --idle-timeout the listening socket stays bound while unloaded, so a cold request waits for the reload instead of being refused; /v1/models answers without reloading.");
     para(fp, c, "Model endpoint aliases include deepseek-v4-flash and deepseek-v4-pro; both serve the loaded GGUF.");
     fputc('\n', fp);
 }

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -12858,15 +12858,10 @@ static void server_mark_activity(server *s) {
     pthread_mutex_unlock(&s->mu);
 }
 
-/* True when nothing is in flight and the idle window has elapsed.  Metadata
- * requests never refresh last_activity, so a client polling /v1/models on a
- * shorter interval than the timeout cannot pin an unused server in memory. */
-static bool server_idle_expired(server *s) {
-    /* The elapsed test below would pass on its own with the flag unset, since
-     * any age is >= a zero window, so being disabled has to be part of the
-     * predicate rather than only of the caller that skips the monitor thread. */
+/* s->mu held.  Flag-disabled is part of the predicate so a zero window cannot
+ * expire on its own (any age is >= 0). */
+static bool server_idle_expired_holding_mu(const server *s) {
     if (s->idle_timeout_sec <= 0) return false;
-    pthread_mutex_lock(&s->mu);
     bool idle = s->clients == 0 && !s->head;
     if (idle && s->batched_mode) {
         for (int i = 0; i < s->slot_count; i++) {
@@ -12876,9 +12871,17 @@ static bool server_idle_expired(server *s) {
             }
         }
     }
-    const double since = now_sec() - s->last_activity;
+    return idle && (now_sec() - s->last_activity) >= (double)s->idle_timeout_sec;
+}
+
+/* True when nothing is in flight and the idle window has elapsed.  Metadata
+ * requests never refresh last_activity, so a client polling /v1/models on a
+ * shorter interval than the timeout cannot pin an unused server in memory. */
+static bool server_idle_expired(server *s) {
+    pthread_mutex_lock(&s->mu);
+    const bool expired = server_idle_expired_holding_mu(s);
     pthread_mutex_unlock(&s->mu);
-    return idle && since >= (double)s->idle_timeout_sec;
+    return expired;
 }
 
 /* engine_mu held.  Sessions go before the engine because they hold references
@@ -12984,10 +12987,21 @@ static void *idle_monitor_main(void *arg) {
         if (g_stop_requested) break;
         pthread_mutex_lock(&s->engine_mu);
         if (s->engine && !s->engine_loading && server_idle_expired(s)) {
-            server_log(DS4_LOG_DEFAULT,
-                       "ds4-server: idle timeout of %ds reached; freeing GPU and engine resources",
-                       s->idle_timeout_sec);
-            server_idle_unload_locked(s);
+            /* Accept can clients++ the instant the snapshot dropped mu.
+             * Recheck immediately before teardown so a request that arrived
+             * after that snapshot does not pay for an unload+reload.
+             * Remaining window is unlock-to-close; s->mu cannot be held
+             * across ds4_engine_close. Not a UAF: ensure_engine_loaded
+             * waits on engine_mu. */
+            pthread_mutex_lock(&s->mu);
+            const bool still_idle = server_idle_expired_holding_mu(s);
+            pthread_mutex_unlock(&s->mu);
+            if (still_idle) {
+                server_log(DS4_LOG_DEFAULT,
+                           "ds4-server: idle timeout of %ds reached; freeing GPU and engine resources",
+                           s->idle_timeout_sec);
+                server_idle_unload_locked(s);
+            }
         }
         pthread_mutex_unlock(&s->engine_mu);
     }

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -8442,6 +8442,16 @@ struct server_slot {
 static bool id_list_contains(const stop_list *ids, const char *id);
 static void id_list_push_unique(stop_list *ids, const char *id);
 
+/* Everything needed to reopen the engine after an idle unload.  The option
+ * strings point into argv, which lives as long as the process, and the GPU
+ * layout kept here is the one resolved at first open: an "auto" reload must
+ * not re-derive a different placement from whatever VRAM is free later. */
+typedef struct {
+    ds4_engine_options engine;
+    ds4_gpu_config gpu;
+    bool use_gpu_config;
+} server_engine_spec;
+
 struct server {
     ds4_engine *engine;
     server_slot *slots;
@@ -8477,6 +8487,26 @@ struct server {
     FILE *trace;
     pthread_mutex_t trace_mu;
     uint64_t trace_seq;
+
+    /* Idle unload policy (--idle-timeout).  engine_mu guards `engine` plus the
+     * engine_loading handshake, and engine_cv wakes threads waiting on a
+     * reload.  The listening socket is deliberately outside all of this: a
+     * client that connects while unloaded completes its TCP handshake at once
+     * and waits for the reload, so fallback chains never see ECONNREFUSED and
+     * walk away from the primary provider. */
+    int idle_timeout_sec;
+    pthread_mutex_t engine_mu;
+    pthread_cond_t engine_cv;
+    bool engine_loading;
+    double last_activity; /* Guarded by mu.  Inference requests only. */
+    pthread_t idle_thread;
+    bool idle_thread_started;
+    server_engine_spec engine_spec;
+    /* Model identity cached at first open so GET /v1/models keeps answering
+     * while the engine is unloaded.  Reloading the weights to satisfy a
+     * metadata request would defeat the whole feature. */
+    char *model_name;
+    bool model_is_glm_dsa;
 };
 
 /* Jobs are stack-owned by the client thread.  A resident-slot worker signals
@@ -12653,7 +12683,7 @@ static void append_model_json_values(buf *b, const char *id, const char *name,
 static void append_model_json(buf *b, const server *s, const char *id) {
     append_model_json_values(b,
                              id,
-                             ds4_engine_model_name(s->engine),
+                             s->model_name,
                              s->ctx_size,
                              s->default_tokens);
 }
@@ -12670,7 +12700,7 @@ static bool send_model(server *s, int fd, const char *id) {
 static bool send_models(server *s, int fd) {
     buf b = {0};
     buf_puts(&b, "{\"object\":\"list\",\"data\":[");
-    if (ds4_engine_is_glm_dsa(s->engine)) {
+    if (s->model_is_glm_dsa) {
         append_model_json(&b, s, "glm-5.2");
         buf_putc(&b, ',');
         append_model_json(&b, s, "glm-5.2-chat");
@@ -12790,6 +12820,180 @@ static void wait_for_job_or_disconnect(server *s, job *j) {
     pthread_mutex_unlock(&j->mu);
 }
 
+/* ---- Idle engine unload (--idle-timeout) ---------------------------------
+ *
+ * Freeing the engine while the process keeps serving is safe because of one
+ * invariant: server.clients is incremented in the accept loop before the
+ * client thread starts, decremented only in client_done(), and a client thread
+ * owns its job until a worker signals completion.  clients == 0 therefore
+ * proves no request path holds a session or engine pointer, which is what
+ * makes tearing both down race-free rather than merely unlikely. */
+
+static int server_engine_spec_open(const server_engine_spec *spec,
+                                   ds4_engine **out) {
+    ds4_engine_options opts = spec->engine;
+    if (spec->use_gpu_config) {
+        ds4_gpu_config gpu = spec->gpu;
+        return ds4_engine_create_with_gpu_config(out, &opts, &gpu);
+    }
+    return ds4_engine_open(out, &opts);
+}
+
+/* The inference endpoints, whose handlers tokenize and therefore need a live
+ * engine.  Twin of the parse chain in client_main(): an inference endpoint
+ * missing here would be served against a NULL engine, and a metadata path
+ * leaking in would let a polling client pay for a full model reload. */
+static bool server_path_needs_engine(const http_request *hr) {
+    if (strcmp(hr->method, "POST")) return false;
+    return !strcmp(hr->path, "/v1/chat/completions") ||
+           !strcmp(hr->path, "/v1/responses") ||
+           !strcmp(hr->path, "/v1/completions") ||
+           !strcmp(hr->path, "/v1/messages");
+}
+
+static void server_mark_activity(server *s) {
+    if (s->idle_timeout_sec <= 0) return;
+    pthread_mutex_lock(&s->mu);
+    s->last_activity = now_sec();
+    pthread_mutex_unlock(&s->mu);
+}
+
+/* True when nothing is in flight and the idle window has elapsed.  Metadata
+ * requests never refresh last_activity, so a client polling /v1/models on a
+ * shorter interval than the timeout cannot pin an unused server in memory. */
+static bool server_idle_expired(server *s) {
+    /* The elapsed test below would pass on its own with the flag unset, since
+     * any age is >= a zero window, so being disabled has to be part of the
+     * predicate rather than only of the caller that skips the monitor thread. */
+    if (s->idle_timeout_sec <= 0) return false;
+    pthread_mutex_lock(&s->mu);
+    bool idle = s->clients == 0 && !s->head;
+    if (idle && s->batched_mode) {
+        for (int i = 0; i < s->slot_count; i++) {
+            if (s->slots[i].busy) {
+                idle = false;
+                break;
+            }
+        }
+    }
+    const double since = now_sec() - s->last_activity;
+    pthread_mutex_unlock(&s->mu);
+    return idle && since >= (double)s->idle_timeout_sec;
+}
+
+/* engine_mu held.  Sessions go before the engine because they hold references
+ * into engine-owned memory; the reverse order dangles. */
+static void server_idle_unload_locked(server *s) {
+    for (int i = 0; s->kv.enabled && i < s->slot_count; i++) {
+        server_slot *slot = &s->slots[i];
+        if (!slot->session) continue;
+        const ds4_tokens *tokens = ds4_session_tokens(slot->session);
+        if (!tokens || tokens->len < s->kv.opt.min_tokens) continue;
+        /* Same reason the shutdown path persists: dropping a live session
+         * without checkpointing it would silently discard the newest
+         * conversation state and leave only an older prefix on disk. */
+        server_log(DS4_LOG_KVCACHE,
+                   "ds4-server: persisting resident KV cache before idle unload slot=%d tokens=%d",
+                   i, tokens->len);
+        kv_cache_store_current(s, slot, "idle");
+    }
+    pthread_mutex_lock(&s->inference_mu);
+    for (int i = 0; i < s->slot_count; i++) {
+        server_slot *slot = &s->slots[i];
+        live_tool_state_free(&slot->responses_live);
+        live_tool_state_free(&slot->anthropic_live);
+        visible_live_free(&slot->thinking_live);
+        ds4_session_free(slot->session);
+        slot->session = NULL;
+        /* The reloaded session starts empty, so stale save-suppression state
+         * would skip the next checkpoint it should write. */
+        slot->continued_last_store_tokens = 0;
+    }
+    pthread_mutex_unlock(&s->inference_mu);
+    ds4_engine_close(s->engine);
+    s->engine = NULL;
+}
+
+/* Reopen the engine and its resident sessions.  Concurrent cold requests wait
+ * on engine_cv while the first one reloads, so N simultaneous requests cost
+ * exactly one reload.  Returns false only when the reload itself failed; the
+ * caller must answer an error rather than use a NULL engine. */
+static bool server_ensure_engine_loaded(server *s) {
+    if (s->idle_timeout_sec <= 0) return true;
+    pthread_mutex_lock(&s->engine_mu);
+    for (;;) {
+        if (s->engine) {
+            pthread_mutex_unlock(&s->engine_mu);
+            return true;
+        }
+        if (!s->engine_loading) break;
+        pthread_cond_wait(&s->engine_cv, &s->engine_mu);
+    }
+    s->engine_loading = true;
+    pthread_mutex_unlock(&s->engine_mu);
+
+    const double t0 = now_sec();
+    ds4_engine *engine = NULL;
+    ds4_session **sessions = NULL;
+    bool ok = server_engine_spec_open(&s->engine_spec, &engine) == 0;
+    if (!ok) {
+        server_log(DS4_LOG_DEFAULT,
+                   "ds4-server: failed to reload engine after idle unload");
+    } else {
+        sessions = xmalloc((size_t)s->slot_count * sizeof(*sessions));
+        memset(sessions, 0, (size_t)s->slot_count * sizeof(*sessions));
+        for (int i = 0; i < s->slot_count; i++) {
+            if (ds4_session_create(&sessions[i], engine, s->ctx_size) == 0) continue;
+            server_log(DS4_LOG_DEFAULT,
+                       "ds4-server: failed to recreate session %d/%d after idle unload",
+                       i + 1, s->slot_count);
+            for (int j = 0; j < i; j++) ds4_session_free(sessions[j]);
+            free(sessions);
+            sessions = NULL;
+            ds4_engine_close(engine);
+            engine = NULL;
+            ok = false;
+            break;
+        }
+    }
+
+    pthread_mutex_lock(&s->engine_mu);
+    if (ok) {
+        s->engine = engine;
+        pthread_mutex_lock(&s->inference_mu);
+        for (int i = 0; i < s->slot_count; i++) {
+            s->slots[i].session = sessions[i];
+        }
+        pthread_mutex_unlock(&s->inference_mu);
+        server_log(DS4_LOG_DEFAULT,
+                   "ds4-server: engine reloaded after idle unload in %.2fs",
+                   now_sec() - t0);
+    }
+    s->engine_loading = false;
+    pthread_cond_broadcast(&s->engine_cv);
+    pthread_mutex_unlock(&s->engine_mu);
+    free(sessions);
+    return ok;
+}
+
+static void *idle_monitor_main(void *arg) {
+    server *s = arg;
+    while (!g_stop_requested) {
+        struct timespec ts = { .tv_sec = 0, .tv_nsec = 250000000 };
+        nanosleep(&ts, NULL);
+        if (g_stop_requested) break;
+        pthread_mutex_lock(&s->engine_mu);
+        if (s->engine && !s->engine_loading && server_idle_expired(s)) {
+            server_log(DS4_LOG_DEFAULT,
+                       "ds4-server: idle timeout of %ds reached; freeing GPU and engine resources",
+                       s->idle_timeout_sec);
+            server_idle_unload_locked(s);
+        }
+        pthread_mutex_unlock(&s->engine_mu);
+    }
+    return NULL;
+}
+
 static void *client_main(void *arg) {
     client_arg *ca = arg;
     server *s = ca->srv;
@@ -12822,6 +13026,19 @@ static void *client_main(void *arg) {
         send_model(s, fd, hr.path + model_path_prefix_len);
         http_request_free(&hr);
         goto done;
+    }
+
+    /* Request parsing tokenizes, so the engine has to be resident before the
+     * parse chain below runs.  Reaching an inference endpoint is also what
+     * defines activity for the idle clock; the GET metadata endpoints handled
+     * above deliberately do not refresh it. */
+    if (server_path_needs_engine(&hr)) {
+        server_mark_activity(s);
+        if (!server_ensure_engine_loaded(s)) {
+            http_error(fd, s->enable_cors, 503, "model engine unavailable");
+            http_request_free(&hr);
+            goto done;
+        }
     }
 
     request req;
@@ -12877,6 +13094,9 @@ static void *client_main(void *arg) {
         goto done;
     }
     wait_for_job_or_disconnect(s, &j);
+    /* Restart the idle clock at the end of the request, not its start, so a
+     * long generation cannot be unloaded moments after it finishes. */
+    server_mark_activity(s);
 
     pthread_cond_destroy(&j.cv);
     pthread_mutex_destroy(&j.mu);
@@ -12949,6 +13169,7 @@ typedef struct {
     bool enable_cors;
     int batched_sessions;
     int mixed_prefill_quantum;
+    int idle_timeout_sec;
 } server_config;
 
 static int parse_int_arg(const char *s, const char *opt) {
@@ -13039,6 +13260,9 @@ static void server_close_resources(server *s) {
     pthread_cond_destroy(&s->clients_cv);
     pthread_cond_destroy(&s->cv);
     pthread_mutex_destroy(&s->mu);
+    pthread_mutex_destroy(&s->engine_mu);
+    pthread_cond_destroy(&s->engine_cv);
+    free(s->model_name);
     ds4_engine_close(s->engine);
     memset(s, 0, sizeof(*s));
 }
@@ -13154,6 +13378,9 @@ static server_config parse_options(int argc, char **argv) {
             c.port = parse_int_arg(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--cors")) {
             c.enable_cors = true;
+        } else if (!strcmp(arg, "--idle-timeout")) {
+            c.idle_timeout_sec =
+                parse_nonneg_int_arg(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--trace")) {
             c.trace_path = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--batched-session")) {
@@ -13326,6 +13553,7 @@ int main(int argc, char **argv) {
         cfg.batched_sessions > 0 ? cfg.batched_sessions : 1;
     cfg.engine.share_session_prefill_workspace = cfg.batched_sessions > 0;
     ds4_engine *engine = NULL;
+    server_engine_spec engine_spec = {0};
     if (cfg.gpu_vram_arg || cfg.gpu_devices_arg) {
         ds4_gpu_config gpu_cfg = {0};
         bool skip_cuda = false;
@@ -13338,6 +13566,7 @@ int main(int argc, char **argv) {
         }
         cfg.engine.backend = skip_cuda ? DS4_BACKEND_CPU : DS4_BACKEND_CUDA;
         if (skip_cuda) {
+            engine_spec.engine = cfg.engine;
             if (ds4_engine_open(&engine, &cfg.engine) != 0) return 1;
         } else {
             const bool was_auto =
@@ -13349,11 +13578,15 @@ int main(int argc, char **argv) {
                 fprintf(stdout, "%s\n", layout);
                 fflush(stdout);
             }
+            engine_spec.engine = cfg.engine;
+            engine_spec.gpu = gpu_cfg;
+            engine_spec.use_gpu_config = true;
             if (ds4_engine_create_with_gpu_config(
                     &engine, &cfg.engine, &gpu_cfg) != 0) return 1;
         }
-    } else if (ds4_engine_open(&engine, &cfg.engine) != 0) {
-        return 1;
+    } else {
+        engine_spec.engine = cfg.engine;
+        if (ds4_engine_open(&engine, &cfg.engine) != 0) return 1;
     }
 
     if (cfg.engine.distributed.role == DS4_DISTRIBUTED_WORKER) {
@@ -13383,6 +13616,11 @@ int main(int argc, char **argv) {
     s.disable_exact_dsml_tool_replay = cfg.disable_exact_dsml_tool_replay;
     s.tool_mem.max_entries = cfg.tool_memory_max_ids;
     s.enable_cors = cfg.enable_cors;
+    s.idle_timeout_sec = cfg.idle_timeout_sec;
+    s.last_activity = now_sec();
+    s.engine_spec = engine_spec;
+    s.model_name = xstrdup(ds4_engine_model_name(engine));
+    s.model_is_glm_dsa = ds4_engine_is_glm_dsa(engine);
     s.slots = xmalloc((size_t)slot_count * sizeof(*s.slots));
     memset(s.slots, 0, (size_t)slot_count * sizeof(*s.slots));
     if (s.batched_mode) {
@@ -13403,6 +13641,8 @@ int main(int argc, char **argv) {
     pthread_mutex_init(&s.model_mu, NULL);
     pthread_cond_init(&s.model_cv, NULL);
     pthread_mutex_init(&s.trace_mu, NULL);
+    pthread_mutex_init(&s.engine_mu, NULL);
+    pthread_cond_init(&s.engine_cv, NULL);
 
     for (int i = 0; i < slot_count; i++) {
         server_slot *slot = &s.slots[i];
@@ -13501,6 +13741,30 @@ int main(int argc, char **argv) {
     g_listen_fd = lfd;
     server_log(DS4_LOG_DEFAULT, "ds4-server: listening on http://%s:%d", cfg.host, cfg.port);
 
+    if (cfg.idle_timeout_sec > 0) {
+        if (pthread_create(&s.idle_thread, NULL, idle_monitor_main, &s) != 0) {
+            server_log(DS4_LOG_DEFAULT, "ds4-server: failed to start idle monitor");
+            close(lfd);
+            g_listen_fd = -1;
+            server_request_worker_stop(&s);
+            if (s.batched_mode) {
+                for (int i = 0; i < slot_threads_started; i++) {
+                    pthread_join(s.slot_threads[i], NULL);
+                }
+                server_request_decode_stop(&s);
+                if (decode_thread_started) pthread_join(s.decode_thread, NULL);
+            } else {
+                pthread_join(worker, NULL);
+            }
+            server_close_resources(&s);
+            return 1;
+        }
+        s.idle_thread_started = true;
+        server_log(DS4_LOG_DEFAULT,
+                   "ds4-server: idle timeout %ds; GPU and engine resources are freed while no request is in flight",
+                   cfg.idle_timeout_sec);
+    }
+
     while (!g_stop_requested) {
         int fd = accept(lfd, NULL, NULL);
         if (fd < 0) {
@@ -13539,6 +13803,7 @@ int main(int argc, char **argv) {
     }
 
     server_log(DS4_LOG_DEFAULT, "ds4-server: shutdown requested, draining requests");
+    if (s.idle_thread_started) pthread_join(s.idle_thread, NULL);
     server_request_worker_stop(&s);
     if (s.batched_mode) {
         for (int i = 0; i < slot_threads_started; i++) {
@@ -13555,6 +13820,7 @@ int main(int argc, char **argv) {
 
     for (int i = 0; s.kv.enabled && i < s.slot_count; i++) {
         server_slot *slot = &s.slots[i];
+        if (!slot->session) continue; /* Idle-unloaded. */
         const ds4_tokens *tokens = ds4_session_tokens(slot->session);
         if (!tokens || tokens->len < s.kv.opt.min_tokens) continue;
         server_log(DS4_LOG_KVCACHE,
@@ -18308,6 +18574,90 @@ static void test_thinking_canonical_non_thinking_mode_noop(void) {
     chat_msgs_free(&msgs);
 }
 
+/* The reload gate must cover exactly the endpoints whose handlers touch the
+ * engine: an inference endpoint missing from it would be served against a NULL
+ * engine, and a metadata path leaking in would let a polling client pay for a
+ * full model reload. */
+static void test_engine_gate_covers_inference_endpoints_only(void) {
+    static const char *needs[] = {
+        "/v1/chat/completions", "/v1/responses", "/v1/completions",
+        "/v1/messages",
+    };
+    for (size_t i = 0; i < sizeof(needs) / sizeof(needs[0]); i++) {
+        http_request hr = {0};
+        snprintf(hr.method, sizeof(hr.method), "%s", "POST");
+        snprintf(hr.path, sizeof(hr.path), "%s", needs[i]);
+        TEST_ASSERT(server_path_needs_engine(&hr));
+        snprintf(hr.method, sizeof(hr.method), "%s", "GET");
+        TEST_ASSERT(!server_path_needs_engine(&hr));
+    }
+    static const char *free_paths[] = {
+        "/v1/models", "/v1/models/deepseek-v4-flash", "/",
+        "/v1/chat/completions/extra",
+    };
+    for (size_t i = 0; i < sizeof(free_paths) / sizeof(free_paths[0]); i++) {
+        http_request hr = {0};
+        snprintf(hr.method, sizeof(hr.method), "%s", "POST");
+        snprintf(hr.path, sizeof(hr.path), "%s", free_paths[i]);
+        TEST_ASSERT(!server_path_needs_engine(&hr));
+    }
+}
+
+/* The idle predicate must keep the engine resident whenever work is in flight,
+ * and release it only when all slots/queues are empty AND the timeout elapsed.
+ * When the flag is disabled (0), it must never expire. */
+static void test_server_idle_expired_predicate_policy(void) {
+    server s;
+    server_slot slot = {0};
+    job j;
+    test_cancel_server_init(&s);
+    test_cancel_job_init(&j);
+    test_server_bind_slot(&s, &slot);
+
+    /* 1. Disabled flag never expires */
+    s.idle_timeout_sec = 0;
+    s.last_activity = now_sec() - 3600.0;
+    s.clients = 0;
+    s.head = NULL;
+    slot.busy = false;
+    TEST_ASSERT(!server_idle_expired(&s));
+
+    /* 2. When disabled, server_mark_activity is a no-op */
+    const double before = s.last_activity;
+    server_mark_activity(&s);
+    TEST_ASSERT(s.last_activity == before);
+
+    /* 3. With timeout set and elapsed, empty server expires */
+    s.idle_timeout_sec = 30;
+    s.last_activity = now_sec() - 31.0;
+    TEST_ASSERT(server_idle_expired(&s));
+
+    /* 4. server_mark_activity resets the idle timer and clears expiration */
+    server_mark_activity(&s);
+    TEST_ASSERT(!server_idle_expired(&s));
+
+    /* 5. In-flight clients block expiration */
+    s.last_activity = now_sec() - 60.0;
+    s.clients = 1;
+    TEST_ASSERT(!server_idle_expired(&s));
+    s.clients = 0;
+
+    /* 6. Queued jobs block expiration */
+    s.head = &j;
+    TEST_ASSERT(!server_idle_expired(&s));
+    s.head = NULL;
+
+    /* 7. Batched busy slots block expiration */
+    s.batched_mode = true;
+    slot.busy = true;
+    TEST_ASSERT(!server_idle_expired(&s));
+    slot.busy = false;
+    TEST_ASSERT(server_idle_expired(&s));
+
+    test_cancel_job_destroy(&j);
+    test_cancel_server_destroy(&s);
+}
+
 static void ds4_server_unit_tests_run(void) {
     test_batched_prefill_round_robin();
     test_mixed_prefill_quantum_option();
@@ -18433,6 +18783,8 @@ static void ds4_server_unit_tests_run(void) {
     test_kv_cache_eviction_score_decays_stale_hits();
     test_kv_cache_eviction_decayed_hits_tie_break_by_age();
     test_kv_cache_eviction_keeps_aligned_continued_frontiers();
+    test_engine_gate_covers_inference_endpoints_only();
+    test_server_idle_expired_predicate_policy();
 }
 
 #ifndef DS4_SERVER_TEST_NO_MAIN


### PR DESCRIPTION
`--idle-timeout N` frees the resident sessions and the engine after N seconds with no request in flight, then reloads both on the next inference request. Default `0` keeps today's behaviour exactly.

The point of the change is that **the listening socket stays bound while unloaded**. A client that connects to an unloaded server completes its TCP handshake immediately and waits for the reload. In a multi-provider fallback chain an `ECONNREFUSED` makes the caller walk away from the primary provider; a slow first token does not. That distinction is the whole reason this is not just "stop the server when idle".

Motivating case: a long local agent session leaves ~81 GB of unified memory pinned between turns, on a machine that also drives a display and other local models.

## AGENT.md flag rule

> *Do not add permanent semantic variants behind flags. Diagnostic switches are fine when they validate the one release path.*

1. **No semantic variant.** This is a memory-lifecycle policy. While loaded, execution, KV mechanics, sampling and DSML parsing are untouched; there is one inference path.
2. **Zero-overhead default.** With the flag unset, `server_ensure_engine_loaded()` and `server_mark_activity()` return on their first line and no monitor thread is created. `server_idle_expired()` also returns false immediately when the flag is 0, so being disabled is part of the predicate rather than only of the caller.
3. **Serves a stated project goal.** AGENT.md aims to *"make long local agent sessions practical"*; residency between turns is the memory half of that problem.

## Implementation

**Why unloading is race-free.** `server.clients` is incremented in the accept loop *before* the client thread starts and decremented only in `client_done()`, and a client thread owns its job until a worker signals completion (`wait_for_job_or_disconnect` loops until `j->done`; `server_cancel_job` only completes a job it detached before any worker claimed it). `clients == 0` therefore proves no request path holds a session or engine pointer. The unload predicate requires it, plus `!s->head` and (in batched mode) no slot `busy`.

This server is one-request-per-connection (`Connection: close`). `clients` is therefore in-flight-request accounting, not keep-alive-socket accounting; an idle HTTP connection cannot pin the model.

- **Teardown order**: per-slot live tool/visible state, then sessions (`slot->session = NULL`), then `ds4_engine_close()`. Sessions hold references into engine-owned memory; the reverse order dangles.
- **Single reload under concurrency**: `engine_mu` + `engine_cv` + `engine_loading`, so N concurrent cold requests wait on the first reload instead of starting N. A failed reload clears `engine_loading`, broadcasts waiters, and the caller answers HTTP 503 (`model engine unavailable`) rather than using a NULL engine.
- **Metadata never reloads.** `GET /v1/models` (and `GET /v1/models/<id>`) answer from model identity cached at first open (`s->model_name`, `s->model_is_glm_dsa`) and do **not** refresh the idle clock. `OPTIONS` preflight is answered 204 before the gate. Otherwise a liveness poller on a shorter interval than the timeout would silently pin the model in memory forever — the feature would appear to work and never fire.
- **Reload gate** is `server_path_needs_engine()`, deliberately a small explicit list matching the parse chain in `client_main()` (`POST` `/v1/chat/completions`, `/v1/responses`, `/v1/completions`, `/v1/messages`). An unknown POST returns 404 without paying for a reload. A unit test pins the list against that parse chain.
- **NULL guards**: the shutdown KV-persist loop skips NULL sessions. `ds4_session_pos()` dereferences its argument, so reporting live tokens while unloaded would crash; that is fixed here, not worked around.
- **KV checkpoint before unload** when `--kv-disk-dir` is set, for the same reason the shutdown path does it: dropping a live session without checkpointing leaves only an older prefix on disk. `slot->continued_last_store_tokens` is reset so the reloaded empty session does not inherit save-suppression state.
- **GPU layout is captured at first open and replayed verbatim**, so an `auto` layout cannot silently land on a different placement after a reload.
- **Idle clock** is `CLOCK_MONOTONIC` (`now_sec()`). Activity is marked at inference-request admission *and* at job completion, so a long generation cannot be unloaded moments after it finishes. Metadata requests never mark activity.
- **Flag parse** reuses `parse_nonneg_int_arg`: negative / non-numeric / overflow values exit 2 with `invalid value for --idle-timeout`. `pthread_create` failure of the monitor refuses to start rather than running with a silently dead unloader.

Observability is the two existing log lines — unload (`idle timeout of Ns reached; freeing GPU and engine resources`) and reload (`engine reloaded after idle unload in %.2fs`). There is no new HTTP surface.

## Tests

Two unit tests in `ds4_server.c`, run by `./ds4_test --server`:

- `test_engine_gate_covers_inference_endpoints_only` — POST to the four inference paths needs the engine; GET on those paths, `/v1/models`, `/v1/models/<id>`, `/`, and an unknown POST suffix do not.
- `test_server_idle_expired_predicate_policy` — flag `0` never expires and `server_mark_activity` is a no-op; elapsed empty server expires; mark_activity clears it; in-flight `clients`, queued `head`, and batched `slot.busy` each block unload.

## Verification

**Environment (Metal, this branch).** Apple M5 Max (`Mac17,6`), 128 GiB unified memory, macOS **26.5.2**, Metal 4 tensor API. Model `DeepSeek-V4-Flash-0731-Abliterated-DS4-Headroom128.gguf` (**82,697 MiB mapped**), `--ctx 65536`.

**Note on measuring memory.** Weights are mmap'd, so process RSS does *not* reflect them (it read 0.1 GiB at every phase). System-wide free memory is the meaningful figure, and engine open is lazy — residency appears on the first inference, not at startup.

| Check | Result |
|---|---|
| Unload fires | `idle timeout of 30s reached; freeing GPU and engine resources` |
| Free memory, resident vs unloaded (same run) | **13.7 GiB → 91.2 GiB** (~77.5 GiB returned) |
| Process survives unload | yes; keeps serving |
| Metadata while unloaded | `GET /v1/models` and `GET /v1/models/<id>` HTTP 200 from cached identity |
| 12 metadata calls while unloaded | **0 reloads** (absolute count) |
| Unknown POST while unloaded | 404, **0 reloads** |
| Cold inference request | HTTP 200, `connect=0.000210s`, `total=0.795s` |
| Reload cost | **0.40 s** (warm page cache; lazy mmap) |
| 2 simultaneous cold requests | **exactly 1 reload**, both HTTP 200 |
| Control, flag unset | 0 unload events, 0 idle log lines |

**Regression tests (this branch, `c3a36ea`).**

- `make clean && make` — clean under `-Wall -Wextra`, zero warnings.
- `make cpu` — clean, zero warnings.
- `./ds4_test --server` — `server: OK` (includes both new unit tests).
- `./ds4-server --idle-timeout -5` / `--idle-timeout abc` — both exit 2 with `invalid value for --idle-timeout`.
- `--help` renders the new option and the "socket stays bound" paragraph.

Full `./ds4_test` groups that need `ds4flash.gguf` were not re-run on this desk (no local copy of the 81 GB GGUF). The change is confined to `ds4_server.c` request admission plus engine open/close; no decode or prefill kernel, graph, or scheduling decision is altered. The `--server` group is the contract this change owns.

**CUDA (same change, fork form `audreyt/main` @ `1c217dc`, previously measured).** Deployed and verified on a **DGX Spark / GB10, CUDA `sm_121a`** build (`make cuda-spark`, `-gencode arch=compute_121a,code=sm_121a -DDS4_CUDA_HAVE_MXF4=1`), 119 GiB host memory, same 81 GB GGUF at `--ctx 65536` with `--kv-disk-dir`:

| Check (CUDA, previously measured) | Result |
|---|---|
| Unload frees host+device memory | `MemAvailable` **7.6 GiB → 114.6 GiB** (~107 GiB returned) |
| Process survives, socket bound | yes; cold connect **0.000062 s** |
| Metadata while unloaded | answers without reload |
| Cold request | HTTP 200, reload **13.65 s**, then served |
| CUDA errors / crashes | **0** / **0** |
| `--kv-disk-dir` unload | `persisting resident KV cache before idle unload`; after reload `cache_hit_after_reload=1` |

Note the backend asymmetry worth knowing before merging: **Metal reloads in ~0.4 s** (lazy unified mmap) while **CUDA takes ~13.7 s** because buffers must be staged. The flag is still correct on both; it just means CUDA operators want a warm-up hook ahead of latency-sensitive scheduled work rather than relying on the first real request.

ROCm remains unexercised.

## Not included

- No new HTTP metrics endpoint. Upstream has no `/stats` / `/health`; operators observe the two log lines. A fork of this change exposes `idle_unloaded` / `idle_unloads` on `/stats` — that is fork-only and not proposed here.
- Live KV is checkpointed to disk on unload only when `--kv-disk-dir` is enabled; there is no new persistence mechanism.
- The acceptance script depends on 30–90 s sleeps, `vm_stat` / `MemAvailable`, and an 81 GB GGUF. Useful as manual QA, too host-dependent for CI.
