### PR TITLE
ROCm: port decode-island graph capture to HIP (staged, default-off)

### DIFF
--- a/ds4_rocm_compat.cu
+++ b/ds4_rocm_compat.cu
@@ -16,12 +16,244 @@ static int rocm_tier_valid(int tier) {
     return tier == 0 && g_n_gpus == 1;
 }
 
-/* Decode-island graph capture is CUDA-only for now; ROCm decodes eagerly. */
-extern "C" int ds4_gpu_decode_graphs_supported(void) { return 0; }
-extern "C" int ds4_gpu_decode_graph_begin(const ds4_decode_graph_key *key) { (void)key; return -1; }
-extern "C" int ds4_gpu_decode_graph_end(const ds4_decode_graph_key *key) { (void)key; return -1; }
-extern "C" void ds4_gpu_decode_graph_abort(const ds4_decode_graph_key *key) { (void)key; }
-extern "C" void ds4_gpu_decode_graphs_invalidate(void) {}
+/* ------------------------------------------------------------------------
+ * Decode-island HIP graph capture.  Port of the CUDA implementation in
+ * ds4_cuda.cu (design from the Entrpi/ds4 batched-serving fork): the
+ * position-independent islands of a decode layer are captured once per
+ * buffer-alias key and replayed afterwards.  A replayed graph re-runs
+ * the captured kernels byte-for-byte, so replay output is bit-identical
+ * to the eager encode it recorded; any capture failure retires the
+ * entry and the island runs eagerly, also byte-identical to before.
+ *
+ * Stream handling mirrors CUDA: kernels normally launch on the legacy
+ * default stream, which cannot be captured, so every launch site in the
+ * backend goes through ds4_rocm_stream(), which returns the capture
+ * stream while g_rocm_decode_graph_capturing is set.
+ */
+#define ROCM_DECODE_GRAPH_LAYERS   64u
+#define ROCM_DECODE_GRAPH_ISLANDS  4u
+#define ROCM_DECODE_GRAPH_VARIANTS 8u
+
+struct rocm_decode_graph_entry {
+    ds4_decode_graph_key key;
+    hipGraphExec_t       exec;
+    int                  state;   /* 0 empty, 1 warmed, 2 ready, 3 dead */
+    uint64_t             hits;
+};
+
+static rocm_decode_graph_entry
+    g_rocm_decode_graphs[ROCM_DECODE_GRAPH_LAYERS][ROCM_DECODE_GRAPH_ISLANDS]
+                        [ROCM_DECODE_GRAPH_VARIANTS];
+static hipStream_t g_rocm_decode_graph_stream = NULL;
+static int g_rocm_decode_graph_capturing = 0;
+static uint64_t g_rocm_decode_graph_replays = 0;
+static uint64_t g_rocm_decode_graph_captures = 0;
+
+extern "C" void ds4_rocm_set_capture_stream(void *stream);
+
+/* Island policy: islands 0/1 are the upstream eval-path islands
+ * (TO_QKV and FROM_ATTN_TO_FFN); island 2 is the speculative span's
+ * batched attention-output stage (C2), island 3 is the span's shared
+ * expert tail (stages D+E).  Live measurements on gfx1151 (MTP draft-2
+ * verify path): the small eval islands replay SLOWER than eager (rounds
+ * 91.0 -> 92.7 ms), and islands 2/3 replay byte-exact (SHA-gated) but
+ * time-neutral (91.1 ms) -- their 60-240 us kernels already hide launch
+ * latency, so the ~11 ms/span launch feed lives in the tiny per-row
+ * chains: position-dependent stages A/B and the per-row router/MoE
+ * stage C3, which is capture-unsafe (deterministic divergence with all
+ * buffer pointers keyed; cause not isolated).  The machinery is kept
+ * because capturing the small-op chains becomes attractive once they
+ * are rows-batched and position-indirect; until then it is dormant, so
+ * so the default is OFF (measured-neutral today) and the machinery is
+ * staged infrastructure: DS4_ROCM_DECODE_GRAPHS=span captures islands
+ * 2+, =all also captures the eval islands. */
+#define ROCM_DECODE_GRAPH_MODE_OFF  0
+#define ROCM_DECODE_GRAPH_MODE_SPAN 1
+#define ROCM_DECODE_GRAPH_MODE_ALL  2
+static int g_rocm_decode_graph_mode = ROCM_DECODE_GRAPH_MODE_OFF;
+
+extern "C" int ds4_gpu_decode_graphs_supported(void) {
+    static int init = 0;
+    static int enabled = 0;
+    if (!init) {
+        init = 1;
+        const char *s = getenv("DS4_ROCM_DECODE_GRAPHS");
+        if (s && (strcmp(s, "span") == 0 || strcmp(s, "SPAN") == 0)) {
+            g_rocm_decode_graph_mode = ROCM_DECODE_GRAPH_MODE_SPAN;
+        } else if (s && (strcmp(s, "all") == 0 || strcmp(s, "ALL") == 0)) {
+            g_rocm_decode_graph_mode = ROCM_DECODE_GRAPH_MODE_ALL;
+        } else {
+            g_rocm_decode_graph_mode = ROCM_DECODE_GRAPH_MODE_OFF;
+        }
+        enabled = g_rocm_decode_graph_mode != ROCM_DECODE_GRAPH_MODE_OFF;
+        if (enabled)
+            fprintf(stderr, "ds4: DS4_ROCM_DECODE_GRAPHS=%s - decode graph capture mode %d\n",
+                    s, g_rocm_decode_graph_mode);
+    }
+    return enabled && g_n_gpus == 1;
+}
+
+static void rocm_decode_graph_entry_kill(rocm_decode_graph_entry *e) {
+    if (e->exec) {
+        (void)hipGraphExecDestroy(e->exec);
+        e->exec = NULL;
+    }
+    e->state = 3;
+}
+
+extern "C" void ds4_gpu_decode_graphs_invalidate(void) {
+    for (uint32_t il = 0; il < ROCM_DECODE_GRAPH_LAYERS; il++) {
+        for (uint32_t is = 0; is < ROCM_DECODE_GRAPH_ISLANDS; is++) {
+            for (uint32_t v = 0; v < ROCM_DECODE_GRAPH_VARIANTS; v++) {
+                rocm_decode_graph_entry *e = &g_rocm_decode_graphs[il][is][v];
+                if (e->exec) {
+                    (void)hipGraphExecDestroy(e->exec);
+                    e->exec = NULL;
+                }
+                e->state = 0;
+                e->hits = 0;
+                memset(&e->key, 0, sizeof(e->key));
+            }
+        }
+    }
+}
+
+static rocm_decode_graph_entry *rocm_decode_graph_find(
+        const ds4_decode_graph_key *key) {
+    if (key->il >= ROCM_DECODE_GRAPH_LAYERS ||
+        key->island >= ROCM_DECODE_GRAPH_ISLANDS) return NULL;
+    rocm_decode_graph_entry *slot = NULL;
+    for (uint32_t v = 0; v < ROCM_DECODE_GRAPH_VARIANTS; v++) {
+        rocm_decode_graph_entry *e = &g_rocm_decode_graphs[key->il][key->island][v];
+        if (e->state != 0 &&
+            memcmp(&e->key, key, sizeof(*key)) == 0) return e;
+        if (e->state == 0 && !slot) slot = e;
+    }
+    if (slot) {
+        memcpy(&slot->key, key, sizeof(*key));
+        slot->state = 0;   /* caller advances the state machine */
+        return slot;
+    }
+    return NULL;           /* all variants busy with other keys: stay eager */
+}
+
+extern "C" int ds4_gpu_decode_graph_begin(const ds4_decode_graph_key *key) {
+    if (!key || !ds4_gpu_decode_graphs_supported()) return -1;
+    if (g_rocm_decode_graph_mode != ROCM_DECODE_GRAPH_MODE_ALL &&
+        key->island < 2u) return -1;   /* eval islands: measured net-negative */
+    if (g_rocm_decode_graph_capturing) return -1;   /* no nesting */
+    rocm_decode_graph_entry *e = rocm_decode_graph_find(key);
+    if (!e || e->state == 3) return -1;
+    if (e->state == 0) {
+        /* Warm pass: run eagerly once so lazy allocators (tmp scratch,
+         * hipBLASLt workspaces) reach steady-state sizes before capture. */
+        e->state = 1;
+        return -1;
+    }
+    if (e->state == 2) {
+        /* Replay on the legacy default stream: the captured chain is
+         * single-stream, so it executes in order against the surrounding
+         * eager work with no cross-stream sync edges.  (Replaying on the
+         * capture stream raced the eager producers in live tests.) */
+        hipError_t err = hipGraphLaunch(e->exec, (hipStream_t)0);
+        if (err != hipSuccess) {
+            fprintf(stderr, "ds4: decode graph replay failed (il=%u island=%u): %s\n",
+                    key->il, key->island, hipGetErrorString(err));
+            (void)hipGetLastError();
+            rocm_decode_graph_entry_kill(e);
+            return -1;     /* caller encodes eagerly; nothing was consumed */
+        }
+        e->hits++;
+        g_rocm_decode_graph_replays++;
+        return 1;
+    }
+    /* state == 1: capture this encode. */
+    if (!g_rocm_decode_graph_stream) {
+        /* Blocking flag (no hipStreamNonBlocking): the legacy default
+         * stream implicitly serializes with blocking streams, so graph
+         * replays on this stream stay ordered against the surrounding
+         * eager work that still launches on the legacy stream. */
+        if (hipStreamCreate(&g_rocm_decode_graph_stream) != hipSuccess) {
+            g_rocm_decode_graph_stream = NULL;
+            rocm_decode_graph_entry_kill(e);
+            return -1;
+        }
+    }
+    if (hipStreamBeginCapture(g_rocm_decode_graph_stream,
+                              hipStreamCaptureModeGlobal) != hipSuccess) {
+        (void)hipGetLastError();
+        rocm_decode_graph_entry_kill(e);
+        return -1;
+    }
+    g_rocm_decode_graph_capturing = 1;
+    ds4_rocm_set_capture_stream(g_rocm_decode_graph_stream);
+    return 0;
+}
+
+extern "C" int ds4_gpu_decode_graph_end(const ds4_decode_graph_key *key) {
+    if (!key || !g_rocm_decode_graph_capturing) return -1;
+    g_rocm_decode_graph_capturing = 0;
+    ds4_rocm_set_capture_stream(NULL);
+    hipGraph_t graph = NULL;
+    hipError_t err = hipStreamEndCapture(g_rocm_decode_graph_stream, &graph);
+    rocm_decode_graph_entry *e = rocm_decode_graph_find(key);
+    if (err != hipSuccess || graph == NULL) {
+        fprintf(stderr, "ds4: decode graph capture failed (il=%u island=%u): %s\n",
+                key->il, key->island, hipGetErrorString(err));
+        (void)hipGetLastError();
+        if (graph) (void)hipGraphDestroy(graph);
+        if (e) rocm_decode_graph_entry_kill(e);
+        return -1;         /* caller re-encodes the island eagerly */
+    }
+    if (!e) {              /* cannot happen: begin() found it */
+        (void)hipGraphDestroy(graph);
+        return -1;
+    }
+    hipGraphExec_t exec = NULL;
+    err = hipGraphInstantiate(&exec, graph, NULL, NULL, 0);
+    (void)hipGraphDestroy(graph);
+    if (err != hipSuccess || exec == NULL) {
+        fprintf(stderr, "ds4: decode graph instantiate failed (il=%u island=%u): %s\n",
+                key->il, key->island, hipGetErrorString(err));
+        (void)hipGetLastError();
+        rocm_decode_graph_entry_kill(e);
+        return -1;
+    }
+    /* Capture recorded the work without executing it: launch now so this
+     * token's island actually runs.  Legacy stream, same as replays. */
+    err = hipGraphLaunch(exec, (hipStream_t)0);
+    if (err != hipSuccess) {
+        fprintf(stderr, "ds4: decode graph first launch failed (il=%u island=%u): %s\n",
+                key->il, key->island, hipGetErrorString(err));
+        (void)hipGetLastError();
+        (void)hipGraphExecDestroy(exec);
+        rocm_decode_graph_entry_kill(e);
+        return -1;
+    }
+    e->exec = exec;
+    e->state = 2;
+    g_rocm_decode_graph_captures++;
+    if (getenv("DS4_ROCM_DECODE_GRAPH_LOG") != NULL) {
+        fprintf(stderr, "ds4: decode graph captured il=%u island=%u (total %llu)\n",
+                key->il, key->island,
+                (unsigned long long)g_rocm_decode_graph_captures);
+    }
+    return 0;
+}
+
+extern "C" void ds4_gpu_decode_graph_abort(const ds4_decode_graph_key *key) {
+    if (!g_rocm_decode_graph_capturing) return;
+    g_rocm_decode_graph_capturing = 0;
+    ds4_rocm_set_capture_stream(NULL);
+    hipGraph_t graph = NULL;
+    (void)hipStreamEndCapture(g_rocm_decode_graph_stream, &graph);
+    if (graph) (void)hipGraphDestroy(graph);
+    (void)hipGetLastError();
+    if (key) {
+        rocm_decode_graph_entry *e = rocm_decode_graph_find(key);
+        if (e) rocm_decode_graph_entry_kill(e);
+    }
+}
 
 extern "C" int ds4_gpu_init_multi(const ds4_gpu_config *cfg) {
     if (!cfg || cfg->n_gpus != 1) {

--- a/rocm/ds4_rocm_attention_launch.cuh
+++ b/rocm/ds4_rocm_attention_launch.cuh
@@ -13,7 +13,7 @@ extern "C" int ds4_gpu_store_raw_kv_tensor(ds4_gpu_tensor *raw_cache, const ds4_
     if (!raw_cache || !kv || raw_cap == 0 ||
         raw_cache->bytes < (uint64_t)raw_cap * head_dim * sizeof(float) ||
         kv->bytes < (uint64_t)head_dim * sizeof(float)) return 0;
-    store_raw_kv_batch_kernel<<<(head_dim + 255) / 256, 256>>>((float *)raw_cache->ptr, (const float *)kv->ptr, raw_cap, row, 1, head_dim);
+    store_raw_kv_batch_kernel<<<(head_dim + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)raw_cache->ptr, (const float *)kv->ptr, raw_cap, row, 1, head_dim);
     return cuda_ok(cudaGetLastError(), "store_raw_kv launch");
 }
 extern "C" int ds4_gpu_store_raw_kv_batch_tensor(ds4_gpu_tensor *raw_cache, const ds4_gpu_tensor *kv, uint32_t raw_cap, uint32_t pos0, uint32_t n_tokens, uint32_t head_dim) {
@@ -21,7 +21,7 @@ extern "C" int ds4_gpu_store_raw_kv_batch_tensor(ds4_gpu_tensor *raw_cache, cons
         raw_cache->bytes < (uint64_t)raw_cap * head_dim * sizeof(float) ||
         kv->bytes < (uint64_t)n_tokens * head_dim * sizeof(float)) return 0;
     uint64_t n = (uint64_t)n_tokens * head_dim;
-    store_raw_kv_batch_kernel<<<(n + 255) / 256, 256>>>((float *)raw_cache->ptr, (const float *)kv->ptr, raw_cap, pos0, n_tokens, head_dim);
+    store_raw_kv_batch_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)raw_cache->ptr, (const float *)kv->ptr, raw_cap, pos0, n_tokens, head_dim);
     return cuda_ok(cudaGetLastError(), "store_raw_kv_batch launch");
 }
 extern "C" int ds4_gpu_attention_noncausal_raw_batch_heads_tensor(
@@ -57,7 +57,7 @@ extern "C" int ds4_gpu_attention_noncausal_raw_batch_heads_tensor(
     const size_t shmem = (size_t)n_raw * sizeof(float);
     if (shmem > 32768u) return 0;
     dim3 grid(n_tokens, n_head, 1);
-    attention_noncausal_raw_batch_heads_kernel<<<grid, 256, shmem>>>(
+    attention_noncausal_raw_batch_heads_kernel<<<grid, 256, shmem, ds4_rocm_stream()>>>(
             (float *)heads->ptr,
             sinks,
             (const float *)q->ptr,
@@ -179,7 +179,7 @@ extern "C" int ds4_gpu_attention_decode_heads_tensor(
     if (cfg->oldhip_attention_decode) {
         const uint32_t rows = n_raw + n_comp;
         const size_t shmem = (size_t)(rows ? rows : 1u) * sizeof(float);
-        attention_decode_mixed_one_fast_oldhip_kernel<<<(unsigned)n_head, 256, shmem>>>(
+        attention_decode_mixed_one_fast_oldhip_kernel<<<(unsigned)n_head, 256, shmem, ds4_rocm_stream()>>>(
                 (float *)heads->ptr,
                 (const float *)q->ptr,
                 (const float *)raw_kv->ptr,
@@ -199,7 +199,7 @@ extern "C" int ds4_gpu_attention_decode_heads_tensor(
     if (!cuda_attention_score_buffer_fits(n_comp)) {
         if (!use_mask && head_dim == 512u) {
             dim3 online_grid(1, (n_head + 7u) / 8u, 1);
-            attention_decode_mixed_heads8_online_kernel<<<online_grid, 256>>>((float *)heads->ptr,
+            attention_decode_mixed_heads8_online_kernel<<<online_grid, 256, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                                               sinks,
                                                                               (const float *)q->ptr,
                                                                               (const float *)raw_kv->ptr,
@@ -220,7 +220,7 @@ extern "C" int ds4_gpu_attention_decode_heads_tensor(
         return 0;
     }
     dim3 grid(1, n_head, 1);
-    attention_decode_mixed_kernel<<<grid, 256>>>((float *)heads->ptr,
+    attention_decode_mixed_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                  sinks,
                                                  (const float *)q->ptr,
                                                  (const float *)raw_kv->ptr,
@@ -245,7 +245,7 @@ extern "C" int ds4_gpu_attention_prefill_raw_heads_tensor(ds4_gpu_tensor *heads,
         !g_quality_mode &&
         ((window != 0u ? window : n_tokens) <= 768u)) {
         dim3 grid(n_tokens, (n_head + 7u) / 8u, 1);
-        attention_static_mixed_heads8_online_kernel<<<grid, 256>>>((float *)heads->ptr,
+        attention_static_mixed_heads8_online_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                                    sinks,
                                                                    (const float *)q->ptr,
                                                                    (const float *)raw_kv->ptr,
@@ -291,7 +291,7 @@ extern "C" int ds4_gpu_attention_prefill_raw_heads_tensor(ds4_gpu_tensor *heads,
                                                       (int)n_head);
         if (!cublas_ok(st, "attention raw score gemm")) return 0;
         dim3 sgrid(n_tokens, n_head, 1);
-        attention_prefill_raw_softmax_kernel<<<sgrid, 256>>>(scores, sinks, n_tokens, window, n_keys);
+        attention_prefill_raw_softmax_kernel<<<sgrid, 256, 0, ds4_rocm_stream()>>>(scores, sinks, n_tokens, window, n_keys);
         if (!cuda_ok(cudaGetLastError(), "attention raw softmax launch")) return 0;
         const float one = 1.0f;
         st = cublasSgemmStridedBatched(g_cublas,
@@ -314,7 +314,7 @@ extern "C" int ds4_gpu_attention_prefill_raw_heads_tensor(ds4_gpu_tensor *heads,
                                        (int)n_head);
         if (!cublas_ok(st, "attention raw value gemm")) return 0;
         uint64_t n = (uint64_t)n_tokens * n_head * head_dim;
-        attention_prefill_unpack_heads_kernel<<<(n + 255) / 256, 256>>>((float *)heads->ptr,
+        attention_prefill_unpack_heads_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                                         out_tmp,
                                                                         n_tokens,
                                                                         n_head,
@@ -323,7 +323,7 @@ extern "C" int ds4_gpu_attention_prefill_raw_heads_tensor(ds4_gpu_tensor *heads,
     }
     if (window == 0u && n_tokens > 256u) return 0;
     dim3 grid(n_tokens, n_head, 1);
-    attention_prefill_raw_kernel<<<grid, 128>>>((float *)heads->ptr,
+    attention_prefill_raw_kernel<<<grid, 128, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                 sinks,
                                                 (const float *)q->ptr,
                                                 (const float *)raw_kv->ptr,
@@ -370,7 +370,7 @@ static int attention_decode_batch_launch(
     if (!cuda_attention_score_buffer_fits(n_comp)) {
         if (!use_comp_mask && head_dim == 512u) {
             dim3 online_grid(n_tokens, (n_head + 7u) / 8u, 1);
-            attention_decode_mixed_heads8_online_kernel<<<online_grid, 256>>>((float *)heads->ptr,
+            attention_decode_mixed_heads8_online_kernel<<<online_grid, 256, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                                               sinks,
                                                                               (const float *)q->ptr,
                                                                               (const float *)raw_kv->ptr,
@@ -393,7 +393,7 @@ static int attention_decode_batch_launch(
     if (!use_comp_mask && n_tokens > 1 && head_dim == 512 &&
         fast_window_attention) {
         dim3 grid(n_tokens, (n_head + 7u) / 8u, 1);
-        attention_decode_mixed_heads8_online_kernel<<<grid, 256>>>((float *)heads->ptr,
+        attention_decode_mixed_heads8_online_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                                    sinks,
                                                                    (const float *)q->ptr,
                                                                    (const float *)raw_kv->ptr,
@@ -411,7 +411,7 @@ static int attention_decode_batch_launch(
         return cuda_ok(cudaGetLastError(), "attention decode window launch");
     }
     dim3 grid(n_tokens, n_head, 1);
-    attention_decode_mixed_kernel<<<grid, 256>>>((float *)heads->ptr,
+    attention_decode_mixed_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                  sinks,
                                                  (const float *)q->ptr,
                                                  (const float *)raw_kv->ptr,
@@ -514,7 +514,7 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
     if (n_tokens == 1u && cfg->oldhip_attention_decode) {
         const uint32_t rows = n_raw + (top_k < n_comp ? top_k : n_comp);
         const size_t shmem = (size_t)(rows ? rows : 1u) * sizeof(float);
-        attention_decode_indexed_mixed_one_fast_oldhip_kernel<<<(unsigned)n_head, 256, shmem>>>(
+        attention_decode_indexed_mixed_one_fast_oldhip_kernel<<<(unsigned)n_head, 256, shmem, ds4_rocm_stream()>>>(
                 (float *)heads->ptr,
                 (const float *)q->ptr,
                 (const float *)raw_kv->ptr,
@@ -537,7 +537,7 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
         const uint64_t sort_bytes = (uint64_t)n_tokens * top_k * sizeof(int32_t);
         int32_t *sorted = (int32_t *)cuda_tmp_alloc(sort_bytes, "indexed attention topk sort");
         if (!sorted) return 0;
-        indexed_topk_sort_512_asc_kernel<<<n_tokens, 512>>>(sorted, topk_ptr, n_tokens);
+        indexed_topk_sort_512_asc_kernel<<<n_tokens, 512, 0, ds4_rocm_stream()>>>(sorted, topk_ptr, n_tokens);
         if (!cuda_ok(cudaGetLastError(), "indexed attention topk sort launch")) return 0;
         topk_ptr = sorted;
     }
@@ -547,7 +547,7 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
         if (!g_quality_mode && n_head <= 64u) {
             dim3 grid(n_tokens, (n_head + 31u) / 32u, 1);
-            attention_indexed_mixed_heads8_online_kernel<8, 32><<<grid, 1024>>>((float *)heads->ptr,
+            attention_indexed_mixed_heads8_online_kernel<8, 32><<<grid, 1024, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                                                 sinks,
                                                                                 (const float *)q->ptr,
                                                                                 (const float *)raw_kv->ptr,
@@ -568,7 +568,7 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
         }
 #endif
         dim3 grid(n_tokens, (n_head + 15u) / 16u, 1);
-        attention_indexed_mixed_heads8_online_kernel<8, 16><<<grid, 512>>>((float *)heads->ptr,
+        attention_indexed_mixed_heads8_online_kernel<8, 16><<<grid, 512, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                                            sinks,
                                                                            (const float *)q->ptr,
                                                                            (const float *)raw_kv->ptr,
@@ -588,7 +588,7 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
         return cuda_ok(cudaGetLastError(), "attention indexed online launch");
     }
     dim3 grid(n_tokens, n_head, 1);
-    attention_indexed_mixed_kernel<<<grid, 256>>>((float *)heads->ptr,
+    attention_indexed_mixed_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                   sinks,
                                                   (const float *)q->ptr,
                                                   (const float *)raw_kv->ptr,
@@ -655,7 +655,7 @@ static int attention_prefill_mixed_cublas_tiled(
     float *kv = tmp;
     float *scores = (float *)((char *)tmp + score_offset);
     float *out_tmp = (float *)((char *)tmp + out_offset);
-    attention_prefill_pack_mixed_kv_kernel<<<(kv_count + 255) / 256, 256>>>(
+    attention_prefill_pack_mixed_kv_kernel<<<(kv_count + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
             kv,
             (const float *)raw_kv->ptr,
             n_comp ? (const float *)comp_kv->ptr : (const float *)raw_kv->ptr,
@@ -690,7 +690,7 @@ static int attention_prefill_mixed_cublas_tiled(
                                                       (int)n_head);
         if (!cublas_ok(st, "attention mixed tiled score gemm")) return 0;
         dim3 sgrid(nt, n_head, 1);
-        attention_prefill_mixed_softmax_tile_kernel<<<sgrid, 256>>>(
+        attention_prefill_mixed_softmax_tile_kernel<<<sgrid, 256, 0, ds4_rocm_stream()>>>(
                 scores,
                 sinks,
                 use_comp_mask ? (const float *)comp_mask->ptr : NULL,
@@ -724,7 +724,7 @@ static int attention_prefill_mixed_cublas_tiled(
         if (!cublas_ok(st, "attention mixed tiled value gemm")) return 0;
         const uint64_t n = (uint64_t)nt * n_head * head_dim;
         float *heads_tile = (float *)heads->ptr + (uint64_t)t0 * n_head * head_dim;
-        attention_prefill_unpack_heads_kernel<<<(n + 255) / 256, 256>>>(
+        attention_prefill_unpack_heads_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
                 heads_tile,
                 out_tmp,
                 nt,
@@ -769,7 +769,7 @@ static int attention_prefill_mixed_launch(
         !g_quality_mode &&
         ((window != 0u ? window : n_tokens) + n_comp <= 768u)) {
         dim3 grid(n_tokens, (n_head + 7u) / 8u, 1);
-        attention_static_mixed_heads8_online_kernel<<<grid, 256>>>((float *)heads->ptr,
+        attention_static_mixed_heads8_online_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                                    sinks,
                                                                    (const float *)q->ptr,
                                                                    (const float *)raw_kv->ptr,
@@ -826,7 +826,7 @@ static int attention_prefill_mixed_launch(
         float *kv = tmp;
         float *scores = (float *)((char *)tmp + score_offset);
         float *out_tmp = (float *)((char *)tmp + out_offset);
-        attention_prefill_pack_mixed_kv_kernel<<<(kv_count + 255) / 256, 256>>>(
+        attention_prefill_pack_mixed_kv_kernel<<<(kv_count + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
                 kv,
                 (const float *)raw_kv->ptr,
                 n_comp ? (const float *)comp_kv->ptr : (const float *)raw_kv->ptr,
@@ -856,7 +856,7 @@ static int attention_prefill_mixed_launch(
                                                       (int)n_head);
         if (!cublas_ok(st, "attention mixed score gemm")) return 0;
         dim3 sgrid(n_tokens, n_head, 1);
-        attention_prefill_mixed_softmax_kernel<<<sgrid, 256>>>(
+        attention_prefill_mixed_softmax_kernel<<<sgrid, 256, 0, ds4_rocm_stream()>>>(
                 scores,
                 sinks,
                 use_comp_mask ? (const float *)comp_mask->ptr : NULL,
@@ -888,7 +888,7 @@ static int attention_prefill_mixed_launch(
                                        (int)n_head);
         if (!cublas_ok(st, "attention mixed value gemm")) return 0;
         uint64_t n = (uint64_t)n_tokens * n_head * head_dim;
-        attention_prefill_unpack_heads_kernel<<<(n + 255) / 256, 256>>>((float *)heads->ptr,
+        attention_prefill_unpack_heads_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                                         out_tmp,
                                                                         n_tokens,
                                                                         n_head,
@@ -908,7 +908,7 @@ static int attention_prefill_mixed_launch(
         return 0;
     }
     dim3 grid(n_tokens, n_head, 1);
-    attention_prefill_mixed_kernel<<<grid, 256>>>((float *)heads->ptr,
+    attention_prefill_mixed_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                   sinks,
                                                   (const float *)q->ptr,
                                                   (const float *)raw_kv->ptr,
@@ -1012,7 +1012,7 @@ extern "C" int ds4_gpu_attention_output_q8_batch_f16_tensor(
     if (!tmp) return 0;
     __half *heads_h = (__half *)tmp;
     __half *low_h = (__half *)((char *)tmp + low_h_offset);
-    attention_pack_group_heads_f16_kernel<<<(heads_h_count + 255u) / 256u, 256>>>(
+    attention_pack_group_heads_f16_kernel<<<(heads_h_count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
             heads_h,
             (const float *)heads->ptr,
             n_tokens,
@@ -1130,7 +1130,7 @@ extern "C" int ds4_gpu_attention_output_q8_batch_tensor(
                                              block_tile);
         } else {
             dim3 grid_a(((unsigned)low_dim + 7u) / 8u, (unsigned)n_tokens, 1);
-            grouped_q8_0_a_f32_batch_warp8_kernel<<<grid_a, 256>>>(
+            grouped_q8_0_a_f32_batch_warp8_kernel<<<grid_a, 256, 0, ds4_rocm_stream()>>>(
                     (float *)low->ptr,
                     out_a,
                     (const float *)heads->ptr,
@@ -1178,7 +1178,7 @@ extern "C" int ds4_gpu_attention_output_q8_batch_tensor(
                 if (!tmp) return 0;
                 __half *heads_h = (__half *)tmp;
                 __half *low_h = (__half *)((char *)tmp + low_h_offset);
-                attention_pack_group_heads_f16_kernel<<<(heads_h_count + 255) / 256, 256>>>(
+                attention_pack_group_heads_f16_kernel<<<(heads_h_count + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
                         heads_h,
                         (const float *)heads->ptr,
                         n_tokens,
@@ -1280,7 +1280,7 @@ extern "C" int ds4_gpu_attention_output_q8_batch_tensor(
         if (!tmp) return 0;
         __half *heads_h = (__half *)tmp;
         float *low_packed = (float *)((char *)tmp + low_tmp_offset);
-        attention_pack_group_heads_f16_kernel<<<(heads_h_count + 255) / 256, 256>>>(
+        attention_pack_group_heads_f16_kernel<<<(heads_h_count + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
                 heads_h,
                 (const float *)heads->ptr,
                 n_tokens,
@@ -1313,7 +1313,7 @@ extern "C" int ds4_gpu_attention_output_q8_batch_tensor(
                                                        CUBLAS_COMPUTE_32F,
                                                        CUBLAS_GEMM_DEFAULT);
         if (!cublas_ok(st, "attention output a gemm")) return 0;
-        attention_unpack_group_low_kernel<<<(low_tmp_count + 255) / 256, 256>>>(
+        attention_unpack_group_low_kernel<<<(low_tmp_count + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
                 (float *)low->ptr,
                 low_packed,
                 n_tokens,
@@ -1331,14 +1331,14 @@ extern "C" int ds4_gpu_attention_output_q8_batch_tensor(
         float *xscale = (float *)((char *)tmp + scale_offset);
         const int use_dp4a = 1;
         dim3 qgrid((unsigned)blocks_a, (unsigned)x_rows, 1);
-        quantize_q8_0_f32_kernel<<<qgrid, 32>>>(xq,
+        quantize_q8_0_f32_kernel<<<qgrid, 32, 0, ds4_rocm_stream()>>>(xq,
                                                 xscale,
                                                 (const float *)heads->ptr,
                                                 group_dim,
                                                 blocks_a);
         if (!cuda_ok(cudaGetLastError(), "attention_output_q8_a prequant launch")) return 0;
         dim3 grid_a(((unsigned)low_dim + 7u) / 8u, (unsigned)n_tokens, 1);
-        grouped_q8_0_a_preq_warp8_kernel<<<grid_a, 256>>>((float *)low->ptr,
+        grouped_q8_0_a_preq_warp8_kernel<<<grid_a, 256, 0, ds4_rocm_stream()>>>((float *)low->ptr,
                                                           out_a,
                                                           xq,
                                                           xscale,
@@ -1408,7 +1408,7 @@ extern "C" int ds4_gpu_attention_output_low_q8_tensor(
         float *partial = (float *)cuda_tmp_alloc((uint64_t)n_splits * low_dim * sizeof(float), "attention output low splitk");
         if (!partial) return 0;
         grouped_q8_0_a_partial16_w32_kernel<<<dim3((unsigned)((low_dim + 31u) / 32u), 8u),
-                                              1024u, 512u * sizeof(float)>>>(
+                                              1024u, 512u * sizeof(float), ds4_rocm_stream()>>>(
                 partial,
                 out_a,
                 (const float *)heads->ptr,
@@ -1416,7 +1416,7 @@ extern "C" int ds4_gpu_attention_output_low_q8_tensor(
                 (uint32_t)rank,
                 blocks_a * 34u);
         if (!cuda_ok(cudaGetLastError(), "attention_output_low_q8 splitk8 partial launch")) return 0;
-        q8_partial_sum8_kernel<<<(unsigned)((low_dim + 255u) / 256u), 256>>>(
+        q8_partial_sum8_kernel<<<(unsigned)((low_dim + 255u) / 256u), 256, 0, ds4_rocm_stream()>>>(
                 (float *)low->ptr,
                 partial,
                 (uint32_t)low_dim);
@@ -1430,7 +1430,7 @@ extern "C" int ds4_gpu_attention_output_low_q8_tensor(
                     (unsigned)((low_dim + rows_per_block - 1u) /
                                rows_per_block),
                     1024u,
-                    (size_t)group_dim * sizeof(float)>>>(
+                    (size_t)group_dim * sizeof(float), ds4_rocm_stream()>>>(
                     (float *)low->ptr,
                     out_a,
                     (const float *)heads->ptr,
@@ -1442,7 +1442,7 @@ extern "C" int ds4_gpu_attention_output_low_q8_tensor(
                            "attention_output_low_q8 f32 sharedx launch");
         }
         grouped_q8_0_a_f32_warp8_kernel<<<
-                ((unsigned)low_dim + 7u) / 8u, 256>>>(
+                ((unsigned)low_dim + 7u) / 8u, 256, 0, ds4_rocm_stream()>>>(
                 (float *)low->ptr,
                 out_a,
                 (const float *)heads->ptr,
@@ -1467,7 +1467,7 @@ extern "C" int ds4_gpu_attention_output_low_q8_tensor(
     const ds4_rocm_runtime_config *cfg = cuda_runtime_config();
     const int use_dp4a = 1;
     dim3 qgrid((unsigned)blocks_a, (unsigned)x_rows, 1);
-    quantize_q8_0_f32_kernel<<<qgrid, 32>>>(
+    quantize_q8_0_f32_kernel<<<qgrid, 32, 0, ds4_rocm_stream()>>>(
             xq,
             xscale,
             (const float *)heads->ptr,
@@ -1483,7 +1483,7 @@ extern "C" int ds4_gpu_attention_output_low_q8_tensor(
             1,
             1);
     grouped_q8_0_a_preq_warp8_kernel<<<grid_a,
-                                       rows_per_block * 32u>>>(
+                                       rows_per_block * 32u, 0, ds4_rocm_stream()>>>(
             (float *)low->ptr,
             out_a,
             xq,

--- a/rocm/ds4_rocm_compressor.cuh
+++ b/rocm/ds4_rocm_compressor.cuh
@@ -221,7 +221,7 @@ extern "C" int ds4_gpu_compressor_store_batch_tensor(
     const char *ape = cuda_model_range_ptr(model_map, ape_offset, ape_bytes, "compressor_ape");
     if (!ape) return 0;
     uint64_t n = (uint64_t)n_tokens * width;
-    compressor_store_kernel<<<(n + 255) / 256, 256>>>(
+    compressor_store_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
             (const float *)kv->ptr,
             (const float *)sc->ptr,
             (float *)state_kv->ptr,
@@ -302,7 +302,7 @@ extern "C" int ds4_gpu_compressor_update_tensor(
             (uint64_t)comp_row * head_dim * sizeof(float),
             (uint64_t)head_dim * sizeof(float));
     if (!comp_row_view) return 0;
-    compressor_update_pool_kernel<<<(head_dim + 255) / 256, 256>>>(
+    compressor_update_pool_kernel<<<(head_dim + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
             (float *)comp_row_view->ptr,
             (const float *)state_kv->ptr,
             (const float *)state_score->ptr,
@@ -319,7 +319,7 @@ extern "C" int ds4_gpu_compressor_update_tensor(
     ds4_gpu_tensor_free(comp_row_view);
     if (ok && ratio == 4u) {
         uint64_t half = 4ull * width;
-        compressor_shift_ratio4_kernel<<<(half + 255) / 256, 256>>>(
+        compressor_shift_ratio4_kernel<<<(half + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
                 (float *)state_kv->ptr, (float *)state_score->ptr, width);
         ok = cuda_ok(cudaGetLastError(), "compressor ratio4 shift launch");
     }
@@ -384,14 +384,14 @@ extern "C" int ds4_gpu_compressor_prefill_tensor(
     uint64_t state_n = (uint64_t)state_rows * width;
     if (!cuda_ok(cudaMemsetAsync(state_kv->ptr, 0, (size_t)(state_n * sizeof(float))),
                  "compressor state kv zero")) return 0;
-    fill_f32_kernel<<<(state_n + 255) / 256, 256>>>((float *)state_score->ptr, state_n, -INFINITY);
+    fill_f32_kernel<<<(state_n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)state_score->ptr, state_n, -INFINITY);
     if (!cuda_ok(cudaGetLastError(), "compressor state score fill launch")) return 0;
 
     if (ratio == 4u) {
         if (cutoff >= ratio) {
             uint32_t prev_start = cutoff - ratio;
             uint64_t n = (uint64_t)ratio * width;
-            compressor_set_rows_kernel<<<(n + 255) / 256, 256>>>(
+            compressor_set_rows_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
                     (float *)state_kv->ptr, (float *)state_score->ptr,
                     (const float *)kv->ptr, (const float *)sc->ptr,
                     ape, 0, ape_type, width, ratio, pos0,
@@ -400,7 +400,7 @@ extern "C" int ds4_gpu_compressor_prefill_tensor(
         }
         if (rem != 0) {
             uint64_t n = (uint64_t)rem * width;
-            compressor_set_rows_kernel<<<(n + 255) / 256, 256>>>(
+            compressor_set_rows_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
                     (float *)state_kv->ptr, (float *)state_score->ptr,
                     (const float *)kv->ptr, (const float *)sc->ptr,
                     ape, 0, ape_type, width, ratio, pos0,
@@ -409,7 +409,7 @@ extern "C" int ds4_gpu_compressor_prefill_tensor(
         }
     } else if (rem != 0) {
         uint64_t n = (uint64_t)rem * width;
-        compressor_set_rows_kernel<<<(n + 255) / 256, 256>>>(
+        compressor_set_rows_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
                 (float *)state_kv->ptr, (float *)state_score->ptr,
                 (const float *)kv->ptr, (const float *)sc->ptr,
                 ape, 0, ape_type, width, ratio, pos0,
@@ -418,7 +418,7 @@ extern "C" int ds4_gpu_compressor_prefill_tensor(
     }
     if (n_comp != 0) {
         dim3 grid((head_dim + 255) / 256, n_comp, 1);
-        compressor_prefill_pool_kernel<<<grid, 256>>>(
+        compressor_prefill_pool_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>(
                 (float *)comp_cache->ptr,
                 (const float *)kv->ptr,
                 (const float *)sc->ptr,
@@ -489,7 +489,7 @@ extern "C" int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
     const char *ape = cuda_model_range_ptr(model_map, ape_offset, ape_bytes, "compressor_ape");
     if (!ape) return 0;
     dim3 grid((head_dim + 255) / 256, n_comp, 1);
-    compressor_prefill_pool_kernel<<<grid, 256>>>(
+    compressor_prefill_pool_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>(
             (float *)comp_cache->ptr,
             (const float *)kv->ptr,
             (const float *)sc->ptr,
@@ -509,11 +509,11 @@ extern "C" int ds4_gpu_compressor_prefill_ratio4_replay_tensor(
     uint64_t state_n = (uint64_t)state_rows * width;
     if (!cuda_ok(cudaMemsetAsync(state_kv->ptr, 0, (size_t)(state_n * sizeof(float))),
                  "compressor replay state kv zero")) return 0;
-    fill_f32_kernel<<<(state_n + 255) / 256, 256>>>((float *)state_score->ptr, state_n, -INFINITY);
+    fill_f32_kernel<<<(state_n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)state_score->ptr, state_n, -INFINITY);
     if (!cuda_ok(cudaGetLastError(), "compressor replay state score fill launch")) return 0;
     uint32_t prev_start = n_tokens - ratio;
     uint64_t n = (uint64_t)ratio * width;
-    compressor_set_rows_kernel<<<(n + 255) / 256, 256>>>(
+    compressor_set_rows_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
             (float *)state_kv->ptr, (float *)state_score->ptr,
             (const float *)kv->ptr, (const float *)sc->ptr,
             ape, 0, ape_type, width, ratio, pos0,
@@ -552,10 +552,10 @@ extern "C" int ds4_gpu_compressor_prefill_state_ratio4_tensor(
     uint64_t state_n = (uint64_t)state_rows * width;
     if (!cuda_ok(cudaMemsetAsync(state_kv->ptr, 0, (size_t)(state_n * sizeof(float))),
                  "compressor state kv zero")) return 0;
-    fill_f32_kernel<<<(state_n + 255) / 256, 256>>>((float *)state_score->ptr, state_n, -INFINITY);
+    fill_f32_kernel<<<(state_n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)state_score->ptr, state_n, -INFINITY);
     if (!cuda_ok(cudaGetLastError(), "compressor state score fill launch")) return 0;
     uint64_t n = (uint64_t)ratio * width;
-    compressor_set_rows_kernel<<<(n + 255) / 256, 256>>>(
+    compressor_set_rows_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
             (float *)state_kv->ptr, (float *)state_score->ptr,
             (const float *)kv_tail->ptr, (const float *)sc_tail->ptr,
             ape, 0, ape_type, width, ratio, pos0,

--- a/rocm/ds4_rocm_current_api_compat.cuh
+++ b/rocm/ds4_rocm_current_api_compat.cuh
@@ -85,7 +85,7 @@ extern "C" int ds4_gpu_tensor_copy_f32_to_f16(
     uint64_t src_bytes = count * sizeof(float);
     if (dst_bytes > dst->bytes - dst_offset || src_bytes > src->bytes - src_offset) return 0;
     if (count == 0) return 1;
-    f32_to_f16_kernel<<<(count + 255u) / 256u, 256>>>(
+    f32_to_f16_kernel<<<(count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
             (__half *)((char *)dst->ptr + dst_offset),
             (const float *)((const char *)src->ptr + src_offset),
             count);

--- a/rocm/ds4_rocm_embedding_launch.cuh
+++ b/rocm/ds4_rocm_embedding_launch.cuh
@@ -10,7 +10,7 @@ extern "C" int ds4_gpu_embed_token_hc_tensor(ds4_gpu_tensor *out_hc, const void 
     const char *wptr = cuda_model_range_ptr(model_map, weight_offset, weight_bytes, "token_embd");
     if (!wptr) return 0;
     uint64_t n = (uint64_t)n_embd * n_hc;
-    embed_token_hc_kernel<<<(n + 255u) / 256u, 256>>>((float *)out_hc->ptr, (const unsigned short *)wptr, token, n_embd, n_hc);
+    embed_token_hc_kernel<<<(n + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>((float *)out_hc->ptr, (const unsigned short *)wptr, token, n_embd, n_hc);
     return cuda_ok(cudaGetLastError(), "embed token launch");
 }
 
@@ -38,7 +38,7 @@ extern "C" int ds4_gpu_embed_tokens_hc_tensor(
     }
     const char *wptr = cuda_model_range_ptr(model_map, weight_offset, weight_bytes, "token_embd");
     if (!wptr) return 0;
-    embed_tokens_hc_kernel<<<(n + 255) / 256, 256>>>(
+    embed_tokens_hc_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
         (float *)out_hc->ptr,
         (const int32_t *)tokens_t->ptr,
         (const __half *)wptr,
@@ -68,7 +68,7 @@ extern "C" int ds4_gpu_embed_token_hc_q8_0_tensor(
     const char *wptr = cuda_model_range_ptr(model_map, weight_offset, weight_bytes, "token_embd_q8_0");
     if (!wptr) return 0;
     const uint64_t n = (uint64_t)n_embd * n_hc;
-    embed_token_hc_q8_0_kernel<<<(n + 255u) / 256u, 256>>>(
+    embed_token_hc_q8_0_kernel<<<(n + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
             (float *)out_hc->ptr,
             (const unsigned char *)wptr,
             token,
@@ -101,7 +101,7 @@ extern "C" int ds4_gpu_embed_tokens_hc_q8_0_tensor(
     }
     const char *wptr = cuda_model_range_ptr(model_map, weight_offset, weight_bytes, "token_embd_q8_0");
     if (!wptr) return 0;
-    embed_tokens_hc_q8_0_kernel<<<(n + 255u) / 256u, 256>>>(
+    embed_tokens_hc_q8_0_kernel<<<(n + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
             (float *)out_hc->ptr,
             (const int32_t *)tokens_t->ptr,
             (const unsigned char *)wptr,

--- a/rocm/ds4_rocm_fp8_kv_launch.cuh
+++ b/rocm/ds4_rocm_fp8_kv_launch.cuh
@@ -4,6 +4,6 @@ extern "C" int ds4_gpu_dsv4_fp8_kv_quantize_tensor(ds4_gpu_tensor *x, uint32_t n
     const uint32_t n_nope = head_dim - n_rot;
     if (n_nope == 0) return 1;
     const uint32_t groups = (n_nope + 63u) / 64u;
-    fp8_kv_quantize_kernel<<<dim3(n_tok, groups), 64>>>((float *)x->ptr, n_tok, head_dim, n_rot);
+    fp8_kv_quantize_kernel<<<dim3(n_tok, groups), 64, 0, ds4_rocm_stream()>>>((float *)x->ptr, n_tok, head_dim, n_rot);
     return cuda_ok(cudaGetLastError(), "fp8_kv_quantize launch");
 }

--- a/rocm/ds4_rocm_glm.cuh
+++ b/rocm/ds4_rocm_glm.cuh
@@ -1342,7 +1342,7 @@ extern "C" int ds4_gpu_glm_kv_lora_rms_norm_tensor(
                                                          weight_bytes,
                                                          "glm_kv_lora_norm");
     if (!w) return 0;
-    glm_kv_lora_rms_norm_kernel<<<n_tokens, 256>>>((float *)out->ptr,
+    glm_kv_lora_rms_norm_kernel<<<n_tokens, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr,
                                                    (const float *)kv_raw->ptr,
                                                    w,
                                                    n_tokens,
@@ -1375,7 +1375,7 @@ extern "C" int ds4_gpu_glm_k_b_project_tensor(
         return 0;
     }
     dim3 grid(n_tokens, n_head, 1);
-    glm_k_b_project_q8_0_head_kernel<<<grid, 256, (size_t)kv_lora_dim * sizeof(float)>>>(
+    glm_k_b_project_q8_0_head_kernel<<<grid, 256, (size_t)kv_lora_dim * sizeof(float), ds4_rocm_stream()>>>(
             (float *)out->ptr,
             w,
             (const float *)kv_norm->ptr,
@@ -1410,7 +1410,7 @@ extern "C" int ds4_gpu_glm_store_compact_kv_tensor(
         return 0;
     }
     dim3 grid(n_tokens, 2, 1);
-    glm_store_compact_kv_kernel<<<grid, 256>>>((char *)kv_lora_cache->ptr,
+    glm_store_compact_kv_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((char *)kv_lora_cache->ptr,
                                                (char *)k_rope_cache->ptr,
                                                (const float *)kv_norm->ptr,
                                                (const float *)kv_raw->ptr,
@@ -1466,7 +1466,7 @@ extern "C" int ds4_gpu_glm_qkv_norm_store_compact_kv_tensor(
                                                            "glm_kv_norm");
     if (!qw || !kvw) return 0;
     dim3 grid(n_tokens, 3, 1);
-    glm_qkv_norm_store_compact_kv_kernel<<<grid, 256>>>((float *)q_out->ptr,
+    glm_qkv_norm_store_compact_kv_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)q_out->ptr,
                                                         (const float *)q->ptr,
                                                         qw,
                                                         q_n,
@@ -1521,7 +1521,7 @@ extern "C" int ds4_gpu_glm_store_indexer_k_tensor(
     const float *w = (const float *)cuda_model_range_ptr(model_map, weight_offset, bytes, "glm_indexer_weight");
     const float *b = (const float *)cuda_model_range_ptr(model_map, bias_offset, bytes, "glm_indexer_bias");
     if (!w || !b) return 0;
-    glm_store_indexer_k_kernel<<<n_tokens, 256>>>((char *)indexer_key_cache->ptr,
+    glm_store_indexer_k_kernel<<<n_tokens, 256, 0, ds4_rocm_stream()>>>((char *)indexer_key_cache->ptr,
                                                   (const float *)raw_k->ptr,
                                                   w,
                                                   b,
@@ -1581,7 +1581,7 @@ extern "C" int ds4_gpu_glm_build_kv_cache_tensor(
         return 0;
     }
     dim3 grid(n_tokens, n_head, 1);
-    glm_build_kv_cache_kernel<<<grid, 256>>>((char *)key_cache->ptr,
+    glm_build_kv_cache_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((char *)key_cache->ptr,
                                              (char *)value_cache->ptr,
                                              (const float *)kv_raw->ptr,
                                              (const float *)k_nope->ptr,
@@ -1666,7 +1666,7 @@ extern "C" int ds4_gpu_glm_attention_full_tensor(
     }
     const size_t shmem = ((size_t)256u + cache_len) * sizeof(float);
     dim3 grid(n_tokens, n_head, 1);
-    glm_attention_full_kernel<<<grid, 256, shmem>>>((float *)heads->ptr,
+    glm_attention_full_kernel<<<grid, 256, shmem, ds4_rocm_stream()>>>((float *)heads->ptr,
                                                     (const float *)q->ptr,
                                                     (const char *)key_cache->ptr,
                                                     (const char *)value_cache->ptr,
@@ -1720,7 +1720,7 @@ extern "C" int ds4_gpu_glm_attention_flash_tensor(
 extern "C" int ds4_gpu_glm_fill_selected_range_tensor(ds4_gpu_tensor *selected, uint32_t n_selected) {
     if (n_selected == 0u) return selected != NULL;
     if (!cuda_tensor_has_i32(selected, n_selected)) return 0;
-    glm_fill_selected_range_kernel<<<(n_selected + 255u) / 256u, 256>>>((int32_t *)selected->ptr, n_selected);
+    glm_fill_selected_range_kernel<<<(n_selected + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>((int32_t *)selected->ptr, n_selected);
     return cuda_ok(cudaGetLastError(), "glm fill selected range launch");
 }
 
@@ -1742,7 +1742,7 @@ extern "C" int ds4_gpu_glm_fill_selected_range_batch_tensor(
         !glm_rocm_launch_blocks(total, 256u, &blocks)) {
         return 0;
     }
-    glm_fill_selected_range_batch_kernel<<<blocks, 256>>>((int32_t *)selected->ptr,
+    glm_fill_selected_range_batch_kernel<<<blocks, 256, 0, ds4_rocm_stream()>>>((int32_t *)selected->ptr,
                                                                          n_tokens,
                                                                          pos0,
                                                                          n_selected,
@@ -1778,7 +1778,7 @@ extern "C" int ds4_gpu_glm_indexer_rope_tail_tensor(
     }
     if (pairs == 0u) return 1;
     if (!glm_rocm_launch_blocks(pairs, 256u, &blocks)) return 0;
-    glm_indexer_rope_tail_kernel<<<blocks, 256>>>((float *)x->ptr,
+    glm_indexer_rope_tail_kernel<<<blocks, 256, 0, ds4_rocm_stream()>>>((float *)x->ptr,
                                                                  n_tokens,
                                                                  n_head,
                                                                  head_dim,
@@ -1813,7 +1813,7 @@ extern "C" int ds4_gpu_glm_indexer_score_one_tensor(
         !glm_rocm_tensor_has_cache2(indexer_key_cache, n_rows, head_dim, elem)) {
         return 0;
     }
-    glm_indexer_score_one_kernel<<<n_rows, 256>>>((float *)scores->ptr,
+    glm_indexer_score_one_kernel<<<n_rows, 256, 0, ds4_rocm_stream()>>>((float *)scores->ptr,
                                                   (const float *)q->ptr,
                                                   (const float *)weights->ptr,
                                                   (const char *)indexer_key_cache->ptr,
@@ -1850,7 +1850,7 @@ extern "C" int ds4_gpu_glm_indexer_scores_batch_tensor(
         return 0;
     }
     dim3 grid(n_rows, n_tokens, 1);
-    glm_indexer_scores_batch_kernel<<<grid, 256>>>((float *)scores->ptr,
+    glm_indexer_scores_batch_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)scores->ptr,
                                                    (const float *)q->ptr,
                                                    (const float *)weights->ptr,
                                                    (const char *)indexer_key_cache->ptr,
@@ -1890,7 +1890,7 @@ extern "C" int ds4_gpu_glm_qk_lowrank_q8_0_tensor(
                                 "glm_qk_lowrank", &w, &row_bytes)) {
         return 0;
     }
-    glm_q8_project_head_kernel<<<dim3(n_head, 1, 1), 256, (size_t)qk_nope * sizeof(float)>>>(
+    glm_q8_project_head_kernel<<<dim3(n_head, 1, 1), 256, (size_t)qk_nope * sizeof(float), ds4_rocm_stream()>>>(
             (float *)qk_low->ptr,
             w,
             (const float *)q->ptr,
@@ -1955,7 +1955,7 @@ extern "C" int ds4_gpu_glm_qk_lowrank_q8_0_batch_tensor(
                        "glm grouped qk lowrank batch launch");
     }
     dim3 grid(n_head, n_tokens, 1);
-    glm_q8_project_head_kernel<<<grid, 256, (size_t)qk_nope * sizeof(float)>>>(
+    glm_q8_project_head_kernel<<<grid, 256, (size_t)qk_nope * sizeof(float), ds4_rocm_stream()>>>(
             (float *)qk_low->ptr,
             w,
             (const float *)q->ptr,
@@ -2028,7 +2028,7 @@ extern "C" int ds4_gpu_glm_value_project_q8_0_batch_heads_tensor(
         dim3 grid((value_dim + waves_per_block - 1u) / waves_per_block,
                   n_head,
                   n_tokens);
-        glm_q8_project_head_wave_kernel<<<grid, threads>>>(
+        glm_q8_project_head_wave_kernel<<<grid, threads, 0, ds4_rocm_stream()>>>(
                 (float *)heads->ptr,
                 w,
                 (const float *)lora->ptr,
@@ -2054,7 +2054,7 @@ extern "C" int ds4_gpu_glm_value_project_q8_0_batch_heads_tensor(
                        "glm wave-parallel value project launch");
     }
     dim3 grid(n_head, n_tokens, 1);
-    glm_q8_project_head_kernel<<<grid, 256, (size_t)kv_lora_dim * sizeof(float)>>>(
+    glm_q8_project_head_kernel<<<grid, 256, (size_t)kv_lora_dim * sizeof(float), ds4_rocm_stream()>>>(
             (float *)heads->ptr,
             w,
             (const float *)lora->ptr,
@@ -2691,7 +2691,7 @@ static int glm_attention_indexed_lora_causal_gemm(
     float *head_out = (float *)(scratch + head_offset);
 
     glm_causal_gemm_cache_to_f16_kernel<<<
-        (kv_count + 255u) / 256u, 256>>>(
+        (kv_count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
             kv_h,
             (const char *)kv_lora_cache->ptr,
             kv_count,
@@ -2701,7 +2701,7 @@ static int glm_attention_indexed_lora_causal_gemm(
     }
     const uint64_t rope_pairs = (uint64_t)n_selected * (qk_rope >> 1u);
     glm_causal_gemm_rope_to_f16_kernel<<<
-        (rope_pairs + 255u) / 256u, 256>>>(
+        (rope_pairs + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
             rope_h,
             (const char *)k_rope_cache->ptr,
             n_selected,
@@ -2725,7 +2725,7 @@ static int glm_attention_indexed_lora_causal_gemm(
     const uint32_t scatter_blocks =
         (uint32_t)((head_count + 255u) / 256u);
     for (uint32_t head = 0; head < n_head; head++) {
-        glm_causal_gemm_gather_head_f16_kernel<<<gather_blocks, 256>>>(
+        glm_causal_gemm_gather_head_f16_kernel<<<gather_blocks, 256, 0, ds4_rocm_stream()>>>(
             low_h,
             qrope_h,
             (const float *)qk_low->ptr,
@@ -2784,7 +2784,7 @@ static int glm_attention_indexed_lora_causal_gemm(
         if (!cublas_ok(st, "glm causal attention rope score gemm")) {
             return 0;
         }
-        glm_causal_gemm_softmax_f16_kernel<<<n_tokens, 256>>>(
+        glm_causal_gemm_softmax_f16_kernel<<<n_tokens, 256, 0, ds4_rocm_stream()>>>(
             probs, scores, n_tokens, n_selected, pos0, scale);
         if (!cuda_ok(cudaGetLastError(),
                      "glm causal attention softmax launch")) {
@@ -2810,7 +2810,7 @@ static int glm_attention_indexed_lora_causal_gemm(
                           CUBLAS_COMPUTE_32F,
                           CUBLAS_GEMM_DEFAULT);
         if (!cublas_ok(st, "glm causal attention value gemm")) return 0;
-        glm_causal_gemm_scatter_head_kernel<<<scatter_blocks, 256>>>(
+        glm_causal_gemm_scatter_head_kernel<<<scatter_blocks, 256, 0, ds4_rocm_stream()>>>(
             (float *)lora_out->ptr,
             head_out,
             n_tokens,
@@ -2934,7 +2934,7 @@ static int glm_attention_indexed_lora_selected_gemm(
     const uint32_t kv_blocks =
         (uint32_t)min((kv_count + 255u) / 256u, 4096ull);
     glm_selected_gemm_profile_begin(&profile);
-    glm_selected_gemm_kv_to_f16_kernel<<<kv_blocks, 256>>>(
+    glm_selected_gemm_kv_to_f16_kernel<<<kv_blocks, 256, 0, ds4_rocm_stream()>>>(
         kv_h,
         (const char *)kv_lora_cache->ptr,
         (const int32_t *)selected->ptr,
@@ -2953,7 +2953,7 @@ static int glm_attention_indexed_lora_selected_gemm(
     const uint32_t rope_blocks =
         (uint32_t)min((rope_pairs + 255u) / 256u, 4096ull);
     glm_selected_gemm_profile_begin(&profile);
-    glm_selected_gemm_rope_to_f16_kernel<<<rope_blocks, 256>>>(
+    glm_selected_gemm_rope_to_f16_kernel<<<rope_blocks, 256, 0, ds4_rocm_stream()>>>(
         rope_h,
         (const char *)k_rope_cache->ptr,
         (const int32_t *)selected->ptr,
@@ -2995,7 +2995,7 @@ static int glm_attention_indexed_lora_selected_gemm(
         const uint32_t tile_heads = min(head_tile, n_head - head0);
         glm_selected_gemm_profile_begin(&profile);
         if (head_tile == 1u) {
-            glm_causal_gemm_gather_head_f16_kernel<<<gather_blocks, 256>>>(
+            glm_causal_gemm_gather_head_f16_kernel<<<gather_blocks, 256, 0, ds4_rocm_stream()>>>(
                 low_h,
                 qrope_h,
                 (const float *)qk_low->ptr,
@@ -3007,7 +3007,7 @@ static int glm_attention_indexed_lora_selected_gemm(
                 qk_nope,
                 qk_rope);
         } else {
-            glm_selected_gemm_gather_heads_f16_kernel<<<gather_blocks, 256>>>(
+            glm_selected_gemm_gather_heads_f16_kernel<<<gather_blocks, 256, 0, ds4_rocm_stream()>>>(
                 low_h,
                 qrope_h,
                 (const float *)qk_low->ptr,
@@ -3089,12 +3089,12 @@ static int glm_attention_indexed_lora_selected_gemm(
             &profile, GLM_SELECTED_PROFILE_ROPE_SCORE);
         glm_selected_gemm_profile_begin(&profile);
         if (head_tile == 1u) {
-            glm_selected_gemm_softmax_f16_kernel<<<n_tokens, 256>>>(
+            glm_selected_gemm_softmax_f16_kernel<<<n_tokens, 256, 0, ds4_rocm_stream()>>>(
                 probs, scores, n_tokens, n_selected, scale);
         } else {
             const dim3 softmax_grid(n_tokens, tile_heads, 1u);
             glm_selected_gemm_softmax_heads_f16_kernel<<<
-                softmax_grid, 256>>>(
+                softmax_grid, 256, 0, ds4_rocm_stream()>>>(
                     probs,
                     scores,
                     n_tokens,
@@ -3145,7 +3145,7 @@ static int glm_attention_indexed_lora_selected_gemm(
             (uint32_t)((scatter_count + 255u) / 256u);
         glm_selected_gemm_profile_begin(&profile);
         if (head_tile == 1u) {
-            glm_causal_gemm_scatter_head_kernel<<<scatter_blocks, 256>>>(
+            glm_causal_gemm_scatter_head_kernel<<<scatter_blocks, 256, 0, ds4_rocm_stream()>>>(
                 (float *)lora_out->ptr,
                 head_out,
                 n_tokens,
@@ -3153,7 +3153,7 @@ static int glm_attention_indexed_lora_selected_gemm(
                 n_head,
                 kv_lora_dim);
         } else {
-            glm_selected_gemm_scatter_heads_kernel<<<scatter_blocks, 256>>>(
+            glm_selected_gemm_scatter_heads_kernel<<<scatter_blocks, 256, 0, ds4_rocm_stream()>>>(
                 (float *)lora_out->ptr,
                 head_out,
                 n_tokens,
@@ -3320,7 +3320,7 @@ static int glm_attention_indexed_lora_launch(
     }
     dim3 grid(n_head, n_tokens, 1);
     const size_t shmem = ((size_t)256u + n_selected) * sizeof(float);
-    glm_attention_indexed_lora_kernel<<<grid, 256, shmem>>>((float *)lora_out->ptr,
+    glm_attention_indexed_lora_kernel<<<grid, 256, shmem, ds4_rocm_stream()>>>((float *)lora_out->ptr,
                                                             (const float *)q->ptr,
                                                             (const float *)qk_low->ptr,
                                                             (const char *)kv_lora_cache->ptr,
@@ -3690,7 +3690,7 @@ extern "C" int ds4_gpu_glm_attention_indexed_decode_split_group8_tensor(
         glm_attention_indexed_decode_split_group8_partial_valid_kernel<<<
                 dim3(n_head / 8u, n_blocks, 1),
                 dim3(32u, 8u, 1),
-                partial_shmem>>>(
+                partial_shmem, ds4_rocm_stream()>>>(
                 (float *)partial_lora->ptr,
                 (float *)partial_ms->ptr,
                 (const float *)q->ptr,
@@ -3716,7 +3716,7 @@ extern "C" int ds4_gpu_glm_attention_indexed_decode_split_group8_tensor(
         const size_t partial_shmem = ((size_t)256u + block_rows) * sizeof(float);
         glm_attention_indexed_decode_split_partial_kernel<<<dim3(n_head, n_blocks, 1),
                                                             256,
-                                                            partial_shmem>>>(
+                                                            partial_shmem, ds4_rocm_stream()>>>(
                 (float *)partial_lora->ptr,
                 (float *)partial_ms->ptr,
                 (const float *)q->ptr,
@@ -3747,7 +3747,7 @@ extern "C" int ds4_gpu_glm_attention_indexed_decode_split_group8_tensor(
     const size_t reduce_shmem = ((size_t)256u + 64u + kv_lora_dim) * sizeof(float);
     glm_attention_indexed_decode_split_reduce_kernel<<<dim3(n_head, 1, 1),
                                                        256,
-                                                       reduce_shmem>>>(
+                                                       reduce_shmem, ds4_rocm_stream()>>>(
             (float *)heads->ptr,
             (const float *)partial_lora->ptr,
             (const float *)partial_ms->ptr,
@@ -3900,7 +3900,7 @@ static int glm_router_select_launch(
 
     dim3 block(32, 4, 1);
     if (active_n_expert == DS4_ROCM_MAX_N_EXPERT) {
-        glm_router_select_warp_topk_kernel<DS4_ROCM_MAX_N_EXPERT><<<(n_tokens + 3u) / 4u, block>>>(
+        glm_router_select_warp_topk_kernel<DS4_ROCM_MAX_N_EXPERT><<<(n_tokens + 3u) / 4u, block, 0, ds4_rocm_stream()>>>(
                 (int32_t *)selected->ptr,
                 (float *)weights->ptr,
                 (float *)probs->ptr,
@@ -3910,7 +3910,7 @@ static int glm_router_select_launch(
                 active_n_expert_used,
                 active_scale);
     } else {
-        glm_router_select_warp_topk_kernel<DS4_ROCM_N_EXPERT><<<(n_tokens + 3u) / 4u, block>>>(
+        glm_router_select_warp_topk_kernel<DS4_ROCM_N_EXPERT><<<(n_tokens + 3u) / 4u, block, 0, ds4_rocm_stream()>>>(
                 (int32_t *)selected->ptr,
                 (float *)weights->ptr,
                 (float *)probs->ptr,

--- a/rocm/ds4_rocm_hc_output_launch.cuh
+++ b/rocm/ds4_rocm_hc_output_launch.cuh
@@ -5,7 +5,7 @@ extern "C" int ds4_gpu_repeat_hc_tensor(ds4_gpu_tensor *out, const ds4_gpu_tenso
         !cuda_tensor_has_f32(row, n_embd) || !cuda_tensor_has_f32(out, n)) {
         return 0;
     }
-    repeat_hc_kernel<<<(n + 255) / 256, 256>>>((float *)out->ptr, (const float *)row->ptr, n_embd, n_hc);
+    repeat_hc_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, (const float *)row->ptr, n_embd, n_hc);
     return cuda_ok(cudaGetLastError(), "repeat_hc launch");
 }
 
@@ -20,7 +20,7 @@ extern "C" int ds4_gpu_repeat_hc_rows_tensor(ds4_gpu_tensor *out, const ds4_gpu_
     }
     const uint64_t blocks = (n + 255u) / 256u;
     if (blocks > UINT32_MAX) return 0;
-    repeat_hc_rows_kernel<<<(unsigned)blocks, 256>>>((float *)out->ptr, (const float *)rows->ptr, n_tokens, n_embd, n_hc);
+    repeat_hc_rows_kernel<<<(unsigned)blocks, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, (const float *)rows->ptr, n_tokens, n_embd, n_hc);
     return cuda_ok(cudaGetLastError(), "repeat_hc_rows launch");
 }
 
@@ -35,7 +35,7 @@ extern "C" int ds4_gpu_hc_split_sinkhorn_tensor(ds4_gpu_tensor *out, const ds4_g
     if (!scale || !base) return 0;
     uint32_t n_rows = (uint32_t)(mix->bytes / mix_bytes);
     if (out->bytes / mix_bytes < n_rows) n_rows = (uint32_t)(out->bytes / mix_bytes);
-    hc_split_sinkhorn_kernel<<<(n_rows + 255) / 256, 256>>>(
+    hc_split_sinkhorn_kernel<<<(n_rows + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
         (float *)out->ptr, (const float *)mix->ptr,
         scale,
         base,
@@ -78,7 +78,7 @@ extern "C" int ds4_gpu_hc_weighted_sum_tensor(ds4_gpu_tensor *out, const ds4_gpu
         !cuda_u64_mul3_checked(n_tokens64, n_hc, sizeof(float), &weights_bytes) ||
         residual_hc->bytes < residual_bytes || weights->bytes < weights_bytes) return 0;
     uint32_t n_tokens = (uint32_t)n_tokens64;
-    hc_weighted_sum_kernel<<<((uint64_t)n_embd * n_tokens + 255) / 256, 256>>>(
+    hc_weighted_sum_kernel<<<((uint64_t)n_embd * n_tokens + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
         (float *)out->ptr, (const float *)residual_hc->ptr, (const float *)weights->ptr,
         n_embd, n_hc, n_tokens, n_hc);
     return cuda_ok(cudaGetLastError(), "hc_weighted_sum launch");
@@ -93,7 +93,7 @@ extern "C" int ds4_gpu_hc_weighted_sum_split_tensor(ds4_gpu_tensor *out, const d
         residual_hc->bytes < residual_bytes || split->bytes < split_bytes) return 0;
     uint32_t n_tokens = (uint32_t)n_tokens64;
     uint32_t stride = (uint32_t)mix_hc;
-    hc_weighted_sum_kernel<<<((uint64_t)n_embd * n_tokens + 255) / 256, 256>>>(
+    hc_weighted_sum_kernel<<<((uint64_t)n_embd * n_tokens + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
         (float *)out->ptr, (const float *)residual_hc->ptr, (const float *)split->ptr,
         n_embd, n_hc, n_tokens, stride);
     return cuda_ok(cudaGetLastError(), "hc_weighted_sum_split launch");
@@ -133,7 +133,7 @@ extern "C" int ds4_gpu_hc_split_weighted_sum_tensor(
     const float *scale = (const float *)cuda_model_range_ptr(model_map, scale_offset, 3ull * sizeof(float), "hc_scale");
     const float *base = (const float *)cuda_model_range_ptr(model_map, base_offset, mix_bytes, "hc_base");
     if (!scale || !base) return 0;
-    hc_split_weighted_sum_fused_kernel<<<(uint32_t)n_rows, 256>>>(
+    hc_split_weighted_sum_fused_kernel<<<(uint32_t)n_rows, 256, 0, ds4_rocm_stream()>>>(
             (float *)out->ptr,
             (float *)split->ptr,
             (const float *)mix->ptr,
@@ -188,7 +188,7 @@ extern "C" int ds4_gpu_hc_split_weighted_sum_norm_tensor(
     const float *norm_w = (const float *)cuda_model_range_ptr(model_map, norm_weight_offset,
             (uint64_t)n_embd * sizeof(float), "hc_norm_weight");
     if (!scale || !base || !norm_w) return 0;
-    hc_split_weighted_sum_norm_fused_kernel<<<(uint32_t)n_rows, 256>>>(
+    hc_split_weighted_sum_norm_fused_kernel<<<(uint32_t)n_rows, 256, 0, ds4_rocm_stream()>>>(
             (float *)out->ptr,
             (float *)norm_out->ptr,
             (float *)split->ptr,
@@ -222,7 +222,7 @@ extern "C" int ds4_gpu_output_hc_weights_tensor(
     const float *base = (const float *)cuda_model_range_ptr(model_map, base_offset, row_bytes, "output_hc_base");
     if (!scale || !base) return 0;
     uint64_t n = n_tokens * n_hc;
-    output_hc_weights_kernel<<<(n + 255) / 256, 256>>>(
+    output_hc_weights_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>(
             (float *)out->ptr,
             (const float *)pre->ptr,
             scale,
@@ -245,7 +245,7 @@ extern "C" int ds4_gpu_hc_expand_tensor(ds4_gpu_tensor *out_hc, const ds4_gpu_te
         post->bytes < post_bytes || comb->bytes < comb_bytes) return 0;
     uint32_t n_tokens = (uint32_t)n_tokens64;
     uint64_t n_elem = (uint64_t)n_tokens * n_hc * n_embd;
-    hc_expand_kernel<<<(n_elem + 255) / 256, 256>>>((float *)out_hc->ptr,
+    hc_expand_kernel<<<(n_elem + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out_hc->ptr,
                                                     (const float *)block_out->ptr,
                                                     (const float *)block_out->ptr,
                                                     (const float *)residual_hc->ptr,
@@ -267,7 +267,7 @@ extern "C" int ds4_gpu_hc_expand_split_tensor(ds4_gpu_tensor *out_hc, const ds4_
     uint32_t n_tokens = (uint32_t)n_tokens64;
     if (n_hc == 4u) {
         const uint64_t n = (uint64_t)n_tokens * n_embd;
-        hc_expand4_kernel<<<(n + 255) / 256, 256>>>((float *)out_hc->ptr,
+        hc_expand4_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out_hc->ptr,
                                                     (const float *)block_out->ptr,
                                                     (const float *)residual_hc->ptr,
                                                     (const float *)split->ptr,
@@ -278,7 +278,7 @@ extern "C" int ds4_gpu_hc_expand_split_tensor(ds4_gpu_tensor *out_hc, const ds4_
     uint32_t mix_hc = (uint32_t)mix_hc64;
     uint64_t n_elem = (uint64_t)n_tokens * n_hc * n_embd;
     const float *base = (const float *)split->ptr;
-    hc_expand_kernel<<<(n_elem + 255) / 256, 256>>>((float *)out_hc->ptr,
+    hc_expand_kernel<<<(n_elem + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out_hc->ptr,
                                                     (const float *)block_out->ptr,
                                                     (const float *)block_out->ptr,
                                                     (const float *)residual_hc->ptr,
@@ -300,7 +300,7 @@ extern "C" int ds4_gpu_hc_expand_split_half_tensor(ds4_gpu_tensor *out_hc, const
     uint32_t n_tokens = (uint32_t)n_tokens64;
     if (n_hc == 4u) {
         const uint64_t n = (uint64_t)n_tokens * n_embd;
-        hc_expand4_half_kernel<<<(n + 255) / 256, 256>>>((float *)out_hc->ptr,
+        hc_expand4_half_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out_hc->ptr,
                                                          (const __half *)block_out_h->ptr,
                                                          (const float *)residual_hc->ptr,
                                                          (const float *)split->ptr,
@@ -311,7 +311,7 @@ extern "C" int ds4_gpu_hc_expand_split_half_tensor(ds4_gpu_tensor *out_hc, const
     uint32_t mix_hc = (uint32_t)mix_hc64;
     uint64_t n_elem = (uint64_t)n_tokens * n_hc * n_embd;
     const float *base = (const float *)split->ptr;
-    hc_expand_half_kernel<<<(n_elem + 255) / 256, 256>>>((float *)out_hc->ptr,
+    hc_expand_half_kernel<<<(n_elem + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out_hc->ptr,
                                                          (const __half *)block_out_h->ptr,
                                                          (const float *)residual_hc->ptr,
                                                          base + n_hc,
@@ -333,7 +333,7 @@ extern "C" int ds4_gpu_hc_expand_add_split_tensor(ds4_gpu_tensor *out_hc, const 
     uint32_t n_tokens = (uint32_t)n_tokens64;
     if (n_hc == 4u) {
         const uint64_t n = (uint64_t)n_tokens * n_embd;
-        hc_expand4_add_kernel<<<(n + 255) / 256, 256>>>((float *)out_hc->ptr,
+        hc_expand4_add_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out_hc->ptr,
                                                         (const float *)block_out->ptr,
                                                         (const float *)block_add->ptr,
                                                         (const float *)residual_hc->ptr,
@@ -345,7 +345,7 @@ extern "C" int ds4_gpu_hc_expand_add_split_tensor(ds4_gpu_tensor *out_hc, const 
     uint32_t mix_hc = (uint32_t)mix_hc64;
     uint64_t n_elem = (uint64_t)n_tokens * n_hc * n_embd;
     const float *base = (const float *)split->ptr;
-    hc_expand_kernel<<<(n_elem + 255) / 256, 256>>>((float *)out_hc->ptr,
+    hc_expand_kernel<<<(n_elem + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out_hc->ptr,
                                                     (const float *)block_out->ptr,
                                                     (const float *)block_add->ptr,
                                                     (const float *)residual_hc->ptr,
@@ -369,7 +369,7 @@ extern "C" int ds4_gpu_hc_expand_add_split_half_add_tensor(ds4_gpu_tensor *out_h
     uint32_t n_tokens = (uint32_t)n_tokens64;
     if (n_hc == 4u) {
         const uint64_t n = (uint64_t)n_tokens * n_embd;
-        hc_expand4_add_half_kernel<<<(n + 255) / 256, 256>>>((float *)out_hc->ptr,
+        hc_expand4_add_half_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out_hc->ptr,
                                                              (const float *)block_out->ptr,
                                                              (const __half *)block_add_h->ptr,
                                                              (const float *)residual_hc->ptr,
@@ -381,7 +381,7 @@ extern "C" int ds4_gpu_hc_expand_add_split_half_add_tensor(ds4_gpu_tensor *out_h
     uint32_t mix_hc = (uint32_t)mix_hc64;
     uint64_t n_elem = (uint64_t)n_tokens * n_hc * n_embd;
     const float *base = (const float *)split->ptr;
-    hc_expand_add_half_kernel<<<(n_elem + 255) / 256, 256>>>((float *)out_hc->ptr,
+    hc_expand_add_half_kernel<<<(n_elem + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out_hc->ptr,
                                                              (const float *)block_out->ptr,
                                                              (const __half *)block_add_h->ptr,
                                                              (const float *)residual_hc->ptr,

--- a/rocm/ds4_rocm_indexer.cuh
+++ b/rocm/ds4_rocm_indexer.cuh
@@ -852,7 +852,7 @@ static int indexer_scores_launch(
     }
     if (causal && ratio == 0) return 0;
     if (n_tokens == 1u && head_dim == 128u && n_head == 64u) {
-        indexer_score_one_direct_kernel<<<n_comp, 128>>>((float *)scores->ptr,
+        indexer_score_one_direct_kernel<<<n_comp, 128, 0, ds4_rocm_stream()>>>((float *)scores->ptr,
                                                          (const float *)q->ptr,
                                                          (const float *)weights->ptr,
                                                          (const float *)index_comp->ptr,
@@ -862,7 +862,7 @@ static int indexer_scores_launch(
     }
     if (!g_quality_mode && head_dim == 128u && n_head == 64u) {
         dim3 grid((n_comp + 127u) / 128u, (n_tokens + 15u) / 16u, 1);
-        indexer_scores_wmma128_kernel<<<grid, 256>>>((float *)scores->ptr,
+        indexer_scores_wmma128_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)scores->ptr,
                                                      (const float *)q->ptr,
                                                      (const float *)weights->ptr,
                                                      (const float *)index_comp->ptr,
@@ -871,7 +871,7 @@ static int indexer_scores_launch(
         return cuda_ok(cudaGetLastError(), "indexer scores wmma128 launch");
     }
     dim3 grid(n_comp, n_tokens, 1);
-    indexer_scores_kernel<<<grid, 256>>>((float *)scores->ptr,
+    indexer_scores_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)scores->ptr,
                                          (const float *)q->ptr,
                                          (const float *)weights->ptr,
                                          (const float *)index_comp->ptr,
@@ -937,13 +937,13 @@ extern "C" int ds4_gpu_indexer_topk_tensor(
         return 0;
     }
     if (top_k == 512u && n_comp <= 1024u) {
-        indexer_topk_1024_kernel<<<n_tokens, 1024>>>((uint32_t *)selected->ptr,
+        indexer_topk_1024_kernel<<<n_tokens, 1024, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                      (const float *)scores->ptr,
                                                      n_comp, n_tokens, top_k);
         return cuda_ok(cudaGetLastError(), "indexer topk 1024 launch");
     }
     if (top_k == 512u && n_comp <= 2048u) {
-        indexer_topk_pow2_kernel<2048><<<n_tokens, 1024>>>((uint32_t *)selected->ptr,
+        indexer_topk_pow2_kernel<2048><<<n_tokens, 1024, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                            (const float *)scores->ptr,
                                                            n_comp, n_tokens, top_k);
         return cuda_ok(cudaGetLastError(), "indexer topk 2048 launch");
@@ -965,14 +965,14 @@ extern "C" int ds4_gpu_indexer_topk_tensor(
                                                 cudaFuncAttributeMaxDynamicSharedMemorySize,
                                                 smem);
                 if (attr_err == cudaSuccess) {
-                    indexer_topk_8192_cub_kernel<<<n_tokens, 512, (size_t)smem>>>((uint32_t *)selected->ptr,
+                    indexer_topk_8192_cub_kernel<<<n_tokens, 512, (size_t)smem, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                                                  (const float *)scores->ptr,
                                                                                  n_comp, n_tokens, top_k);
                     return cuda_ok(cudaGetLastError(), "indexer topk 4096 cub launch");
                 }
             }
         }
-        indexer_topk_pow2_kernel<4096><<<n_tokens, 1024>>>((uint32_t *)selected->ptr,
+        indexer_topk_pow2_kernel<4096><<<n_tokens, 1024, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                            (const float *)scores->ptr,
                                                            n_comp, n_tokens, top_k);
         return cuda_ok(cudaGetLastError(), "indexer topk 4096 launch");
@@ -994,32 +994,32 @@ extern "C" int ds4_gpu_indexer_topk_tensor(
                                                 cudaFuncAttributeMaxDynamicSharedMemorySize,
                                                 smem);
                 if (attr_err == cudaSuccess) {
-                    indexer_topk_8192_cub_kernel<<<n_tokens, 512, (size_t)smem>>>((uint32_t *)selected->ptr,
+                    indexer_topk_8192_cub_kernel<<<n_tokens, 512, (size_t)smem, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                                                  (const float *)scores->ptr,
                                                                                  n_comp, n_tokens, top_k);
                     return cuda_ok(cudaGetLastError(), "indexer topk 8192 cub launch");
                 }
             }
         }
-        indexer_topk_pow2_u16_kernel<8192><<<n_tokens, 1024>>>((uint32_t *)selected->ptr,
+        indexer_topk_pow2_u16_kernel<8192><<<n_tokens, 1024, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                                (const float *)scores->ptr,
                                                                n_comp, n_tokens, top_k);
         return cuda_ok(cudaGetLastError(), "indexer topk 8192 launch");
     }
     if (top_k == 1024u && n_comp <= 1024u) {
-        indexer_topk_1024_kernel<<<n_tokens, 1024>>>((uint32_t *)selected->ptr,
+        indexer_topk_1024_kernel<<<n_tokens, 1024, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                      (const float *)scores->ptr,
                                                      n_comp, n_tokens, top_k);
         return cuda_ok(cudaGetLastError(), "indexer topk 1024x1024 launch");
     }
     if (top_k == 1024u && n_comp <= 2048u) {
-        indexer_topk_pow2_kernel<2048><<<n_tokens, 1024>>>((uint32_t *)selected->ptr,
+        indexer_topk_pow2_kernel<2048><<<n_tokens, 1024, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                            (const float *)scores->ptr,
                                                            n_comp, n_tokens, top_k);
         return cuda_ok(cudaGetLastError(), "indexer topk 2048x1024 launch");
     }
     if (top_k == 1024u && n_comp <= 4096u) {
-        indexer_topk_pow2_kernel<4096><<<n_tokens, 1024>>>((uint32_t *)selected->ptr,
+        indexer_topk_pow2_kernel<4096><<<n_tokens, 1024, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                            (const float *)scores->ptr,
                                                            n_comp, n_tokens, top_k);
         return cuda_ok(cudaGetLastError(), "indexer topk 4096x1024 launch");
@@ -1041,20 +1041,20 @@ extern "C" int ds4_gpu_indexer_topk_tensor(
                                                 cudaFuncAttributeMaxDynamicSharedMemorySize,
                                                 smem);
                 if (attr_err == cudaSuccess) {
-                    indexer_topk_8192_cub_kernel<<<n_tokens, 512, (size_t)smem>>>((uint32_t *)selected->ptr,
+                    indexer_topk_8192_cub_kernel<<<n_tokens, 512, (size_t)smem, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                                                  (const float *)scores->ptr,
                                                                                  n_comp, n_tokens, top_k);
                     return cuda_ok(cudaGetLastError(), "indexer topk 8192x1024 cub launch");
                 }
             }
         }
-        indexer_topk_pow2_u16_kernel<8192><<<n_tokens, 1024>>>((uint32_t *)selected->ptr,
+        indexer_topk_pow2_u16_kernel<8192><<<n_tokens, 1024, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                                (const float *)scores->ptr,
                                                                n_comp, n_tokens, top_k);
         return cuda_ok(cudaGetLastError(), "indexer topk 8192x1024 launch");
     }
     if (top_k == 2048u && n_comp <= 4096u) {
-        indexer_topk_pow2_kernel<4096><<<n_tokens, 1024>>>((uint32_t *)selected->ptr,
+        indexer_topk_pow2_kernel<4096><<<n_tokens, 1024, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                            (const float *)scores->ptr,
                                                            n_comp, n_tokens, top_k);
         return cuda_ok(cudaGetLastError(), "indexer topk 4096x2048 launch");
@@ -1076,14 +1076,14 @@ extern "C" int ds4_gpu_indexer_topk_tensor(
                                                 cudaFuncAttributeMaxDynamicSharedMemorySize,
                                                 smem);
                 if (attr_err == cudaSuccess) {
-                    indexer_topk_8192_cub_kernel<<<n_tokens, 512, (size_t)smem>>>((uint32_t *)selected->ptr,
+                    indexer_topk_8192_cub_kernel<<<n_tokens, 512, (size_t)smem, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                                                  (const float *)scores->ptr,
                                                                                  n_comp, n_tokens, top_k);
                     return cuda_ok(cudaGetLastError(), "indexer topk 8192x2048 cub launch");
                 }
             }
         }
-        indexer_topk_pow2_u16_kernel<8192><<<n_tokens, 1024>>>((uint32_t *)selected->ptr,
+        indexer_topk_pow2_u16_kernel<8192><<<n_tokens, 1024, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                                (const float *)scores->ptr,
                                                                n_comp, n_tokens, top_k);
         return cuda_ok(cudaGetLastError(), "indexer topk 8192x2048 launch");
@@ -1110,7 +1110,7 @@ extern "C" int ds4_gpu_indexer_topk_tensor(
         n_sets = n_chunks;
         uint32_t cur_stride = candidate_stride;
         dim3 grid_chunks(n_tokens, n_chunks, 1);
-        indexer_topk_chunk_pow2_kernel<4096><<<grid_chunks, 1024>>>(cur,
+        indexer_topk_chunk_pow2_kernel<4096><<<grid_chunks, 1024, 0, ds4_rocm_stream()>>>(cur,
                                                                     (const float *)scores->ptr,
                                                                     n_comp,
                                                                     n_tokens,
@@ -1123,7 +1123,7 @@ extern "C" int ds4_gpu_indexer_topk_tensor(
             const uint32_t next_stride = next_sets * top_k;
             uint32_t *next = cur + (uint64_t)n_tokens * cur_stride;
             dim3 grid_merge(n_tokens, next_sets, 1);
-            indexer_topk_tree_merge_pow2_kernel<4096><<<grid_merge, 1024>>>(
+            indexer_topk_tree_merge_pow2_kernel<4096><<<grid_merge, 1024, 0, ds4_rocm_stream()>>>(
                     next,
                     cur,
                     (const float *)scores->ptr,
@@ -1140,7 +1140,7 @@ extern "C" int ds4_gpu_indexer_topk_tensor(
             cur_stride = next_stride;
         }
 
-        indexer_topk_merge_pow2_kernel<4096><<<n_tokens, 1024>>>((uint32_t *)selected->ptr,
+        indexer_topk_merge_pow2_kernel<4096><<<n_tokens, 1024, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                                                  cur,
                                                                  (const float *)scores->ptr,
                                                                  n_comp,
@@ -1150,7 +1150,7 @@ extern "C" int ds4_gpu_indexer_topk_tensor(
                                                                  cur_stride);
         return cuda_ok(cudaGetLastError(), "indexer topk tree final launch");
     }
-    indexer_topk_kernel<<<n_tokens, 1>>>((uint32_t *)selected->ptr,
+    indexer_topk_kernel<<<n_tokens, 1, 0, ds4_rocm_stream()>>>((uint32_t *)selected->ptr,
                                          (const float *)scores->ptr,
                                          n_comp, n_tokens, top_k);
     return cuda_ok(cudaGetLastError(), "indexer topk launch");
@@ -1167,7 +1167,7 @@ extern "C" int ds4_gpu_argmax_tensor(
         logits->bytes < logits_bytes) {
         return 0;
     }
-    argmax_kernel<<<1, 1024>>>((int32_t *)out_idx->ptr,
+    argmax_kernel<<<1, 1024, 0, ds4_rocm_stream()>>>((int32_t *)out_idx->ptr,
                                (const float *)logits->ptr,
                                n_vocab);
     return cuda_ok(cudaGetLastError(), "argmax launch");
@@ -1219,7 +1219,7 @@ extern "C" int ds4_gpu_dspark_markov_argmax_tensor(
                  "DSpark markov argmax clear")) {
         return 0;
     }
-    dspark_markov_argmax_kernel<<<128, 256>>>(
+    dspark_markov_argmax_kernel<<<128, 256, 0, ds4_rocm_stream()>>>(
             (unsigned long long *)out_idx->ptr,
             (const float *)logits_row->ptr,
             w1_row,
@@ -1243,7 +1243,7 @@ extern "C" int ds4_gpu_dsv4_topk_mask_tensor(
     uint64_t n = (uint64_t)n_tokens * n_comp;
     uint64_t nk = (uint64_t)n_tokens * top_k;
     uint64_t blocks = ((n > nk ? n : nk) + 255) / 256;
-    topk_mask_kernel<<<blocks, 256>>>((float *)mask->ptr,
+    topk_mask_kernel<<<blocks, 256, 0, ds4_rocm_stream()>>>((float *)mask->ptr,
                                       (const uint32_t *)topk->ptr,
                                       n_comp, n_tokens, top_k);
     return cuda_ok(cudaGetLastError(), "topk mask launch");
@@ -1254,6 +1254,6 @@ extern "C" int ds4_gpu_dsv4_indexer_qat_tensor(ds4_gpu_tensor *x, uint32_t n_row
         x->bytes < (uint64_t)n_rows * head_dim * sizeof(float)) {
         return 0;
     }
-    indexer_hadamard_fp4_kernel<<<n_rows, 128>>>((float *)x->ptr, n_rows, head_dim);
+    indexer_hadamard_fp4_kernel<<<n_rows, 128, 0, ds4_rocm_stream()>>>((float *)x->ptr, n_rows, head_dim);
     return cuda_ok(cudaGetLastError(), "indexer_hadamard_fp4 launch");
 }

--- a/rocm/ds4_rocm_matmul.cuh
+++ b/rocm/ds4_rocm_matmul.cuh
@@ -12,15 +12,15 @@ static void cuda_launch_q8_batch_sharedx_bt(
         uint32_t tile) {
     const size_t shmem = (size_t)tile * BT * 32u * sizeof(float);
     if (tile == 2u) {
-        matmul_q8_0_f32_batch_sharedx_warp_rows_w32_toktile_kernel<2u, BT><<<grid, rows_per_block * 32u, shmem>>>(out, w, x, n_blocks, out_dim, n_tok, row_bytes);
+        matmul_q8_0_f32_batch_sharedx_warp_rows_w32_toktile_kernel<2u, BT><<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(out, w, x, n_blocks, out_dim, n_tok, row_bytes);
     } else if (tile == 4u) {
-        matmul_q8_0_f32_batch_sharedx_warp_rows_w32_toktile_kernel<4u, BT><<<grid, rows_per_block * 32u, shmem>>>(out, w, x, n_blocks, out_dim, n_tok, row_bytes);
+        matmul_q8_0_f32_batch_sharedx_warp_rows_w32_toktile_kernel<4u, BT><<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(out, w, x, n_blocks, out_dim, n_tok, row_bytes);
     } else if (tile == 8u) {
-        matmul_q8_0_f32_batch_sharedx_warp_rows_w32_toktile_kernel<8u, BT><<<grid, rows_per_block * 32u, shmem>>>(out, w, x, n_blocks, out_dim, n_tok, row_bytes);
+        matmul_q8_0_f32_batch_sharedx_warp_rows_w32_toktile_kernel<8u, BT><<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(out, w, x, n_blocks, out_dim, n_tok, row_bytes);
     } else if (tile == 16u) {
-        matmul_q8_0_f32_batch_sharedx_warp_rows_w32_toktile_kernel<16u, BT><<<grid, rows_per_block * 32u, shmem>>>(out, w, x, n_blocks, out_dim, n_tok, row_bytes);
+        matmul_q8_0_f32_batch_sharedx_warp_rows_w32_toktile_kernel<16u, BT><<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(out, w, x, n_blocks, out_dim, n_tok, row_bytes);
     } else {
-        matmul_q8_0_f32_batch_sharedx_warp_rows_w32_toktile_kernel<32u, BT><<<grid, rows_per_block * 32u, shmem>>>(out, w, x, n_blocks, out_dim, n_tok, row_bytes);
+        matmul_q8_0_f32_batch_sharedx_warp_rows_w32_toktile_kernel<32u, BT><<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(out, w, x, n_blocks, out_dim, n_tok, row_bytes);
     }
 }
 
@@ -62,15 +62,15 @@ static void cuda_launch_grouped_q8_a_sharedx_bt(
         uint32_t tile) {
     const size_t shmem = (size_t)tile * BT * 32u * sizeof(float);
     if (tile == 2u) {
-        grouped_q8_0_a_f32_batch_sharedx_chunked_w32_kernel<2u, BT><<<grid, rows_per_block * 32u, shmem>>>(low, w, heads, n_tokens, n_groups, n_blocks, rank, row_bytes);
+        grouped_q8_0_a_f32_batch_sharedx_chunked_w32_kernel<2u, BT><<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(low, w, heads, n_tokens, n_groups, n_blocks, rank, row_bytes);
     } else if (tile == 4u) {
-        grouped_q8_0_a_f32_batch_sharedx_chunked_w32_kernel<4u, BT><<<grid, rows_per_block * 32u, shmem>>>(low, w, heads, n_tokens, n_groups, n_blocks, rank, row_bytes);
+        grouped_q8_0_a_f32_batch_sharedx_chunked_w32_kernel<4u, BT><<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(low, w, heads, n_tokens, n_groups, n_blocks, rank, row_bytes);
     } else if (tile == 8u) {
-        grouped_q8_0_a_f32_batch_sharedx_chunked_w32_kernel<8u, BT><<<grid, rows_per_block * 32u, shmem>>>(low, w, heads, n_tokens, n_groups, n_blocks, rank, row_bytes);
+        grouped_q8_0_a_f32_batch_sharedx_chunked_w32_kernel<8u, BT><<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(low, w, heads, n_tokens, n_groups, n_blocks, rank, row_bytes);
     } else if (tile == 16u) {
-        grouped_q8_0_a_f32_batch_sharedx_chunked_w32_kernel<16u, BT><<<grid, rows_per_block * 32u, shmem>>>(low, w, heads, n_tokens, n_groups, n_blocks, rank, row_bytes);
+        grouped_q8_0_a_f32_batch_sharedx_chunked_w32_kernel<16u, BT><<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(low, w, heads, n_tokens, n_groups, n_blocks, rank, row_bytes);
     } else {
-        grouped_q8_0_a_f32_batch_sharedx_chunked_w32_kernel<32u, BT><<<grid, rows_per_block * 32u, shmem>>>(low, w, heads, n_tokens, n_groups, n_blocks, rank, row_bytes);
+        grouped_q8_0_a_f32_batch_sharedx_chunked_w32_kernel<32u, BT><<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(low, w, heads, n_tokens, n_groups, n_blocks, rank, row_bytes);
     }
 }
 
@@ -117,27 +117,27 @@ static void cuda_launch_grouped_q8_a_sharedx_strided_bt(
     const size_t shmem = (size_t)tile * BT * 32u * sizeof(float);
     if (tile == 2u) {
         grouped_q8_0_a_f32_batch_sharedx_chunked_strided_w32_kernel<2u, BT>
-            <<<grid, rows_per_block * 32u, shmem>>>(
+            <<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(
                 low, w, heads, n_tokens, n_groups, n_blocks, rank,
                 x_token_stride, x_group_stride, row_bytes);
     } else if (tile == 4u) {
         grouped_q8_0_a_f32_batch_sharedx_chunked_strided_w32_kernel<4u, BT>
-            <<<grid, rows_per_block * 32u, shmem>>>(
+            <<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(
                 low, w, heads, n_tokens, n_groups, n_blocks, rank,
                 x_token_stride, x_group_stride, row_bytes);
     } else if (tile == 8u) {
         grouped_q8_0_a_f32_batch_sharedx_chunked_strided_w32_kernel<8u, BT>
-            <<<grid, rows_per_block * 32u, shmem>>>(
+            <<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(
                 low, w, heads, n_tokens, n_groups, n_blocks, rank,
                 x_token_stride, x_group_stride, row_bytes);
     } else if (tile == 16u) {
         grouped_q8_0_a_f32_batch_sharedx_chunked_strided_w32_kernel<16u, BT>
-            <<<grid, rows_per_block * 32u, shmem>>>(
+            <<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(
                 low, w, heads, n_tokens, n_groups, n_blocks, rank,
                 x_token_stride, x_group_stride, row_bytes);
     } else {
         grouped_q8_0_a_f32_batch_sharedx_chunked_strided_w32_kernel<32u, BT>
-            <<<grid, rows_per_block * 32u, shmem>>>(
+            <<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>(
                 low, w, heads, n_tokens, n_groups, n_blocks, rank,
                 x_token_stride, x_group_stride, row_bytes);
     }
@@ -207,7 +207,7 @@ static int cuda_matmul_q8_0_tensor_f16_gemm(
     const uint64_t xh_count = n_tok * in_dim;
     __half *xh = (__half *)cuda_tmp_alloc(xh_count * sizeof(__half), "q8 f16 gemm activations");
     if (!xh) return 0;
-    f32_to_f16_kernel<<<(xh_count + 255u) / 256u, 256>>>(xh, (const float *)x->ptr, xh_count);
+    f32_to_f16_kernel<<<(xh_count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(xh, (const float *)x->ptr, xh_count);
     if (!cuda_ok(cudaGetLastError(), "q8 f16 activation convert launch")) return 0;
     const float alpha = 1.0f;
     const float beta = 0.0f;
@@ -264,7 +264,7 @@ static int cuda_matmul_q8_0_tensor_f16_gemm_out_half(
     const uint64_t xh_count = n_tok * in_dim;
     __half *xh = (__half *)cuda_tmp_alloc(xh_count * sizeof(__half), "q8 f16-out gemm activations");
     if (!xh) return 0;
-    f32_to_f16_kernel<<<(xh_count + 255u) / 256u, 256>>>(xh, (const float *)x->ptr, xh_count);
+    f32_to_f16_kernel<<<(xh_count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(xh, (const float *)x->ptr, xh_count);
     if (!cuda_ok(cudaGetLastError(), "q8 f16-out activation convert launch")) return 0;
     const float alpha = 1.0f;
     const float beta = 0.0f;
@@ -341,7 +341,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
             matmul_q8_0_f32_sharedx_warp_rows_w32_kernel<<<
                     (unsigned)((out_dim + rows_per_block - 1u) / rows_per_block),
                     threads,
-                    (size_t)in_dim * sizeof(float)>>>(
+                    (size_t)in_dim * sizeof(float), ds4_rocm_stream()>>>(
                     (float *)out->ptr,
                     reinterpret_cast<const unsigned char *>(wptr),
                     (const float *)x->ptr,
@@ -377,7 +377,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
                 fallback_notice_printed = 1;
             }
         }
-        matmul_q8_0_f32_warp8_kernel<<<((unsigned)out_dim + 7u) / 8u, 256>>>(
+        matmul_q8_0_f32_warp8_kernel<<<((unsigned)out_dim + 7u) / 8u, 256, 0, ds4_rocm_stream()>>>(
                 (float *)out->ptr,
                 reinterpret_cast<const unsigned char *>(wptr),
                 (const float *)x->ptr,
@@ -395,7 +395,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
             const dim3 grid((uint32_t)((out_dim + 63u) / 64u),
                             (uint32_t)((n_tok + 63u) / 64u),
                             1u);
-            matmul_q8_0_f32_batch_wmma_4w_kernel<<<grid, 128u>>>(
+            matmul_q8_0_f32_batch_wmma_4w_kernel<<<grid, 128u, 0, ds4_rocm_stream()>>>(
                     (float *)out->ptr,
                     reinterpret_cast<const unsigned char *>(wptr),
                     (const float *)x->ptr,
@@ -423,7 +423,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
             return cuda_ok(cudaGetLastError(), "matmul_q8_0 f32 batch sharedx launch");
         }
         dim3 bgrid(((unsigned)out_dim + 7u) / 8u, (unsigned)n_tok, 1);
-        matmul_q8_0_f32_batch_warp8_kernel<<<bgrid, 256>>>(
+        matmul_q8_0_f32_batch_warp8_kernel<<<bgrid, 256, 0, ds4_rocm_stream()>>>(
                 (float *)out->ptr,
                 reinterpret_cast<const unsigned char *>(wptr),
                 (const float *)x->ptr,
@@ -439,7 +439,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
             const uint64_t xh_count = n_tok * in_dim;
             __half *xh = (__half *)cuda_tmp_alloc(xh_count * sizeof(__half), "q8 f16 gemm activations");
             if (!xh) return 0;
-            f32_to_f16_kernel<<<(xh_count + 255) / 256, 256>>>(xh, (const float *)x->ptr, xh_count);
+            f32_to_f16_kernel<<<(xh_count + 255) / 256, 256, 0, ds4_rocm_stream()>>>(xh, (const float *)x->ptr, xh_count);
             if (!cuda_ok(cudaGetLastError(), "q8 f16 activation convert launch")) return 0;
             const float alpha = 1.0f;
             const float beta = 0.0f;
@@ -481,13 +481,13 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
     const ds4_rocm_runtime_config *cfg = cuda_runtime_config();
     const int use_dp4a = 1;
     dim3 qgrid((unsigned)blocks, (unsigned)n_tok, 1);
-    quantize_q8_0_f32_kernel<<<qgrid, 32>>>(xq, xscale, (const float *)x->ptr, in_dim, blocks);
+    quantize_q8_0_f32_kernel<<<qgrid, 32, 0, ds4_rocm_stream()>>>(xq, xscale, (const float *)x->ptr, in_dim, blocks);
     if (!cuda_ok(cudaGetLastError(), "matmul_q8_0 quantize launch")) return 0;
     if (n_tok == 1) {
         const uint32_t rows_per_block = cfg->q8_decode_rpb;
         matmul_q8_0_preq_rows_w32_kernel<<<
                 ((unsigned)out_dim + rows_per_block - 1u) / rows_per_block,
-                rows_per_block * 32u>>>(
+                rows_per_block * 32u, 0, ds4_rocm_stream()>>>(
                 (float *)out->ptr,
                 reinterpret_cast<const unsigned char *>(wptr),
                 xq,
@@ -501,7 +501,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
     }
     if (blocks <= 32u) {
         dim3 bgrid(((unsigned)out_dim + 7u) / 8u, (unsigned)n_tok, 1);
-        matmul_q8_0_preq_batch_warp8_kernel<<<bgrid, 256>>>(
+        matmul_q8_0_preq_batch_warp8_kernel<<<bgrid, 256, 0, ds4_rocm_stream()>>>(
                 (float *)out->ptr,
                 reinterpret_cast<const unsigned char *>(wptr),
                 xq,
@@ -514,7 +514,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
         return cuda_ok(cudaGetLastError(), "matmul_q8_0 batch warp launch");
     }
     dim3 grid((unsigned)out_dim, (unsigned)n_tok, 1);
-    matmul_q8_0_preq_kernel<<<grid, 256>>>((float *)out->ptr,
+    matmul_q8_0_preq_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr,
                                            reinterpret_cast<const unsigned char *>(wptr),
                                            xq,
                                            xscale,
@@ -631,7 +631,7 @@ extern "C" int ds4_gpu_matmul_q8_0_pair_tensor(
             matmul_q8_0_pair_f32_sharedx_warp_rows_w32_kernel<<<
                     (unsigned)((max_out + rows_per_block - 1u) / rows_per_block),
                     threads,
-                    (size_t)in_dim * sizeof(float)>>>(
+                    (size_t)in_dim * sizeof(float), ds4_rocm_stream()>>>(
                     (float *)out0->ptr,
                     (float *)out1->ptr,
                     reinterpret_cast<const unsigned char *>(w0),
@@ -643,7 +643,7 @@ extern "C" int ds4_gpu_matmul_q8_0_pair_tensor(
                     blocks * 34u);
             return cuda_ok(cudaGetLastError(), "matmul_q8_0 pair f32 sharedx launch");
         }
-        matmul_q8_0_pair_f32_warp8_kernel<<<((unsigned)max_out + 7u) / 8u, 256>>>(
+        matmul_q8_0_pair_f32_warp8_kernel<<<((unsigned)max_out + 7u) / 8u, 256, 0, ds4_rocm_stream()>>>(
                 (float *)out0->ptr,
                 (float *)out1->ptr,
                 reinterpret_cast<const unsigned char *>(w0),
@@ -665,14 +665,14 @@ extern "C" int ds4_gpu_matmul_q8_0_pair_tensor(
     float *xscale = (float *)((char *)tmp + scale_offset);
     const int use_dp4a = 1;
     dim3 qgrid((unsigned)blocks, 1, 1);
-    quantize_q8_0_f32_kernel<<<qgrid, 32>>>(
+    quantize_q8_0_f32_kernel<<<qgrid, 32, 0, ds4_rocm_stream()>>>(
             xq, xscale, (const float *)x->ptr, in_dim, blocks);
     if (!cuda_ok(cudaGetLastError(), "matmul_q8_0 pair quantize launch")) {
         return 0;
     }
     const uint64_t max_out = out0_dim > out1_dim ? out0_dim : out1_dim;
     matmul_q8_0_pair_preq_warp8_kernel<<<
-            ((unsigned)max_out + 7u) / 8u, 256>>>(
+            ((unsigned)max_out + 7u) / 8u, 256, 0, ds4_rocm_stream()>>>(
             (float *)out0->ptr,
             (float *)out1->ptr,
             reinterpret_cast<const unsigned char *>(w0),
@@ -730,7 +730,7 @@ static int cuda_matmul_q8_0_hc_expand_tensor_labeled(
             matmul_q8_0_hc_expand_f32_sharedx_warp_rows_w32_kernel<<<
                     (unsigned)((out_dim + rows_per_block - 1u) / rows_per_block),
                     threads,
-                    (size_t)in_dim * sizeof(float)>>>(
+                    (size_t)in_dim * sizeof(float), ds4_rocm_stream()>>>(
                     (float *)out_hc->ptr,
                     (float *)block_out->ptr,
                     block_add ? (const float *)block_add->ptr : (const float *)block_out->ptr,
@@ -747,7 +747,7 @@ static int cuda_matmul_q8_0_hc_expand_tensor_labeled(
             return cuda_ok(cudaGetLastError(), "matmul_q8_0_hc_expand f32 sharedx launch");
         }
         matmul_q8_0_hc_expand_f32_warp8_kernel<<<
-                ((unsigned)out_dim + 7u) / 8u, 256>>>(
+                ((unsigned)out_dim + 7u) / 8u, 256, 0, ds4_rocm_stream()>>>(
                 (float *)out_hc->ptr,
                 (float *)block_out->ptr,
                 block_add ? (const float *)block_add->ptr : (const float *)block_out->ptr,
@@ -773,7 +773,7 @@ static int cuda_matmul_q8_0_hc_expand_tensor_labeled(
     float *xscale = (float *)((char *)tmp + scale_offset);
     const ds4_rocm_runtime_config *cfg = cuda_runtime_config();
     const int use_dp4a = 1;
-    quantize_q8_0_f32_kernel<<<(unsigned)blocks, 32>>>(
+    quantize_q8_0_f32_kernel<<<(unsigned)blocks, 32, 0, ds4_rocm_stream()>>>(
             xq, xscale, (const float *)x->ptr, in_dim, blocks);
     if (!cuda_ok(cudaGetLastError(), "matmul_q8_0_hc_expand quantize launch")) {
         return 0;
@@ -781,7 +781,7 @@ static int cuda_matmul_q8_0_hc_expand_tensor_labeled(
     const uint32_t rows_per_block = cfg->q8_hc_decode_rpb;
     matmul_q8_0_hc_expand_preq_rows_w32_kernel<<<
             ((unsigned)out_dim + rows_per_block - 1u) / rows_per_block,
-            rows_per_block * 32u>>>(
+            rows_per_block * 32u, 0, ds4_rocm_stream()>>>(
             (float *)out_hc->ptr,
             (float *)block_out->ptr,
             block_add ? (const float *)block_add->ptr : (const float *)block_out->ptr,
@@ -820,7 +820,7 @@ extern "C" int ds4_gpu_matmul_f16_tensor(ds4_gpu_tensor *out, const void *model_
         const uint64_t xh_count = n_tok * in_dim;
         __half *xh = (__half *)cuda_tmp_alloc(xh_count * sizeof(__half), "f16 gemm activations");
         if (!xh) return 0;
-        f32_to_f16_kernel<<<(xh_count + 255) / 256, 256>>>(xh, (const float *)x->ptr, xh_count);
+        f32_to_f16_kernel<<<(xh_count + 255) / 256, 256, 0, ds4_rocm_stream()>>>(xh, (const float *)x->ptr, xh_count);
         if (!cuda_ok(cudaGetLastError(), "f16 activation convert launch")) return 0;
         const float alpha = 1.0f;
         const float beta = 0.0f;
@@ -856,17 +856,17 @@ extern "C" int ds4_gpu_matmul_f16_tensor(ds4_gpu_tensor *out, const void *model_
             matmul_f16_f32_sharedx_warp_rows_w32_kernel<<<
                     ((unsigned)out_dim + rows_per_block - 1u) / rows_per_block,
                     rows_per_block * 32u,
-                    (size_t)in_dim * sizeof(float)>>>(
+                    (size_t)in_dim * sizeof(float), ds4_rocm_stream()>>>(
                     (float *)out->ptr, w, (const float *)x->ptr, (uint32_t)in_dim, out_dim);
             return cuda_ok(cudaGetLastError(), "matmul_f16 sharedx launch");
         }
     }
     dim3 grid((unsigned)out_dim, (unsigned)n_tok, 1);
     if (ordered_decode) {
-        matmul_f16_ordered_chunks_kernel<<<grid, 32>>>((float *)out->ptr, w, (const float *)x->ptr, in_dim, out_dim, n_tok);
+        matmul_f16_ordered_chunks_kernel<<<grid, 32, 0, ds4_rocm_stream()>>>((float *)out->ptr, w, (const float *)x->ptr, in_dim, out_dim, n_tok);
         return cuda_ok(cudaGetLastError(), "matmul_f16_ordered_chunks launch");
     }
-    matmul_f16_kernel<<<grid, 256>>>((float *)out->ptr, w, (const float *)x->ptr, in_dim, out_dim, n_tok);
+    matmul_f16_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, w, (const float *)x->ptr, in_dim, out_dim, n_tok);
     return cuda_ok(cudaGetLastError(), "matmul_f16 launch");
 }
 
@@ -912,13 +912,13 @@ extern "C" int ds4_gpu_matmul_f16_pair_tensor(
             matmul_f16_pair_f32_sharedx_warp_rows_w32_kernel<<<
                     ((unsigned)out_dim + rows_per_block - 1u) / rows_per_block,
                     rows_per_block * 32u,
-                    (size_t)in_dim * sizeof(float)>>>(
+                    (size_t)in_dim * sizeof(float), ds4_rocm_stream()>>>(
                     (float *)out0->ptr, (float *)out1->ptr, w0, w1,
                     (const float *)x->ptr, (uint32_t)in_dim, out_dim);
             return cuda_ok(cudaGetLastError(), "matmul_f16_pair sharedx launch");
         }
     }
-    matmul_f16_pair_ordered_chunks_kernel<<<(unsigned)out_dim, 32>>>(
+    matmul_f16_pair_ordered_chunks_kernel<<<(unsigned)out_dim, 32, 0, ds4_rocm_stream()>>>(
         (float *)out0->ptr,
         (float *)out1->ptr,
         w0,
@@ -997,6 +997,6 @@ extern "C" int ds4_gpu_matmul_f32_tensor(ds4_gpu_tensor *out, const void *model_
         return cublas_ok(st, "f32 matmul");
     }
     dim3 grid((unsigned)out_dim, (unsigned)n_tok, 1);
-    matmul_f32_kernel<<<grid, 256>>>((float *)out->ptr, w, (const float *)x->ptr, in_dim, out_dim, n_tok);
+    matmul_f32_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, w, (const float *)x->ptr, in_dim, out_dim, n_tok);
     return cuda_ok(cudaGetLastError(), "matmul_f32 launch");
 }

--- a/rocm/ds4_rocm_misc_launch.cuh
+++ b/rocm/ds4_rocm_misc_launch.cuh
@@ -1,7 +1,7 @@
 extern "C" int ds4_gpu_add_tensor(ds4_gpu_tensor *out, const ds4_gpu_tensor *a, const ds4_gpu_tensor *b, uint32_t n) {
     if (!cuda_tensor_has_f32(out, n) || !cuda_tensor_has_f32(a, n) || !cuda_tensor_has_f32(b, n)) return 0;
     if (n == 0u) return 1;
-    add_kernel<<<(n + 255) / 256, 256>>>((float *)out->ptr, (const float *)a->ptr, (const float *)b->ptr, n);
+    add_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, (const float *)a->ptr, (const float *)b->ptr, n);
     return cuda_ok(cudaGetLastError(), "add launch");
 }
 
@@ -24,7 +24,7 @@ extern "C" int ds4_gpu_pack_slot_rows_f32_tensor(
     }
     const uint64_t blocks = (out_elems + 255u) / 256u;
     if (blocks > UINT32_MAX) return 0;
-    pack_slot_rows_f32_kernel<<<(unsigned)blocks, 256>>>(
+    pack_slot_rows_f32_kernel<<<(unsigned)blocks, 256, 0, ds4_rocm_stream()>>>(
             (float *)out->ptr,
             (const float *)slots->ptr,
             n_rows,
@@ -47,7 +47,7 @@ extern "C" int ds4_gpu_add3_tensor(
         return 0;
     }
     if (n == 0u) return 1;
-    add3_kernel<<<(n + 255) / 256, 256>>>((float *)out->ptr,
+    add3_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr,
                                           (const float *)a->ptr,
                                           (const float *)b->ptr,
                                           (const float *)c->ptr,
@@ -71,7 +71,7 @@ extern "C" int ds4_gpu_directional_steering_project_tensor(
 
     uint32_t nth = 256u;
     while (nth > width && nth > 1u) nth >>= 1;
-    directional_steering_project_kernel<<<rows, nth>>>(
+    directional_steering_project_kernel<<<rows, nth, 0, ds4_rocm_stream()>>>(
             (float *)x->ptr,
             (const float *)directions->ptr,
             layer,

--- a/rocm/ds4_rocm_moe_launch.cuh
+++ b/rocm/ds4_rocm_moe_launch.cuh
@@ -259,33 +259,33 @@ static int routed_moe_q2_float_down_launch(
     const dim3 down_grid((out_dim + down_rpb - 1u) / down_rpb, n_total_expert, 1u);
     if (use_f16_down) {
         if (down_tile == 4u) {
-            moe_down_q2K_expert_batch_sharedmid_kernel<4,false,true><<<down_grid, down_threads, down_shmem>>>(
+            moe_down_q2K_expert_batch_sharedmid_kernel<4,false,true><<<down_grid, down_threads, down_shmem, ds4_rocm_stream()>>>(
                     NULL, down_h, down_w, (const float *)mid->ptr, NULL,
                     counts, offsets, sorted_pairs, 1u, scalar_max, expert_mid_dim, out_dim,
                     down_expert_bytes, down_row_bytes, n_expert);
         } else if (down_tile == 8u) {
-            moe_down_q2K_expert_batch_sharedmid_kernel<8,false,true><<<down_grid, down_threads, down_shmem>>>(
+            moe_down_q2K_expert_batch_sharedmid_kernel<8,false,true><<<down_grid, down_threads, down_shmem, ds4_rocm_stream()>>>(
                     NULL, down_h, down_w, (const float *)mid->ptr, NULL,
                     counts, offsets, sorted_pairs, 1u, scalar_max, expert_mid_dim, out_dim,
                     down_expert_bytes, down_row_bytes, n_expert);
         } else {
-            moe_down_q2K_expert_batch_sharedmid_kernel<16,false,true><<<down_grid, down_threads, down_shmem>>>(
+            moe_down_q2K_expert_batch_sharedmid_kernel<16,false,true><<<down_grid, down_threads, down_shmem, ds4_rocm_stream()>>>(
                     NULL, down_h, down_w, (const float *)mid->ptr, NULL,
                     counts, offsets, sorted_pairs, 1u, scalar_max, expert_mid_dim, out_dim,
                     down_expert_bytes, down_row_bytes, n_expert);
         }
     } else if (down_tile == 4u) {
-        moe_down_q2K_expert_batch_sharedmid_kernel<4><<<down_grid, down_threads, down_shmem>>>(
+        moe_down_q2K_expert_batch_sharedmid_kernel<4><<<down_grid, down_threads, down_shmem, ds4_rocm_stream()>>>(
                 (float *)down->ptr, NULL, down_w, (const float *)mid->ptr, NULL,
                 counts, offsets, sorted_pairs, 1u, scalar_max, expert_mid_dim, out_dim,
                 down_expert_bytes, down_row_bytes, n_expert);
     } else if (down_tile == 8u) {
-        moe_down_q2K_expert_batch_sharedmid_kernel<8><<<down_grid, down_threads, down_shmem>>>(
+        moe_down_q2K_expert_batch_sharedmid_kernel<8><<<down_grid, down_threads, down_shmem, ds4_rocm_stream()>>>(
                 (float *)down->ptr, NULL, down_w, (const float *)mid->ptr, NULL,
                 counts, offsets, sorted_pairs, 1u, scalar_max, expert_mid_dim, out_dim,
                 down_expert_bytes, down_row_bytes, n_expert);
     } else {
-        moe_down_q2K_expert_batch_sharedmid_kernel<16><<<down_grid, down_threads, down_shmem>>>(
+        moe_down_q2K_expert_batch_sharedmid_kernel<16><<<down_grid, down_threads, down_shmem, ds4_rocm_stream()>>>(
                 (float *)down->ptr, NULL, down_w, (const float *)mid->ptr, NULL,
                 counts, offsets, sorted_pairs, 1u, scalar_max, expert_mid_dim, out_dim,
                 down_expert_bytes, down_row_bytes, n_expert);
@@ -311,22 +311,22 @@ static int routed_moe_q2_float_down_launch(
                 const size_t shmem_n2 = (mt * bm * bk + 2u * bk * bn) * sizeof(half) +
                                         (2u * mt * bm * bn) * sizeof(float);
                 if (use_f16_down && hot_mid_f16 && mid_h_hot) {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<4,16,16,16,true,true><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<4,16,16,16,true,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             NULL, down_h, down_w, NULL, mid_h_hot,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
                 } else if (use_f16_down) {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<4,16,16,16,false,true><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<4,16,16,16,false,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             NULL, down_h, down_w, (const float *)mid->ptr, NULL,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
                 } else if (hot_mid_f16 && mid_h_hot) {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<4,16,16,16,true,false><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<4,16,16,16,true,false><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             (float *)down->ptr, NULL, down_w, NULL, mid_h_hot,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
                 } else {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<4,16,16,16><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<4,16,16,16><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             (float *)down->ptr, NULL, down_w, (const float *)mid->ptr, NULL,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
@@ -339,22 +339,22 @@ static int routed_moe_q2_float_down_launch(
                 const size_t shmem_n2 = (mt * bm * bk + 2u * bk * bn) * sizeof(half) +
                                         (2u * mt * bm * bn) * sizeof(float);
                 if (use_f16_down && hot_mid_f16 && mid_h_hot) {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<16,16,16,16,true,true><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<16,16,16,16,true,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             NULL, down_h, down_w, NULL, mid_h_hot,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
                 } else if (use_f16_down) {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<16,16,16,16,false,true><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<16,16,16,16,false,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             NULL, down_h, down_w, (const float *)mid->ptr, NULL,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
                 } else if (hot_mid_f16 && mid_h_hot) {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<16,16,16,16,true,false><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<16,16,16,16,true,false><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             (float *)down->ptr, NULL, down_w, NULL, mid_h_hot,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
                 } else {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<16,16,16,16><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<16,16,16,16><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             (float *)down->ptr, NULL, down_w, (const float *)mid->ptr, NULL,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
@@ -367,22 +367,22 @@ static int routed_moe_q2_float_down_launch(
                 const size_t shmem_n2 = (mt * bm * bk + 2u * bk * bn) * sizeof(half) +
                                         (2u * mt * bm * bn) * sizeof(float);
                 if (use_f16_down && hot_mid_f16 && mid_h_hot) {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<8,16,16,16,true,true><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<8,16,16,16,true,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             NULL, down_h, down_w, NULL, mid_h_hot,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
                 } else if (use_f16_down) {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<8,16,16,16,false,true><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<8,16,16,16,false,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             NULL, down_h, down_w, (const float *)mid->ptr, NULL,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
                 } else if (hot_mid_f16 && mid_h_hot) {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<8,16,16,16,true,false><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<8,16,16,16,true,false><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             (float *)down->ptr, NULL, down_w, NULL, mid_h_hot,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
                 } else {
-                    moe_down_q2K_hotlist_wmma_n2_kernel<8,16,16,16><<<grid, block, shmem_n2>>>(
+                    moe_down_q2K_hotlist_wmma_n2_kernel<8,16,16,16><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                             (float *)down->ptr, NULL, down_w, (const float *)mid->ptr, NULL,
                             counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                             expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
@@ -394,7 +394,7 @@ static int routed_moe_q2_float_down_launch(
             const dim3 grid(out_dim / bn, (hot_max + mt * bm - 1u) / (mt * bm), hot_count);
             const size_t shmem = (mt * bm * bk + bk * bn) * sizeof(half) +
                                  (mt * bm * bn) * sizeof(float);
-            moe_down_q2K_hotlist_wmma_kernel<16,16,16,16><<<grid, block, shmem>>>(
+            moe_down_q2K_hotlist_wmma_kernel<16,16,16,16><<<grid, block, shmem, ds4_rocm_stream()>>>(
                     (float *)down->ptr, down_w, (const float *)mid->ptr,
                     counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                     expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes);
@@ -404,7 +404,7 @@ static int routed_moe_q2_float_down_launch(
             const dim3 grid(out_dim / bn, (hot_max + mt * bm - 1u) / (mt * bm), hot_count);
             const size_t shmem = (mt * bm * bk + bk * bn) * sizeof(half) +
                                  (mt * bm * bn) * sizeof(float);
-            moe_down_q2K_hotlist_wmma_kernel<4,16,16,16><<<grid, block, shmem>>>(
+            moe_down_q2K_hotlist_wmma_kernel<4,16,16,16><<<grid, block, shmem, ds4_rocm_stream()>>>(
                     (float *)down->ptr, down_w, (const float *)mid->ptr,
                     counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                     expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes);
@@ -414,7 +414,7 @@ static int routed_moe_q2_float_down_launch(
             const dim3 grid(out_dim / bn, (hot_max + mt * bm - 1u) / (mt * bm), hot_count);
             const size_t shmem = (mt * bm * bk + bk * bn) * sizeof(half) +
                                  (mt * bm * bn) * sizeof(float);
-            moe_down_q2K_hotlist_wmma_kernel<8,16,16,16><<<grid, block, shmem>>>(
+            moe_down_q2K_hotlist_wmma_kernel<8,16,16,16><<<grid, block, shmem, ds4_rocm_stream()>>>(
                     (float *)down->ptr, down_w, (const float *)mid->ptr,
                     counts, offsets, sorted_pairs, hot_experts_dev, hot_count,
                     expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes);
@@ -426,13 +426,13 @@ static int routed_moe_q2_float_down_launch(
     const uint64_t n = (uint64_t)n_tokens * out_dim;
     if (use_f16_down && (out_dim & 1u) == 0u) {
         const uint64_t n2 = (uint64_t)n_tokens * (out_dim >> 1u);
-        moe_sum_f16x2_kernel<<<(n2 + 255u) / 256u, 256>>>(
+        moe_sum_f16x2_kernel<<<(n2 + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
                 (float *)out->ptr, down_h, out_dim, n_expert, n_tokens);
     } else if (use_f16_down) {
-        moe_sum_f16_kernel<<<(n + 255u) / 256u, 256>>>(
+        moe_sum_f16_kernel<<<(n + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
                 (float *)out->ptr, down_h, out_dim, n_expert, n_tokens);
     } else {
-        moe_sum_kernel<<<(n + 255u) / 256u, 256>>>(
+        moe_sum_kernel<<<(n + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
                 (float *)out->ptr, (const float *)down->ptr, out_dim, n_expert, n_tokens);
     }
     return cuda_ok(cudaGetLastError(), "routed_moe iq2/q2 float-down sum launch");
@@ -776,13 +776,13 @@ static int routed_moe_launch(
         uint32_t tile_capacity = 0;
         uint32_t tile16_capacity = 0;
         dim3 xq_grid(xq_blocks, n_tokens, 1);
-        q8_K_quantize_kernel<<<xq_grid, 256>>>(xq, (const float *)x->ptr, expert_in_dim, n_tokens);
+        q8_K_quantize_kernel<<<xq_grid, 256, 0, ds4_rocm_stream()>>>(xq, (const float *)x->ptr, expert_in_dim, n_tokens);
         ok = cuda_ok(cudaGetLastError(), "routed_moe x quantize launch");
         if (ok && (batch_stream_selected || batch_stream_split_selected)) {
             dim3 qgrid((expert_mid_dim + 127u) / 128u, pair_count, 1);
             if (batch_stream_split_selected) {
                 if (stream_batch_resident_count != 0u) {
-                    moe_gate_up_mid_qwarp32_ptrs_split_kernel<<<qgrid, 256>>>(
+                    moe_gate_up_mid_qwarp32_ptrs_split_kernel<<<qgrid, 256, 0, ds4_rocm_stream()>>>(
                             (float *)gate->ptr,
                             (float *)up->ptr,
                             (float *)mid->ptr,
@@ -808,7 +808,7 @@ static int routed_moe_launch(
                     ok = cuda_stream_batch_selected_finish_pending_missing();
                 }
                 if (ok && stream_batch_missing_count != 0u) {
-                    moe_gate_up_mid_qwarp32_ptrs_split_kernel<<<qgrid, 256>>>(
+                    moe_gate_up_mid_qwarp32_ptrs_split_kernel<<<qgrid, 256, 0, ds4_rocm_stream()>>>(
                             (float *)gate->ptr,
                             (float *)up->ptr,
                             (float *)mid->ptr,
@@ -829,7 +829,7 @@ static int routed_moe_launch(
                                  "routed_moe streaming batch missing gate/up launch");
                 }
             } else {
-                moe_gate_up_mid_qwarp32_ptrs_kernel<<<qgrid, 256>>>(
+                moe_gate_up_mid_qwarp32_ptrs_kernel<<<qgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -849,7 +849,7 @@ static int routed_moe_launch(
             }
             if (ok) {
                 dim3 midq_grid(midq_blocks, pair_count, 1);
-                q8_K_quantize_kernel<<<midq_grid, 256>>>(
+                q8_K_quantize_kernel<<<midq_grid, 256, 0, ds4_rocm_stream()>>>(
                         midq,
                         (const float *)mid->ptr,
                         expert_mid_dim,
@@ -859,7 +859,7 @@ static int routed_moe_launch(
             if (ok) {
                 dim3 dgrid((out_dim + 31u) / 32u, n_tokens, 1);
                 if (iq2_iq2_path) {
-                    moe_down_iq2_sum_qwarp32_ptrs_batch_kernel<<<dgrid, 256>>>(
+                    moe_down_iq2_sum_qwarp32_ptrs_batch_kernel<<<dgrid, 256, 0, ds4_rocm_stream()>>>(
                             (float *)out->ptr,
                             down_slot_ptrs,
                             midq,
@@ -872,7 +872,7 @@ static int routed_moe_launch(
                     ok = cuda_ok(cudaGetLastError(),
                                  "routed_moe streaming batch iq2 down launch");
                 } else {
-                    moe_down_sum6_qwarp32_ptrs_batch_kernel<<<dgrid, 256>>>(
+                    moe_down_sum6_qwarp32_ptrs_batch_kernel<<<dgrid, 256, 0, ds4_rocm_stream()>>>(
                             (float *)out->ptr,
                             down_slot_ptrs,
                             midq,
@@ -938,7 +938,7 @@ static int routed_moe_launch(
                 iq2_gate_hot_dev = (uint32_t *)(scratch + iq2_gate_hot_off);
                 ok = cuda_ok(cudaMemset(counts, 0, counts_bytes), "routed_moe sorted counts clear");
                 if (ok) {
-                    moe_count_sorted_pairs_kernel<<<(pair_count + 255u) / 256u, 256>>>(
+                    moe_count_sorted_pairs_kernel<<<(pair_count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
                         counts,
                         (const int32_t *)selected_exec->ptr,
                         pair_count,
@@ -946,11 +946,11 @@ static int routed_moe_launch(
                     ok = cuda_ok(cudaGetLastError(), "routed_moe sorted count launch");
                 }
                 if (ok) {
-                    moe_prefix_sorted_pairs_kernel<<<1, 1>>>(offsets, cursors, counts, bucket_count);
+                    moe_prefix_sorted_pairs_kernel<<<1, 1, 0, ds4_rocm_stream()>>>(offsets, cursors, counts, bucket_count);
                     ok = cuda_ok(cudaGetLastError(), "routed_moe sorted prefix launch");
                 }
                 if (ok) {
-                    moe_scatter_sorted_pairs_deterministic_kernel<<<bucket_count, 1u>>>(
+                    moe_scatter_sorted_pairs_deterministic_kernel<<<bucket_count, 1u, 0, ds4_rocm_stream()>>>(
                         sorted_pairs,
                         offsets,
                         (const int32_t *)selected_exec->ptr,
@@ -959,20 +959,20 @@ static int routed_moe_launch(
                     ok = cuda_ok(cudaGetLastError(), "routed_moe sorted scatter launch");
                 }
                 if (ok && use_expert_tiles) {
-                    moe_build_expert_tile_offsets_kernel<<<1, 1>>>(tile_offsets, tile_total, counts, expert_tile_m, bucket_count);
+                    moe_build_expert_tile_offsets_kernel<<<1, 1, 0, ds4_rocm_stream()>>>(tile_offsets, tile_total, counts, expert_tile_m, bucket_count);
                     ok = cuda_ok(cudaGetLastError(), "routed_moe expert tile offsets launch");
                 }
                 if (ok && use_expert_tiles) {
-                    moe_build_expert_tiles_kernel<<<(bucket_count + 255u) / 256u, 256>>>(
+                    moe_build_expert_tiles_kernel<<<(bucket_count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
                             tile_experts, tile_starts, tile_offsets, counts, expert_tile_m, bucket_count);
                     ok = cuda_ok(cudaGetLastError(), "routed_moe expert tiles launch");
                 }
                 if (ok && use_expert_tiles && use_down_tile16) {
-                    moe_build_expert_tile_offsets_kernel<<<1, 1>>>(tile16_offsets, tile16_total, counts, 16u, bucket_count);
+                    moe_build_expert_tile_offsets_kernel<<<1, 1, 0, ds4_rocm_stream()>>>(tile16_offsets, tile16_total, counts, 16u, bucket_count);
                     ok = cuda_ok(cudaGetLastError(), "routed_moe expert tile16 offsets launch");
                 }
                 if (ok && use_expert_tiles && use_down_tile16) {
-                    moe_build_expert_tiles_kernel<<<(bucket_count + 255u) / 256u, 256>>>(
+                    moe_build_expert_tiles_kernel<<<(bucket_count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
                             tile16_experts, tile16_starts, tile16_offsets, counts, 16u, bucket_count);
                     ok = cuda_ok(cudaGetLastError(), "routed_moe expert tile16 launch");
                 }
@@ -1019,7 +1019,7 @@ static int routed_moe_launch(
         half *iq2_x_h = use_iq2_x_f16 ? (half *)up->ptr : NULL;
         if (ok && use_iq2_x_f16) {
             const uint64_t xh_count = (uint64_t)n_tokens * expert_in_dim;
-            f32_to_f16_kernel<<<(xh_count + 255u) / 256u, 256>>>(iq2_x_h, (const float *)x->ptr, xh_count);
+            f32_to_f16_kernel<<<(xh_count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(iq2_x_h, (const float *)x->ptr, xh_count);
             ok = cuda_ok(cudaGetLastError(), "routed_moe iq2 gate x f16 launch");
         }
         int split_gateup_done = 0;
@@ -1035,7 +1035,7 @@ static int routed_moe_launch(
             if (split_supported) {
                 dim3 qgrid((expert_mid_dim + 127u) / 128u, pair_count, 1);
                 if (use_decode_lut_gate) {
-                    moe_gate_up_mid_decode_lut_qwarp32_ptrs_kernel<<<qgrid, 256>>>(
+                    moe_gate_up_mid_decode_lut_qwarp32_ptrs_kernel<<<qgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -1052,7 +1052,7 @@ static int routed_moe_launch(
                         stream_resident_mask,
                         clamp);
                 } else {
-                    moe_gate_up_mid_qwarp32_ptrs_kernel<<<qgrid, 256>>>(
+                    moe_gate_up_mid_qwarp32_ptrs_kernel<<<qgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -1075,7 +1075,7 @@ static int routed_moe_launch(
                     ok = cuda_stream_selected_finish_pending_missing(0);
                 }
                 if (ok && use_decode_lut_gate) {
-                    moe_gate_up_mid_decode_lut_qwarp32_ptrs_kernel<<<qgrid, 256>>>(
+                    moe_gate_up_mid_decode_lut_qwarp32_ptrs_kernel<<<qgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -1092,7 +1092,7 @@ static int routed_moe_launch(
                         stream_missing_mask,
                         clamp);
                 } else if (ok) {
-                    moe_gate_up_mid_qwarp32_ptrs_kernel<<<qgrid, 256>>>(
+                    moe_gate_up_mid_qwarp32_ptrs_kernel<<<qgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -1121,14 +1121,14 @@ static int routed_moe_launch(
                 if (q4k_path) {
                     dim3 tgrid((expert_mid_dim + 31u) / 32u, tile_capacity, 1);
                     if (expert_tile_m == 8u) {
-                        moe_gate_up_mid_q4K_expert_tile8_row32_kernel<<<tgrid, 256>>>(
+                        moe_gate_up_mid_q4K_expert_tile8_row32_kernel<<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                             (float *)gate->ptr, (float *)up->ptr, (float *)mid->ptr,
                             gate_w, up_w, xq, sorted_pairs, sorted_offsets, sorted_counts,
                             tile_total, tile_experts, tile_starts, (const float *)weights->ptr,
                             gate_expert_bytes, gate_row_bytes, xq_blocks, expert_mid_dim, n_expert,
                             0u, write_gate_up, clamp);
                     } else {
-                        moe_gate_up_mid_q4K_expert_tile4_row32_kernel<<<tgrid, 256>>>(
+                        moe_gate_up_mid_q4K_expert_tile4_row32_kernel<<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                             (float *)gate->ptr, (float *)up->ptr, (float *)mid->ptr,
                             gate_w, up_w, xq, sorted_pairs, sorted_offsets, sorted_counts,
                             tile_total, tile_experts, tile_starts, (const float *)weights->ptr,
@@ -1138,7 +1138,7 @@ static int routed_moe_launch(
                 } else if (use_gate_row2048) {
                     if (gate_row_span == 512u) {
                         dim3 tgrid((expert_mid_dim + 511u) / 512u, tile_capacity, 1);
-                        moe_gate_up_mid_expert_tile8_rowspan_kernel<512><<<tgrid, 256>>>(
+                        moe_gate_up_mid_expert_tile8_rowspan_kernel<512><<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                             (float *)gate->ptr, (float *)up->ptr, (float *)mid->ptr,
                             gate_w, up_w, xq, sorted_pairs, sorted_offsets, sorted_counts,
                             tile_total, tile_experts, tile_starts, (const float *)weights->ptr,
@@ -1146,7 +1146,7 @@ static int routed_moe_launch(
                             iq2_gate_scalar_max, write_gate_up, clamp);
                     } else if (gate_row_span == 1024u) {
                         dim3 tgrid((expert_mid_dim + 1023u) / 1024u, tile_capacity, 1);
-                        moe_gate_up_mid_expert_tile8_rowspan_kernel<1024><<<tgrid, 256>>>(
+                        moe_gate_up_mid_expert_tile8_rowspan_kernel<1024><<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                             (float *)gate->ptr, (float *)up->ptr, (float *)mid->ptr,
                             gate_w, up_w, xq, sorted_pairs, sorted_offsets, sorted_counts,
                             tile_total, tile_experts, tile_starts, (const float *)weights->ptr,
@@ -1154,7 +1154,7 @@ static int routed_moe_launch(
                             iq2_gate_scalar_max, write_gate_up, clamp);
                     } else {
                         dim3 tgrid((expert_mid_dim + 2047u) / 2048u, tile_capacity, 1);
-                        moe_gate_up_mid_expert_tile8_row2048_kernel<<<tgrid, 256>>>(
+                        moe_gate_up_mid_expert_tile8_row2048_kernel<<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                             (float *)gate->ptr, (float *)up->ptr, (float *)mid->ptr,
                             gate_w, up_w, xq, sorted_pairs, sorted_offsets, sorted_counts,
                             tile_total, tile_experts, tile_starts, (const float *)weights->ptr,
@@ -1163,7 +1163,7 @@ static int routed_moe_launch(
                     }
                 } else if (expert_tile_m == 8u) {
                     dim3 tgrid((expert_mid_dim + 31u) / 32u, tile_capacity, 1);
-                    moe_gate_up_mid_expert_tile8_row32_kernel<<<tgrid, 256>>>(
+                    moe_gate_up_mid_expert_tile8_row32_kernel<<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr, (float *)up->ptr, (float *)mid->ptr,
                         gate_w, up_w, xq, sorted_pairs, sorted_offsets, sorted_counts,
                         tile_total, tile_experts, tile_starts, (const float *)weights->ptr,
@@ -1171,7 +1171,7 @@ static int routed_moe_launch(
                         iq2_gate_scalar_max, write_gate_up, clamp);
                 } else {
                     dim3 tgrid((expert_mid_dim + 31u) / 32u, tile_capacity, 1);
-                    moe_gate_up_mid_expert_tile4_row32_kernel<<<tgrid, 256>>>(
+                    moe_gate_up_mid_expert_tile4_row32_kernel<<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr, (float *)up->ptr, (float *)mid->ptr,
                         gate_w, up_w, xq, sorted_pairs, sorted_offsets, sorted_counts,
                         tile_total, tile_experts, tile_starts, (const float *)weights->ptr,
@@ -1180,7 +1180,7 @@ static int routed_moe_launch(
                 }
             } else if (ok && sorted_pairs && use_p2_sorted) {
                 dim3 p2_mgrid((expert_mid_dim + 15u) / 16u, (pair_count + 1u) / 2u, 1);
-                moe_gate_up_mid_sorted_p2_qwarp32_kernel<<<p2_mgrid, 256>>>(
+                moe_gate_up_mid_sorted_p2_qwarp32_kernel<<<p2_mgrid, 256, 0, ds4_rocm_stream()>>>(
                     (float *)gate->ptr,
                     (float *)up->ptr,
                     (float *)mid->ptr,
@@ -1199,7 +1199,7 @@ static int routed_moe_launch(
                     clamp);
             } else if (ok && sorted_pairs) {
                 if (q4k_path) {
-                    moe_gate_up_mid_q4K_sorted_qwarp32_kernel<<<mgrid, 256>>>(
+                    moe_gate_up_mid_q4K_sorted_qwarp32_kernel<<<mgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -1216,7 +1216,7 @@ static int routed_moe_launch(
                         n_expert,
                         clamp);
                 } else {
-                    moe_gate_up_mid_sorted_qwarp32_kernel<<<mgrid, 256>>>(
+                    moe_gate_up_mid_sorted_qwarp32_kernel<<<mgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -1236,7 +1236,7 @@ static int routed_moe_launch(
             } else if (ok) {
                 dim3 qgrid((expert_mid_dim + 127u) / 128u, pair_count, 1);
                 if (q4k_path) {
-                    moe_gate_up_mid_decode_q4K_qwarp32_kernel<<<qgrid, 256>>>(
+                    moe_gate_up_mid_decode_q4K_qwarp32_kernel<<<qgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -1253,7 +1253,7 @@ static int routed_moe_launch(
                         write_gate_up,
                         clamp);
                 } else if (use_decode_lut_gate) {
-                    moe_gate_up_mid_decode_lut_qwarp32_kernel<<<qgrid, 256>>>(
+                    moe_gate_up_mid_decode_lut_qwarp32_kernel<<<qgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -1271,7 +1271,7 @@ static int routed_moe_launch(
                         0xffffffffu,
                         clamp);
                 } else {
-                    moe_gate_up_mid_qwarp32_kernel<<<qgrid, 256>>>(
+                    moe_gate_up_mid_qwarp32_kernel<<<qgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -1303,25 +1303,25 @@ static int routed_moe_launch(
                     const size_t shmem_n2 = (mt * bm * bk + 4u * bk * bn) * sizeof(half) +
                                             (4u * mt * bm * bn) * sizeof(float);
                     if (use_iq2_hot_f16_mid && use_iq2_x_f16) {
-                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<4,16,16,16,true,true><<<grid, block, shmem_n2>>>(
+                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<4,16,16,16,true,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                                 NULL, iq2_hot_mid_h, gate_w, up_w, (const float *)x->ptr, iq2_x_h,
                                 (const float *)weights->ptr, sorted_counts, sorted_offsets, sorted_pairs,
                                 iq2_gate_hot_dev, iq2_gate_hot_count, expert_in_dim, expert_mid_dim,
                                 gate_expert_bytes, gate_row_bytes, clamp);
                     } else if (use_iq2_hot_f16_mid) {
-                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<4,16,16,16,true><<<grid, block, shmem_n2>>>(
+                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<4,16,16,16,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                                 NULL, iq2_hot_mid_h, gate_w, up_w, (const float *)x->ptr, NULL,
                                 (const float *)weights->ptr, sorted_counts, sorted_offsets, sorted_pairs,
                                 iq2_gate_hot_dev, iq2_gate_hot_count, expert_in_dim, expert_mid_dim,
                                 gate_expert_bytes, gate_row_bytes, clamp);
                     } else if (use_iq2_x_f16) {
-                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<4,16,16,16,false,true><<<grid, block, shmem_n2>>>(
+                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<4,16,16,16,false,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                                 (float *)mid->ptr, NULL, gate_w, up_w, (const float *)x->ptr, iq2_x_h,
                                 (const float *)weights->ptr, sorted_counts, sorted_offsets, sorted_pairs,
                                 iq2_gate_hot_dev, iq2_gate_hot_count, expert_in_dim, expert_mid_dim,
                                 gate_expert_bytes, gate_row_bytes, clamp);
                     } else {
-                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<4,16,16,16><<<grid, block, shmem_n2>>>(
+                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<4,16,16,16><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                                 (float *)mid->ptr, NULL, gate_w, up_w, (const float *)x->ptr, NULL,
                                 (const float *)weights->ptr, sorted_counts, sorted_offsets, sorted_pairs,
                                 iq2_gate_hot_dev, iq2_gate_hot_count, expert_in_dim, expert_mid_dim,
@@ -1336,25 +1336,25 @@ static int routed_moe_launch(
                     const size_t shmem_n2 = (mt * bm * bk + 4u * bk * bn) * sizeof(half) +
                                             (4u * mt * bm * bn) * sizeof(float);
                     if (use_iq2_hot_f16_mid && use_iq2_x_f16) {
-                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<8,16,16,16,true,true><<<grid, block, shmem_n2>>>(
+                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<8,16,16,16,true,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                                 NULL, iq2_hot_mid_h, gate_w, up_w, (const float *)x->ptr, iq2_x_h,
                                 (const float *)weights->ptr, sorted_counts, sorted_offsets, sorted_pairs,
                                 iq2_gate_hot_dev, iq2_gate_hot_count, expert_in_dim, expert_mid_dim,
                                 gate_expert_bytes, gate_row_bytes, clamp);
                     } else if (use_iq2_hot_f16_mid) {
-                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<8,16,16,16,true><<<grid, block, shmem_n2>>>(
+                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<8,16,16,16,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                                 NULL, iq2_hot_mid_h, gate_w, up_w, (const float *)x->ptr, NULL,
                                 (const float *)weights->ptr, sorted_counts, sorted_offsets, sorted_pairs,
                                 iq2_gate_hot_dev, iq2_gate_hot_count, expert_in_dim, expert_mid_dim,
                                 gate_expert_bytes, gate_row_bytes, clamp);
                     } else if (use_iq2_x_f16) {
-                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<8,16,16,16,false,true><<<grid, block, shmem_n2>>>(
+                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<8,16,16,16,false,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                                 (float *)mid->ptr, NULL, gate_w, up_w, (const float *)x->ptr, iq2_x_h,
                                 (const float *)weights->ptr, sorted_counts, sorted_offsets, sorted_pairs,
                                 iq2_gate_hot_dev, iq2_gate_hot_count, expert_in_dim, expert_mid_dim,
                                 gate_expert_bytes, gate_row_bytes, clamp);
                     } else {
-                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<8,16,16,16><<<grid, block, shmem_n2>>>(
+                        moe_gate_up_mid_iq2_hotlist_wmma_n2_kernel<8,16,16,16><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                                 (float *)mid->ptr, NULL, gate_w, up_w, (const float *)x->ptr, NULL,
                                 (const float *)weights->ptr, sorted_counts, sorted_offsets, sorted_pairs,
                                 iq2_gate_hot_dev, iq2_gate_hot_count, expert_in_dim, expert_mid_dim,
@@ -1371,14 +1371,14 @@ static int routed_moe_launch(
             sorted_pairs && sorted_offsets && sorted_counts && tile_experts;
         if (ok && !use_iq2_q2_float_down) {
             dim3 midq_grid(midq_blocks, pair_count, 1);
-            q8_K_quantize_kernel<<<midq_grid, 256>>>(midq, (const float *)mid->ptr, expert_mid_dim, pair_count);
+            q8_K_quantize_kernel<<<midq_grid, 256, 0, ds4_rocm_stream()>>>(midq, (const float *)mid->ptr, expert_mid_dim, pair_count);
             ok = cuda_ok(cudaGetLastError(), "routed_moe mid quantize launch");
         }
         int direct_iq2_down_done = 0;
         if (ok && iq2_iq2_path) {
             dim3 dgrid((out_dim + 31u) / 32u, n_tokens, 1);
             if (split_gateup_done) {
-                moe_down_iq2_sum_qwarp32_ptrs_batch_kernel<<<dgrid, 256>>>(
+                moe_down_iq2_sum_qwarp32_ptrs_batch_kernel<<<dgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)out->ptr,
                         down_slot_ptrs,
                         midq,
@@ -1389,7 +1389,7 @@ static int routed_moe_launch(
                         n_expert,
                         n_tokens);
             } else {
-                moe_down_iq2_sum_qwarp32_batch_kernel<<<dgrid, 256>>>(
+                moe_down_iq2_sum_qwarp32_batch_kernel<<<dgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)out->ptr,
                         down_w,
                         midq,
@@ -1406,7 +1406,7 @@ static int routed_moe_launch(
         }
         int split_ptr_down_done = 0;
         if (ok && !direct_iq2_down_done && split_gateup_done) {
-            moe_down_sum6_qwarp32_ptrs_kernel<<<(out_dim + 31u) / 32u, 256>>>(
+            moe_down_sum6_qwarp32_ptrs_kernel<<<(out_dim + 31u) / 32u, 256, 0, ds4_rocm_stream()>>>(
                     (float *)out->ptr,
                     down_slot_ptrs,
                     midq,
@@ -1443,7 +1443,7 @@ static int routed_moe_launch(
             if (use_direct_down_sum6) {
                 dim3 sgrid((out_dim + 31u) / 32u, 1, 1);
                 if (q4k_path) {
-                    moe_down_q4K_sum6_qwarp32_kernel<<<sgrid, 256>>>(
+                    moe_down_q4K_sum6_qwarp32_kernel<<<sgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)out->ptr,
                         down_w,
                         midq,
@@ -1454,7 +1454,7 @@ static int routed_moe_launch(
                         out_dim,
                         n_expert);
                 } else {
-                    moe_down_sum6_qwarp32_kernel<<<sgrid, 256>>>(
+                    moe_down_sum6_qwarp32_kernel<<<sgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)out->ptr,
                         down_w,
                         midq,
@@ -1467,7 +1467,7 @@ static int routed_moe_launch(
                 }
             } else if (use_atomic_down) {
                 uint64_t n = (uint64_t)n_tokens * out_dim;
-                zero_kernel<<<(n + 255u) / 256u, 256>>>((float *)out->ptr, n);
+                zero_kernel<<<(n + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, n);
                 ok = cuda_ok(cudaGetLastError(), "routed_moe atomic zero launch");
             }
             if (use_direct_down_sum6) {
@@ -1477,13 +1477,13 @@ static int routed_moe_launch(
                 if (q4k_path) {
                     dim3 tgrid((out_dim + 31u) / 32u, down_tile_capacity, 1);
                     if (expert_tile_m == 8u) {
-                        moe_down_q4K_expert_tile8_row32_kernel<<<tgrid, 256>>>(
+                        moe_down_q4K_expert_tile8_row32_kernel<<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                             use_atomic_down ? (float *)out->ptr : (float *)down->ptr,
                             down_w, midq, sorted_pairs, sorted_offsets, sorted_counts,
                             down_tile_total, down_tile_experts, down_tile_starts, down_expert_bytes, down_row_bytes,
                             midq_blocks, out_dim, n_expert, use_atomic_down);
                     } else {
-                        moe_down_q4K_expert_tile4_row32_kernel<<<tgrid, 256>>>(
+                        moe_down_q4K_expert_tile4_row32_kernel<<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                             use_atomic_down ? (float *)out->ptr : (float *)down->ptr,
                             down_w, midq, sorted_pairs, sorted_offsets, sorted_counts,
                             down_tile_total, down_tile_experts, down_tile_starts, down_expert_bytes, down_row_bytes,
@@ -1492,21 +1492,21 @@ static int routed_moe_launch(
                 } else if (use_down_row2048) {
                     if (down_row_span == 512u) {
                         dim3 tgrid((out_dim + 511u) / 512u, down_tile_capacity, 1);
-                        moe_down_expert_tile16_rowspan_kernel<512><<<tgrid, 256>>>(
+                        moe_down_expert_tile16_rowspan_kernel<512><<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                             use_atomic_down ? (float *)out->ptr : (float *)down->ptr,
                             down_w, midq, sorted_pairs, sorted_offsets, sorted_counts,
                             down_tile_total, down_tile_experts, down_tile_starts, down_expert_bytes, down_row_bytes,
                             midq_blocks, out_dim, n_expert, use_atomic_down);
                     } else if (down_row_span == 1024u) {
                         dim3 tgrid((out_dim + 1023u) / 1024u, down_tile_capacity, 1);
-                        moe_down_expert_tile16_rowspan_kernel<1024><<<tgrid, 256>>>(
+                        moe_down_expert_tile16_rowspan_kernel<1024><<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                             use_atomic_down ? (float *)out->ptr : (float *)down->ptr,
                             down_w, midq, sorted_pairs, sorted_offsets, sorted_counts,
                             down_tile_total, down_tile_experts, down_tile_starts, down_expert_bytes, down_row_bytes,
                             midq_blocks, out_dim, n_expert, use_atomic_down);
                     } else {
                         dim3 tgrid((out_dim + 2047u) / 2048u, down_tile_capacity, 1);
-                        moe_down_expert_tile16_row2048_kernel<<<tgrid, 256>>>(
+                        moe_down_expert_tile16_row2048_kernel<<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                             use_atomic_down ? (float *)out->ptr : (float *)down->ptr,
                             down_w, midq, sorted_pairs, sorted_offsets, sorted_counts,
                             down_tile_total, down_tile_experts, down_tile_starts, down_expert_bytes, down_row_bytes,
@@ -1514,21 +1514,21 @@ static int routed_moe_launch(
                     }
                 } else if (use_down_tile16) {
                     dim3 tgrid((out_dim + 31u) / 32u, down_tile_capacity, 1);
-                    moe_down_expert_tile16_row32_kernel<<<tgrid, 256>>>(
+                    moe_down_expert_tile16_row32_kernel<<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                         use_atomic_down ? (float *)out->ptr : (float *)down->ptr,
                         down_w, midq, sorted_pairs, sorted_offsets, sorted_counts,
                         down_tile_total, down_tile_experts, down_tile_starts, down_expert_bytes, down_row_bytes,
                         midq_blocks, out_dim, n_expert, use_atomic_down);
                 } else if (expert_tile_m == 8u) {
                     dim3 tgrid((out_dim + 31u) / 32u, down_tile_capacity, 1);
-                    moe_down_expert_tile8_row32_kernel<<<tgrid, 256>>>(
+                    moe_down_expert_tile8_row32_kernel<<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                         use_atomic_down ? (float *)out->ptr : (float *)down->ptr,
                         down_w, midq, sorted_pairs, sorted_offsets, sorted_counts,
                         down_tile_total, down_tile_experts, down_tile_starts, down_expert_bytes, down_row_bytes,
                         midq_blocks, out_dim, n_expert, use_atomic_down);
                 } else {
                     dim3 tgrid((out_dim + 31u) / 32u, down_tile_capacity, 1);
-                    moe_down_expert_tile4_row32_kernel<<<tgrid, 256>>>(
+                    moe_down_expert_tile4_row32_kernel<<<tgrid, 256, 0, ds4_rocm_stream()>>>(
                         use_atomic_down ? (float *)out->ptr : (float *)down->ptr,
                         down_w, midq, sorted_pairs, sorted_offsets, sorted_counts,
                         down_tile_total, down_tile_experts, down_tile_starts, down_expert_bytes, down_row_bytes,
@@ -1536,7 +1536,7 @@ static int routed_moe_launch(
                 }
             } else if (sorted_pairs && use_p2_sorted) {
                 dim3 p2_dgrid((out_dim + 15u) / 16u, (pair_count + 1u) / 2u, 1);
-                moe_down_sorted_p2_qwarp32_kernel<<<p2_dgrid, 256>>>(
+                moe_down_sorted_p2_qwarp32_kernel<<<p2_dgrid, 256, 0, ds4_rocm_stream()>>>(
                     (float *)down->ptr,
                     down_w,
                     midq,
@@ -1550,7 +1550,7 @@ static int routed_moe_launch(
                     pair_count);
             } else if (sorted_pairs) {
                 if (q4k_path) {
-                    moe_down_q4K_sorted_qwarp32_kernel<<<dgrid, 256>>>(
+                    moe_down_q4K_sorted_qwarp32_kernel<<<dgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)down->ptr,
                         down_w,
                         midq,
@@ -1562,7 +1562,7 @@ static int routed_moe_launch(
                         out_dim,
                         n_expert);
                 } else {
-                    moe_down_sorted_qwarp32_kernel<<<dgrid, 256>>>(
+                    moe_down_sorted_qwarp32_kernel<<<dgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)down->ptr,
                         down_w,
                         midq,
@@ -1576,7 +1576,7 @@ static int routed_moe_launch(
                 }
             } else {
                 if (q4k_path) {
-                    moe_down_q4K_qwarp32_kernel<<<dgrid, 256>>>(
+                    moe_down_q4K_qwarp32_kernel<<<dgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)down->ptr,
                         down_w,
                         midq,
@@ -1587,7 +1587,7 @@ static int routed_moe_launch(
                         out_dim,
                         n_expert);
                 } else {
-                    moe_down_qwarp32_kernel<<<dgrid, 256>>>(
+                    moe_down_qwarp32_kernel<<<dgrid, 256, 0, ds4_rocm_stream()>>>(
                         (float *)down->ptr,
                         down_w,
                         midq,
@@ -1605,7 +1605,7 @@ static int routed_moe_launch(
         if (ok && !direct_iq2_down_done && !use_atomic_down &&
             !use_direct_down_sum6 && !use_iq2_q2_float_down) {
             uint64_t n = (uint64_t)n_tokens * out_dim;
-            moe_sum_kernel<<<(n + 255) / 256, 256>>>((float *)out->ptr, (const float *)down->ptr, out_dim, n_expert, n_tokens);
+            moe_sum_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, (const float *)down->ptr, out_dim, n_expert, n_tokens);
             ok = cuda_ok(cudaGetLastError(), "routed_moe sum launch");
         }
         if (ok && compact_selected) ok = cuda_stream_selected_mark_inflight();
@@ -1626,7 +1626,7 @@ static int routed_moe_launch(
                        1);
         if (batch_stream_split_selected) {
             if (stream_batch_resident_count != 0u) {
-                moe_gate_up_mid_q2K_rows_w32_ptrs_kernel<<<gate_grid, gate_threads>>>(
+                moe_gate_up_mid_q2K_rows_w32_ptrs_kernel<<<gate_grid, gate_threads, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -1653,7 +1653,7 @@ static int routed_moe_launch(
                 ok = cuda_stream_batch_selected_finish_pending_missing();
             }
             if (ok && stream_batch_missing_count != 0u) {
-                moe_gate_up_mid_q2K_rows_w32_ptrs_kernel<<<gate_grid, gate_threads>>>(
+                moe_gate_up_mid_q2K_rows_w32_ptrs_kernel<<<gate_grid, gate_threads, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -1675,7 +1675,7 @@ static int routed_moe_launch(
                              "routed_moe q2 streaming batch missing gate/up launch");
             }
         } else {
-            moe_gate_up_mid_q2K_rows_w32_ptrs_kernel<<<gate_grid, gate_threads>>>(
+            moe_gate_up_mid_q2K_rows_w32_ptrs_kernel<<<gate_grid, gate_threads, 0, ds4_rocm_stream()>>>(
                     (float *)gate->ptr,
                     (float *)up->ptr,
                     (float *)mid->ptr,
@@ -1700,7 +1700,7 @@ static int routed_moe_launch(
             dim3 down_grid((out_dim + down_rows_per_block - 1u) / down_rows_per_block,
                            n_tokens,
                            1);
-            moe_down_q2K_sum_rows_w32_ptrs_batch_kernel<<<down_grid, down_threads>>>(
+            moe_down_q2K_sum_rows_w32_ptrs_batch_kernel<<<down_grid, down_threads, 0, ds4_rocm_stream()>>>(
                     (float *)out->ptr,
                     down_slot_ptrs,
                     (const float *)mid->ptr,
@@ -1783,7 +1783,7 @@ static int routed_moe_launch(
         __half *wmma_x_h = moe_wmma_hot ? (__half *)(scratch + wmma_x_off) : NULL;
         ok = cuda_ok(cudaMemset(counts, 0, counts_bytes), "routed_moe q2 expert counts clear");
         if (ok) {
-            moe_count_sorted_pairs_kernel<<<(pair_count + 255u) / 256u, 256>>>(
+            moe_count_sorted_pairs_kernel<<<(pair_count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
                     counts,
                     (const int32_t *)selected_exec->ptr,
                     pair_count,
@@ -1791,11 +1791,11 @@ static int routed_moe_launch(
             ok = cuda_ok(cudaGetLastError(), "routed_moe q2 expert count launch");
         }
         if (ok) {
-            moe_prefix_sorted_pairs_kernel<<<1, 1>>>(offsets, cursors, counts, bucket_count);
+            moe_prefix_sorted_pairs_kernel<<<1, 1, 0, ds4_rocm_stream()>>>(offsets, cursors, counts, bucket_count);
             ok = cuda_ok(cudaGetLastError(), "routed_moe q2 expert prefix launch");
         }
         if (ok) {
-            moe_scatter_sorted_pairs_deterministic_kernel<<<bucket_count, 1u>>>(
+            moe_scatter_sorted_pairs_deterministic_kernel<<<bucket_count, 1u, 0, ds4_rocm_stream()>>>(
                     sorted_pairs,
                     offsets,
                     (const int32_t *)selected_exec->ptr,
@@ -1805,7 +1805,7 @@ static int routed_moe_launch(
         }
         if (ok && moe_wmma_hot) {
             const uint64_t xh_count = (uint64_t)n_tokens * expert_in_dim;
-            f32_to_f16_kernel<<<(xh_count + 255u) / 256u, 256>>>(wmma_x_h, (const float *)x->ptr, xh_count);
+            f32_to_f16_kernel<<<(xh_count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(wmma_x_h, (const float *)x->ptr, xh_count);
             ok = cuda_ok(cudaGetLastError(), "routed_moe q2 wmma x f16 launch");
         }
         if (!ok) return 0;
@@ -1842,7 +1842,7 @@ static int routed_moe_launch(
         const uint32_t scalar_max = moe_wmma_hot && (wmma_f16_low_count != 0u || wmma_f16_hot_count != 0u)
             ? wmma_hot_threshold : 0u;
         dim3 gate_grid((expert_mid_dim + gate_rpb - 1u) / gate_rpb, bucket_count, 1);
-        moe_gate_up_mid_q2K_expert_batch_sharedx_kernel<4><<<gate_grid, gate_threads, gate_shmem>>>(
+        moe_gate_up_mid_q2K_expert_batch_sharedx_kernel<4><<<gate_grid, gate_threads, gate_shmem, ds4_rocm_stream()>>>(
                 (float *)mid->ptr, NULL, gate_w, up_w, (const float *)x->ptr, (const float *)weights->ptr,
                 counts, offsets, sorted_pairs, 1u, scalar_max, expert_in_dim, expert_mid_dim,
                 gate_expert_bytes, gate_row_bytes, n_expert, clamp);
@@ -1859,7 +1859,7 @@ static int routed_moe_launch(
             if (!cuda_ok(cudaMemcpy(wmma_gate_f16_low_dev, h_f16_low,
                                     wmma_f16_low_count * sizeof(uint32_t), cudaMemcpyHostToDevice),
                          "routed_moe q2 wmma f16-low hot copy")) return 0;
-            moe_gate_up_mid_q2K_hotlist_wmma_n2_kernel<4,16,16,16,true,true><<<grid, block, shmem_n2>>>(
+            moe_gate_up_mid_q2K_hotlist_wmma_n2_kernel<4,16,16,16,true,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                     NULL, wmma_mid_h, gate_w, up_w, (const float *)x->ptr, wmma_x_h, (const float *)weights->ptr,
                     counts, offsets, sorted_pairs, wmma_gate_f16_low_dev, wmma_f16_low_count,
                     expert_in_dim, expert_mid_dim, gate_expert_bytes, gate_row_bytes, n_expert, clamp);
@@ -1876,7 +1876,7 @@ static int routed_moe_launch(
             if (!cuda_ok(cudaMemcpy(wmma_gate_hot_dev, h_f16_hot,
                                     wmma_f16_hot_count * sizeof(uint32_t), cudaMemcpyHostToDevice),
                          "routed_moe q2 wmma f16-mid hot copy")) return 0;
-            moe_gate_up_mid_q2K_hotlist_wmma_n2_kernel<8,16,16,16,true,true><<<grid, block, shmem_n2>>>(
+            moe_gate_up_mid_q2K_hotlist_wmma_n2_kernel<8,16,16,16,true,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                     NULL, wmma_mid_h, gate_w, up_w, (const float *)x->ptr, wmma_x_h, (const float *)weights->ptr,
                     counts, offsets, sorted_pairs, wmma_gate_hot_dev, wmma_f16_hot_count,
                     expert_in_dim, expert_mid_dim, gate_expert_bytes, gate_row_bytes, n_expert, clamp);
@@ -1885,12 +1885,12 @@ static int routed_moe_launch(
 #endif
         dim3 down_grid((out_dim + down_rpb - 1u) / down_rpb, bucket_count, 1);
         if (moe_wmma_hot) {
-            moe_down_q2K_expert_batch_sharedmid_kernel<4,false,true><<<down_grid, down_threads, down_shmem>>>(
+            moe_down_q2K_expert_batch_sharedmid_kernel<4,false,true><<<down_grid, down_threads, down_shmem, ds4_rocm_stream()>>>(
                     NULL, wmma_down_h, down_w, (const float *)mid->ptr, NULL,
                     counts, offsets, sorted_pairs, 1u, scalar_max, expert_mid_dim, out_dim,
                     down_expert_bytes, down_row_bytes, n_expert);
         } else {
-            moe_down_q2K_expert_batch_sharedmid_kernel<4><<<down_grid, down_threads, down_shmem>>>(
+            moe_down_q2K_expert_batch_sharedmid_kernel<4><<<down_grid, down_threads, down_shmem, ds4_rocm_stream()>>>(
                     (float *)down->ptr, NULL, down_w, (const float *)mid->ptr, NULL,
                     counts, offsets, sorted_pairs, 1u, scalar_max, expert_mid_dim, out_dim,
                     down_expert_bytes, down_row_bytes, n_expert);
@@ -1908,7 +1908,7 @@ static int routed_moe_launch(
             if (!cuda_ok(cudaMemcpy(wmma_down_f16_low_dev, h_f16_low,
                                     wmma_f16_low_count * sizeof(uint32_t), cudaMemcpyHostToDevice),
                          "routed_moe q2 wmma f16-low down hot copy")) return 0;
-            moe_down_q2K_hotlist_wmma_n2_kernel<4,16,16,16,true,true><<<grid, block, shmem_n2>>>(
+            moe_down_q2K_hotlist_wmma_n2_kernel<4,16,16,16,true,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                     NULL, wmma_down_h, down_w, NULL, wmma_mid_h,
                     counts, offsets, sorted_pairs, wmma_down_f16_low_dev, wmma_f16_low_count,
                     expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
@@ -1925,7 +1925,7 @@ static int routed_moe_launch(
             if (!cuda_ok(cudaMemcpy(wmma_down_hot_dev, h_f16_hot,
                                     wmma_f16_hot_count * sizeof(uint32_t), cudaMemcpyHostToDevice),
                          "routed_moe q2 wmma f16-mid down hot copy")) return 0;
-            moe_down_q2K_hotlist_wmma_n2_kernel<8,16,16,16,true,true><<<grid, block, shmem_n2>>>(
+            moe_down_q2K_hotlist_wmma_n2_kernel<8,16,16,16,true,true><<<grid, block, shmem_n2, ds4_rocm_stream()>>>(
                     NULL, wmma_down_h, down_w, NULL, wmma_mid_h,
                     counts, offsets, sorted_pairs, wmma_down_hot_dev, wmma_f16_hot_count,
                     expert_mid_dim, out_dim, down_expert_bytes, down_row_bytes, n_expert);
@@ -1936,14 +1936,14 @@ static int routed_moe_launch(
         if (moe_wmma_hot) {
             if ((out_dim & 1u) == 0u) {
                 const uint64_t n2 = n >> 1u;
-                moe_sum_f16x2_kernel<<<(n2 + 255u) / 256u, 256>>>(
+                moe_sum_f16x2_kernel<<<(n2 + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
                         (float *)out->ptr, wmma_down_h, out_dim, n_expert, n_tokens);
             } else {
-                moe_sum_f16_kernel<<<(n + 255u) / 256u, 256>>>(
+                moe_sum_f16_kernel<<<(n + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
                         (float *)out->ptr, wmma_down_h, out_dim, n_expert, n_tokens);
             }
         } else {
-            moe_sum_kernel<<<(n + 255u) / 256u, 256>>>(
+            moe_sum_kernel<<<(n + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(
                     (float *)out->ptr, (const float *)down->ptr, out_dim, n_expert, n_tokens);
         }
         ok = cuda_ok(cudaGetLastError(), "routed_moe q2 expert sum launch");
@@ -1983,7 +1983,7 @@ static int routed_moe_launch(
                             "Q2 decode MoE profile resident gate/up start")) {
                     return 0;
                 }
-                moe_gate_up_mid_q2K_rows_w32_ptrs_kernel<<<gate_grid, gate_threads>>>(
+                moe_gate_up_mid_q2K_rows_w32_ptrs_kernel<<<gate_grid, gate_threads, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -2030,7 +2030,7 @@ static int routed_moe_launch(
                             "Q2 decode MoE profile missing gate/up start")) {
                     return 0;
                 }
-                moe_gate_up_mid_q2K_rows_w32_ptrs_kernel<<<gate_grid, gate_threads>>>(
+                moe_gate_up_mid_q2K_rows_w32_ptrs_kernel<<<gate_grid, gate_threads, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -2069,11 +2069,11 @@ static int routed_moe_launch(
             }
             cuda_block_q8_K *xq_gate = (cuda_block_q8_K *)down->ptr;
             dim3 xq_grid(xq_blocks, n_tokens, 1);
-            q8_K_quantize_kernel<<<xq_grid, 256>>>(xq_gate, (const float *)x->ptr, expert_in_dim, n_tokens);
+            q8_K_quantize_kernel<<<xq_grid, 256, 0, ds4_rocm_stream()>>>(xq_gate, (const float *)x->ptr, expert_in_dim, n_tokens);
             ok_gateup = cuda_ok(cudaGetLastError(), "routed_moe q2 oldhip q8k gate input quantize launch");
             if (ok_gateup) {
                 dim3 gate_grid((expert_mid_dim + 255u) / 256u, pair_count, 1);
-                moe_gate_up_mid_q2K_decode_q8_qwarp32_kernel<<<gate_grid, 256u>>>(
+                moe_gate_up_mid_q2K_decode_q8_qwarp32_kernel<<<gate_grid, 256u, 0, ds4_rocm_stream()>>>(
                         (float *)gate->ptr,
                         (float *)up->ptr,
                         (float *)mid->ptr,
@@ -2107,7 +2107,7 @@ static int routed_moe_launch(
                 return 0;
             }
             dim3 gate_grid(expert_mid_dim, pair_count, 1);
-            moe_gate_up_mid_q2K_rows_rpb1_w32_kernel<<<gate_grid, 32u>>>(
+            moe_gate_up_mid_q2K_rows_rpb1_w32_kernel<<<gate_grid, 32u, 0, ds4_rocm_stream()>>>(
                     (float *)gate->ptr,
                     (float *)up->ptr,
                     (float *)mid->ptr,
@@ -2140,7 +2140,7 @@ static int routed_moe_launch(
                 return 0;
             }
             dim3 gate_grid((expert_mid_dim + gate_rows_per_block - 1u) / gate_rows_per_block, pair_count, 1);
-            moe_gate_up_mid_q2K_rows_w32_kernel<<<gate_grid, gate_threads>>>(
+            moe_gate_up_mid_q2K_rows_w32_kernel<<<gate_grid, gate_threads, 0, ds4_rocm_stream()>>>(
                     (float *)gate->ptr,
                     (float *)up->ptr,
                     (float *)mid->ptr,
@@ -2182,7 +2182,7 @@ static int routed_moe_launch(
                         "Q2 decode MoE profile mid quant start")) {
                 return 0;
             }
-            q8_K_quantize_kernel<<<midq_grid, 256>>>(midq, (const float *)mid->ptr, expert_mid_dim, pair_count);
+            q8_K_quantize_kernel<<<midq_grid, 256, 0, ds4_rocm_stream()>>>(midq, (const float *)mid->ptr, expert_mid_dim, pair_count);
             ok_decode_moe = cuda_ok(cudaGetLastError(), "routed_moe q2 oldhip q8k mid quantize launch");
             if (decode_profile && ok_decode_moe) {
                 decode_profile_rec.mid_quant = 1;
@@ -2200,7 +2200,7 @@ static int routed_moe_launch(
                     return 0;
                 }
                 if (split_selected) {
-                    moe_down_sum6_qwarp32_ptrs_kernel<<<(out_dim + 31u) / 32u, 256>>>(
+                    moe_down_sum6_qwarp32_ptrs_kernel<<<(out_dim + 31u) / 32u, 256, 0, ds4_rocm_stream()>>>(
                             (float *)out->ptr,
                             down_slot_ptrs,
                             midq,
@@ -2209,7 +2209,7 @@ static int routed_moe_launch(
                             out_dim,
                             n_expert);
                 } else {
-                    moe_down_sum6_qwarp32_kernel<<<(out_dim + 31u) / 32u, 256>>>(
+                    moe_down_sum6_qwarp32_kernel<<<(out_dim + 31u) / 32u, 256, 0, ds4_rocm_stream()>>>(
                             (float *)out->ptr,
                             down_w,
                             midq,
@@ -2239,7 +2239,7 @@ static int routed_moe_launch(
                 return 0;
             }
             if (split_selected) {
-                moe_down_q2K_sum_rows_w32_ptrs_batch_kernel<<<down_grid, down_threads>>>(
+                moe_down_q2K_sum_rows_w32_ptrs_batch_kernel<<<down_grid, down_threads, 0, ds4_rocm_stream()>>>(
                         (float *)out->ptr,
                         down_slot_ptrs,
                         (const float *)mid->ptr,
@@ -2250,7 +2250,7 @@ static int routed_moe_launch(
                         down_row_bytes,
                         n_expert);
             } else {
-                moe_down_q2K_sum_rows_w32_kernel<<<down_grid, down_threads>>>(
+                moe_down_q2K_sum_rows_w32_kernel<<<down_grid, down_threads, 0, ds4_rocm_stream()>>>(
                         (float *)out->ptr,
                         down_w,
                         (const float *)mid->ptr,
@@ -2285,7 +2285,7 @@ static int routed_moe_launch(
     if (ok) {
         dim3 mgrid(expert_mid_dim, pair_count, 1);
         if (q2k_path) {
-            moe_gate_up_mid_q2K_f32_kernel<<<mgrid, 256>>>(
+            moe_gate_up_mid_q2K_f32_kernel<<<mgrid, 256, 0, ds4_rocm_stream()>>>(
                 (float *)gate->ptr,
                 (float *)up->ptr,
                 (float *)mid->ptr,
@@ -2301,7 +2301,7 @@ static int routed_moe_launch(
                 n_expert,
                 clamp);
         } else {
-            moe_gate_up_mid_f32_kernel<<<mgrid, 256>>>(
+            moe_gate_up_mid_f32_kernel<<<mgrid, 256, 0, ds4_rocm_stream()>>>(
                 (float *)gate->ptr,
                 (float *)up->ptr,
                 (float *)mid->ptr,
@@ -2321,7 +2321,7 @@ static int routed_moe_launch(
     }
     if (ok) {
         dim3 dgrid(out_dim, pair_count, 1);
-        moe_down_f32_kernel<<<dgrid, 256>>>(
+        moe_down_f32_kernel<<<dgrid, 256, 0, ds4_rocm_stream()>>>(
             (float *)down->ptr,
             down_w,
             (const float *)mid->ptr,
@@ -2335,7 +2335,7 @@ static int routed_moe_launch(
     }
     if (ok) {
         uint64_t n = (uint64_t)n_tokens * out_dim;
-        moe_sum_kernel<<<(n + 255) / 256, 256>>>((float *)out->ptr, (const float *)down->ptr, out_dim, n_expert, n_tokens);
+        moe_sum_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, (const float *)down->ptr, out_dim, n_expert, n_tokens);
         ok = cuda_ok(cudaGetLastError(), "routed_moe sum launch");
     }
     if (ok && compact_selected) ok = cuda_stream_selected_mark_inflight();

--- a/rocm/ds4_rocm_norm_rope.cuh
+++ b/rocm/ds4_rocm_norm_rope.cuh
@@ -412,14 +412,14 @@ __device__ static DS4_ROCM_UNUSED void rope_tail_one_dev(float *x, uint32_t head
 extern "C" int ds4_gpu_rms_norm_plain_tensor(ds4_gpu_tensor *out, const ds4_gpu_tensor *x, uint32_t n, float eps) {
     if (!cuda_tensor_has_f32(out, n) || !cuda_tensor_has_f32(x, n)) return 0;
     if (n == 0u) return 1;
-    rms_norm_plain_kernel<<<1, 256>>>((float *)out->ptr, (const float *)x->ptr, n, 1, eps);
+    rms_norm_plain_kernel<<<1, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, (const float *)x->ptr, n, 1, eps);
     return cuda_ok(cudaGetLastError(), "rms_norm_plain launch");
 }
 extern "C" int ds4_gpu_rms_norm_plain_rows_tensor(ds4_gpu_tensor *out, const ds4_gpu_tensor *x, uint32_t n, uint32_t rows, float eps) {
     if (!cuda_tensor_has_elems2(out, n, rows, sizeof(float)) ||
         !cuda_tensor_has_elems2(x, n, rows, sizeof(float))) return 0;
     if (n == 0u || rows == 0u) return 1;
-    rms_norm_plain_kernel<<<rows, 256>>>((float *)out->ptr, (const float *)x->ptr, n, rows, eps);
+    rms_norm_plain_kernel<<<rows, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, (const float *)x->ptr, n, rows, eps);
     return cuda_ok(cudaGetLastError(), "rms_norm_plain launch");
 }
 extern "C" int ds4_gpu_rms_norm_weight_tensor(ds4_gpu_tensor *out, const ds4_gpu_tensor *x, const void *model_map, uint64_t model_size, uint64_t weight_offset, uint32_t n, float eps) {
@@ -431,7 +431,7 @@ extern "C" int ds4_gpu_rms_norm_weight_tensor(ds4_gpu_tensor *out, const ds4_gpu
     const char *wptr = cuda_model_range_ptr(model_map, weight_offset, weight_bytes, "rms_weight");
     if (!wptr) return 0;
     const float *w = (const float *)wptr;
-    rms_norm_weight_kernel<<<1, 256>>>((float *)out->ptr, (const float *)x->ptr, w, n, 1, eps);
+    rms_norm_weight_kernel<<<1, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, (const float *)x->ptr, w, n, 1, eps);
     return cuda_ok(cudaGetLastError(), "rms_norm_weight launch");
 }
 extern "C" int ds4_gpu_rms_norm_weight_rows_tensor(ds4_gpu_tensor *out, const ds4_gpu_tensor *x, const void *model_map, uint64_t model_size, uint64_t weight_offset, uint32_t n, uint32_t rows, float eps) {
@@ -444,7 +444,7 @@ extern "C" int ds4_gpu_rms_norm_weight_rows_tensor(ds4_gpu_tensor *out, const ds
     const char *wptr = cuda_model_range_ptr(model_map, weight_offset, weight_bytes, "rms_weight");
     if (!wptr) return 0;
     const float *w = (const float *)wptr;
-    rms_norm_weight_kernel<<<rows, 256>>>((float *)out->ptr, (const float *)x->ptr, w, n, rows, eps);
+    rms_norm_weight_kernel<<<rows, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, (const float *)x->ptr, w, n, rows, eps);
     return cuda_ok(cudaGetLastError(), "rms_norm_weight launch");
 }
 
@@ -499,7 +499,7 @@ extern "C" int ds4_gpu_dsv4_qkv_rms_norm_rows_tensor(
             kv_weight_offset, kv_weight_bytes, "kv_rms_weight");
     if (!q_w || !kv_w) return 0;
     dim3 grid(rows, 2u, 1u);
-    dsv4_qkv_rms_norm_rows_kernel<<<grid, 256>>>(
+    dsv4_qkv_rms_norm_rows_kernel<<<grid, 256, 0, ds4_rocm_stream()>>>(
             (float *)q_out->ptr,
             (const float *)q->ptr,
             q_w,
@@ -517,7 +517,7 @@ extern "C" int ds4_gpu_head_rms_norm_tensor(ds4_gpu_tensor *x, uint32_t n_tok, u
     if (!cuda_u64_mul_checked(n_tok, n_head, &rows64) || rows64 > UINT32_MAX ||
         !cuda_tensor_has_elems3(x, n_tok, n_head, head_dim, sizeof(float))) return 0;
     if (rows64 == 0u || head_dim == 0u) return 1;
-    head_rms_norm_kernel<<<(uint32_t)rows64, 256>>>((float *)x->ptr, n_tok, n_head, head_dim, eps);
+    head_rms_norm_kernel<<<(uint32_t)rows64, 256, 0, ds4_rocm_stream()>>>((float *)x->ptr, n_tok, n_head, head_dim, eps);
     return cuda_ok(cudaGetLastError(), "head_rms_norm launch");
 }
 extern "C" int ds4_gpu_head_rms_norm_rope_tail_tensor(ds4_gpu_tensor *x, uint32_t n_tok, uint32_t n_head, uint32_t head_dim, uint32_t n_rot, uint32_t pos0, uint32_t n_ctx_orig, bool inverse, float freq_base, float freq_scale, float ext_factor, float attn_factor, float beta_fast, float beta_slow, float eps) {
@@ -526,7 +526,7 @@ extern "C" int ds4_gpu_head_rms_norm_rope_tail_tensor(ds4_gpu_tensor *x, uint32_
         !cuda_u64_mul_checked(n_tok, n_head, &rows64) || rows64 > UINT32_MAX ||
         !cuda_tensor_has_elems3(x, n_tok, n_head, head_dim, sizeof(float))) return 0;
     if (rows64 == 0u || head_dim == 0u) return 1;
-    head_rms_norm_rope_tail_kernel<<<(uint32_t)rows64, 256>>>((float *)x->ptr, n_tok, n_head, head_dim, n_rot, pos0, n_ctx_orig, inverse ? 1 : 0, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow, eps);
+    head_rms_norm_rope_tail_kernel<<<(uint32_t)rows64, 256, 0, ds4_rocm_stream()>>>((float *)x->ptr, n_tok, n_head, head_dim, n_rot, pos0, n_ctx_orig, inverse ? 1 : 0, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow, eps);
     return cuda_ok(cudaGetLastError(), "head_rms_norm_rope_tail launch");
 }
 extern "C" int ds4_gpu_attn_q_b_f16_head_rms_rope_tail_tensor(
@@ -566,7 +566,7 @@ extern "C" int ds4_gpu_attn_q_b_f16_head_rms_rope_tail_tensor(
     const uint64_t xh_count = (uint64_t)n_tok * in_dim;
     __half *xh = (__half *)cuda_tmp_alloc(xh_count * sizeof(__half), "attn q_b f16 activations");
     if (!xh) return 0;
-    f32_to_f16_kernel<<<(xh_count + 255u) / 256u, 256>>>(xh, (const float *)x->ptr, xh_count);
+    f32_to_f16_kernel<<<(xh_count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(xh, (const float *)x->ptr, xh_count);
     if (!cuda_ok(cudaGetLastError(), "attn q_b f16 activation convert launch")) return 0;
     const float alpha = 1.0f;
     const float beta = 0.0f;
@@ -593,7 +593,7 @@ extern "C" int ds4_gpu_attn_q_b_f16_head_rms_rope_tail_tensor(
         fprintf(stderr, "ds4: " DS4_GPU_BLAS_NAME " attn q_b f16-out matmul failed: status %d\n", (int)st);
         return 0;
     }
-    head_rms_norm_rope_tail_from_half_kernel<<<n_tok * n_head, 256>>>(
+    head_rms_norm_rope_tail_from_half_kernel<<<n_tok * n_head, 256, 0, ds4_rocm_stream()>>>(
             (float *)out->ptr, (const __half *)q_half->ptr, n_tok, n_head, head_dim, n_rot,
             pos0, n_ctx_orig, inverse ? 1 : 0, freq_base, freq_scale, ext_factor, attn_factor,
             beta_fast, beta_slow, eps);
@@ -603,7 +603,7 @@ extern "C" int ds4_gpu_attn_q_b_f16_head_rms_rope_tail_tensor(
 static int cuda_rope_tail_stride_tensor(ds4_gpu_tensor *x, uint32_t n_tok, uint32_t n_head, uint32_t head_dim, uint32_t n_rot, uint32_t pos0, uint32_t pos_stride, uint32_t n_ctx_orig, bool inverse, float freq_base, float freq_scale, float ext_factor, float attn_factor, float beta_fast, float beta_slow) {
     if (!x || n_rot > head_dim || (n_rot & 1) || x->bytes < (uint64_t)n_tok * n_head * head_dim * sizeof(float)) return 0;
     uint32_t pairs = n_tok * n_head * (n_rot / 2);
-    rope_tail_kernel<<<(pairs + 255) / 256, 256>>>((float *)x->ptr, n_tok, n_head, head_dim, n_rot, pos0, pos_stride, n_ctx_orig, inverse ? 1 : 0, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
+    rope_tail_kernel<<<(pairs + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)x->ptr, n_tok, n_head, head_dim, n_rot, pos0, pos_stride, n_ctx_orig, inverse ? 1 : 0, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
     return cuda_ok(cudaGetLastError(), "rope_tail launch");
 }
 

--- a/rocm/ds4_rocm_router.cuh
+++ b/rocm/ds4_rocm_router.cuh
@@ -151,12 +151,12 @@ extern "C" int ds4_gpu_router_select_tensor(ds4_gpu_tensor *selected, ds4_gpu_te
     if (ok) {
         dim3 block(32, 4, 1);
         if (active_n_expert == DS4_ROCM_MAX_N_EXPERT) {
-            router_select_warp_topk_kernel<DS4_ROCM_MAX_N_EXPERT><<<1, block>>>(
+            router_select_warp_topk_kernel<DS4_ROCM_MAX_N_EXPERT><<<1, block, 0, ds4_rocm_stream()>>>(
                     (int32_t *)selected->ptr, (float *)weights->ptr, (float *)probs->ptr,
                     bias, hash, (const float *)logits->ptr, NULL, tok, hash_rows, 1,
                     active_n_expert_used, active_scale, has_bias && !hash_mode, hash_mode);
         } else {
-            router_select_warp_topk_kernel<DS4_ROCM_N_EXPERT><<<1, block>>>(
+            router_select_warp_topk_kernel<DS4_ROCM_N_EXPERT><<<1, block, 0, ds4_rocm_stream()>>>(
                     (int32_t *)selected->ptr, (float *)weights->ptr, (float *)probs->ptr,
                     bias, hash, (const float *)logits->ptr, NULL, tok, hash_rows, 1,
                     active_n_expert_used, active_scale, has_bias && !hash_mode, hash_mode);
@@ -197,7 +197,7 @@ extern "C" int ds4_gpu_router_select_batch_tensor(ds4_gpu_tensor *selected, ds4_
     }
     dim3 block(32, 4, 1);
     if (active_n_expert == DS4_ROCM_MAX_N_EXPERT) {
-        router_select_warp_topk_kernel<DS4_ROCM_MAX_N_EXPERT><<<(n_tokens + 3u) / 4u, block>>>(
+        router_select_warp_topk_kernel<DS4_ROCM_MAX_N_EXPERT><<<(n_tokens + 3u) / 4u, block, 0, ds4_rocm_stream()>>>(
                 (int32_t *)selected->ptr,
                 (float *)weights->ptr,
                 (float *)probs->ptr,
@@ -213,7 +213,7 @@ extern "C" int ds4_gpu_router_select_batch_tensor(ds4_gpu_tensor *selected, ds4_
                 has_bias && !hash_mode,
                 hash_mode);
     } else {
-        router_select_warp_topk_kernel<DS4_ROCM_N_EXPERT><<<(n_tokens + 3u) / 4u, block>>>(
+        router_select_warp_topk_kernel<DS4_ROCM_N_EXPERT><<<(n_tokens + 3u) / 4u, block, 0, ds4_rocm_stream()>>>(
                 (int32_t *)selected->ptr,
                 (float *)weights->ptr,
                 (float *)probs->ptr,

--- a/rocm/ds4_rocm_runtime.cuh
+++ b/rocm/ds4_rocm_runtime.cuh
@@ -20,6 +20,24 @@ static int g_cublas_ready;
 #ifdef __HIP_PLATFORM_AMD__
 #include "ds4_rocm_hipblaslt.cuh"
 #endif
+
+/* Decode-island graph capture stream indirection.  While a HIP graph
+ * capture is in flight, every kernel launch and stream-wait in this
+ * backend must target the capture stream instead of the legacy default
+ * stream (which cannot be captured).  ds4_rocm_stream() returns the
+ * capture stream during capture and the legacy stream otherwise, so
+ * eager launches behave exactly as before.  The whole backend compiles
+ * into one translation unit, so a file-scope static is a single
+ * instance; the setter is exported for the API-glue TU
+ * (ds4_rocm_compat.cu), which owns the graph state machine. */
+static hipStream_t g_ds4_rocm_capture_stream = (hipStream_t)0;
+static inline hipStream_t ds4_rocm_stream(void) {
+    return g_ds4_rocm_capture_stream;
+}
+extern "C" void ds4_rocm_set_capture_stream(void *stream) {
+    g_ds4_rocm_capture_stream = (hipStream_t)stream;
+}
+
 static int g_quality_mode;
 static int g_glm_model;
 
@@ -876,7 +894,7 @@ static int cuda_stream_selected_wait_upload_ready(void) {
     if (!g_stream_selected_upload_event_pending) return 1;
 #ifdef __HIP_PLATFORM_AMD__
     cudaError_t err =
-        hipStreamWaitEvent(0, g_stream_selected_upload_ready_event, 0);
+        hipStreamWaitEvent(ds4_rocm_stream(), g_stream_selected_upload_ready_event, 0);
 #else
     cudaError_t err =
         cudaStreamWaitEvent(0, g_stream_selected_upload_ready_event, 0);
@@ -972,7 +990,7 @@ static int cuda_stream_batch_selected_wait_upload_ready(void) {
     if (!g_stream_batch_selected_upload_event_pending) return 1;
 #ifdef __HIP_PLATFORM_AMD__
     cudaError_t err =
-        hipStreamWaitEvent(0, g_stream_batch_selected_upload_ready_event, 0);
+        hipStreamWaitEvent(ds4_rocm_stream(), g_stream_batch_selected_upload_ready_event, 0);
 #else
     cudaError_t err =
         cudaStreamWaitEvent(0, g_stream_batch_selected_upload_ready_event, 0);
@@ -5078,7 +5096,7 @@ static const __half *cuda_q8_f16_ptr(
     }
     const uint64_t blocks = (in_dim + 31) / 32;
     const uint64_t n = in_dim * out_dim;
-    dequant_q8_0_to_f16_kernel<<<(n + 255) / 256, 256>>>(dev,
+    dequant_q8_0_to_f16_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>(dev,
                                                           (const unsigned char *)q8,
                                                           in_dim,
                                                           out_dim,
@@ -5133,7 +5151,7 @@ static const __half *cuda_q8_f16_transpose_ptr(
     }
     const uint64_t blocks = (in_dim + 31u) / 32u;
     const uint64_t n = in_dim * out_dim;
-    dequant_q8_0_to_f16_transpose_kernel<<<(n + 255u) / 256u, 256>>>(dev,
+    dequant_q8_0_to_f16_transpose_kernel<<<(n + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>(dev,
                                                                      (const unsigned char *)q8,
                                                                      in_dim,
                                                                      out_dim,
@@ -6017,7 +6035,7 @@ extern "C" void *ds4_gpu_tensor_contents(ds4_gpu_tensor *tensor) {
 extern "C" int ds4_gpu_tensor_fill_f32(ds4_gpu_tensor *tensor, float value, uint64_t count) {
     if (!tensor || count > tensor->bytes / sizeof(float)) return 0;
     if (count == 0) return 1;
-    fill_f32_kernel<<<(count + 255u) / 256u, 256>>>((float *)tensor->ptr, count, value);
+    fill_f32_kernel<<<(count + 255u) / 256u, 256, 0, ds4_rocm_stream()>>>((float *)tensor->ptr, count, value);
     return cuda_ok(cudaGetLastError(), "tensor fill f32 launch");
 }
 

--- a/rocm/ds4_rocm_shared_expert.cuh
+++ b/rocm/ds4_rocm_shared_expert.cuh
@@ -1,7 +1,7 @@
 extern "C" int ds4_gpu_swiglu_tensor(ds4_gpu_tensor *out, const ds4_gpu_tensor *gate, const ds4_gpu_tensor *up, uint32_t n, float clamp, float weight) {
     if (!cuda_tensor_has_f32(out, n) || !cuda_tensor_has_f32(gate, n) || !cuda_tensor_has_f32(up, n)) return 0;
     if (n == 0u) return 1;
-    swiglu_kernel<<<(n + 255) / 256, 256>>>((float *)out->ptr, (const float *)gate->ptr, (const float *)up->ptr, n, clamp, weight);
+    swiglu_kernel<<<(n + 255) / 256, 256, 0, ds4_rocm_stream()>>>((float *)out->ptr, (const float *)gate->ptr, (const float *)up->ptr, n, clamp, weight);
     return cuda_ok(cudaGetLastError(), "swiglu launch");
 }
 extern "C" int ds4_gpu_shared_gate_up_swiglu_q8_0_tensor(
@@ -44,7 +44,7 @@ extern "C" int ds4_gpu_shared_gate_up_swiglu_q8_0_tensor(
         const unsigned rows_per_block = 32u;
         shared_gate_up_swiglu_q8_0_rows_w32_kernel<<<
                 (unsigned)((out_dim + rows_per_block - 1u) / rows_per_block),
-                rows_per_block * 32u>>>(
+                rows_per_block * 32u, 0, ds4_rocm_stream()>>>(
                 (float *)gate->ptr,
                 (float *)up->ptr,
                 (float *)mid->ptr,
@@ -429,7 +429,7 @@ extern "C" int ds4_gpu_shared_gate_up_swiglu_q8_0_batch_tensor(
     const size_t shmem = (size_t)tile * block_tile * 32u * sizeof(float);
     const int store_gate_up = (g_quality_mode || cuda_runtime_config()->graph_dump) ? 1 : 0;
 #define DS4_LAUNCH_SHARED_GU_BATCH(TT, BT) \
-    shared_gate_up_swiglu_q8_0_batch_sharedx_w32_kernel<TT, BT><<<grid, rows_per_block * 32u, shmem>>>( \
+    shared_gate_up_swiglu_q8_0_batch_sharedx_w32_kernel<TT, BT><<<grid, rows_per_block * 32u, shmem, ds4_rocm_stream()>>>( \
             (float *)gate->ptr, (float *)up->ptr, (float *)mid->ptr, \
             reinterpret_cast<const unsigned char *>(wg), reinterpret_cast<const unsigned char *>(wu), \
             (const float *)x->ptr, (uint32_t)blocks, (uint32_t)out_dim, (uint32_t)n_tok, row_bytes, store_gate_up)


### PR DESCRIPTION
## What this does

Ports decode-island graph capture to HIP for the ROCm backend. The feature is disabled by default.

A decode island is a group of kernels in the decode layer whose launch geometry and buffer bindings do not depend on the token position. Such a group can be captured once as a HIP graph and replayed on later tokens, removing the per-launch CPU overhead. The capture interface (`ds4_gpu_decode_graph_*`) already exists in the tree and is implemented for CUDA; on ROCm it was stubbed out. This pull request implements it:

- Islands are captured once per buffer-alias key and replayed afterwards. A replayed graph re-runs the recorded kernels exactly, so replay output is byte-identical to the eager execution it recorded. Any capture failure retires the entry, and the island runs eagerly from then on — also byte-identical.
- Every kernel launch in the ROCm backend now targets `ds4_rocm_stream()`, which is the capture stream while capture is armed and the default stream otherwise. Behavior without capture is unchanged.
- Enable with `DS4_ROCM_DECODE_GRAPHS=span` (islands two and up) or `DS4_ROCM_DECODE_GRAPHS=all` (also the eval islands). Single-GPU processes only.

Why it ships disabled: on gfx1151 today, decode time is dominated by other stages, and capture measures as neutral — 13.42 tokens/s eager against 13.37 with graphs enabled. The implementation is included anyway because the per-island launch chains become worth capturing once they are batched across rows (the multi-row decode work, tracked separately), and because the port is complete, tested, and inert when off.

One integration point is deliberately absent: capture of speculative-span stages belongs with the multi-row decode work and will arrive with it. This branch does not modify `ds4.c`.

## Correctness

Rebased on current main (`84cc882`), Radeon 8060S (gfx1151), TheRock toolchain:

- Warning-free `make strix-halo`. Built with `-fPIC` in `CFLAGS`; main does not yet carry the `ROCM_HOST_CFLAGS` fix, which ships separately in #656.
- Launch-site audit: every kernel launch in the ROCm backend goes through `ds4_rocm_stream()`, except the three launches that intentionally use the dedicated shared-expert stream, which are unchanged.
- End to end on two machines with greedy decoding and the released Q4_K-experts model file:
  - with the variable unset: output byte-identical to unmodified main;
  - with `DS4_ROCM_DECODE_GRAPHS=all`: output byte-identical to eager execution;
  - throughput within noise of eager, as stated above.

## How to test

`make strix-halo`, then any ROCm decode run with and without `DS4_ROCM_DECODE_GRAPHS=all`. Outputs must match exactly.
