### PR TITLE
server: drop a partial trailing UTF-8 sequence from finished text

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -11991,6 +11991,15 @@ decode_again:
                             &last_decode_log_completion);
     }
 
+    /* A generation cut mid-codepoint (max_tokens, a stop sequence) must not
+     * leak the partial sequence: no client can decode it and the JSON body is
+     * required to be UTF-8. Streaming already holds such a tail back between
+     * chunks; the final flush and the non-stream body have to drop it. */
+    if (text.ptr) {
+        text.len = utf8_stream_safe_len(text.ptr, 0, text.len, false);
+        text.ptr[text.len] = '\0';
+    }
+
     if (j->req.stream && !structured_stream && text.len > plain_stream_pos) {
         char *tail = xstrndup(text.ptr + plain_stream_pos, text.len - plain_stream_pos);
         if (!sse_chunk(j->fd, &j->req, id, tail, NULL)) {
@@ -14922,6 +14931,23 @@ static void test_streaming_holds_partial_utf8(void) {
     request_free(&r);
     close(sv[0]);
     close(sv[1]);
+}
+
+/* The same boundary rule the stream applies between chunks is applied once to
+ * the finished text, so a generation cut inside a codepoint never reaches a
+ * response body: a lone lead byte and a half-written sequence are dropped, a
+ * complete sequence and plain ASCII are kept whole. */
+static void test_generation_tail_drops_partial_utf8(void) {
+    const char lead_only[] = {'A', ' ', (char)0xc3, 0};
+    const char half[] = {'A', ' ', (char)0xf0, (char)0x9f, 0};
+    const char whole[] = {'A', ' ', (char)0xf0, (char)0x9f, (char)0x9a, (char)0xa9, 0};
+    const char accent[] = {(char)0xc3, (char)0xa9, 0};
+
+    TEST_ASSERT(utf8_stream_safe_len(lead_only, 0, strlen(lead_only), false) == 2);
+    TEST_ASSERT(utf8_stream_safe_len(half, 0, strlen(half), false) == 2);
+    TEST_ASSERT(utf8_stream_safe_len(whole, 0, strlen(whole), false) == strlen(whole));
+    TEST_ASSERT(utf8_stream_safe_len(accent, 0, strlen(accent), false) == 2);
+    TEST_ASSERT(utf8_stream_safe_len("done", 0, 4, false) == 4);
 }
 
 static void test_request_defaults_use_min_p_filtering(void) {
@@ -18357,6 +18383,7 @@ static void ds4_server_unit_tests_run(void) {
     test_openai_tool_stream_holds_partial_utf8_arguments();
     test_openai_tool_stream_handles_multiple_calls();
     test_streaming_holds_partial_utf8();
+    test_generation_tail_drops_partial_utf8();
     test_parse_short_dsml_and_canonical_suffix();
     test_parse_glm_tool_call_message();
     test_dsml_parser_recovers_loose_nested_parameters();


### PR DESCRIPTION
When a generation stops inside a multibyte token (`max_tokens`, a stop sequence), the last bytes of the generated text are an incomplete UTF-8 sequence. Streaming already holds such a tail back between chunks (`utf8_stream_safe_len`), but the final flush and the non-stream body emitted it as-is, so the JSON response carried invalid UTF-8.

Repro on `84cc882` (Metal, DeepSeek V4 Flash MXFP4 0731, `--batched-session 4`): a Spanish group-chat prompt whose greedy first token is 👋, `"max_tokens": 1`, non-stream. The body contains `"content":"\xf0\x9f\x91"` (three of the four bytes) and Python's `json.loads` fails with `UnicodeDecodeError: invalid continuation byte`; any strict client does the same. With this change the same request returns `"content":""` and `max_tokens: 2` returns `"👋"`, as before.

The change applies the same boundary once to the finished text, before any response is built (stream final flush or non-stream body). Only the partial sequence is dropped; complete sequences and ASCII are untouched, and the streamed prefix is unaffected since it never crossed that boundary. Unit test `test_generation_tail_drops_partial_utf8` added; `./ds4_test --server` passes (macOS, Metal build). The live checkpoint keeps the full token; a client replaying the returned text will not extend the session in this corner case, which it could not before either (the text was undecodable).
