### PR TITLE
ROCm: env opt-in to keep the Q8->F16 weight cache in multi-model (MTP) setups

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -59664,13 +59664,31 @@ int ds4_session_eval_layer_slice(ds4_session *s,
         }
     } else {
         if (ok) ok = ds4_gpu_begin_commands() != 0;
+        static int batch_layer_timing = -1;
+        if (batch_layer_timing < 0)
+            batch_layer_timing = getenv("DS4_ROCM_BATCH_LAYER_TIMING") != NULL ? 1 : 0;
         for (uint32_t il = layer_start; ok && il <= layer_end; il++) {
+            double lt0 = 0.0;
+            if (batch_layer_timing) {
+                if (ok) ok = ds4_gpu_end_commands() != 0;
+                if (ok) ok = ds4_gpu_synchronize() != 0;
+                lt0 = now_sec();
+                if (ok) ok = ds4_gpu_begin_commands() != 0;
+            }
             ok = metal_graph_encode_layer_batch(g,
                                                 &e->model,
                                                 &e->weights.layer[il],
                                                 il,
                                                 pos0,
                                                 n_tokens);
+            if (batch_layer_timing) {
+                if (ok) ok = ds4_gpu_end_commands() != 0;
+                if (ok) ok = ds4_gpu_synchronize() != 0;
+                if (ok) ok = ds4_gpu_begin_commands() != 0;
+                fprintf(stderr,
+                        "ds4: batch layer timing pos=%u n=%u il=%u elapsed=%.1f ms\n",
+                        pos0, n_tokens, il, (now_sec() - lt0) * 1000.0);
+            }
         }
     }
     if (ok && output_logits) {
@@ -59695,7 +59713,19 @@ int ds4_session_eval_layer_slice(ds4_session *s,
 
     if (ok && !output_hc && !output_logits) ok = ds4_gpu_synchronize() != 0;
     if (ok && output_hc) {
+        const bool time_readback = getenv("DS4_DIST_SYNC_TIMING") != NULL;
+        const double rb_t0 = time_readback ? now_sec() : 0.0;
         ok = ds4_gpu_tensor_read(metal_graph_batch_cur_hc(g), 0, output_hc, hc_bytes) != 0;
+        if (time_readback) {
+            fprintf(stderr,
+                    "ds4: dist sync timing hidden readback n=%u bytes=%llu elapsed=%.1f ms (%.1f MiB/s)\n",
+                    n_tokens,
+                    (unsigned long long)hc_bytes,
+                    (now_sec() - rb_t0) * 1000.0,
+                    (now_sec() - rb_t0) > 0.0
+                        ? (double)hc_bytes / (1024.0 * 1024.0) / (now_sec() - rb_t0)
+                        : 0.0);
+        }
     }
     if (ok && output_logits) {
         ok = ds4_gpu_tensor_read(metal_graph_logits(g), 0, logits, (uint64_t)DS4_N_VOCAB * sizeof(float)) != 0;

--- a/rocm/ds4_rocm_runtime.cuh
+++ b/rocm/ds4_rocm_runtime.cuh
@@ -4996,7 +4996,12 @@ static void cuda_q8_f16_cache_disable_after_failure(const char *what, uint64_t r
 static int cuda_q8_f16_cache_allowed(const char *label, uint64_t in_dim, uint64_t out_dim) {
     if (g_quality_mode) return 0;
     if (g_q8_f16_disabled_after_oom) return 0;
-    if (g_q8_f16_disabled_for_multi_model) return 0;
+    /* Multi-model (MTP) setups disable the cache by default to protect the
+     * memory margin for session/context tensors.  The budget check in
+     * cuda_q8_f16_cache_has_budget() still applies per allocation; the env
+     * opt-in re-enables the speed path when the host has headroom. */
+    if (g_q8_f16_disabled_for_multi_model &&
+        getenv("DS4_ROCM_Q8_F16_CACHE_MULTI_MODEL") == NULL) return 0;
     if (getenv("DS4_CUDA_NO_Q8_F16_CACHE") != NULL) return 0;
     if (!label) return 0;
     if (strstr(label, "attn_output_a") != NULL ||


### PR DESCRIPTION
## What this does

Fixes a silent prefill regression in multi-model ROCm setups, behind an opt-in environment variable.

The chain of events being fixed:

- Loading a second model map — a multi-token-prediction or DSpark support model — trips the runtime's multi-model guard, which disables the optional Q8→F16 expanded-weight cache for the entire process.
- With the cache disabled, the attention-output matrix multiply runs on the direct Q8 path instead of the hipBLAS F16 path. At prefill shapes the direct path is 5.2 times slower: 348.7 ms against 66.7 ms per layer per 4096-token chunk in the original measurement.
- Setting `DS4_ROCM_Q8_F16_CACHE_MULTI_MODEL=1` lets the cache build alongside the second model map. The existing per-allocation budget check (a 512 MiB reserve on GPUs with 112 GiB or more) still guards against overcommit, and an allocation failure falls back to the Q8 path with a log line.
- Without the environment variable set, behavior is completely unchanged.

Measured effect with a support model loaded: a 10,500-token prefill went from 74.2 s to 61.5 s — 21% faster. Decode is unchanged.

The pull request also includes the two diagnostics that found the problem: `DS4_ROCM_BATCH_LAYER_TIMING` (per-layer GPU timing with command-buffer boundaries) and `DS4_DIST_SYNC_TIMING` (a readback timer for distributed synchronization).

## Correctness

On Radeon 8060S (gfx1151, TheRock toolchain), rebased on current main:

- Warning-free `make strix-halo`. Built with `-fPIC` in `CFLAGS`; main does not yet carry the `ROCM_HOST_CFLAGS` fix, which ships separately in #656.
- End to end on two machines with greedy decoding and the released Q4_K-experts model file:
  - with the variable unset, output is byte-identical to unmodified main — the default path is untouched;
  - with the variable set, runs complete with correct output. In single-model runs the setting changes nothing, since the guard only trips when a second model is loaded.
- Numerics: with the variable set in a multi-model setup, the expanded-weight cache runs in F16 instead of falling back to Q8. This is the more precise path and is deterministic across runs, but it is not bit-identical to the Q8 fallback. Anyone who needs to reproduce the old fallback exactly leaves the variable unset.

## How to test

`make strix-halo`, then any ROCm run with a multi-token-prediction support model loaded. Compare prefill rates with and without `DS4_ROCM_Q8_F16_CACHE_MULTI_MODEL=1`.
