### PR TITLE
kvstore: cold checkpoints outrank live dumps in eviction

### DIFF
--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -49,10 +49,14 @@
  * store. */
 #define KV_CACHE_CONTINUED_PREFIX_MIN_FACTOR 0.05
 #define KV_CACHE_CONTINUED_PREFIX_HIT_FACTOR 0.45
-/* Cold/evict/shutdown checkpoints are intentional anchors, not just automatic
- * waypoints in a single growing conversation. Give them a soft prior so they
- * survive comparable continued entries, while still allowing pressure and poor
- * density to evict them. */
+/* Cold checkpoints are intentional anchors, not just automatic waypoints in a
+ * single growing conversation: they cut at a chat boundary so a whole class of
+ * later prompts can extend them. Give them a soft prior so they survive
+ * comparable continued entries and the live dumps written on eviction or
+ * shutdown, while still allowing pressure and poor density to evict them.
+ * Evict/shutdown dumps are the live tail as it stood, ending in sampled output,
+ * so only a client that replays that exact output can ever extend one; when the
+ * disk is full and nothing has hits, the anchor is the one worth keeping. */
 #define KV_CACHE_ANCHOR_REASON_SCORE_FACTOR 2.0
 
 typedef struct {
@@ -524,9 +528,7 @@ static bool kv_cache_incoming_supersedes_continued(
 }
 
 static bool kv_cache_reason_is_anchor(uint8_t reason) {
-    return reason == DS4_KVSTORE_REASON_COLD ||
-           reason == DS4_KVSTORE_REASON_EVICT ||
-           reason == DS4_KVSTORE_REASON_SHUTDOWN;
+    return reason == DS4_KVSTORE_REASON_COLD;
 }
 
 double ds4_kvstore_entry_eviction_score(

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -17795,6 +17795,47 @@ static void test_kv_cache_eviction_prefers_anchor_reason(void) {
     rmdir(dir);
 }
 
+/* A cold anchor is usually the smallest file on disk (it cuts at the last
+ * chat boundary before the assistant spoke), while a live dump written on
+ * eviction holds the whole session. On density alone the anchor is always the
+ * first victim, and a full disk then evicts every fresh anchor on the very
+ * next store. The anchor factor must not extend to the dumps. */
+static void test_kv_cache_eviction_prefers_cold_anchor_over_live_dump(void) {
+    char tmpl[] = "/tmp/ds4-kv-cold-over-dump-test.XXXXXX";
+    char *dir = mkdtemp(tmpl);
+    TEST_ASSERT(dir != NULL);
+    if (!dir) return;
+
+    const char *cold_sha = "1111111111111111111111111111111111111111";
+    const char *dump_sha = "2222222222222222222222222222222222222222";
+    uint64_t now = (uint64_t)time(NULL);
+    test_kv_stub_file(dir, cold_sha, KV_REASON_COLD, 1536, 0, now, 2048);
+    test_kv_stub_file(dir, dump_sha, KV_REASON_EVICT, 2048, 0, now, 2048);
+
+    char cold_name[44], dump_name[44];
+    snprintf(cold_name, sizeof(cold_name), "%.40s.kv", cold_sha);
+    snprintf(dump_name, sizeof(dump_name), "%.40s.kv", dump_sha);
+    char *cold_path = path_join(dir, cold_name);
+    char *dump_path = path_join(dir, dump_name);
+
+    kv_disk_cache kc = {0};
+    kc.enabled = true;
+    kc.dir = xstrdup(dir);
+    kc.opt = kv_cache_default_options();
+    kc.budget_bytes = (KV_CACHE_FIXED_HEADER + 4u + 2048u) + 16u;
+    kv_cache_evict(&kc, NULL, 0, NULL);
+
+    TEST_ASSERT(access(cold_path, F_OK) == 0);
+    TEST_ASSERT(access(dump_path, F_OK) != 0);
+
+    kv_cache_close(&kc);
+    unlink(cold_path);
+    unlink(dump_path);
+    free(cold_path);
+    free(dump_path);
+    rmdir(dir);
+}
+
 static void test_kv_cache_eviction_makes_room_before_store(void) {
     char tmpl[] = "/tmp/ds4-kv-pre-store-evict-test.XXXXXX";
     char *dir = mkdtemp(tmpl);
@@ -18426,6 +18467,7 @@ static void ds4_server_unit_tests_run(void) {
     test_kv_cache_lookup_rejects_stale_payload_abi();
     test_kv_cache_eviction_values_fresh_snapshots();
     test_kv_cache_eviction_prefers_anchor_reason();
+    test_kv_cache_eviction_prefers_cold_anchor_over_live_dump();
     test_kv_cache_eviction_makes_room_before_store();
     test_kv_cache_eviction_ignores_oversize_incoming();
     test_kv_cache_eviction_prefers_superseded_continued_prefix();


### PR DESCRIPTION
A cold checkpoint cuts at the last chat boundary before the assistant spoke, so it is usually the smallest file on disk and the one a whole class of later prompts can extend. An evict/shutdown dump is the live tail as it stood, ending in sampled output, so only a client that replays that exact output can ever extend it. Both carried `KV_CACHE_ANCHOR_REASON_SCORE_FACTOR`, and with a full disk and no hits the score reduces to token density: the small cold anchor was always the first victim, evicted on the very next store.

**Seen in production.** Mac Studio M3 Ultra 512 GB, Metal, DeepSeek V4 Flash MXFP4 0731 (README default), `84cc882`, `--batched-session 4 --ctx 300000 --kv-disk-dir ... --kv-disk-space-mb 16384`, serving a Telegram chat bot (OpenAI chat/completions, no tool replay). Once the directory filled, every request logged the pair

```
kv cache stored tokens=5343 trimmed=1433 reason=cold key=token-text size=92.97 MiB save=12.6 ms
kv cache evicted reason=disk-cache-full tokens=5343 hits=0 size=92.97 MiB file=.../caa8385...kv
```

and every chat prompt prefilled ~7k tokens from zero (~20 s at ~340 t/s) instead of ~3k from the anchor. Independent of #711 (measured with and without it).

**Reproduced on clean `84cc882`** with `--kv-disk-space-mb 768` so it fills in a few requests: room A cold (anchor 4088 tokens, 76.5 MiB), five unrelated ~5.7k-token prompts (each writes a bigger cold checkpoint, ~98 MiB, and an evict dump, ~98 MiB), then room A + one message. Same binary flags otherwise (`--batched-session 4 --ctx 300000`), fresh cache directory per run.

| | first eviction victim | A + one message |
|---|---|---|
| main | A's cold anchor (4088 tokens, the smallest file) | `cached_tokens=0`, full prefill, 12.1 s |
| this change | the evict dumps (5716, 5770, 5770, 5770) | `kv cache hit text tokens=4088`, 5.1 s |

Log lines from both runs are below. Only `COLD` keeps the factor; among cold entries density and age still decide, as before. Live dumps still get written and still serve the replaying-client case, they just no longer outrank the deliberate anchors under pressure.

Tests: `./ds4_test --server` (macOS, Metal build). New `test_kv_cache_eviction_prefers_cold_anchor_over_live_dump` fails on `main` (`assertion failed: access(cold_path, F_OK) == 0`) and passes with the change. No inference path touched; no speed impact beyond the fewer cold prefills.

<details><summary>Repro log, main (768 MB)</summary>

```
kv cache evicted reason=disk-cache-full tokens=4088 hits=0 size=76.52 MiB   <- A's anchor, first victim
kv cache evicted reason=disk-cache-full tokens=5716 hits=0 size=97.91 MiB
kv cache evicted reason=disk-cache-full tokens=5755 hits=0 size=98.37 MiB
kv cache evicted reason=disk-cache-full tokens=5755 hits=0 size=98.37 MiB
kv cache evicted reason=disk-cache-full tokens=5755 hits=0 size=98.37 MiB
A +1: prompt_tokens=5743 cached_tokens=0   12.1 s
```
</details>

<details><summary>Repro log, patched (768 MB)</summary>

```
kv cache evicted reason=disk-cache-full tokens=5716 hits=0 size=97.91 MiB   <- evict dumps first
kv cache evicted reason=disk-cache-full tokens=5770 hits=0 size=98.62 MiB
kv cache evicted reason=disk-cache-full tokens=5770 hits=0 size=98.62 MiB
kv cache evicted reason=disk-cache-full tokens=5770 hits=0 size=98.62 MiB
kv cache hit text tokens=4088 text=17512 quant=2 key=token-text load=12.3 ms
A +1: prompt_tokens=5743 cached_tokens=4088   5.1 s
```
</details>
