### PR TITLE
distributed: descriptor-framed NHI transport, ROCm event timing, regression gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,17 @@
 /tests/test_mxfp4_cuda
 /tests/test_mxfp4_dot
 /tests/test_mxfp4_metal
+/tests/test_mxfp4_rocm
 /tests/test_q4k_dot
+/tests/test_rocm_qkv_fusion
+/tests/test_rocm_timing_fake
+/tests/test_gpu_timing_stubs
 /tests/test_sampling
+/tests/test_transport
+/tests/test_dist_v3
+/tests/test_distributed_transport
+/tests/test_nhi_live
+/tests/test_nhi_live_rocm
 *.o
 *.dSYM/
 __pycache__/
@@ -37,3 +46,4 @@ __pycache__/
 /misc/
 .*.swp
 .DS_Store
+/.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,20 @@
 CC ?= cc
+CXX ?= c++
 UNAME_S := $(shell uname -s)
 
 ifeq ($(UNAME_S),Darwin)
 NATIVE_CPU_FLAG ?= -mcpu=native
 SAMPLING_TEST :=
+METAL_SYNTH_TEST := tests/test_mxfp4_metal
 else
 NATIVE_CPU_FLAG ?= -march=native
 SAMPLING_TEST := tests/test_sampling
+METAL_SYNTH_TEST :=
 endif
 
 DEBUG_FLAGS ?= -g
 CFLAGS ?= -O3 -ffast-math $(DEBUG_FLAGS) $(NATIVE_CPU_FLAG) -Wall -Wextra -std=c99
+CXXFLAGS ?= -O2 $(DEBUG_FLAGS) $(NATIVE_CPU_FLAG) -Wall -Wextra -std=c++11
 OBJCFLAGS ?= -O3 -ffast-math $(DEBUG_FLAGS) $(NATIVE_CPU_FLAG) -Wall -Wextra -fobjc-arc
 QUALITY_CFLAGS ?= -O3 $(DEBUG_FLAGS) $(NATIVE_CPU_FLAG) -Wall -Wextra -std=c11
 
@@ -24,8 +28,8 @@ DS4_DSPARK_SUPPORT ?= gguf/DeepSeek-V4-Flash-DSpark-support-0731.gguf
 
 ifeq ($(UNAME_S),Darwin)
 METAL_LDLIBS := $(LDLIBS) -framework Foundation -framework Metal
-CORE_OBJS = ds4.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_metal.o ds4_layer_pack.o
-CPU_CORE_OBJS = ds4_cpu.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
+CORE_OBJS = ds4.o ds4_distributed.o ds4_dist_v3.o ds4_transport.o ds4_transport_nhi.o ds4_tp.o ds4_ssd.o ds4_metal.o ds4_layer_pack.o
+CPU_CORE_OBJS = ds4_cpu.o ds4_distributed.o ds4_dist_v3.o ds4_transport.o ds4_transport_nhi.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
 else
 CFLAGS += -D_GNU_SOURCE -fno-finite-math-only
 CUDA_HOME ?= $(shell if [ -x /usr/local/cuda/bin/nvcc ]; then \
@@ -50,19 +54,20 @@ NVCCFLAGS ?= -O3 -g -lineinfo --use_fast_math $(NVCC_ARCH_FLAGS) -Xcompiler $(NA
 # Vendored llama.cpp mmq prefill tier (cuda/mmq/, see cuda/mmq/VENDOR.md).
 MMQ_INCLUDES := -Icuda/mmq
 MMQ_OBJS := cuda/mmq/ds4_ggml_stubs.o cuda/mmq/ds4_mmq.o cuda/mmq/ds4_mmq_d2r.o cuda/mmq/quantize.o cuda/mmq/mmid.o cuda/mmq/mmvq.o cuda/mmq/ds4_repack.o
-CORE_OBJS = ds4.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o $(MMQ_OBJS)
-CPU_CORE_OBJS = ds4_cpu.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
+CORE_OBJS = ds4.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o ds4_dist_v3.o ds4_transport.o ds4_transport_nhi.o $(MMQ_OBJS)
+CPU_CORE_OBJS = ds4_cpu.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o ds4_dist_v3.o ds4_transport.o ds4_transport_nhi.o
 CUDA_LDLIBS ?= -lm -Xcompiler -pthread -L$(CUDA_HOME)/targets/sbsa-linux/lib -L$(CUDA_HOME)/lib64 -lcudart -lcublas
 HIPCC ?= $(shell command -v hipcc 2>/dev/null || echo /opt/rocm/bin/hipcc)
+ROCM_ROOT ?= $(abspath $(dir $(HIPCC))/..)
 ROCM_ARCH ?= gfx1151
 ROCM_CFLAGS ?= -O3 -ffast-math -g -fno-finite-math-only -pthread -D__HIP_PLATFORM_AMD__ -Wno-unused-command-line-argument --offload-arch=$(ROCM_ARCH)
-ROCM_LDLIBS ?= -lm -pthread -lhipblas -lhipblaslt
+ROCM_LDLIBS ?= -lm -pthread -lhipblas -lhipblaslt -Wl,-rpath,$(ROCM_ROOT)/lib
 DS4_LINK ?= $(NVCC) $(NVCCFLAGS)
 DS4_LINK_LIBS ?= $(CUDA_LDLIBS)
 METAL_LDLIBS := $(LDLIBS)
 endif
 
-.PHONY: all help clean test test-metal-session-batch test-mxfp4-cuda test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
+.PHONY: all help clean test test-metal-session-batch test-mxfp4-cuda test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm test-dist-v3 test-gpu-timing test-rocm-timing test-nhi-live test-nhi-live-rocm
 
 ifeq ($(UNAME_S),Darwin)
 .PHONY: metal-decode-schedule-bench metal-prefill-variant-bench check-mxfp4-half-lut
@@ -78,6 +83,7 @@ help:
 	@echo "  make metal-prefill-variant-bench  Build the balanced Metal prefill variant benchmark"
 	@echo "  make check-mxfp4-half-lut  Verify the checked-in MXFP4 half LUT matches the generator"
 	@echo "  make test-mxfp4-metal  Check the MXFP4 half LUT, then run Metal MXFP4 exactness tests"
+	@echo "  make test-rocm-timing  Run host-only ROCm timing backend and stub tests"
 	@echo "  make dspark-verify-depth  Run DSpark speculative verification smoke if support GGUF is present"
 	@echo "  make mtp-verify-depth  Run legacy MTP speculative verification smoke if MTP GGUF is present"
 	@echo "  make clean        Remove build outputs"
@@ -156,8 +162,11 @@ help:
 	@echo "  make cuda CUDA_ARCH=sm_N Build CUDA with an explicit nvcc -arch value"
 	@echo "  make strix-halo          Build ROCm for Strix Halo / gfx1151"
 	@echo "  make rocm                Alias for make strix-halo"
+	@echo "  make test-nhi-live       Run the opt-in two-host NHI CPU-copy gate"
+	@echo "  make test-nhi-live-rocm  Run the opt-in mapped-plus-copy ROCm NHI gate"
 	@echo "  make cpu                 Build CPU-only ./ds4, ./ds4-server, ./ds4-bench, ./ds4-eval, and ./ds4-agent"
 	@echo "  make test                Build and run tests"
+	@echo "  make test-rocm-timing    Run host-only ROCm timing backend and stub tests"
 	@echo "  make dspark-verify-depth Run DSpark speculative verification smoke if support GGUF is present"
 	@echo "  make mtp-verify-depth    Run legacy MTP speculative verification smoke if MTP GGUF is present"
 	@echo "  make clean               Remove build outputs"
@@ -178,8 +187,8 @@ cuda:
 
 strix-halo:
 	$(MAKE) -B ds4 ds4-server ds4-bench ds4-eval ds4-agent \
-		CORE_OBJS="ds4.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o" \
-		CFLAGS="$(CFLAGS) -DDS4_ROCM_BUILD" \
+		CORE_OBJS="ds4.o ds4_distributed.o ds4_dist_v3.o ds4_transport.o ds4_transport_nhi.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o" \
+		CFLAGS="$(CFLAGS) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD" \
 		DS4_LINK="$(HIPCC) $(ROCM_CFLAGS)" \
 		DS4_LINK_LIBS="$(ROCM_LDLIBS)"
 
@@ -232,8 +241,20 @@ ds4_ssd.o: ds4_ssd.c ds4_ssd.h
 ds4_cli.o: ds4_cli.c ds4.h ds4_ssd.h ds4_distributed.h ds4_help.h linenoise.h
 	$(CC) $(CFLAGS) -c -o $@ ds4_cli.c
 
-ds4_distributed.o: ds4_distributed.c ds4_distributed.h ds4.h ds4_ssd.h
+ds4_distributed.o: ds4_distributed.c ds4_distributed.h ds4.h ds4_ssd.h ds4_transport.h ds4_dist_v3.h
 	$(CC) $(CFLAGS) -c -o $@ ds4_distributed.c
+
+ds4_distributed_test.o: ds4_distributed.c ds4_distributed.h ds4.h ds4_ssd.h ds4_transport.h ds4_dist_v3.h
+	$(CC) $(CFLAGS) -DDS4_TEST_HOOKS -c -o $@ ds4_distributed.c
+
+ds4_dist_v3.o: ds4_dist_v3.c ds4_dist_v3.h ds4_transport.h
+	$(CC) $(CFLAGS) -c -o $@ ds4_dist_v3.c
+
+ds4_transport.o: ds4_transport.c ds4_transport.h ds4_transport_internal.h
+	$(CC) $(CFLAGS) -c -o $@ ds4_transport.c
+
+ds4_transport_nhi.o: ds4_transport_nhi.c ds4_transport.h ds4_transport_internal.h ds4_tbstream_uapi.h ds4_gpu.h
+	$(CC) $(CFLAGS) -c -o $@ ds4_transport_nhi.c
 
 ds4_tp.o: ds4_tp.c ds4_tp.h ds4.h ds4_ssd.h
 	$(CC) $(CFLAGS) -c -o $@ ds4_tp.c
@@ -346,6 +367,83 @@ tests/test_layer_pack.o: tests/test_layer_pack.c ds4_layer_pack.h
 tests/test_layer_pack: tests/test_layer_pack.o ds4_layer_pack.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
+tests/test_transport.o: tests/test_transport.c ds4_transport.h ds4_transport_internal.h
+	$(CC) $(CFLAGS) -I. -c -o $@ $<
+
+tests/test_transport: tests/test_transport.o ds4_transport.o
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
+
+tests/test_rocm_timing_fake: tests/test_rocm_timing_fake.cc rocm/ds4_rocm_timing.cuh ds4_gpu.h
+	$(CXX) $(CXXFLAGS) -I. -o $@ $< -pthread
+
+tests/test_gpu_timing_stubs: tests/test_gpu_timing_stubs.c ds4_gpu.h
+	$(CC) $(CFLAGS) -UDS4_ROCM_BUILD -U__HIP_PLATFORM_AMD__ -I. -o $@ $< $(LDLIBS)
+
+test-gpu-timing: tests/test_rocm_timing_fake tests/test_gpu_timing_stubs
+	./tests/test_rocm_timing_fake
+	./tests/test_gpu_timing_stubs
+
+test-rocm-timing: test-gpu-timing
+
+# Opt-in two-host hardware test. Compile the backend with ROCm mapping disabled
+# so this target always exercises the model-independent CPU-copy NHI path.
+tests/test_nhi_live: tests/test_nhi_live.c ds4_transport.c ds4_transport_nhi.c ds4_transport.h ds4_transport_internal.h ds4_tbstream_uapi.h ds4_gpu.h
+	$(CC) $(CFLAGS) -UDS4_ROCM_BUILD -U__HIP_PLATFORM_AMD__ -I. -o $@ tests/test_nhi_live.c ds4_transport.c ds4_transport_nhi.c $(LDLIBS)
+
+test-nhi-live: tests/test_nhi_live
+	@if [ -z "$(NHI_LIVE_ARGS)" ]; then \
+		./tests/test_nhi_live --help; \
+		echo "Run on both hosts, e.g. make test-nhi-live NHI_LIVE_ARGS='--listen --device /dev/tbstream0'"; \
+		exit 2; \
+	fi
+	./tests/test_nhi_live --require-copy $(NHI_LIVE_ARGS)
+
+# Optional ROCm-linked variant: the same harness automatically uses mapped
+# leases for contiguous slots and reports copy fallbacks at ring boundaries.
+ifneq ($(UNAME_S),Darwin)
+tests/test_nhi_live_rocm.o: tests/test_nhi_live.c ds4_transport.h
+	$(CC) $(filter-out -ffast-math,$(CFLAGS)) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD -I. -c -o $@ $<
+
+tests/ds4_transport_live_rocm.o: ds4_transport.c ds4_transport.h ds4_transport_internal.h
+	$(CC) $(filter-out -ffast-math,$(CFLAGS)) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD -I. -c -o $@ $<
+
+tests/ds4_transport_nhi_live_rocm.o: ds4_transport_nhi.c ds4_transport.h ds4_transport_internal.h ds4_tbstream_uapi.h ds4_gpu.h
+	$(CC) $(filter-out -ffast-math,$(CFLAGS)) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD -I. -c -o $@ $<
+
+tests/test_nhi_live_rocm_alias.o: tests/test_nhi_live_rocm_alias.cu
+	$(HIPCC) $(ROCM_CFLAGS) -I. -c -o $@ $<
+
+tests/test_nhi_live_rocm: tests/test_nhi_live_rocm.o tests/test_nhi_live_rocm_alias.o tests/ds4_transport_live_rocm.o tests/ds4_transport_nhi_live_rocm.o ds4_rocm.o
+	$(HIPCC) $(ROCM_CFLAGS) -o $@ $^ $(ROCM_LDLIBS)
+
+test-nhi-live-rocm: tests/test_nhi_live_rocm
+	@if [ -z "$(NHI_LIVE_ARGS)" ]; then \
+		./tests/test_nhi_live_rocm --help; \
+		echo "Run on both ROCm hosts, e.g. make test-nhi-live-rocm NHI_LIVE_ARGS='--listen --device /dev/tbstream0'"; \
+		exit 2; \
+	fi
+	DS4_DIST_NHI_MAPPED=1 ./tests/test_nhi_live_rocm --require-mapped --require-copy --require-gpu-alias $(NHI_LIVE_ARGS)
+else
+test-nhi-live-rocm:
+	@echo "test-nhi-live-rocm requires Linux and ROCm"
+	@exit 2
+endif
+
+tests/test_dist_v3.o: tests/test_dist_v3.c ds4_dist_v3.h ds4_transport.h
+	$(CC) $(CFLAGS) -I. -c -o $@ $<
+
+tests/test_dist_v3: tests/test_dist_v3.o ds4_dist_v3.o ds4_transport.o
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
+
+test-dist-v3: tests/test_dist_v3
+	./tests/test_dist_v3
+
+tests/test_distributed_transport.o: tests/test_distributed_transport.c ds4_distributed.h
+	$(CC) $(CFLAGS) -DDS4_TEST_HOOKS -I. -c -o $@ $<
+
+tests/test_distributed_transport: tests/test_distributed_transport.o ds4_cpu_test_hooks.o ds4_distributed_test.o ds4_dist_v3.o ds4_transport.o ds4_transport_nhi.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
+
 tests/test_gpu_args.o: tests/test_gpu_args.c ds4_gpu_args.h ds4_gpu_mgpu.h
 	$(CC) $(CFLAGS) -I. -DDS4_NO_GPU -c -o $@ $<
 
@@ -358,7 +456,7 @@ ds4_cpu_test_hooks.o: ds4.c ds4.h ds4_gpu.h ds4_gpu_mgpu.h ds4_layer_pack.h
 tests/test_engine_mgpu_placement.o: tests/test_engine_mgpu_placement.c ds4.h ds4_gpu_mgpu.h ds4_layer_pack.h
 	$(CC) $(CFLAGS) -I. -c -o $@ $<
 
-tests/test_engine_mgpu_placement: tests/test_engine_mgpu_placement.o ds4_cpu_test_hooks.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
+tests/test_engine_mgpu_placement: tests/test_engine_mgpu_placement.o ds4_cpu_test_hooks.o ds4_distributed.o ds4_dist_v3.o ds4_transport.o ds4_transport_nhi.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
 ifneq ($(UNAME_S),Darwin)
@@ -392,7 +490,7 @@ tests/test_engine_mgpu_refusal: tests/test_engine_mgpu_refusal.o ds4_gpu_args.o 
 tests/test_engine_mgpu_runtime.o: tests/test_engine_mgpu_runtime.c ds4.h ds4_gpu_mgpu.h
 	$(CC) $(CFLAGS) -DDS4_TEST_HOOKS -I. -I$(CUDA_HOME)/include -c -o $@ $<
 
-tests/test_engine_mgpu_runtime: tests/test_engine_mgpu_runtime.o ds4_cuda_test_hooks.o ds4_gpu_args.o ds4_kvstore.o rax.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o $(MMQ_OBJS)
+tests/test_engine_mgpu_runtime: tests/test_engine_mgpu_runtime.o ds4_cuda_test_hooks.o ds4_gpu_args.o ds4_kvstore.o rax.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o ds4_dist_v3.o ds4_transport.o ds4_transport_nhi.o $(MMQ_OBJS)
 	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(CUDA_LDLIBS)
 
 tests/test_engine_correctness.o: tests/test_engine_correctness.c ds4.h ds4_gpu_mgpu.h
@@ -404,7 +502,7 @@ tests/test_engine_correctness: tests/test_engine_correctness.o ds4_gpu_args.o ds
 tests/test_sampling.o: tests/test_sampling.c ds4.h
 	$(CC) $(CFLAGS) -DDS4_TEST_HOOKS -I. -c -o $@ $<
 
-tests/test_sampling: tests/test_sampling.o ds4_cuda_test_hooks.o ds4_gpu_args.o ds4_kvstore.o rax.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o $(MMQ_OBJS)
+tests/test_sampling: tests/test_sampling.o ds4_cuda_test_hooks.o ds4_gpu_args.o ds4_kvstore.o rax.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o ds4_dist_v3.o ds4_transport.o ds4_transport_nhi.o $(MMQ_OBJS)
 	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(CUDA_LDLIBS)
 
 tests/test_cuda_session_batch.o: tests/test_cuda_session_batch.c ds4.h ds4_gpu_args.h ds4_gpu_mgpu.h
@@ -419,7 +517,7 @@ test-cuda-session-batch: tests/test_cuda_session_batch
 tests/test_cuda_mixed_batch.o: tests/test_cuda_mixed_batch.c ds4.h ds4_gpu_args.h ds4_gpu_mgpu.h
 	$(CC) $(CFLAGS) -DDS4_TEST_HOOKS -I. -I$(CUDA_HOME)/include -c -o $@ $<
 
-tests/test_cuda_mixed_batch: tests/test_cuda_mixed_batch.o ds4_cuda_test_hooks.o ds4_gpu_args.o ds4_kvstore.o rax.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o $(MMQ_OBJS)
+tests/test_cuda_mixed_batch: tests/test_cuda_mixed_batch.o ds4_cuda_test_hooks.o ds4_gpu_args.o ds4_kvstore.o rax.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o ds4_dist_v3.o ds4_transport.o ds4_transport_nhi.o $(MMQ_OBJS)
 	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(CUDA_LDLIBS)
 
 test-cuda-mixed-batch: tests/test_cuda_mixed_batch
@@ -441,18 +539,28 @@ else
 endif
 
 test: ds4_test ds4_agent_test ds4-eval q4k-dot-test mxfp4-dot-test \
-	tests/test_layer_pack tests/test_engine_mgpu_placement tests/test_gpu_args \
-	$(SAMPLING_TEST) ds4 ds4-server ds4-bench ds4-agent
+	tests/test_layer_pack tests/test_transport tests/test_rocm_timing_fake tests/test_gpu_timing_stubs tests/test_dist_v3 tests/test_distributed_transport tests/test_engine_mgpu_placement tests/test_gpu_args \
+	$(SAMPLING_TEST) $(METAL_SYNTH_TEST) ds4 ds4-server ds4-bench ds4-agent
 	./ds4-eval --self-test-extractors
 	./ds4_agent_test
-	./ds4_test
+	./ds4_test --server
 	./tests/test_layer_pack
+	./tests/test_transport
+	./tests/test_rocm_timing_fake
+	./tests/test_gpu_timing_stubs
+	./tests/test_dist_v3
+	./tests/test_distributed_transport
 	./tests/test_engine_mgpu_placement
 	./tests/test_gpu_args
 	./tests/test_gpu_args_cli.sh
+ifeq ($(UNAME_S),Darwin)
+	./ds4_test --metal-kernels
+	./tests/test_mxfp4_metal
+endif
 ifneq ($(UNAME_S),Darwin)
 	./tests/test_sampling
 endif
+	./ds4_test
 
 dspark-acceptance: ds4
 	DS4_DSPARK_MODEL="$(DS4_DSPARK_MODEL)" \
@@ -488,4 +596,4 @@ mxfp4-dot-test: tests/test_mxfp4_dot.c
 	./tests/test_mxfp4_dot
 
 clean:
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o tests/test_mxfp4_rocm tests/test_mxfp4_rocm tests/test_rocm_qkv_fusion tests/test_transport tests/test_rocm_timing_fake tests/test_gpu_timing_stubs tests/test_nhi_live tests/test_nhi_live_rocm tests/test_dist_v3 tests/test_distributed_transport

--- a/QA_BEFORE_RELEASES.md
+++ b/QA_BEFORE_RELEASES.md
@@ -517,6 +517,30 @@ loading code changes.
 - Save and restore a distributed KV snapshot if that code changed.
 - If CUDA distributed is relevant, test across the CUDA hosts and record
   generation speed, not just "it works".
+- If the Linux NHI transport changed, first run `test-nhi-live` and
+  `test-nhi-live-rocm` on the directly connected pair. Require exit zero and a
+  PASS line from both roles; the CPU gate must report copy traffic in both
+  directions, and the ROCm gate must report both mapped traffic and wrap-copy
+  fallback. The ROCm Make target explicitly enables `DS4_DIST_NHI_MAPPED=1`;
+  leave mapped model I/O disabled outside that experiment. Retain the separate
+  full-pool GPU mapping test because the live harness deliberately verifies
+  leases through its host alias.
+- Also run `../strix-rdma/tools/ds4-shape/tbstream-ds4-gate` for at least 33
+  exchanges so the actual asymmetric request/response geometry crosses the
+  ring boundary. Repeat it from fresh opens and verify recovery after a forced
+  failure. Equal-size and fixed-size harnesses do not replace this gate. The
+  2026-08-05 post-fix stack completed 2,880 exact DS4-shaped exchanges across
+  27 sessions and repeated fresh opens; rerun this gate after every kernel or
+  transport change instead of relying on that historical qualification.
+- Before qualifying NHI for a release, compare model output against v3 TCP with
+  identical settings, then cover automatic/required fallback, process and
+  cable reconnect, IOMMU fault recovery, and the documented soak interval.
+- Verify production service manifests use `--dist-transport auto` without
+  `--dist-nhi-device`; that is descriptor-framed v3 TCP. Explicit
+  `--dist-transport tcp` is legacy v2. Any supplied NHI device, and required
+  `nhi` mode, must remain confined to an explicitly identified lab service until
+  the asymmetric gate, fresh-open recovery, full-model equivalence, and soak
+  all pass.
 
 ## 11. Disk KV Cache
 

--- a/RDMA.md
+++ b/RDMA.md
@@ -1,0 +1,331 @@
+# Hardware-assisted DS4 transport over Thunderbolt/USB4
+
+## Goal
+
+Reduce the latency and CPU overhead of moving DS4 boundary tensors between a
+paired set of Strix Halo systems. The target is hardware-assisted data movement,
+not a software RDMA implementation layered over the existing Thunderbolt TCP
+link.
+
+## Conclusion
+
+Soft-RoCE (`rxe`) or software iWARP (`siw`) is not the useful path here. Both
+would retain the network stack and execute the RDMA protocol in software, so
+they are unlikely to improve on well-tuned TCP over `thunderbolt-net` for this
+latency-sensitive workload.
+
+The experimental path explored here is a custom zero-copy DS4 transport built
+on the USB4/Thunderbolt Native Host Interface (NHI) DMA rings. The NHI already
+performs the physical
+transfer from a local DMA address into pre-posted memory on the other host. A
+kernel driver can expose fixed, mmap-able TX/RX buffer pools to userspace and
+submit those buffers directly to the NHI rings. If ROCm can access the same
+pages, boundary tensors can move:
+
+```text
+sending GPU -> shared DMA page -> NHI -> cable -> NHI -> shared DMA page -> receiving GPU
+```
+
+This would be hardware-DMA message passing with send/receive semantics. It is
+not full InfiniBand-style RDMA: the Strix Halo NHI has no public support for
+remote virtual addresses, rkeys, queue-pair state, RDMA reads/writes, atomics,
+or an RDMA reliability engine. A kernel patch cannot add those missing hardware
+features. True one-sided RDMA would require an external RDMA NIC or FPGA.
+
+## Implementation status (2026-08-06)
+
+The initial one-device-to-one-device DS4 path is now implemented in software.
+TCP remains the control channel. Protocol v3 negotiates either
+descriptor-framed TCP or NHI, uses an ACK/READY activation barrier, and carries
+an exact 64-byte bulk descriptor with generation, directional sequence,
+identity, size, width, and frame count. The Linux NHI backend persistently owns
+the zero-copy mmap and one mixed completion dispatcher.
+
+The production selection is `--dist-transport auto` with no
+`--dist-nhi-device`. That keeps descriptor-framed protocol v3 and selects TCP
+when no NHI candidate is supplied. Explicit `--dist-transport tcp` selects
+legacy protocol v2. Any configuration that supplies an NHI device is lab-only
+and remains an explicit single-link experiment because it has not improved
+full-model token throughput.
+
+Within the experimental NHI backend, the normal path stages payloads through
+the mmap pools with CPU copies. Contiguous 32-bit payloads can instead be handed
+off through mapped TX/RX leases by setting `DS4_DIST_NHI_MAPPED=1` on both
+peers. In that explicit qualification mode, graph tensor copies go directly to
+or from the registered driver slot and a HIP synchronization fences every NHI
+ownership transfer; there is no intermediate application heap buffer.
+Ring-wrapping or reduced-precision payloads retain the CPU-copy NHI path.
+Single-token ROCm decode can additionally rebind graph I/O to the mapped alias
+with `DS4_DIST_NHI_DIRECT_SLOTS=rx|tx|both` (default `off`). The mapped pages are
+system/GTT memory, not peer VRAM and not GPUDirect RDMA.
+
+`DS4_DIST_NHI_UNSAFE_FAST=1` enables a benchmark-only handoff that skips the
+redundant userspace HIP synchronization when the caller has already completed
+GPU work, and omits canonical copyback for terminal outputs proven dead before
+reuse. The transport still validates generation/sequence descriptors and the
+kernel still owns NHI DMA submission and RX reposting. The conservative path
+remains the default.
+
+Every connection gets a new coordinator-issued generation. TCP descriptors and
+NHI envelopes repeat it and the exact next directional sequence. Malformed,
+stale, partially written, or ambiguous traffic abandons the generation. The
+implementation currently rejects v3 routes with more than one remote worker.
+Semantic WORK rejection consumes and reposts an already validated mapped RX
+lease before returning the error, so ordinary request errors do not poison a
+healthy generation.
+
+The current applications build and pass the ROCm, transport, and protocol
+gates in isolated directories on both Strix hosts. Fixed-size raw zero-copy,
+ring-wrap, mapped-pool, orderly-close, GPU-alias, asymmetric DS4-shape, and
+full-model equivalence checks pass. The earlier full-model delivery failure was
+traced below DS4 to a lost MSI-X notification and RX priming order; the stream
+driver repairs now survive ring wrap and fresh-open qualification. Local TX
+completion is still not proof of remote delivery, and pre-activation fallback
+still does not make an already active or ambiguous generation safe to replay.
+
+The host safety prerequisites are now in place: translated/default IOMMU
+operation is enabled, ROCm and the NPU remain healthy, the stream device is
+`0660 root:tbstream`, and the allocator/follower lifecycle publishes
+`/run/ds4-tbstream/device`. The repaired pair completes repeated full-model NHI
+cohorts without timeout or replay. A matched 800-token A/B on the current
+direct-slot build measured 11.2557 tok/s on staged NHI and 11.2407 tok/s with
+direct TX plus the fast handoff, a noise-scale -0.13% change. Per-token
+profiling attributes about 33.5 ms to each synchronized model-evaluation span
+in a 68.1 ms distributed decode step; all four mapped-lease synchronizations
+total about 0.015 ms. The spans include setup and staging inside the evaluation
+calls, so the remaining target is evaluation internals and scheduling, not
+ownership-fence removal.
+
+The opt-in ROCm event profiler now resolves that evaluation span without adding
+a synchronization point. Set `DS4_ROCM_EVENT_PROFILE=1`; reports contain
+`DS4_ROCM_EVENT_PROFILE_INTERVAL` samples (default `32`). It is limited to
+ordinary resident, non-streaming, non-speculative single-token layer-slice
+decode on one tier/device, with no placement plan or synchronized stage
+profiler. Fourteen timing-enabled HIP events form 13 adjacent stream-0 segments
+while rotating the sampled layer across tokens. Collection occurs only after
+the existing `ds4_gpu_end_commands()` completion. Timing failure disables
+profiling and leaves inference running.
+
+Two balanced 800-token TCP arms measured pooled request service time of
+`7.15150 s` with profiling and `7.14820 s` without it: `+0.04617%` latency, or
+`-0.04614%` throughput, with zero dropped samples or coverage differences. The
+profiled full-model means were `33.98704 ms` stream-0 versus `34.09416 ms` host
+on the coordinator (`0.10712 ms` residual), and `33.69936 ms` versus
+`33.82140 ms` on the worker (`0.12204 ms` residual). The worker output head was
+`2.51466 ms`. The approximately extrapolated sampled-layer body divided into
+routed MoE `24.55%`, attention output `24.24%`, QKV `20.71%`, shared/post
+`10.05%`, compressor/indexer `9.80%`, FFN/router `7.33%`, and attention core
+`3.13%`. These percentages are directional because one rotating layer carries
+the event overhead. They show that stream-0 GPU work accounts for nearly all
+of each evaluation span and that no one repeated layer stage dominates it.
+
+The event `copyback` segment counts only queued direct/canonical D2D copies;
+ordinary staged GPU-to-host reads occur after collection and appear in
+`host_minus_stream0`. In a same-nonce NHI comparison, worker output-head time
+was `2.51525 ms` staged and `2.58050 ms` with direct logits (`+0.06525 ms`,
+`+2.594%`), while combined coordinator-plus-worker stream-0 time was
+effectively unchanged (`67.84875 ms` staged versus `67.85050 ms` direct).
+Direct-slot coverage was 124/128 worker samples at mask `0x4` and 127/128
+coordinator samples at mask `0x2`. This is consistent with mapped GTT output
+slightly slowing the head rather than exposing hidden transport savings.
+
+## Why the current TCP path costs more
+
+The current DS4 layer-slice path reads a GPU tensor into host memory, sends it
+through the distributed TCP transport, and writes the received host buffer into
+the peer GPU tensor. Below that, `thunderbolt-net` copies TX payload into its own
+4 KiB DMA buffers, while TCP/socket handling adds further copies, protocol work,
+and wakeups.
+
+The resulting data path is approximately:
+
+```text
+GPU -> DS4 host buffer -> socket/TCP -> thunderbolt-net DMA pages
+    -> NHI/cable/NHI -> network/TCP -> DS4 host buffer -> GPU
+```
+
+The relevant DS4 calls are currently in `ds4_session_eval_layer_slice()` and
+use `ds4_gpu_tensor_read()`, the distributed socket transport, and
+`ds4_gpu_tensor_write()`.
+
+Linux's [`thunderbolt-net` TX path](https://github.com/torvalds/linux/blob/master/drivers/net/thunderbolt/main.c#L1040-L1151)
+supports scatter/gather and TCP segmentation offload, but it still copies SKB
+payload into NHI ring pages.
+
+## Upstream USB4STREAM support
+
+Upstream Linux has a much better starting point than `thunderbolt-net`:
+
+- [`USB4STREAM` support](https://github.com/torvalds/linux/commit/6db21d817b43f8ce5654ccc7aff80d40e4dba4ac)
+  adds the `thunderbolt-stream` driver and `/dev/tbstreamX` character devices.
+- It transfers data directly over a Thunderbolt/USB4 tunnel without traversing
+  the network stack.
+- Multiple bidirectional streams can coexist, including alongside
+  `thunderbolt-net`.
+- It supports configurable ring sizes and interrupt throttling.
+- The ABI entry in the upstream change identifies Linux 7.2. The test systems
+  were running 7.1.5 when this was investigated, so using it requires a 7.2
+  kernel or a backport.
+
+The [upstream kernel documentation](https://docs.kernel.org/admin-guide/thunderbolt.html#streaming-data-directly-over-thunderbolt-cable)
+describes ConfigFS setup and the `/dev/tbstreamX` interface.
+
+Stock USB4STREAM is not yet zero-copy. It allocates and DMA-maps its own pages,
+then uses [`copy_page_from_iter()` on TX](https://github.com/torvalds/linux/blob/master/drivers/thunderbolt/stream.c#L467-L505)
+and [`copy_page_to_iter()` on RX](https://github.com/torvalds/linux/blob/master/drivers/thunderbolt/stream.c#L599-L745).
+It should remove TCP overhead and is worth measuring as a baseline, but it will
+not provide the desired GPU-to-NHI direct path without further changes.
+
+## What the NHI can offload
+
+An NHI ring descriptor contains a local physical/DMA address, a length, framing
+flags, and completion/interrupt flags. See the upstream
+[`nhi_ring_desc`](https://github.com/torvalds/linux/blob/master/drivers/thunderbolt/nhi_regs.h#L20-L38).
+The public ring interface currently describes frames of at most 4096 bytes.
+
+That is enough for an efficient pre-posted message transport:
+
+1. The receiver posts DMA-mapped slots to its RX ring.
+2. The sender fills a registered TX slot and submits descriptors that reference
+   it.
+3. NHI hardware moves the frames over the cable into the peer's posted slots.
+4. The receiver gets one completion for the logical tensor and hands ownership
+   to the GPU.
+
+Large tensors will span many 4 KiB NHI frames. The driver should request a
+completion interrupt only for the last descriptor in a logical message, rather
+than waking the CPU for every frame. The current ring code may need a small core
+change because descriptor interrupt behavior is not fully controlled by the
+USB4STREAM client.
+
+## DS4 NHI transport
+
+TCP is kept for discovery, negotiation, health checks, and small control
+messages. A dedicated NHI stream carries only bulk boundary tensors and
+successful batched logits.
+
+This section describes the implemented experimental path, not the current
+production configuration. Production uses v3 TCP via `auto` without an NHI
+device.
+
+### Kernel side
+
+Start from Linux 7.2 USB4STREAM or backport its driver, then add a zero-copy UAPI
+with the following concepts:
+
+- Fixed TX and RX slot pools allocated and DMA-mapped once.
+- `mmap()` access to those pools from the DS4 process.
+- Explicit `POST_RX`, `SUBMIT_TX`, and `REAP_COMPLETIONS` operations, either as
+  ioctls or `io_uring` commands.
+- Producer/consumer indices and generation numbers so stale completions cannot
+  reuse a slot incorrectly.
+- Credit-based flow control so the sender never overruns peer RX slots.
+- Scatter/gather descriptors for messages larger than one page.
+- Per-message rather than per-frame completion interrupts.
+- Event notification through polling, `eventfd`, or `io_uring`, with a busy-poll
+  option for the lowest-latency benchmark.
+- Correct disconnect cancellation and cleanup of every pinned/mapped page.
+
+Use multiple slots (at least double buffering, probably 4-8 per direction) so
+the next tensor can be produced while the previous one is on the link.
+
+### ROCm integration
+
+The first proof of concept should mmap driver-owned pages into the DS4 process
+and test whether `hipHostRegister()`/mapped host memory lets the Strix Halo GPU
+read and write those pages at acceptable latency. The integrated GPU and shared
+system memory make this plausible, but it must be demonstrated; it should not
+be assumed.
+
+If registering driver-mapped pages is unsupported or slow, investigate exporting
+the slot pool as DMA-BUF and importing it through the supported ROCm/KFD memory
+path. Explicit ownership fencing is required in either case:
+
+```text
+TX: GPU completion -> DMA sync/fence -> NHI owns slot -> TX completion -> reusable
+RX: NHI completion -> DMA sync/fence -> GPU owns slot -> GPU completion -> repost
+```
+
+The driver must use the Linux DMA API correctly for the NHI device. Keep the
+IOMMU enabled: it provides DMA isolation and does not prevent this design.
+Disabling it would enlarge the blast radius of a driver or protocol bug and is
+not a prerequisite for direct DMA.
+
+### DS4 integration
+
+The implemented transport abstraction preserves TCP rather than replacing it.
+The initial NHI backend:
+
+- negotiates protocol capabilities and local geometry without exposing local
+  slot IDs, because peer ring cursors are independent;
+- validates a generation/sequence-tagged TCP descriptor before consuming NHI;
+- moves 32-bit graph tensor data directly between HIP and a registered TX/RX
+  slot where the payload is contiguous;
+- retains a persistent CPU-copy NHI path for wrapping/reduced-width data;
+- carries only control metadata on TCP for an out-of-band tensor;
+- supports hidden-state and successful logit payloads; and
+- preserves descriptor-framed TCP and legacy v2 reconnect as pre-activation
+  fallbacks.
+
+## Suggested implementation order
+
+1. Record current TCP latency, bandwidth, CPU time, copies, message sizes, and
+   token throughput at batch sizes 1, 2, 4, and 8.
+2. Boot Linux 7.2 (or backport USB4STREAM) on both hosts and benchmark unmodified
+   `/dev/tbstreamX` with DS4-sized messages. This isolates the benefit of
+   bypassing TCP even though copies remain.
+3. Add mmap-able fixed buffer pools and a userspace ping-pong test. Validate
+   correctness, NHI DMA, interrupt count, and QD1 latency before involving ROCm.
+4. Prove GPU access to the mapped pool and measure GPU-to-GPU latency. Fall back
+   to DMA-BUF work only if the simpler mapped-memory path fails.
+5. Add the optional NHI backend to DS4 and pipeline tensor production, transfer,
+   and consumption.
+6. Tune ring depth, slot count, CPU affinity, interrupt affinity, interrupt
+   throttling, frame batching, and spin-versus-sleep completion behavior.
+7. Run long soak tests, disconnect/reconnect tests, IOMMU fault tests, and output
+   equivalence checks before using it as the default transport.
+
+## Benchmark matrix
+
+Compare all three transports with identical tensors and model settings:
+
+| Transport | Network stack | User/kernel payload copies | Intended role |
+|---|---:|---:|---|
+| TCP over `thunderbolt-net` | Yes | Yes | Production baseline |
+| Stock USB4STREAM | No | Yes | Low-risk intermediate baseline |
+| NHI stream | No | CPU-copy or mapped, by mode | Experimental; no measured model gain |
+
+For each, measure:
+
+- One-way and round-trip latency at the actual hidden-state and logit sizes.
+- p50, p95, p99, and maximum latency, not just aggregate bandwidth.
+- Queue depth 1 and pipelined transfers.
+- Batch sizes 1, 2, 4, and 8.
+- Prefill and decode separately.
+- CPU utilization, context switches, interrupts, and bytes copied.
+- End-to-end tokens/second and time/token.
+
+The end-to-end gain is bounded by the share of token time currently spent on
+transport. A large reduction in microbenchmark latency may produce a smaller
+token-rate improvement if GPU compute dominates. Batched inference and logit
+movement are likely to benefit more because transferred messages are larger and
+there is more opportunity to pipeline work.
+
+## Decision gates
+
+- If stock USB4STREAM does not materially beat TCP at DS4's message sizes,
+  profile the GPU staging copies and scheduling before writing a large kernel
+  patch.
+- If mmap zero-copy materially beats stock USB4STREAM, proceed with GPU mapping.
+- If the GPU cannot access the NHI pool efficiently, estimate DMA-BUF work versus
+  the measured maximum benefit before continuing.
+- If true one-sided RDMA semantics become a requirement, use external hardware;
+  do not try to synthesize an HCA in the NHI driver.
+
+## Rough effort
+
+A focused proof of concept is approximately one week once both hosts have a
+USB4STREAM-capable kernel: bring-up and baseline testing, mmap-able ring pools,
+a userspace ping-pong tool, and a first ROCm registration experiment. Production
+hardening and upstream-quality interfaces would take longer, especially around
+disconnect handling, synchronization, security, and compatibility.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ make strix-halo       # Linux ROCm, AMD Strix Halo
 make cpu              # CPU-only diagnostics build
 ```
 
+ROCm links record `$(ROCM_ROOT)/lib` as an ELF RUNPATH, derived from the
+selected `HIPCC`, so the applications do not depend on a service-specific
+`LD_LIBRARY_PATH`. Set both `HIPCC` and `ROCM_ROOT` when using a nonstandard
+toolchain layout.
+
 `./ds4flash.gguf` is the default model path used by both binaries. Pass `-m` to
 select another supported GGUF from `./gguf/`. Run `./ds4 --help` and
 `./ds4-server --help` for the full flag list.
@@ -565,6 +570,127 @@ many prefill chunks may be in flight end-to-end; the default is conservative
 and bounded. `--dist-prefill-chunk N` exists for experiments, but the default
 4096-token chunk is the canonical setting and should be used unless you are
 explicitly validating a different chunk size.
+
+On Linux, the production single-worker transport uses descriptor-framed
+protocol v3:
+
+```sh
+# Add these to both the coordinator and worker commands.
+--dist-transport auto
+```
+
+With no `--dist-nhi-device`, current peers negotiate descriptor-framed v3 TCP.
+Explicit `--dist-transport tcp` selects legacy protocol v2 and is retained for
+compatibility and A/B checks; it is not the v3 production spelling.
+
+The single-link NHI backend remains experimental. Supplying an NHI device to
+`auto`, or selecting `--dist-transport nhi`, enables the lab path. The earlier
+lost MSI-X notification and fresh-open RX ordering failures were repaired in
+the stream driver; the asymmetric raw gate, mapped GPU-alias gate, full-model
+output-equivalence checks, and repeated full-model cohorts now pass. NHI is not
+the default because the current serial layer split shows no tokens/second gain,
+not because a timed-out or replayed run is being counted as a benchmark.
+
+For lab qualification only, use the lifecycle-managed device on both peers:
+
+```sh
+--dist-transport auto --dist-nhi-device /run/ds4-tbstream/device
+# Or require the experiment to fail rather than select TCP:
+--dist-transport nhi --dist-nhi-device /run/ds4-tbstream/device
+```
+
+The current NHI implementation permits exactly one remote worker link. Its
+normal path stages tensors through mmap pools with CPU copies while bypassing
+the socket/network bulk path. Set `DS4_DIST_NHI_MAPPED=1` on both peers to
+enable mapped leases for contiguous 32-bit tensors. Reduced-width activations
+and ring-wrapping tensors always use CPU-copy NHI.
+
+Single-token ROCm decode can also alias graph I/O directly to a mapped lease.
+Set `DS4_DIST_NHI_DIRECT_SLOTS=rx`, `tx`, or `both` on both peers; the default is
+`off`. These are GPU mappings of driver-owned system/GTT pages, not peer VRAM or
+GPUDirect RDMA. `DS4_DIST_NHI_UNSAFE_FAST=1` is a benchmark-only companion that
+uses a caller-proven GPU-quiesced ownership handoff and skips copyback of
+terminal graph values that are dead before reuse. The conservative mapped
+lease synchronization remains the default. A matched 800-token A/B measured
+11.2557 tok/s on staged NHI and 11.2407 tok/s with direct TX plus the fast
+handoff, so the fast mode is not a throughput optimization on the current
+serial split.
+
+For qualification profiling, `DS4_DIST_DECODE_PROFILE=1` emits coordinator and
+worker synchronized evaluation spans, `DS4_DIST_NHI_TRACE=1` emits correlated NHI ownership and
+ioctl spans, and `DS4_DIST_NHI_DIRECT_TRACE=1` reports direct-slot masks. These
+logs are verbose and should be disabled for headline throughput measurements.
+
+For a low-overhead GPU-side breakdown on ROCm, set
+`DS4_ROCM_EVENT_PROFILE=1`. `DS4_ROCM_EVENT_PROFILE_INTERVAL=N` controls the
+number of samples in each report and defaults to `32`. It applies only to
+ordinary resident, non-streaming, non-speculative single-token layer-slice
+decode on one tier/device, without a placement plan or the older synchronized
+stage profiler. A rotating layer is sampled each token. Fourteen timing-enabled
+HIP events form 13 adjacent stream-0 segments covering input, work before and
+after the sampled layer, the sampled layer's QKV, compressor/indexer,
+attention, router/MoE and shared/post stages, the output head, and direct
+copyback. Each window also reports layer compression-ratio groups `0`, `4`,
+and `128`, compression emits, cache spans, direct-slot masks, and dropped
+samples. Events are collected after the existing `ds4_gpu_end_commands()`
+completion, so the profiler adds no synchronization point and disables itself
+without aborting inference if timing fails.
+
+Interpret `copyback` narrowly: it contains only queued direct/canonical D2D
+copies. An ordinary staged GPU-to-host read happens after event collection and
+is therefore included in `host_minus_stream0`, not `copyback`. In two balanced
+800-token profiler-on/off TCP arms, pooled request service time was `7.15150 s`
+on versus `7.14820 s` off: `+0.04617%` latency (`-0.04614%` throughput), with
+zero dropped samples or coverage differences. The profiler-on full-model
+means were `33.98704 ms` stream-0 and `34.09416 ms` host time on the coordinator
+(`0.10712 ms` residual), and `33.69936 ms` stream-0 and `33.82140 ms` host time
+on the worker (`0.12204 ms` residual). The worker output head cost
+`2.51466 ms` per token. Within the approximately extrapolated sampled-layer
+bodies, the largest buckets were routed MoE (`24.55%`), attention output
+(`24.24%`), and QKV (`20.71%`), followed by shared/post (`10.05%`),
+compressor/indexer (`9.80%`), FFN/router (`7.33%`), and attention core
+(`3.13%`). Treat those layer percentages as directional because event overhead
+is extrapolated from one rotating sampled layer.
+
+Resident single-token DeepSeek V4 decode on ROCm fuses Q/KV weighted RMS
+normalization and KV RoPE into one launch when the shape has at most 256 RoPE
+pairs. Larger synthetic shapes use the retained two-launch path. Set
+`DS4_ROCM_DISABLE_QKV_KV_ROPE_FUSION=1` before process startup for a diagnostic
+rollback. The strict reference comparison is model-independent:
+
+```sh
+make HIPCC=/opt/rocm-therock/bin/hipcc test-rocm-qkv-fusion
+```
+
+It covers dense and YaRN parameters, inverse and multi-row/head layouts,
+zero rotation, the 256-pair boundary, the 257-pair fallback, and rejected
+shapes, requiring bit-exact Q and KV output.
+
+The opt-in, model-independent two-host gate exercises the same descriptor and
+NHI backend without loading a GGUF. Run one role on each connected host after
+building the current tree and granting the account access to the stream device:
+
+```sh
+# CPU-copy backend; run the complementary --connect HOST role on the peer.
+make test-nhi-live \
+  NHI_LIVE_ARGS='--listen --device /run/ds4-tbstream/device --timeout 120'
+
+# Explicit ROCm registration plus mapped leases and ring-wrap copy fallback.
+# The Make target enables DS4_DIST_NHI_MAPPED=1 for this qualification gate.
+make test-nhi-live-rocm \
+  NHI_LIVE_ARGS='--listen --device /run/ds4-tbstream/device --timeout 120'
+```
+
+The runners require the expected paths in both directions and fail rather than
+reporting a mapped pass after silent CPU-copy fallback. They are intentionally
+excluded from `make test` because they require an exclusive physical endpoint.
+The mapped harness accesses the registered lease through its host alias; retain
+the separate full-pool GPU read/write gate when qualifying a deployment.
+These equal-size runners are component tests. NHI qualification must also pass
+`../strix-rdma/tools/ds4-shape/tbstream-ds4-gate` through ring wrap, prove
+reliable fresh-open recovery, and pass full-model output equivalence. The
+post-fix host pair passes those gates; deployment qualification still requires
+running them again after any kernel or transport change.
 
 By default DwarfStar sends hidden-state activations as 32-bit floats. To reduce
 traffic, pass `--dist-activation-bits 16` or `--dist-activation-bits 8` on the

--- a/STRIXHALO.md
+++ b/STRIXHALO.md
@@ -65,8 +65,12 @@ buffers.
 Use these kernel parameters:
 
 ```text
-amd_iommu=off amdgpu.gttsize=126976 ttm.pages_limit=32505856 ttm.page_pool_size=32505856
+amdgpu.gttsize=126976 ttm.pages_limit=32505856 ttm.page_pool_size=32505856
 ```
+
+Keep the IOMMU enabled. Disabling it is not required for the large GTT aperture
+and removes DMA isolation. The paired Strix Halo qualification hosts retain the
+expected ROCm-visible memory with translated/default IOMMU operation enabled.
 
 On Ubuntu with GRUB:
 
@@ -78,7 +82,7 @@ sudoedit /etc/default/grub
 Set:
 
 ```text
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash amd_iommu=off amdgpu.gttsize=126976 ttm.pages_limit=32505856 ttm.page_pool_size=32505856"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash amdgpu.gttsize=126976 ttm.pages_limit=32505856 ttm.page_pool_size=32505856"
 ```
 
 Then:
@@ -92,9 +96,13 @@ After reboot, verify:
 
 ```sh
 cat /proc/cmdline
-sudo dmesg | grep -Ei 'GTT|gttsize|TTM|VRAM'
+sudo dmesg | grep -Ei 'IOMMU|AMD-Vi|GTT|gttsize|TTM|VRAM'
 rocminfo | grep -A80 'Name:                    gfx1151'
 ```
+
+Confirm that the command line does not contain `amd_iommu=off` and that the
+kernel reports the IOMMU enabled before granting a DMA-capable transport device
+to DS4.
 
 Expected signs:
 
@@ -134,3 +142,25 @@ Run it normally:
 ```
 
 The ROCm build uses the Strix Halo backend automatically.
+
+## 7. Run the batched server
+
+For resident-session serving, keep the canonical prefill graph quantum at its
+default unless a different numerical graph shape is being qualified:
+
+```sh
+DS4_SERVER_PREFILL_GRAPH_QUANTUM=128 \
+  ./ds4-server --batched-session 2 \
+  --kv-disk-dir /path/to/kv-canonical-128-v1 \
+  -m gguf/DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix.gguf
+```
+
+`DS4_SERVER_PREFILL_QUANTUM` and
+`DS4_SERVER_MIXED_PREFILL_QUANTUM` are only idle and generation-active burst
+budgets; they change scheduler yield frequency, not graph boundaries. Confirm
+the resolved graph quantum and both burst values in the startup log.
+
+On the first canonical-boundary deployment, stop the old server and use a new,
+empty, versioned KV directory. Repeat that rollover whenever the graph quantum
+or boundary policy changes; an older or off-grid checkpoint retains its prior
+numerical history and must not be reused for deterministic comparisons.

--- a/ds4.c
+++ b/ds4.c
@@ -14968,6 +14968,44 @@ static void print_vec_stats(const char *name, const float *x, uint64_t n) {
 
 enum { DS4_STREAMING_PREFILL_CACHE_SEED_MAX_TOKENS = 64 };
 
+enum {
+    DS4_ROCM_EVENT_SEG_INPUT = 0,
+    DS4_ROCM_EVENT_SEG_BEFORE_SAMPLE,
+    DS4_ROCM_EVENT_SEG_QKV_PREP,
+    DS4_ROCM_EVENT_SEG_COMPRESSOR_INDEXER,
+    DS4_ROCM_EVENT_SEG_ATTN_CORE,
+    DS4_ROCM_EVENT_SEG_ATTN_OUTPUT,
+    DS4_ROCM_EVENT_SEG_ATTN_HC_POST,
+    DS4_ROCM_EVENT_SEG_FFN_ROUTER,
+    DS4_ROCM_EVENT_SEG_ROUTED_MOE,
+    DS4_ROCM_EVENT_SEG_SHARED_POST,
+    DS4_ROCM_EVENT_SEG_AFTER_SAMPLE,
+    DS4_ROCM_EVENT_SEG_OUTPUT_HEAD,
+    DS4_ROCM_EVENT_SEG_COPYBACK,
+    DS4_ROCM_EVENT_SEG_COUNT,
+};
+
+enum {
+    DS4_ROCM_EVENT_GROUP_UNCOMPRESSED = 0,
+    DS4_ROCM_EVENT_GROUP_RATIO4,
+    DS4_ROCM_EVENT_GROUP_RATIO128,
+    DS4_ROCM_EVENT_GROUP_COUNT,
+};
+
+typedef struct {
+    uint64_t samples;
+    uint64_t dropped;
+    double host_ms;
+    uint64_t n_raw;
+    uint64_t n_comp;
+    double segment_ms[DS4_ROCM_EVENT_SEG_COUNT];
+    uint64_t group_samples[DS4_ROCM_EVENT_GROUP_COUNT];
+    uint64_t group_emit_samples[DS4_ROCM_EVENT_GROUP_COUNT];
+    double group_segment_ms[DS4_ROCM_EVENT_GROUP_COUNT]
+                           [DS4_ROCM_EVENT_SEG_COUNT];
+    uint64_t direct_mask_samples[8];
+} ds4_rocm_event_profile_stats;
+
 typedef struct {
     /* Class P — per-tier replicated kernel scratch buffers.
      * Each used tier has its own copy; active_tier names the slot the
@@ -15235,6 +15273,23 @@ typedef struct {
     bool decode_stage_profile;
     bool decode_index_stage_profile;
     bool output_stage_profile;
+    bool rocm_event_profile;
+    bool rocm_event_profile_failed;
+    bool rocm_event_profile_active;
+    bool rocm_event_profile_layer_active;
+    bool rocm_event_profile_range_valid;
+    uint32_t rocm_event_profile_interval;
+    uint32_t rocm_event_profile_range_start;
+    uint32_t rocm_event_profile_range_end;
+    uint32_t rocm_event_profile_sample_layer;
+    uint32_t rocm_event_profile_sample_ratio;
+    uint32_t rocm_event_profile_sample_n_raw;
+    uint32_t rocm_event_profile_sample_n_comp;
+    uint32_t rocm_event_profile_sample_direct_mask;
+    bool rocm_event_profile_sample_emit;
+    uint64_t rocm_event_profile_sequence;
+    ds4_gpu_timing_sample rocm_event_profile_sample;
+    ds4_rocm_event_profile_stats rocm_event_profile_stats;
     ds4_gpu_tensor *tp_peer_tmp_by_tier[DS4_MAX_GPUS];
     uint32_t power_percent;
     double prefill_layer_avg_sec[DS4_MAX_LAYER];
@@ -15269,6 +15324,281 @@ typedef struct {
     ds4_gpu_tensor *tp_zero;
     ds4_gpu_tensor *tp_logits_half;
 } ds4_gpu_graph;
+
+static bool metal_graph_rocm_event_profile_requested(void) {
+#ifdef DS4_ROCM_BUILD
+    const char *value = getenv("DS4_ROCM_EVENT_PROFILE");
+    return value && strcmp(value, "1") == 0;
+#else
+    return false;
+#endif
+}
+
+static uint32_t metal_graph_rocm_event_profile_interval(void) {
+    const char *value = getenv("DS4_ROCM_EVENT_PROFILE_INTERVAL");
+    if (!value || !value[0]) return 32u;
+    char *end = NULL;
+    unsigned long parsed = strtoul(value, &end, 10);
+    while (end && isspace((unsigned char)*end)) end++;
+    if (end != value && end && *end == '\0' && parsed > 0 &&
+        parsed <= 1000000ul) {
+        return (uint32_t)parsed;
+    }
+    fprintf(stderr,
+            "ds4: invalid DS4_ROCM_EVENT_PROFILE_INTERVAL=%s; using 32\n",
+            value);
+    return 32u;
+}
+
+static uint32_t metal_graph_rocm_event_profile_group(uint32_t ratio) {
+    if (ratio == 4u) return DS4_ROCM_EVENT_GROUP_RATIO4;
+    if (ratio == 128u) return DS4_ROCM_EVENT_GROUP_RATIO128;
+    return DS4_ROCM_EVENT_GROUP_UNCOMPRESSED;
+}
+
+static const char *metal_graph_rocm_event_profile_group_name(uint32_t group) {
+    switch (group) {
+        case DS4_ROCM_EVENT_GROUP_RATIO4: return "4";
+        case DS4_ROCM_EVENT_GROUP_RATIO128: return "128";
+        default: return "0";
+    }
+}
+
+static void metal_graph_rocm_event_profile_drop(
+        ds4_gpu_graph *g,
+        const char    *where) {
+    if (!g) return;
+    ds4_gpu_timing_discard(&g->rocm_event_profile_sample);
+    g->rocm_event_profile_active = false;
+    g->rocm_event_profile_layer_active = false;
+    g->rocm_event_profile_stats.dropped++;
+    if (!g->rocm_event_profile_failed) {
+        fprintf(stderr,
+                "ds4: ROCm event profile disabled after %s failure; "
+                "inference continues\n",
+                where ? where : "timing");
+    }
+    g->rocm_event_profile_failed = true;
+}
+
+static bool metal_graph_rocm_event_profile_eligible(
+        const ds4_gpu_graph *g) {
+    return g && g->rocm_event_profile && !g->rocm_event_profile_failed &&
+           !g->ssd_streaming && !g->placement && g->active_tier == 0 &&
+           g->head_tier == 0 && g->tp_world <= 1u &&
+           !g->decode_stage_profile && !g->decode_index_stage_profile &&
+           !g->output_stage_profile &&
+           getenv("DS4_ROCM_DECODE_STAGE_PROFILE") == NULL &&
+           getenv("DS4_METAL_DECODE_STAGE_PROFILE") == NULL;
+}
+
+static void metal_graph_rocm_event_profile_print(ds4_gpu_graph *g);
+
+static void metal_graph_rocm_event_profile_prepare_range(
+        ds4_gpu_graph *g,
+        uint32_t       layer_start,
+        uint32_t       layer_end) {
+    if (!g) return;
+    const bool changed = g->rocm_event_profile_range_valid &&
+        (g->rocm_event_profile_range_start != layer_start ||
+         g->rocm_event_profile_range_end != layer_end);
+    if (changed) {
+        metal_graph_rocm_event_profile_print(g);
+        g->rocm_event_profile_sequence = 0;
+    }
+    if (!g->rocm_event_profile_range_valid || changed) {
+        g->rocm_event_profile_range_start = layer_start;
+        g->rocm_event_profile_range_end = layer_end;
+        g->rocm_event_profile_range_valid = true;
+    }
+}
+
+static uint32_t metal_graph_rocm_event_profile_choose_layer(
+        uint32_t layer_start,
+        uint32_t layer_end,
+        uint64_t sequence) {
+    const uint32_t count = layer_end - layer_start + 1u;
+    const uint64_t cycle = sequence / count;
+    const uint32_t slot = (uint32_t)(sequence % count);
+    const uint32_t shift = count > 2u ? ((count & 1u) ? 2u : 1u) : 1u;
+    const uint32_t offset =
+        (slot + (uint32_t)((cycle * shift) % count)) % count;
+    return layer_start + offset;
+}
+
+static bool metal_graph_rocm_event_profile_begin(
+        ds4_gpu_graph *g,
+        uint32_t       layer_start,
+        uint32_t       layer_end,
+        uint32_t       pos,
+        uint32_t       n_raw,
+        uint32_t       direct_mask) {
+    if (!metal_graph_rocm_event_profile_eligible(g) ||
+        layer_start > layer_end || layer_end >= DS4_N_LAYER) {
+        return false;
+    }
+    metal_graph_rocm_event_profile_prepare_range(g, layer_start, layer_end);
+    if (!ds4_gpu_timing_begin(&g->rocm_event_profile_sample)) {
+        metal_graph_rocm_event_profile_drop(g, "begin");
+        return false;
+    }
+    const uint32_t sample_layer = metal_graph_rocm_event_profile_choose_layer(
+        layer_start, layer_end, g->rocm_event_profile_sequence++);
+    const uint32_t ratio = ds4_layer_compress_ratio(sample_layer);
+    g->rocm_event_profile_sample_layer = sample_layer;
+    g->rocm_event_profile_sample_ratio = ratio;
+    g->rocm_event_profile_sample_n_raw = n_raw;
+    g->rocm_event_profile_sample_n_comp = g->layer_n_comp[sample_layer];
+    g->rocm_event_profile_sample_direct_mask = direct_mask & 7u;
+    g->rocm_event_profile_sample_emit =
+        ratio != 0u && ((pos + 1u) % ratio) == 0u;
+    g->rocm_event_profile_active = true;
+    g->rocm_event_profile_layer_active = false;
+    return true;
+}
+
+static void metal_graph_rocm_event_profile_mark(ds4_gpu_graph *g) {
+    if (!g || !g->rocm_event_profile_active) return;
+    if (!ds4_gpu_timing_mark(&g->rocm_event_profile_sample)) {
+        metal_graph_rocm_event_profile_drop(g, "mark");
+    }
+}
+
+static double metal_graph_rocm_event_profile_segment_sum(
+        const double *segments,
+        uint32_t      first,
+        uint32_t      last) {
+    double total = 0.0;
+    for (uint32_t i = first; i <= last; i++) total += segments[i];
+    return total;
+}
+
+static void metal_graph_rocm_event_profile_print(ds4_gpu_graph *g) {
+    ds4_rocm_event_profile_stats *stats = &g->rocm_event_profile_stats;
+    if (stats->samples == 0) return;
+    const double inv = 1.0 / (double)stats->samples;
+    const double stream0 = metal_graph_rocm_event_profile_segment_sum(
+        stats->segment_ms, 0, DS4_ROCM_EVENT_SEG_COUNT - 1u) * inv;
+    const double sampled = metal_graph_rocm_event_profile_segment_sum(
+        stats->segment_ms,
+        DS4_ROCM_EVENT_SEG_QKV_PREP,
+        DS4_ROCM_EVENT_SEG_SHARED_POST) * inv;
+    const double unsampled =
+        (stats->segment_ms[DS4_ROCM_EVENT_SEG_BEFORE_SAMPLE] +
+         stats->segment_ms[DS4_ROCM_EVENT_SEG_AFTER_SAMPLE]) * inv;
+    const double host = stats->host_ms * inv;
+    fprintf(stderr,
+            "ds4: ROCm event profile: samples=%llu dropped=%llu layers=%u:%u "
+            "stream0=%.3fms host=%.3fms host_minus_stream0=%.3fms "
+            "input=%.3fms unsampled=%.3fms sampled_layer=%.3fms "
+            "qkv=%.3fms compressor_indexer=%.3fms attn_core=%.3fms "
+            "attn_output=%.3fms attn_hc=%.3fms ffn_router=%.3fms "
+            "routed_moe=%.3fms shared_post=%.3fms output_head=%.3fms "
+            "copyback=%.3fms n_raw=%.1f n_comp=%.1f "
+            "direct0=%llu direct1=%llu direct2=%llu direct3=%llu "
+            "direct4=%llu direct5=%llu direct6=%llu direct7=%llu\n",
+            (unsigned long long)stats->samples,
+            (unsigned long long)stats->dropped,
+            g->rocm_event_profile_range_start,
+            g->rocm_event_profile_range_end,
+            stream0,
+            host,
+            host - stream0,
+            stats->segment_ms[DS4_ROCM_EVENT_SEG_INPUT] * inv,
+            unsampled,
+            sampled,
+            stats->segment_ms[DS4_ROCM_EVENT_SEG_QKV_PREP] * inv,
+            stats->segment_ms[DS4_ROCM_EVENT_SEG_COMPRESSOR_INDEXER] * inv,
+            stats->segment_ms[DS4_ROCM_EVENT_SEG_ATTN_CORE] * inv,
+            stats->segment_ms[DS4_ROCM_EVENT_SEG_ATTN_OUTPUT] * inv,
+            stats->segment_ms[DS4_ROCM_EVENT_SEG_ATTN_HC_POST] * inv,
+            stats->segment_ms[DS4_ROCM_EVENT_SEG_FFN_ROUTER] * inv,
+            stats->segment_ms[DS4_ROCM_EVENT_SEG_ROUTED_MOE] * inv,
+            stats->segment_ms[DS4_ROCM_EVENT_SEG_SHARED_POST] * inv,
+            stats->segment_ms[DS4_ROCM_EVENT_SEG_OUTPUT_HEAD] * inv,
+            stats->segment_ms[DS4_ROCM_EVENT_SEG_COPYBACK] * inv,
+            (double)stats->n_raw * inv,
+            (double)stats->n_comp * inv,
+            (unsigned long long)stats->direct_mask_samples[0],
+            (unsigned long long)stats->direct_mask_samples[1],
+            (unsigned long long)stats->direct_mask_samples[2],
+            (unsigned long long)stats->direct_mask_samples[3],
+            (unsigned long long)stats->direct_mask_samples[4],
+            (unsigned long long)stats->direct_mask_samples[5],
+            (unsigned long long)stats->direct_mask_samples[6],
+            (unsigned long long)stats->direct_mask_samples[7]);
+
+    for (uint32_t group = 0; group < DS4_ROCM_EVENT_GROUP_COUNT; group++) {
+        const uint64_t count = stats->group_samples[group];
+        if (count == 0) continue;
+        const double group_inv = 1.0 / (double)count;
+        const double *segments = stats->group_segment_ms[group];
+        const double layer = metal_graph_rocm_event_profile_segment_sum(
+            segments,
+            DS4_ROCM_EVENT_SEG_QKV_PREP,
+            DS4_ROCM_EVENT_SEG_SHARED_POST) * group_inv;
+        fprintf(stderr,
+                "ds4: ROCm event profile group: ratio=%s samples=%llu "
+                "emit=%llu sampled_layer=%.3fms qkv=%.3fms "
+                "compressor_indexer=%.3fms attn_core=%.3fms "
+                "attn_output=%.3fms attn_hc=%.3fms ffn_router=%.3fms "
+                "routed_moe=%.3fms shared_post=%.3fms\n",
+                metal_graph_rocm_event_profile_group_name(group),
+                (unsigned long long)count,
+                (unsigned long long)stats->group_emit_samples[group],
+                layer,
+                segments[DS4_ROCM_EVENT_SEG_QKV_PREP] * group_inv,
+                segments[DS4_ROCM_EVENT_SEG_COMPRESSOR_INDEXER] * group_inv,
+                segments[DS4_ROCM_EVENT_SEG_ATTN_CORE] * group_inv,
+                segments[DS4_ROCM_EVENT_SEG_ATTN_OUTPUT] * group_inv,
+                segments[DS4_ROCM_EVENT_SEG_ATTN_HC_POST] * group_inv,
+                segments[DS4_ROCM_EVENT_SEG_FFN_ROUTER] * group_inv,
+                segments[DS4_ROCM_EVENT_SEG_ROUTED_MOE] * group_inv,
+                segments[DS4_ROCM_EVENT_SEG_SHARED_POST] * group_inv);
+    }
+    memset(stats, 0, sizeof(*stats));
+}
+
+static void metal_graph_rocm_event_profile_record(
+        ds4_gpu_graph *g,
+        uint32_t       layer_start,
+        uint32_t       layer_end,
+        const float   *segments,
+        uint32_t       segment_count,
+        double         host_ms) {
+    if (!g || !segments || segment_count != DS4_ROCM_EVENT_SEG_COUNT ||
+        !isfinite(host_ms) || host_ms < 0.0 ||
+        !g->rocm_event_profile_range_valid ||
+        layer_start != g->rocm_event_profile_range_start ||
+        layer_end != g->rocm_event_profile_range_end) {
+        metal_graph_rocm_event_profile_drop(g, "record shape");
+        return;
+    }
+    for (uint32_t i = 0; i < segment_count; i++) {
+        if (!isfinite(segments[i]) || segments[i] < 0.0f) {
+            metal_graph_rocm_event_profile_drop(g, "record value");
+            return;
+        }
+    }
+    ds4_rocm_event_profile_stats *stats = &g->rocm_event_profile_stats;
+    stats->samples++;
+    stats->host_ms += host_ms;
+    stats->n_raw += g->rocm_event_profile_sample_n_raw;
+    stats->n_comp += g->rocm_event_profile_sample_n_comp;
+    const uint32_t group = metal_graph_rocm_event_profile_group(
+        g->rocm_event_profile_sample_ratio);
+    stats->group_samples[group]++;
+    if (g->rocm_event_profile_sample_emit)
+        stats->group_emit_samples[group]++;
+    stats->direct_mask_samples[g->rocm_event_profile_sample_direct_mask]++;
+    for (uint32_t i = 0; i < segment_count; i++) {
+        stats->segment_ms[i] += segments[i];
+        stats->group_segment_ms[group][i] += segments[i];
+    }
+    if (stats->samples >= g->rocm_event_profile_interval) {
+        metal_graph_rocm_event_profile_print(g);
+    }
+}
 
 /* Tensors that are temporary for chunked prefill and grouped multi-session
  * decode. The batched server serializes every operation that uses them, so one
@@ -15735,6 +16065,11 @@ static void metal_graph_free(ds4_gpu_graph *g) {
      * no-op. The hc_pre / hc_post / hc_comb views must be freed BEFORE
      * their parent hc_split — view destruction releases its own struct
      * but does not touch the parent's memory. */
+    if (g && g->rocm_event_profile_active) {
+        ds4_gpu_timing_discard(&g->rocm_event_profile_sample);
+        g->rocm_event_profile_active = false;
+        g->rocm_event_profile_layer_active = false;
+    }
     metal_graph_free_prefill_workspace(g);
     for (int t = 0; t < DS4_MAX_GPUS; t++) {
         ds4_gpu_tensor_free(g->directional_steering_dirs_by_tier[t]);
@@ -16858,7 +17193,8 @@ static bool metal_graph_alloc_raw_cap(
         uint32_t                raw_cap,
         uint32_t                ctx_size,
         uint32_t                prefill_cap,
-        bool                    enable_mtp,
+        bool                    enable_mtp_draft,
+        bool                    enable_spec_verify,
         const int              *placement,
         bool                    cuda_tensor_parallel,
         const ds4_gpu_graph    *shared_prefill_workspace) {
@@ -16906,13 +17242,24 @@ static bool metal_graph_alloc_raw_cap(
     g->decode_stage_profile = getenv("DS4_METAL_DECODE_STAGE_PROFILE") != NULL;
     g->decode_index_stage_profile = getenv("DS4_METAL_INDEXER_STAGE_PROFILE") != NULL;
     g->output_stage_profile = getenv("DS4_METAL_OUTPUT_STAGE_PROFILE") != NULL;
+    g->rocm_event_profile = metal_graph_rocm_event_profile_requested();
+    g->rocm_event_profile_interval =
+        metal_graph_rocm_event_profile_interval();
+    if (g->rocm_event_profile) {
+        fprintf(stderr,
+                "ds4: ROCm event profile enabled: interval=%u, "
+                "single-tier resident decode only\n",
+                g->rocm_event_profile_interval);
+    }
     const bool enable_splitkv_spec = metal_graph_cuda_splitkv_spec_requested();
     const bool enable_splitkv_batch_verify =
         enable_splitkv_spec && metal_graph_cuda_splitkv_spec_batch_verify_requested();
-    const bool enable_spec_logits = enable_mtp || enable_splitkv_batch_verify;
-    const bool enable_prefix1_snapshot = enable_mtp || enable_splitkv_spec;
+    const bool enable_spec_logits =
+        enable_spec_verify || enable_splitkv_batch_verify;
+    const bool enable_prefix1_snapshot =
+        enable_spec_verify || enable_splitkv_spec;
     const bool enable_frontier_snapshot =
-        enable_mtp ||
+        enable_spec_verify ||
         enable_splitkv_spec ||
         (metal_graph_cuda_greedy_splitkv_requested() &&
          metal_graph_cuda_greedy_splitkv_fallback_requested()) ||
@@ -16939,7 +17286,7 @@ static bool metal_graph_alloc_raw_cap(
                 "ds4: CUDA routed MoE expert ownership enabled "
                 "(half-resident decode and prefill)\n");
     }
-    g->mtp_enabled = enable_mtp;
+    g->mtp_enabled = enable_mtp_draft;
     if (raw_cap == 0) raw_cap = 1;
     if (ctx_size == 0) ctx_size = raw_cap;
     if (prefill_cap == 0) prefill_cap = 1;
@@ -17292,7 +17639,7 @@ static bool metal_graph_alloc_raw_cap(
      * buffers as the plain decoder: no support-model mapping, no draft logits,
      * and no MTP scratch hidden behind otherwise unused tensors.
      */
-    if (enable_mtp) {
+    if (enable_mtp_draft) {
         g->mtp_embed = ds4_gpu_tensor_alloc((uint64_t)DS4_N_EMBD * sizeof(float));
         g->mtp_enorm = ds4_gpu_tensor_alloc((uint64_t)DS4_N_EMBD * sizeof(float));
         g->mtp_eproj = ds4_gpu_tensor_alloc((uint64_t)DS4_N_EMBD * sizeof(float));
@@ -17482,7 +17829,7 @@ static bool metal_graph_alloc_raw_cap(
                     metal_graph_output_pre(g) && metal_graph_output_weights(g) &&
                     metal_graph_output_embd(g) && metal_graph_output_norm(g) &&
                     metal_graph_logits(g) && output_tp_ok &&
-                    (!enable_mtp ||
+                    (!enable_mtp_draft ||
                      (g->mtp_embed && g->mtp_enorm && g->mtp_eproj &&
                       g->mtp_eproj_hc && g->mtp_hnorm_hc && g->mtp_hproj_hc &&
                       g->mtp_input_hc && g->mtp_state_hc && g->mtp_next_hc &&
@@ -17504,7 +17851,7 @@ static bool metal_graph_alloc(
     /* single-tier convenience wrapper; placement=NULL routes
      * all per-layer allocations to tier 0. */
     return metal_graph_alloc_raw_cap(g, weights, layer, DS4_N_SWA, DS4_N_SWA,
-                                     1, false, NULL, false, NULL);
+                                     1, false, false, NULL, false, NULL);
 }
 
 static bool metal_graph_install_model_spans(
@@ -19645,6 +19992,8 @@ static bool metal_graph_capture_prefix_attn_state(
      * frontier; mirror spec_frontier_snapshot/commit which skip them. */
     if (ds4_layer_compress_ratio(il) == 0) return true;
     if (slot >= DS4_SPEC_PREFIX_SLOTS ||
+        !g->layer_attn_state_kv[il] ||
+        !g->layer_attn_state_score[il] ||
         !g->spec_prefix1_attn_state_kv[il] ||
         !g->spec_prefix1_attn_state_score[il]) {
         return false;
@@ -19667,6 +20016,8 @@ static bool metal_graph_capture_prefix_index_state(
      * mirror spec_frontier_snapshot/commit which skip the rest. */
     if (ds4_layer_compress_ratio(il) != 4) return true;
     if (slot >= DS4_SPEC_PREFIX_SLOTS ||
+        !g->layer_index_state_kv[il] ||
+        !g->layer_index_state_score[il] ||
         !g->spec_prefix1_index_state_kv[il] ||
         !g->spec_prefix1_index_state_score[il]) {
         return false;
@@ -20311,8 +20662,23 @@ static bool metal_graph_q4_selected_paths_allowed(const ds4_gpu_graph *g) {
 static bool metal_graph_use_iq2_selected_shared_overlap(const ds4_gpu_graph *g) {
     return g &&
            g->ssd_streaming &&
-           getenv("DS4_METAL_DISABLE_STREAMING_SELECTED_SHARED_OVERLAP") == NULL &&
-           getenv("DS4_METAL_DISABLE_IQ2_SELECTED_SHARED_OVERLAP") == NULL;
+           !glm_graph_env_present("DS4_ROCM_DISABLE_STREAMING_SELECTED_SHARED_OVERLAP",
+                                  "DS4_METAL_DISABLE_STREAMING_SELECTED_SHARED_OVERLAP") &&
+           !glm_graph_env_present("DS4_ROCM_DISABLE_IQ2_SELECTED_SHARED_OVERLAP",
+                                  "DS4_METAL_DISABLE_IQ2_SELECTED_SHARED_OVERLAP");
+}
+
+static bool metal_graph_use_rocm_selected_shared_overlap(
+        const ds4_gpu_graph *g) {
+#ifdef DS4_ROCM_BUILD
+    return g &&
+           g->ssd_streaming &&
+           !glm_graph_env_present("DS4_ROCM_DISABLE_STREAMING_SELECTED_SHARED_OVERLAP",
+                                  "DS4_METAL_DISABLE_STREAMING_SELECTED_SHARED_OVERLAP");
+#else
+    (void)g;
+    return false;
+#endif
 }
 
 static bool metal_graph_use_iq2_selected_async_load(const ds4_gpu_graph *g) {
@@ -20458,6 +20824,7 @@ static bool metal_graph_decode_iq2_selected_slots_expected(
 static bool metal_graph_decode_mxfp4_selected_slots_expected(
         const ds4_gpu_graph     *g,
         const ds4_layer_weights *layer) {
+#if defined(__APPLE__) || defined(DS4_ROCM_BUILD)
     return g &&
            g->ssd_streaming &&
            !g->quality &&
@@ -20470,7 +20837,13 @@ static bool metal_graph_decode_mxfp4_selected_slots_expected(
                                   "DS4_METAL_MOE_WRITE_CLAMPED_ACT") &&
            !glm_graph_env_present("DS4_ROCM_DISABLE_ROUTED_PAIR_SWIGLU_FUSION",
                                   "DS4_METAL_DISABLE_ROUTED_PAIR_SWIGLU_FUSION") &&
-           getenv("DS4_METAL_DISABLE_MXFP4_SELECTED_EXPERT_VIEWS") == NULL;
+           !glm_graph_env_present("DS4_ROCM_DISABLE_MXFP4_SELECTED_EXPERT_VIEWS",
+                                  "DS4_METAL_DISABLE_MXFP4_SELECTED_EXPERT_VIEWS");
+#else
+    (void)g;
+    (void)layer;
+    return false;
+#endif
 }
 
 static bool metal_graph_streaming_expert_cache_seed_layer_expected(
@@ -20484,7 +20857,11 @@ static bool metal_graph_streaming_expert_cache_seed_layer_expected(
         !layer->ffn_down_exps) {
         return false;
     }
-    if (metal_graph_decode_iq2_selected_slots_expected(g, layer) ||
+    if (metal_graph_decode_q4_selected_slots_expected(g,
+                                                      layer,
+                                                      layer->ffn_gate_exps->bytes,
+                                                      layer->ffn_down_exps->bytes) ||
+        metal_graph_decode_iq2_selected_slots_expected(g, layer) ||
         metal_graph_decode_mxfp4_selected_slots_expected(g, layer)) return true;
     if (DS4_MODEL_FAMILY == DS4_MODEL_FAMILY_GLM_DSA &&
         !g->quality &&
@@ -21952,6 +22329,11 @@ static bool metal_graph_encode_decode_layer_phase(
             ok = metal_graph_layer_stage_profile_boundary("decode", (name), il, pos, 1, &decode_stage_t0); \
         } \
     } while (0)
+#define DS4_ROCM_EVENT_PROFILE_MARK() do { \
+        if (ok && g->rocm_event_profile_layer_active) { \
+            metal_graph_rocm_event_profile_mark(g); \
+        } \
+    } while (0)
     const bool tp_ablate_hcpre = metal_graph_tp_ablate("hcpre");
     /* Decode-island CUDA graph capture (design ported from the Entrpi/ds4
      * batched-serving fork).  Two position-independent islands of the
@@ -22578,6 +22960,7 @@ static bool metal_graph_encode_decode_layer_phase(
             metal_graph_debug_dump_tensor("KVcur", metal_graph_kv(g), DS4_N_HEAD_DIM, il, pos);
         }
     }
+    DS4_ROCM_EVENT_PROFILE_MARK();
 
     uint32_t n_comp = 0;
     ds4_gpu_tensor *comp_cache = NULL;
@@ -23053,6 +23436,7 @@ static bool metal_graph_encode_decode_layer_phase(
         comp_cache = g->layer_attn_comp_cache[il];
     }
     DS4_METAL_PROFILE_DECODE_STAGE("compressor_indexer");
+    DS4_ROCM_EVENT_PROFILE_MARK();
 
     if (stop_before_attn) return ok;
     if (ok) {
@@ -23305,6 +23689,7 @@ static bool metal_graph_encode_decode_layer_phase(
                                       DS4_ROPE_YARN_BETA_SLOW) != 0;
     }
     DS4_METAL_PROFILE_DECODE_STAGE("attn_inv_rope");
+    DS4_ROCM_EVENT_PROFILE_MARK();
     if (ok && !cuda_tp_attn_heads_active) {
         metal_graph_debug_dump_tensor("kqv_back", metal_graph_heads(g), q_dim, il, pos);
     }
@@ -23590,6 +23975,7 @@ static bool metal_graph_encode_decode_layer_phase(
         }
     }
     DS4_METAL_PROFILE_DECODE_STAGE("attn_output");
+    DS4_ROCM_EVENT_PROFILE_MARK();
     if (ok) {
         metal_graph_debug_dump_tensor("attn_low", metal_graph_attn_low(g), (uint64_t)n_groups * rank, il, pos);
     }
@@ -23620,6 +24006,7 @@ static bool metal_graph_encode_decode_layer_phase(
         }
     }
     DS4_METAL_PROFILE_DECODE_STAGE("attn_hc_post");
+    DS4_ROCM_EVENT_PROFILE_MARK();
     if (ok) {
         metal_graph_debug_dump_tensor("hc_attn_post", metal_graph_after_attn_hc(g), hc_dim, il, pos);
     }
@@ -23857,6 +24244,7 @@ static bool metal_graph_encode_decode_layer_phase(
                                                                    g);
     }
     DS4_METAL_PROFILE_DECODE_STAGE("router");
+    DS4_ROCM_EVENT_PROFILE_MARK();
     if (ok) ok = metal_graph_profile_router_selection(g, layer, il, pos);
     if (ok) {
         metal_graph_debug_dump_tensor("ffn_moe_logits", metal_graph_router_logits(g), DS4_N_EXPERT, il, pos);
@@ -24301,7 +24689,8 @@ static bool metal_graph_encode_decode_layer_phase(
      * needs the unfused gate/up/swiglu/down sequence. */
     const bool tp_split_shared = g->tp_world == 2;
     const bool q4_selected_shared_overlap =
-        metal_graph_use_q4_selected_shared_overlap(g) &&
+        (metal_graph_use_q4_selected_shared_overlap(g) ||
+         metal_graph_use_rocm_selected_shared_overlap(g)) &&
         metal_graph_decode_q4_selected_slots_expected(g,
                                                       layer,
                                                       layer->ffn_gate_exps->bytes,
@@ -24310,7 +24699,8 @@ static bool metal_graph_encode_decode_layer_phase(
         metal_graph_use_iq2_selected_shared_overlap(g) &&
         metal_graph_decode_iq2_selected_slots_expected(g, layer);
     const bool mxfp4_selected_shared_overlap =
-        metal_graph_use_iq2_selected_shared_overlap(g) &&
+        (metal_graph_use_iq2_selected_shared_overlap(g) ||
+         metal_graph_use_rocm_selected_shared_overlap(g)) &&
         metal_graph_decode_mxfp4_selected_slots_expected(g, layer);
     const bool cuda_selected_shared_overlap =
         metal_graph_use_cuda_selected_shared_overlap(g) &&
@@ -24750,6 +25140,7 @@ static bool metal_graph_encode_decode_layer_phase(
 #endif
     }
     DS4_METAL_PROFILE_DECODE_STAGE("routed_moe");
+    DS4_ROCM_EVENT_PROFILE_MARK();
     if (ok) {
         metal_graph_debug_dump_tensor("ffn_moe_gate_clamped", metal_graph_routed_gate(g),
                                       (uint64_t)DS4_N_EXPERT_USED * down_in_dim, il, pos);
@@ -25090,6 +25481,8 @@ static bool metal_graph_encode_decode_layer_phase(
                                                   DS4_N_HC) != 0;
     }
     DS4_METAL_PROFILE_DECODE_STAGE("ffn_hc_post");
+    DS4_ROCM_EVENT_PROFILE_MARK();
+#undef DS4_ROCM_EVENT_PROFILE_MARK
 #undef DS4_METAL_PROFILE_DECODE_STAGE
     if (ok) {
         metal_graph_debug_dump_tensor("hc_ffn_post", metal_graph_after_ffn_hc(g), hc_dim, il, pos);
@@ -30781,6 +31174,12 @@ static bool metal_graph_streaming_decode_prefill_wide_default(
         return false;
     }
     const uint32_t type = weights->layer[0].ffn_gate_exps->type;
+#if defined(DS4_ROCM_BUILD)
+    /* The first ROCm MXFP4 path uses resident expert tables. Keep streamed
+     * decode-prefill on the conservative path until pointer-table kernels
+     * cover type 39 as well. */
+    if (type == DS4_TENSOR_MXFP4) return false;
+#endif
     return (type == DS4_TENSOR_Q4_K || type == DS4_TENSOR_MXFP4) &&
            weights->layer[0].ffn_up_exps->type == type &&
            weights->layer[0].ffn_down_exps->type == type;
@@ -34063,6 +34462,7 @@ static bool imatrix_collector_save(
 static bool metal_graph_reset_prefill_state(ds4_gpu_graph *g) {
     memset(g->layer_n_comp, 0, sizeof(g->layer_n_comp));
     memset(g->layer_n_index_comp, 0, sizeof(g->layer_n_index_comp));
+    g->spec_capture_prefixes = false;
     g->mtp_n_raw = 0;
     metal_graph_dspark_cache_reset(g);
     metal_graph_dspark_capture_invalidate(g);
@@ -35715,8 +36115,13 @@ static bool metal_graph_verify_decode2_exact(
                                              metal_graph_raw_span_for_batch(g, pos0, 1),
                                              token0);
         if (!ok) break;
-        ok = metal_graph_capture_prefix_attn_state(g, il, 0) &&
-             metal_graph_capture_prefix_index_state(g, il, 0);
+        const uint32_t ratio = ds4_layer_compress_ratio(il);
+        if (ratio != 0) {
+            ok = metal_graph_capture_prefix_attn_state(g, il, 0);
+        }
+        if (ok && ratio == 4) {
+            ok = metal_graph_capture_prefix_index_state(g, il, 0);
+        }
         if (!ok) break;
 
         g->cur_hc_by_tier[this_tier] = cur1_by_tier[this_tier];
@@ -36514,7 +36919,8 @@ static int metal_graph_prompt_logits_test(
     /* diagnostic single-tier callsite; placement=NULL. */
     bool ok = metal_graph_alloc_raw_cap(&g, weights, &weights->layer[0],
                                         raw_cap, (uint32_t)ctx_size,
-                                        (uint32_t)n_test, false, NULL, false, NULL);
+                                        (uint32_t)n_test, false, false,
+                                        NULL, false, NULL);
     if (!ok) {
         metal_graph_free(&g);
         fprintf(stderr, "ds4: failed to initialize Metal graph prompt test runtime\n");
@@ -36877,6 +37283,7 @@ struct ds4_engine {
     bool ssd_streaming_cold;
     bool ssd_streaming_full_layers_set;
     ds4_distributed_options distributed;
+    ds4_dist_coordinator *dist_coordinator;
     ds4_engine_tp_state tp;
     bool metal_ready;
     bool mtp_ready;
@@ -48473,7 +48880,8 @@ static int generate_metal_graph_raw_swa(
     /* diagnostic single-tier callsite; placement=NULL. */
     bool ok = metal_graph_alloc_raw_cap(&g, weights, &weights->layer[0],
                                         raw_cap, (uint32_t)ctx_size,
-                                        prefill_cap, false, NULL, false, NULL);
+                                        prefill_cap, false, false,
+                                        NULL, false, NULL);
     if (!ok) {
         fprintf(stderr, "ds4: failed to allocate GPU graph runtime\n");
         return 1;
@@ -49286,6 +49694,12 @@ struct ds4_session {
     float *glm_mtp_hc;
     float *glm_mtp_logits0;
     ds4_spec_frontier greedy_splitkv_anchor;
+    ds4_spec_frontier slice_spec_frontier;
+    int slice_spec_checkpoint_len;
+    bool slice_spec_checkpoint_valid;
+    bool slice_spec_pending;
+    bool slice_spec_saved_capture;
+    bool slice_spec_capture_prefixes;
 #endif
     ds4_kv_cache cpu_cache;
     ds4_cpu_decode_scratch cpu_scratch;
@@ -50965,7 +51379,7 @@ static bool ds4_engine_glm_mtp_spec_enabled(const ds4_engine *e) {
 
 bool ds4_engine_has_mtp(ds4_engine *e) {
     return e && e->backend != DS4_BACKEND_CPU &&
-           e->distributed.role == DS4_DISTRIBUTED_NONE &&
+           e->distributed.role != DS4_DISTRIBUTED_WORKER &&
            e->mtp_ready;
 }
 
@@ -50997,7 +51411,35 @@ static void spec_frontier_free(ds4_spec_frontier *f) {
     memset(f, 0, sizeof(*f));
 }
 
+static bool spec_frontier_layer_owned(const ds4_gpu_graph *g, uint32_t il) {
+    return g && il < DS4_N_LAYER && g->layer_raw_cache[il] != NULL;
+}
+
+static bool spec_frontier_prefix_capture_ready(const ds4_gpu_graph *g) {
+    if (!g) return false;
+    for (uint32_t il = 0; il < DS4_N_LAYER; il++) {
+        if (!spec_frontier_layer_owned(g, il)) continue;
+        const uint32_t ratio = ds4_layer_compress_ratio(il);
+        if (ratio == 0) continue;
+        if (!g->layer_attn_state_kv[il] ||
+            !g->layer_attn_state_score[il] ||
+            !g->spec_prefix1_attn_state_kv[il] ||
+            !g->spec_prefix1_attn_state_score[il]) {
+            return false;
+        }
+        if (ratio == 4 &&
+            (!g->layer_index_state_kv[il] ||
+             !g->layer_index_state_score[il] ||
+             !g->spec_prefix1_index_state_kv[il] ||
+             !g->spec_prefix1_index_state_score[il])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static bool spec_frontier_snapshot(ds4_spec_frontier *f, ds4_session *s) {
+    if (!f || !s) return false;
     memset(f, 0, sizeof(*f));
     ds4_gpu_graph *g = &s->graph;
     if (!metal_graph_dspark_cache_current_window_valid(g)) return false;
@@ -51010,16 +51452,32 @@ static bool spec_frontier_snapshot(ds4_spec_frontier *f, ds4_session *s) {
     for (uint32_t il = 0; ok && il < DS4_N_LAYER; il++) {
         f->n_comp[il] = g->layer_n_comp[il];
         f->n_index_comp[il] = g->layer_n_index_comp[il];
+        if (!spec_frontier_layer_owned(g, il)) continue;
         const uint32_t ratio = ds4_layer_compress_ratio(il);
         if (ratio == 0) continue;
+        if (!g->layer_attn_state_kv[il] ||
+            !g->layer_attn_state_score[il] ||
+            !g->spec_attn_state_kv[il] ||
+            !g->spec_attn_state_score[il]) {
+            ok = false;
+            break;
+        }
         const uint64_t ab = ds4_gpu_tensor_bytes(g->layer_attn_state_kv[il]);
-        ok = ds4_gpu_tensor_copy(g->spec_attn_state_kv[il], 0,
+        ok = ab != 0 &&
+             ds4_gpu_tensor_copy(g->spec_attn_state_kv[il], 0,
                                    g->layer_attn_state_kv[il], 0, ab) != 0 &&
              ds4_gpu_tensor_copy(g->spec_attn_state_score[il], 0,
                                    g->layer_attn_state_score[il], 0, ab) != 0;
         if (ratio == 4) {
+            if (!g->layer_index_state_kv[il] ||
+                !g->layer_index_state_score[il] ||
+                !g->spec_index_state_kv[il] ||
+                !g->spec_index_state_score[il]) {
+                ok = false;
+                break;
+            }
             const uint64_t ib = ds4_gpu_tensor_bytes(g->layer_index_state_kv[il]);
-            ok = ok &&
+            ok = ok && ib != 0 &&
                  ds4_gpu_tensor_copy(g->spec_index_state_kv[il], 0,
                                        g->layer_index_state_kv[il], 0, ib) != 0 &&
                  ds4_gpu_tensor_copy(g->spec_index_state_score[il], 0,
@@ -51035,6 +51493,7 @@ static bool spec_frontier_snapshot(ds4_spec_frontier *f, ds4_session *s) {
 }
 
 static bool spec_frontier_restore(ds4_spec_frontier *f, ds4_session *s) {
+    if (!f || !s) return false;
     ds4_gpu_graph *g = &s->graph;
     if (!metal_graph_dspark_cache_window_valid(g,
                                                f->dspark_cache_token_start,
@@ -51050,18 +51509,35 @@ static bool spec_frontier_restore(ds4_spec_frontier *f, ds4_session *s) {
                                                  f->dspark_cache_len);
     }
     for (uint32_t il = 0; ok && il < DS4_N_LAYER; il++) {
+        if (!spec_frontier_layer_owned(g, il)) continue;
         g->layer_n_comp[il] = f->n_comp[il];
         g->layer_n_index_comp[il] = f->n_index_comp[il];
         const uint32_t ratio = ds4_layer_compress_ratio(il);
         if (ratio == 0) continue;
+        if (!g->layer_attn_state_kv[il] ||
+            !g->layer_attn_state_score[il] ||
+            !g->spec_attn_state_kv[il] ||
+            !g->spec_attn_state_score[il]) {
+            ok = false;
+            break;
+        }
         const uint64_t ab = ds4_gpu_tensor_bytes(g->layer_attn_state_kv[il]);
-        ok = ds4_gpu_tensor_copy(g->layer_attn_state_kv[il], 0,
+        ok = ab != 0 &&
+             ds4_gpu_tensor_copy(g->layer_attn_state_kv[il], 0,
                                    g->spec_attn_state_kv[il], 0, ab) != 0 &&
              ds4_gpu_tensor_copy(g->layer_attn_state_score[il], 0,
                                    g->spec_attn_state_score[il], 0, ab) != 0;
         if (ok && ratio == 4) {
+            if (!g->layer_index_state_kv[il] ||
+                !g->layer_index_state_score[il] ||
+                !g->spec_index_state_kv[il] ||
+                !g->spec_index_state_score[il]) {
+                ok = false;
+                break;
+            }
             const uint64_t ib = ds4_gpu_tensor_bytes(g->layer_index_state_kv[il]);
-            ok = ds4_gpu_tensor_copy(g->layer_index_state_kv[il], 0,
+            ok = ib != 0 &&
+                 ds4_gpu_tensor_copy(g->layer_index_state_kv[il], 0,
                                        g->spec_index_state_kv[il], 0, ib) != 0 &&
                  ds4_gpu_tensor_copy(g->layer_index_state_score[il], 0,
                                        g->spec_index_state_score[il], 0, ib) != 0;
@@ -51084,25 +51560,69 @@ static bool spec_frontier_commit_prefix(ds4_session *s, uint32_t prefix_len) {
     ds4_gpu_graph *g = &s->graph;
     bool ok = ds4_gpu_begin_commands() != 0;
     for (uint32_t il = 0; ok && il < DS4_N_LAYER; il++) {
+        if (!spec_frontier_layer_owned(g, il)) continue;
         const uint32_t ratio = ds4_layer_compress_ratio(il);
         if (ratio == 0) continue;
 
+        if (!g->layer_attn_state_kv[il] ||
+            !g->layer_attn_state_score[il] ||
+            !g->spec_prefix1_attn_state_kv[il] ||
+            !g->spec_prefix1_attn_state_score[il]) {
+            ok = false;
+            break;
+        }
         g->layer_n_comp[il] = g->spec_prefix_n_comp[slot][il];
         const uint64_t ab = ds4_gpu_tensor_bytes(g->layer_attn_state_kv[il]);
         const uint64_t aoff = (uint64_t)slot * ab;
-        ok = ds4_gpu_tensor_copy(g->layer_attn_state_kv[il], 0,
+        ok = ab != 0 &&
+             ds4_gpu_tensor_copy(g->layer_attn_state_kv[il], 0,
                                    g->spec_prefix1_attn_state_kv[il], aoff, ab) != 0 &&
              ds4_gpu_tensor_copy(g->layer_attn_state_score[il], 0,
                                    g->spec_prefix1_attn_state_score[il], aoff, ab) != 0;
         if (ok && ratio == 4) {
+            if (!g->layer_index_state_kv[il] ||
+                !g->layer_index_state_score[il] ||
+                !g->spec_prefix1_index_state_kv[il] ||
+                !g->spec_prefix1_index_state_score[il]) {
+                ok = false;
+                break;
+            }
             g->layer_n_index_comp[il] =
                 g->spec_prefix_n_index_comp[slot][il];
             const uint64_t ib = ds4_gpu_tensor_bytes(g->layer_index_state_kv[il]);
             const uint64_t ioff = (uint64_t)slot * ib;
-            ok = ds4_gpu_tensor_copy(g->layer_index_state_kv[il], 0,
+            ok = ib != 0 &&
+                 ds4_gpu_tensor_copy(g->layer_index_state_kv[il], 0,
                                        g->spec_prefix1_index_state_kv[il], ioff, ib) != 0 &&
                  ds4_gpu_tensor_copy(g->layer_index_state_score[il], 0,
                                        g->spec_prefix1_index_state_score[il], ioff, ib) != 0;
+        }
+    }
+    if (ok) ok = ds4_gpu_end_commands() != 0;
+    else (void)ds4_gpu_synchronize();
+    return ok;
+}
+
+/* Save the live frontier after one exact verifier row.  The generic batch
+ * kernels capture these slots while replaying their compressor loop; a
+ * distributed verifier instead runs the ordinary one-token slice path for
+ * exact greedy equivalence and snapshots the same state between rows. */
+static bool spec_frontier_capture_prefix(ds4_session *s,
+                                         uint32_t prefix_len) {
+    if (!s || !s->graph.spec_capture_prefixes || prefix_len == 0 ||
+        prefix_len > DS4_SPEC_PREFIX_SLOTS) {
+        return false;
+    }
+    const uint32_t slot = prefix_len - 1u;
+    ds4_gpu_graph *g = &s->graph;
+    bool ok = ds4_gpu_begin_commands() != 0;
+    for (uint32_t il = 0; ok && il < DS4_N_LAYER; il++) {
+        if (!spec_frontier_layer_owned(g, il)) continue;
+        const uint32_t ratio = ds4_layer_compress_ratio(il);
+        if (ratio == 0) continue;
+        ok = metal_graph_capture_prefix_attn_state(g, il, slot);
+        if (ok && ratio == 4) {
+            ok = metal_graph_capture_prefix_index_state(g, il, slot);
         }
     }
     if (ok) ok = ds4_gpu_end_commands() != 0;
@@ -51122,6 +51642,148 @@ static void session_greedy_splitkv_reset(ds4_session *s) {
     spec_frontier_free(&s->greedy_splitkv_anchor);
 }
 #endif
+
+int ds4_session_speculative_begin(ds4_session *s,
+                                  bool capture_prefixes,
+                                  char *err,
+                                  size_t errlen) {
+    if (!s || !s->engine) {
+        if (errlen) snprintf(err, errlen, "missing speculative layer-slice session");
+        return 1;
+    }
+    if (ds4_session_is_cpu(s)) {
+        if (errlen) snprintf(err, errlen, "speculative layer-slice state requires the graph backend");
+        return 1;
+    }
+#ifdef DS4_NO_GPU
+    (void)capture_prefixes;
+    if (errlen) snprintf(err, errlen, "GPU support is not compiled in");
+    return 1;
+#else
+    if (ds4_session_is_glm(s)) {
+        if (errlen) snprintf(err, errlen, "speculative layer-slice state is not implemented for GLM");
+        return 1;
+    }
+    if (!s->checkpoint_valid) {
+        if (errlen) snprintf(err, errlen, "speculative layer-slice state requires a valid checkpoint");
+        return 1;
+    }
+    if (s->slice_spec_pending || s->graph.spec_capture_prefixes) {
+        if (errlen) snprintf(err, errlen, "a speculative layer-slice transaction is already active");
+        return 1;
+    }
+    if (capture_prefixes && !spec_frontier_prefix_capture_ready(&s->graph)) {
+        if (errlen) snprintf(err, errlen, "speculative prefix-capture buffers are unavailable for this slice");
+        return 1;
+    }
+    if (!spec_frontier_snapshot(&s->slice_spec_frontier, s)) {
+        if (errlen) snprintf(err, errlen, "failed to snapshot speculative layer-slice frontier");
+        return 1;
+    }
+
+    s->slice_spec_checkpoint_len = s->checkpoint.len;
+    s->slice_spec_checkpoint_valid = s->checkpoint_valid;
+    s->slice_spec_saved_capture = s->graph.spec_capture_prefixes;
+    s->slice_spec_capture_prefixes = capture_prefixes;
+    s->slice_spec_pending = true;
+    s->graph.spec_capture_prefixes = capture_prefixes;
+    return 0;
+#endif
+}
+
+int ds4_session_speculative_commit(ds4_session *s,
+                                   uint32_t keep_n,
+                                   char *err,
+                                   size_t errlen) {
+    if (!s || !s->engine) {
+        if (errlen) snprintf(err, errlen, "missing speculative layer-slice session");
+        return 1;
+    }
+#ifdef DS4_NO_GPU
+    (void)keep_n;
+    if (errlen) snprintf(err, errlen, "GPU support is not compiled in");
+    return 1;
+#else
+    if (!s->slice_spec_pending) {
+        if (errlen) snprintf(err, errlen, "no speculative layer-slice transaction is active");
+        return 1;
+    }
+    if (s->slice_spec_checkpoint_len < 0 ||
+        s->checkpoint.len < s->slice_spec_checkpoint_len) {
+        if (errlen) snprintf(err, errlen, "speculative layer-slice timeline moved before its snapshot");
+        return 1;
+    }
+    const uint32_t evaluated_n =
+        (uint32_t)(s->checkpoint.len - s->slice_spec_checkpoint_len);
+    if (evaluated_n == 0 || keep_n == 0 || keep_n > evaluated_n) {
+        if (errlen) snprintf(err, errlen,
+                             "invalid speculative prefix %u for %u evaluated rows",
+                             keep_n, evaluated_n);
+        return 1;
+    }
+
+    if (keep_n < evaluated_n) {
+        if (!s->slice_spec_capture_prefixes ||
+            keep_n > DS4_SPEC_PREFIX_SLOTS) {
+            if (errlen) snprintf(err, errlen,
+                                 "speculative prefix %u was not captured",
+                                 keep_n);
+            return 1;
+        }
+        if (!spec_frontier_commit_prefix(s, keep_n)) {
+            if (errlen) snprintf(err, errlen,
+                                 "failed to commit speculative prefix %u",
+                                 keep_n);
+            return 1;
+        }
+        s->checkpoint.len = s->slice_spec_checkpoint_len + (int)keep_n;
+        s->checkpoint_valid = true;
+        s->mtp_draft_valid = false;
+        ds4_session_dspark_capture_invalidate(s);
+        ds4_session_dspark_capture_note_checkpoint(s);
+    }
+
+    s->graph.spec_capture_prefixes = s->slice_spec_saved_capture;
+    s->slice_spec_pending = false;
+    s->slice_spec_capture_prefixes = false;
+    spec_frontier_free(&s->slice_spec_frontier);
+    return 0;
+#endif
+}
+
+int ds4_session_speculative_rollback(ds4_session *s,
+                                     char *err,
+                                     size_t errlen) {
+    if (!s || !s->engine) {
+        if (errlen) snprintf(err, errlen, "missing speculative layer-slice session");
+        return 1;
+    }
+#ifdef DS4_NO_GPU
+    if (errlen) snprintf(err, errlen, "GPU support is not compiled in");
+    return 1;
+#else
+    if (!s->slice_spec_pending) {
+        if (errlen) snprintf(err, errlen, "no speculative layer-slice transaction is active");
+        return 1;
+    }
+
+    const bool restored =
+        spec_frontier_restore(&s->slice_spec_frontier, s);
+    s->checkpoint.len = s->slice_spec_checkpoint_len;
+    s->checkpoint_valid = restored && s->slice_spec_checkpoint_valid;
+    s->mtp_draft_valid = false;
+    ds4_session_dspark_capture_invalidate(s);
+    s->graph.spec_capture_prefixes = s->slice_spec_saved_capture;
+    s->slice_spec_pending = false;
+    s->slice_spec_capture_prefixes = false;
+    spec_frontier_free(&s->slice_spec_frontier);
+    if (!restored) {
+        if (errlen) snprintf(err, errlen, "failed to restore speculative layer-slice frontier");
+        return 1;
+    }
+    return 0;
+#endif
+}
 
 uint64_t ds4_session_payload_bytes(ds4_session *s) {
     if (!s || !s->checkpoint_valid) return 0;
@@ -52314,7 +52976,8 @@ int ds4_engine_collect_imatrix(ds4_engine *e,
     /* diagnostic single-tier callsite; placement=NULL. */
     bool ok = metal_graph_alloc_raw_cap(&g, weights, &weights->layer[0],
                                         raw_cap, (uint32_t)ctx_size,
-                                        prefill_cap, false, NULL, false, NULL);
+                                        prefill_cap, false, false,
+                                        NULL, false, NULL);
     if (!ok) {
         fprintf(stderr, "ds4: failed to allocate imatrix Metal graph runtime\n");
         free(dataset);
@@ -57452,7 +58115,7 @@ static int ds4_engine_open_internal(ds4_engine **out,
     }
     if (opt->inspect_only) {
         if (opt->mtp_path && opt->mtp_path[0] &&
-            opt->distributed.role == DS4_DISTRIBUTED_NONE) {
+            opt->distributed.role != DS4_DISTRIBUTED_WORKER) {
             model_open(&e->mtp_model, opt->mtp_path, false, false);
             ds4_dspark_summary dspark = {0};
             e->support_kind =
@@ -57548,7 +58211,7 @@ static int ds4_engine_open_internal(ds4_engine **out,
         }
     }
     if (opt->mtp_path && opt->mtp_path[0] &&
-        opt->distributed.role == DS4_DISTRIBUTED_NONE) {
+        opt->distributed.role != DS4_DISTRIBUTED_WORKER) {
         if (e->ssd_streaming) {
             fprintf(stderr, "ds4: --ssd-streaming is not compatible with --mtp yet\n");
             ds4_engine_close(e);
@@ -57568,6 +58231,16 @@ static int ds4_engine_open_internal(ds4_engine **out,
                 e->support_kind = DS4_SUPPORT_NONE;
                 e->support_stages = 0;
             } else {
+                if (opt->distributed.role == DS4_DISTRIBUTED_COORDINATOR &&
+                    (!e->weights.token_embd ||
+                     !weights_have_output_head(&e->weights))) {
+                    fprintf(stderr,
+                            "ds4: distributed legacy MTP requires the coordinator "
+                            "to load token_embd.weight and the output head\n");
+                    ds4_engine_close(e);
+                    *out = NULL;
+                    return 1;
+                }
                 mtp_weights_bind(&e->mtp_weights, &e->mtp_model);
                 e->mtp_ready = true;
                 fprintf(stderr, "ds4: MTP support model loaded: %s (draft=%d)\n",
@@ -58319,6 +58992,8 @@ bool ds4_engine_is_glm_dsa(ds4_engine *e) {
 
 void ds4_engine_close(ds4_engine *e) {
     if (!e) return;
+    ds4_dist_coordinator_free(e->dist_coordinator);
+    e->dist_coordinator = NULL;
 #if !defined(DS4_NO_GPU) && defined(__APPLE__)
     if (e->tp.active) {
         ds4_gpu_tp_shutdown();
@@ -58600,6 +59275,7 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
         if (e->distributed.role == DS4_DISTRIBUTED_COORDINATOR) {
             char err[256];
             if (ds4_dist_session_create(&s->distributed,
+                                        &e->dist_coordinator,
                                         e,
                                         &e->distributed,
                                         s,
@@ -58634,10 +59310,12 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
         free(s);
         return 1;
     }
+    const bool need_mtp_draft = e->mtp_ready;
     const bool need_spec_verifier =
         e->mtp_ready ||
         (e->support_kind == DS4_SUPPORT_DSPARK && e->dspark) ||
-        e->tp.active; /* TP worker mirrors the leader's verify blocks */
+        e->tp.active || /* TP worker mirrors the leader's verify blocks */
+        e->distributed.role != DS4_DISTRIBUTED_NONE;
     const int *placement = e->multi_tier ? e->placement : NULL;
     const ds4_gpu_graph *shared_prefill_workspace =
         e->share_session_prefill_workspace &&
@@ -58647,6 +59325,7 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
     s->graph.dspark_exec_tier = e->multi_tier ? e->dspark_exec_tier : 0;
     if (!metal_graph_alloc_raw_cap(&s->graph, &e->weights, shape_layer,
                                    raw_cap, (uint32_t)ctx_size, s->prefill_cap,
+                                   need_mtp_draft,
                                    need_spec_verifier,
                                    placement,
                                    e->cuda_tensor_parallel,
@@ -58759,6 +59438,7 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
     if (e->distributed.role == DS4_DISTRIBUTED_COORDINATOR) {
         char err[256];
         if (ds4_dist_session_create(&s->distributed,
+                                    &e->dist_coordinator,
                                     e,
                                     &e->distributed,
                                     s,
@@ -59008,6 +59688,161 @@ int ds4_session_eval_output_head_from_hc(ds4_session *s,
 #endif
 }
 
+int ds4_session_eval_output_heads_from_hc(ds4_session *s,
+                                          const float *hidden_hc,
+                                          uint32_t n_tokens,
+                                          uint32_t selected_row,
+                                          float *row_logits,
+                                          char *err,
+                                          size_t errlen) {
+    if (!s || !s->engine || !hidden_hc || n_tokens == 0 ||
+        selected_row >= n_tokens || !row_logits) {
+        if (errlen) snprintf(err, errlen, "invalid batched output-head hidden-state input");
+        return 1;
+    }
+    if (!weights_have_output_head(&s->engine->weights)) {
+        if (errlen) snprintf(err, errlen, "output head is not loaded");
+        return 1;
+    }
+
+    const uint64_t hidden_dim = ds4_engine_hidden_f32_values(s->engine);
+    const uint64_t vocab_dim = (uint64_t)DS4_N_VOCAB;
+    if (n_tokens == 1) {
+        return ds4_session_eval_output_head_from_hc(s,
+                                                    hidden_hc,
+                                                    1,
+                                                    row_logits,
+                                                    err,
+                                                    errlen);
+    }
+    if (ds4_session_is_cpu(s)) {
+        for (uint32_t row = 0; row < n_tokens; row++) {
+            output_logits_one(row_logits + (uint64_t)row * vocab_dim,
+                              &s->engine->model,
+                              &s->engine->weights,
+                              hidden_hc + (uint64_t)row * hidden_dim);
+        }
+        return 0;
+    }
+#ifdef DS4_NO_GPU
+    (void)selected_row;
+    if (errlen) snprintf(err, errlen, "GPU support is not compiled in");
+    return 1;
+#else
+    /* GLM and graphs without batched verifier logits retain a correctness
+     * fallback. Re-evaluate the selected row last so the graph's current
+     * hidden state has the same postcondition as the native batch path. */
+    ds4_gpu_graph *g = &s->graph;
+    const uint64_t hidden_bytes =
+        (uint64_t)n_tokens * hidden_dim * sizeof(float);
+    const uint64_t logits_bytes =
+        (uint64_t)n_tokens * vocab_dim * sizeof(float);
+    const bool batch_ready =
+        !ds4_session_is_glm(s) &&
+        !s->slice_spec_pending &&
+        n_tokens <= g->prefill_cap &&
+        metal_graph_batch_cur_hc(g) &&
+        ds4_gpu_tensor_bytes(metal_graph_batch_cur_hc(g)) >= hidden_bytes &&
+        g->spec_logits &&
+        ds4_gpu_tensor_bytes(g->spec_logits) >= logits_bytes;
+    if (!batch_ready) {
+        for (uint32_t row = 0; row < n_tokens; row++) {
+            if (ds4_session_eval_output_head_from_hc(
+                        s,
+                        hidden_hc + (uint64_t)row * hidden_dim,
+                        1,
+                        row_logits + (uint64_t)row * vocab_dim,
+                        err,
+                        errlen) != 0) {
+                return 1;
+            }
+        }
+        if (selected_row + 1u != n_tokens &&
+            ds4_session_eval_output_head_from_hc(
+                    s,
+                    hidden_hc + (uint64_t)selected_row * hidden_dim,
+                    1,
+                    row_logits + (uint64_t)selected_row * vocab_dim,
+                    err,
+                    errlen) != 0) {
+            return 1;
+        }
+        return 0;
+    }
+
+    bool ok = ds4_gpu_tensor_write(metal_graph_batch_cur_hc(g),
+                                   0,
+                                   hidden_hc,
+                                   hidden_bytes) != 0;
+    if (ok) ok = ds4_gpu_begin_commands() != 0;
+    if (ok) ok = metal_graph_encode_output_head_batch(g,
+                                                       &s->engine->model,
+                                                       &s->engine->weights,
+                                                       n_tokens,
+                                                       vocab_dim);
+    if (ok) ok = ds4_gpu_end_commands() != 0;
+    else (void)ds4_gpu_synchronize();
+    if (ok) ok = ds4_gpu_tensor_read(g->spec_logits,
+                                     0,
+                                     row_logits,
+                                     logits_bytes) != 0;
+    if (ok) ok = ds4_gpu_tensor_write(
+            metal_graph_cur_hc(g),
+            0,
+            hidden_hc + (uint64_t)selected_row * hidden_dim,
+            hidden_dim * sizeof(float)) != 0;
+    if (!ok) {
+        if (ds4_gpu_synchronize() == 0) {
+            fprintf(stderr,
+                    "ds4: synchronize after batched output-head hidden-state failure also failed\n");
+        }
+        if (errlen) snprintf(err, errlen,
+                             "%s batched output-head hidden-state evaluation failed",
+                             ds4_backend_name(s->engine->backend));
+        return 1;
+    }
+    return 0;
+#endif
+}
+
+int ds4_session_select_hidden_state_from_hc(ds4_session *s,
+                                            const float *hidden_hc,
+                                            uint32_t n_tokens,
+                                            uint32_t selected_row,
+                                            char *err,
+                                            size_t errlen) {
+    if (!s || !s->engine || !hidden_hc || n_tokens == 0 ||
+        selected_row >= n_tokens) {
+        if (errlen) snprintf(err, errlen, "invalid hidden-state row selection");
+        return 1;
+    }
+    if (ds4_session_is_cpu(s)) {
+        if (errlen) snprintf(err, errlen, "hidden-state row selection requires the graph backend");
+        return 1;
+    }
+#ifdef DS4_NO_GPU
+    if (errlen) snprintf(err, errlen, "GPU support is not compiled in");
+    return 1;
+#else
+    const uint64_t hidden_dim = ds4_engine_hidden_f32_values(s->engine);
+    ds4_gpu_tensor *dst = ds4_session_is_glm(s)
+        ? s->glm_graph.cur
+        : metal_graph_cur_hc(&s->graph);
+    const bool ok = dst &&
+        ds4_gpu_tensor_write(dst,
+                             0,
+                             hidden_hc + (uint64_t)selected_row * hidden_dim,
+                             hidden_dim * sizeof(float)) != 0;
+    if (!ok) {
+        if (errlen) snprintf(err, errlen,
+                             "%s hidden-state row selection failed",
+                             ds4_backend_name(s->engine->backend));
+        return 1;
+    }
+    return 0;
+#endif
+}
+
 
 static int ds4_session_eval_internal(ds4_session *s, int token, bool probe_mtp,
                                      char *err, size_t errlen);
@@ -59217,7 +60052,8 @@ static DS4_MAYBE_UNUSED void ds4_session_slice_commit_timeline(ds4_session *s, c
     ds4_session_dspark_capture_note_checkpoint(s);
 }
 
-int ds4_session_eval_layer_slice(ds4_session *s,
+static int ds4_session_eval_layer_slice_impl(
+                                 ds4_session *s,
                                  const int *tokens,
                                  uint32_t n_tokens,
                                  uint32_t pos0,
@@ -59227,8 +60063,12 @@ int ds4_session_eval_layer_slice(ds4_session *s,
                                  float *output_hc,
                                  bool output_logits,
                                  float *logits,
+                                 const ds4_layer_slice_device_io *device_io,
+                                 uint32_t *direct_used,
                                  char *err,
                                  size_t errlen) {
+    if (direct_used) *direct_used = 0;
+    (void)device_io;
     if (!s || !s->engine) {
         if (errlen) snprintf(err, errlen, "missing layer-slice session");
         return 1;
@@ -59431,6 +60271,56 @@ int ds4_session_eval_layer_slice(ds4_session *s,
 
     ds4_engine *e = s->engine;
     ds4_gpu_graph *g = &s->graph;
+
+    /* A speculative layer-slice transaction must preserve the ordinary
+     * autoregressive target exactly.  The generic N-row prefill kernels use
+     * different MoE/output arithmetic and are explicitly not safe as a greedy
+     * verifier: near ties can accept an MTP token that one-token decode would
+     * reject, and a full accept would retain that different KV state.  Keep
+     * the inter-host operation batched, but execute its tiny row set through
+     * the established one-token slice path locally on each host. */
+    if (s->slice_spec_pending && n_tokens > 1) {
+        if (n_tokens > DS4_SPEC_PREFIX_SLOTS + 1u) {
+            if (errlen) snprintf(err, errlen,
+                                 "speculative layer-slice span %u exceeds exact verifier capacity %u",
+                                 n_tokens,
+                                 (uint32_t)DS4_SPEC_PREFIX_SLOTS + 1u);
+            return 1;
+        }
+        const uint64_t hc_dim = (uint64_t)DS4_N_HC * DS4_N_EMBD;
+        for (uint32_t row = 0; row < n_tokens; row++) {
+            const float *row_input = input_hc
+                ? input_hc + (uint64_t)row * hc_dim
+                : NULL;
+            float *row_output = output_hc
+                ? output_hc + (uint64_t)row * hc_dim
+                : NULL;
+            const bool row_logits = output_logits && row + 1u == n_tokens;
+            if (ds4_session_eval_layer_slice(s,
+                                             tokens + row,
+                                             1,
+                                             pos0 + row,
+                                             layer_start,
+                                             layer_end,
+                                             row_input,
+                                             row_output,
+                                             row_logits,
+                                             row_logits ? logits : NULL,
+                                             err,
+                                             errlen) != 0) {
+                return 1;
+            }
+            if (s->slice_spec_capture_prefixes && row + 1u < n_tokens &&
+                !spec_frontier_capture_prefix(s, row + 1u)) {
+                if (errlen) snprintf(err, errlen,
+                                     "failed to capture exact speculative prefix %u",
+                                     row + 1u);
+                return 1;
+            }
+        }
+        return 0;
+    }
+
     if (!input_hc && !output_hc && output_logits &&
         layer_start == 0 && layer_end + 1u == (uint32_t)DS4_N_LAYER) {
         bool ok = false;
@@ -59506,11 +60396,83 @@ int ds4_session_eval_layer_slice(ds4_session *s,
         }
 
         bool ok = true;
+        ds4_gpu_tensor *direct_input_tensor = NULL;
+        ds4_gpu_tensor *direct_output_tensor = NULL;
+        ds4_gpu_tensor *direct_logits_tensor = NULL;
+        uint32_t direct_candidate_mask = 0;
+        const uint64_t logits_bytes = (uint64_t)DS4_N_VOCAB * sizeof(float);
+        const bool rocm_event_profile_candidate =
+            metal_graph_rocm_event_profile_eligible(g) &&
+            !s->slice_spec_pending && layer_start <= layer_end &&
+            layer_end < DS4_N_LAYER;
+        if (rocm_event_profile_candidate) {
+            metal_graph_rocm_event_profile_prepare_range(
+                g, layer_start, layer_end);
+        }
+        const double rocm_event_profile_host_t0 =
+            rocm_event_profile_candidate ? now_sec() : 0.0;
+        float rocm_event_profile_segments[DS4_ROCM_EVENT_SEG_COUNT] = {0};
+        uint32_t rocm_event_profile_segment_count = 0;
+        bool rocm_event_profile_collected = false;
+        ds4_gpu_tensor *saved_cur = metal_graph_cur_hc(g);
+        ds4_gpu_tensor *saved_after = metal_graph_after_ffn_hc(g);
+        ds4_gpu_tensor *saved_logits = metal_graph_logits(g);
+        ds4_gpu_tensor *logical_cur = saved_cur;
+        ds4_gpu_tensor *logical_after = saved_after;
+        const uint32_t device_io_flags = device_io ? device_io->flags : 0u;
+        const bool discard_direct_output_state =
+            (device_io_flags &
+             DS4_LAYER_SLICE_DEVICE_IO_DISCARD_OUTPUT_HC_STATE) != 0;
+        const bool discard_direct_logits_state =
+            (device_io_flags &
+             DS4_LAYER_SLICE_DEVICE_IO_DISCARD_LOGITS_STATE) != 0;
+#ifdef DS4_ROCM_BUILD
+        const bool direct_base_eligible =
+            device_io != NULL && !g->placement && g->active_tier == 0 &&
+            g->head_tier == 0 && g->tp_world <= 1u &&
+            !s->slice_spec_pending;
+        if (direct_base_eligible && input_hc && device_io->input_hc_device &&
+            device_io->input_hc_bytes == hc_bytes) {
+            direct_input_tensor = ds4_gpu_tensor_wrap_external(
+                (void *)device_io->input_hc_device, hc_bytes);
+            if (direct_input_tensor)
+                direct_candidate_mask |= DS4_LAYER_SLICE_DIRECT_INPUT_HC;
+        }
+        if (direct_base_eligible && output_hc && device_io->output_hc_device &&
+            device_io->output_hc_bytes == hc_bytes) {
+            direct_output_tensor = ds4_gpu_tensor_wrap_external(
+                device_io->output_hc_device, hc_bytes);
+            if (direct_output_tensor)
+                direct_candidate_mask |= DS4_LAYER_SLICE_DIRECT_OUTPUT_HC;
+        }
+        if (direct_base_eligible && output_logits && logits &&
+            device_io->logits_device && device_io->logits_bytes == logits_bytes) {
+            direct_logits_tensor = ds4_gpu_tensor_wrap_external(
+                device_io->logits_device, logits_bytes);
+            if (direct_logits_tensor)
+                direct_candidate_mask |= DS4_LAYER_SLICE_DIRECT_LOGITS;
+        }
+#else
+        (void)device_io;
+#endif
+        if (direct_input_tensor)
+            g->cur_hc_by_tier[g->active_tier] = direct_input_tensor;
+        const uint32_t raw_row = pos0 % g->raw_cap;
+        const uint32_t n_raw = metal_graph_raw_span_for_batch(g, pos0, 1);
+        if (rocm_event_profile_candidate) {
+            (void)metal_graph_rocm_event_profile_begin(
+                g,
+                layer_start,
+                layer_end,
+                pos0,
+                n_raw,
+                direct_candidate_mask);
+        }
         if (g->ssd_streaming && !input_hc) {
             g->streaming_static_decode_map_current = false;
             ok = metal_graph_stream_map_token(&e->model, &e->weights);
         }
-        if (input_hc) {
+        if (input_hc && !direct_input_tensor) {
             ok = ds4_gpu_tensor_write(metal_graph_cur_hc(g), 0, input_hc, hc_dim * sizeof(float)) != 0;
         }
         if (ok) ok = ds4_gpu_begin_commands() != 0;
@@ -59524,8 +60486,8 @@ int ds4_session_eval_layer_slice(ds4_session *s,
                                                DS4_N_EMBD,
                                                DS4_N_HC) != 0;
         }
-        const uint32_t raw_row = pos0 % g->raw_cap;
-        const uint32_t n_raw = metal_graph_raw_span_for_batch(g, pos0, 1);
+        if (ok && g->rocm_event_profile_active)
+            metal_graph_rocm_event_profile_mark(g);
         const uint32_t split_after_layers = metal_graph_token_split_after_layers();
         uint32_t encoded_layers = 0;
         if (g->ssd_streaming) {
@@ -59535,6 +60497,8 @@ int ds4_session_eval_layer_slice(ds4_session *s,
                 ok = metal_graph_stream_map_layer_decode(&e->model, &e->weights, il);
                 if (ok) ok = ds4_gpu_begin_commands() != 0;
                 if (ok) {
+                    if (il == layer_end && direct_output_tensor)
+                        g->after_ffn_hc_by_tier[g->active_tier] = direct_output_tensor;
                     ok = metal_graph_encode_decode_layer(g,
                                                          &e->model,
                                                          &e->weights.layer[il],
@@ -59545,9 +60509,29 @@ int ds4_session_eval_layer_slice(ds4_session *s,
                                                          raw_row,
                                                          n_raw,
                                                          tokens[0]);
-                    ds4_gpu_tensor *tmp = metal_graph_cur_hc(g);
-                    g->cur_hc_by_tier[g->active_tier] = metal_graph_after_ffn_hc(g);
-                    g->after_ffn_hc_by_tier[g->active_tier] = tmp;
+                    if (ok) {
+                        ds4_gpu_tensor *tmp = metal_graph_cur_hc(g);
+                        g->cur_hc_by_tier[g->active_tier] = metal_graph_after_ffn_hc(g);
+                        g->after_ffn_hc_by_tier[g->active_tier] = tmp;
+                        tmp = logical_cur;
+                        logical_cur = logical_after;
+                        logical_after = tmp;
+                        if (!(il == layer_end && direct_output_tensor)) {
+                            g->cur_hc_by_tier[g->active_tier] = logical_cur;
+                            g->after_ffn_hc_by_tier[g->active_tier] = logical_after;
+                        }
+                    }
+                }
+                if (ok) ok = ds4_gpu_end_commands() != 0;
+            }
+            if (ok && direct_output_tensor && !discard_direct_output_state) {
+                ok = ds4_gpu_begin_commands() != 0;
+                if (ok) {
+                    ok = ds4_gpu_tensor_copy(logical_cur,
+                                             0,
+                                             direct_output_tensor,
+                                             0,
+                                             hc_bytes) != 0;
                 }
                 if (ok) ok = ds4_gpu_end_commands() != 0;
             }
@@ -59555,11 +60539,28 @@ int ds4_session_eval_layer_slice(ds4_session *s,
                 g->streaming_static_decode_map_current = false;
                 ok = metal_graph_stream_map_output(&e->model, &e->weights);
                 if (ok) ok = ds4_gpu_begin_commands() != 0;
+                if (ok && direct_logits_tensor)
+                    g->logits_by_tier[g->head_tier] = direct_logits_tensor;
                 if (ok) ok = metal_graph_encode_output_head(g, &e->model, &e->weights, e->weights.output->dim[1]);
+                if (ok && direct_logits_tensor && !discard_direct_logits_state) {
+                    ok = ds4_gpu_tensor_copy(saved_logits,
+                                             0,
+                                             direct_logits_tensor,
+                                             0,
+                                             logits_bytes) != 0;
+                }
                 if (ok) ok = ds4_gpu_end_commands() != 0;
             }
         } else {
             for (uint32_t il = layer_start; ok && il <= layer_end; il++) {
+                if (il == layer_end && direct_output_tensor)
+                    g->after_ffn_hc_by_tier[g->active_tier] = direct_output_tensor;
+                if (g->rocm_event_profile_active &&
+                    il == g->rocm_event_profile_sample_layer) {
+                    metal_graph_rocm_event_profile_mark(g);
+                    g->rocm_event_profile_layer_active =
+                        g->rocm_event_profile_active;
+                }
                 ok = metal_graph_encode_decode_layer(g,
                                                      &e->model,
                                                      &e->weights.layer[il],
@@ -59570,10 +60571,20 @@ int ds4_session_eval_layer_slice(ds4_session *s,
                                                      raw_row,
                                                      n_raw,
                                                      tokens[0]);
-                ds4_gpu_tensor *tmp = metal_graph_cur_hc(g);
-                g->cur_hc_by_tier[g->active_tier] = metal_graph_after_ffn_hc(g);
-                g->after_ffn_hc_by_tier[g->active_tier] = tmp;
-                encoded_layers++;
+                g->rocm_event_profile_layer_active = false;
+                if (ok) {
+                    ds4_gpu_tensor *tmp = metal_graph_cur_hc(g);
+                    g->cur_hc_by_tier[g->active_tier] = metal_graph_after_ffn_hc(g);
+                    g->after_ffn_hc_by_tier[g->active_tier] = tmp;
+                    tmp = logical_cur;
+                    logical_cur = logical_after;
+                    logical_after = tmp;
+                    if (!(il == layer_end && direct_output_tensor)) {
+                        g->cur_hc_by_tier[g->active_tier] = logical_cur;
+                        g->after_ffn_hc_by_tier[g->active_tier] = logical_after;
+                    }
+                    encoded_layers++;
+                }
                 if (ok &&
                     split_after_layers != 0 &&
                     encoded_layers == split_after_layers &&
@@ -59582,28 +60593,89 @@ int ds4_session_eval_layer_slice(ds4_session *s,
                     ok = ds4_gpu_flush_commands() != 0;
                 }
             }
+            if (ok && g->rocm_event_profile_active)
+                metal_graph_rocm_event_profile_mark(g);
             if (ok && output_logits) {
+                if (direct_logits_tensor)
+                    g->logits_by_tier[g->head_tier] = direct_logits_tensor;
                 ok = metal_graph_encode_output_head(g, &e->model, &e->weights, e->weights.output->dim[1]);
             }
+            if (ok && g->rocm_event_profile_active)
+                metal_graph_rocm_event_profile_mark(g);
+            if (ok && direct_output_tensor && !discard_direct_output_state) {
+                ok = ds4_gpu_tensor_copy(logical_cur,
+                                         0,
+                                         direct_output_tensor,
+                                         0,
+                                         hc_bytes) != 0;
+            }
+            if (ok && direct_logits_tensor && !discard_direct_logits_state) {
+                ok = ds4_gpu_tensor_copy(saved_logits,
+                                         0,
+                                         direct_logits_tensor,
+                                         0,
+                                         logits_bytes) != 0;
+            }
+            if (ok && g->rocm_event_profile_active)
+                metal_graph_rocm_event_profile_mark(g);
             if (ok) ok = ds4_gpu_end_commands() != 0;
+            if (g->rocm_event_profile_active) {
+                if (ok && ds4_gpu_timing_collect(
+                            &g->rocm_event_profile_sample,
+                            rocm_event_profile_segments,
+                            DS4_ROCM_EVENT_SEG_COUNT,
+                            &rocm_event_profile_segment_count)) {
+                    g->rocm_event_profile_active = false;
+                    g->rocm_event_profile_layer_active = false;
+                    if (rocm_event_profile_segment_count ==
+                        DS4_ROCM_EVENT_SEG_COUNT) {
+                        rocm_event_profile_collected = true;
+                    } else {
+                        metal_graph_rocm_event_profile_drop(
+                            g, "segment count");
+                    }
+                } else {
+                    metal_graph_rocm_event_profile_drop(g, "collect");
+                }
+            }
         }
         if (ok && !output_hc && !output_logits) ok = ds4_gpu_synchronize() != 0;
-        if (ok && output_hc) {
+        if (!ok && ds4_gpu_synchronize() == 0) {
+            fprintf(stderr, "ds4: synchronize after layer-slice decode failure also failed\n");
+        }
+        g->cur_hc_by_tier[g->active_tier] = ok ? logical_cur : saved_cur;
+        g->after_ffn_hc_by_tier[g->active_tier] = ok ? logical_after : saved_after;
+        g->logits_by_tier[g->head_tier] = saved_logits;
+        ds4_gpu_tensor_free(direct_input_tensor);
+        ds4_gpu_tensor_free(direct_output_tensor);
+        ds4_gpu_tensor_free(direct_logits_tensor);
+        if (ok && output_hc &&
+            !(direct_candidate_mask & DS4_LAYER_SLICE_DIRECT_OUTPUT_HC)) {
             ok = ds4_gpu_tensor_read(metal_graph_cur_hc(g), 0, output_hc, hc_dim * sizeof(float)) != 0;
         }
-        if (ok && output_logits) {
+        if (ok && output_logits &&
+            !(direct_candidate_mask & DS4_LAYER_SLICE_DIRECT_LOGITS)) {
             ok = ds4_gpu_tensor_read(metal_graph_logits(g), 0, logits, (uint64_t)DS4_N_VOCAB * sizeof(float)) != 0;
         }
+        if (rocm_event_profile_collected) {
+            metal_graph_rocm_event_profile_record(
+                g,
+                layer_start,
+                layer_end,
+                rocm_event_profile_segments,
+                rocm_event_profile_segment_count,
+                (now_sec() - rocm_event_profile_host_t0) * 1000.0);
+        }
         if (!ok) {
-            if (ds4_gpu_synchronize() == 0) {
-                fprintf(stderr, "ds4: synchronize after layer-slice decode failure also failed\n");
-            }
+            if (g->rocm_event_profile_active)
+                metal_graph_rocm_event_profile_drop(g, "evaluation");
             if (errlen) snprintf(err, errlen, "%s layer-slice decode failed",
                                  ds4_backend_name(e->backend));
             s->checkpoint_valid = false;
             return 1;
         }
 
+        if (direct_used) *direct_used = direct_candidate_mask;
         ds4_session_slice_commit_timeline(s, tokens, n_tokens);
         return 0;
     }
@@ -59713,6 +60785,65 @@ int ds4_session_eval_layer_slice(ds4_session *s,
     ds4_session_slice_commit_timeline(s, tokens, n_tokens);
     return 0;
 #endif
+}
+
+int ds4_session_eval_layer_slice(ds4_session *s,
+                                 const int *tokens,
+                                 uint32_t n_tokens,
+                                 uint32_t pos0,
+                                 uint32_t layer_start,
+                                 uint32_t layer_end,
+                                 const float *input_hc,
+                                 float *output_hc,
+                                 bool output_logits,
+                                 float *logits,
+                                 char *err,
+                                 size_t errlen) {
+    return ds4_session_eval_layer_slice_impl(s,
+                                             tokens,
+                                             n_tokens,
+                                             pos0,
+                                             layer_start,
+                                             layer_end,
+                                             input_hc,
+                                             output_hc,
+                                             output_logits,
+                                             logits,
+                                             NULL,
+                                             NULL,
+                                             err,
+                                             errlen);
+}
+
+int ds4_session_eval_layer_slice_device_io(
+                                 ds4_session *s,
+                                 const int *tokens,
+                                 uint32_t n_tokens,
+                                 uint32_t pos0,
+                                 uint32_t layer_start,
+                                 uint32_t layer_end,
+                                 const float *input_hc,
+                                 float *output_hc,
+                                 bool output_logits,
+                                 float *logits,
+                                 const ds4_layer_slice_device_io *device_io,
+                                 uint32_t *direct_used,
+                                 char *err,
+                                 size_t errlen) {
+    return ds4_session_eval_layer_slice_impl(s,
+                                             tokens,
+                                             n_tokens,
+                                             pos0,
+                                             layer_start,
+                                             layer_end,
+                                             input_hc,
+                                             output_hc,
+                                             output_logits,
+                                             logits,
+                                             device_io,
+                                             direct_used,
+                                             err,
+                                             errlen);
 }
 
 #ifndef DS4_NO_GPU
@@ -61467,14 +62598,33 @@ static int ds4_session_eval_internal(ds4_session *s, int token, bool probe_mtp,
             if (errlen) snprintf(err, errlen, "distributed decode requires a valid checkpoint");
             return 1;
         }
+#ifndef DS4_NO_GPU
+        const uint32_t pos = (uint32_t)s->checkpoint.len;
+        const bool mtp_probe_log = getenv("DS4_MTP_PROBE") != NULL;
+        if (probe_mtp && s->engine &&
+            s->engine->support_kind == DS4_SUPPORT_MTP_LEGACY) {
+            ds4_session_note_legacy_mtp_probe(s, token, mtp_probe_log);
+        }
+#else
         (void)probe_mtp;
-        return ds4_dist_session_eval(s->distributed,
-                                     s,
-                                     &s->checkpoint,
-                                     token,
-                                     s->logits,
-                                     err,
-                                     errlen);
+#endif
+        const int rc = ds4_dist_session_eval(s->distributed,
+                                             s,
+                                             &s->checkpoint,
+                                             token,
+                                             s->logits,
+                                             err,
+                                             errlen);
+#ifndef DS4_NO_GPU
+        if (rc == 0 && probe_mtp && s->engine &&
+            s->engine->support_kind == DS4_SUPPORT_MTP_LEGACY) {
+            (void)ds4_session_prepare_legacy_mtp_draft(s,
+                                                       token,
+                                                       pos,
+                                                       mtp_probe_log);
+        }
+#endif
+        return rc;
     }
     if (ds4_session_is_cpu(s)) {
         ds4_engine *e = s->engine;
@@ -62488,6 +63638,31 @@ int ds4_sessions_eval_batch(ds4_decode_item *items, int count,
         }
     }
 
+    if (first->distributed) {
+        /* Workers multiplex independent remote session IDs on one shared
+         * coordinator connection.  Keep protocol traffic serialized until a
+         * native distributed batch frame exists. */
+        for (int i = 0; i < count; i++) {
+            if (!items[i].session->distributed) {
+                if (err && errlen) {
+                    snprintf(err, errlen,
+                             "decode batch mixes distributed and local sessions");
+                }
+                return 1;
+            }
+        }
+        for (int i = 0; i < count; i++) {
+            if (ds4_session_eval(items[i].session, items[i].token,
+                                 err, errlen) != 0) {
+                for (int j = 0; j < count; j++) {
+                    ds4_session_invalidate(items[j].session);
+                }
+                return 1;
+            }
+        }
+        return 0;
+    }
+
 #ifndef DS4_NO_GPU
     if (e->backend == DS4_BACKEND_CUDA) {
         return ds4_sessions_eval_batch_cuda(items, count, err, errlen);
@@ -62555,6 +63730,23 @@ int ds4_sessions_eval_batch_with_prefill(
                 return 1;
             }
         }
+    }
+
+    if (prefill_session->distributed) {
+        for (int i = 0; i < count; i++) {
+            if (!items[i].session->distributed) {
+                if (err && errlen) {
+                    snprintf(err, errlen,
+                             "mixed batch combines distributed and local sessions");
+                }
+                return 1;
+            }
+        }
+        int rc = ds4_session_sync(prefill_session, prefill_prompt, err, errlen);
+        if (rc != 0) return rc;
+        rc = ds4_sessions_eval_batch(items, count, err, errlen);
+        if (rc != 0) ds4_session_invalidate(prefill_session);
+        return rc;
     }
 
 #ifndef DS4_NO_GPU
@@ -65940,9 +67132,8 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                                         int max_tokens, int eos_token,
                                         int *accepted, int accepted_cap,
                                         char *err, size_t errlen) {
-    if (!s || max_tokens <= 0 || accepted_cap <= 0) return 0;
-    if (s->distributed) {
-        if (!accepted) return 0;
+    if (!s || !accepted || max_tokens <= 0 || accepted_cap <= 0) return 0;
+    if (s->distributed && !ds4_engine_has_mtp(s->engine)) {
         if (ds4_session_eval(s, first_token, err, errlen) != 0) return -1;
         accepted[0] = first_token;
         return 1;
@@ -66079,6 +67270,10 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
     int draft_cap = e->mtp_draft_tokens;
     if (draft_cap > max_tokens - n_accept) draft_cap = max_tokens - n_accept;
     if (draft_cap > accepted_cap - n_accept) draft_cap = accepted_cap - n_accept;
+    if (s->distributed &&
+        draft_cap > (int)DS4_DIST_SPEC_MAX_DRAFT_TOKENS) {
+        draft_cap = (int)DS4_DIST_SPEC_MAX_DRAFT_TOKENS;
+    }
     int room = s->ctx_size - s->checkpoint.len;
     if (draft_cap > room - 1) draft_cap = room - 1;
     if (draft_cap <= 0) return n_accept;
@@ -66162,6 +67357,100 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
     }
     if (mtp_timing) mtp_t_after_draft = now_sec();
 
+    if (s->distributed) {
+        /* Quality mode preserves the exact one-token target path. It is a
+         * correctness fallback, not a throughput optimization. */
+        if (strict_mtp) {
+            int verified = 0;
+            for (int i = 0; i < draft_n && n_accept < accepted_cap; i++) {
+                if (sample_argmax(s->logits, DS4_N_VOCAB) != drafts[i]) break;
+                if (ds4_session_eval_internal(s,
+                                              drafts[i],
+                                              false,
+                                              err,
+                                              errlen) != 0) {
+                    s->checkpoint_valid = false;
+                    DS4_MTP_KEEP_ACCEPTED(verified);
+                    return -1;
+                }
+                accepted[n_accept++] = drafts[i];
+                verified++;
+                if (drafts[i] == eos_token) break;
+            }
+            DS4_MTP_KEEP_ACCEPTED(verified);
+            if (mtp_timing) {
+                fprintf(stderr,
+                        "ds4: mtp timing distributed-seq drafted=%d verified=%d draft=%.3f ms total=%.3f ms\n",
+                        draft_n,
+                        verified,
+                        (mtp_t_after_draft - mtp_t0) * 1000.0,
+                        (now_sec() - mtp_t0) * 1000.0);
+            }
+            return n_accept;
+        }
+
+        uint32_t verify_n = (uint32_t)draft_n;
+        if (draft_n == 2 && mtp_margin_threshold > 0.0f) {
+            if (!mtp_conf_log) {
+                float v0 = 0.0f, v1 = 0.0f;
+                logits_top2(s->mtp_logits,
+                            DS4_N_VOCAB,
+                            &mtp_last_top0,
+                            &v0,
+                            &mtp_last_top1,
+                            &v1);
+                mtp_last_margin = v0 - v1;
+            }
+            if (mtp_last_margin < mtp_margin_threshold) verify_n = 1;
+        }
+
+        uint32_t committed = 0;
+        const int verify_rc = ds4_dist_session_verify_greedy(
+            s->distributed,
+            s,
+            &s->checkpoint,
+            drafts,
+            verify_n,
+            &committed,
+            s->logits,
+            err,
+            errlen);
+        if (verify_rc != 0) {
+            if (getenv("DS4_MTP_SPEC_LOG")) {
+                fprintf(stderr,
+                        "ds4: distributed MTP verifier failed; retained target prefix: %s\n",
+                        err && err[0] ? err : "unknown error");
+            }
+            DS4_MTP_KEEP_ACCEPTED(0);
+            return n_accept;
+        }
+        for (uint32_t i = 0; i < committed && n_accept < accepted_cap; i++) {
+            accepted[n_accept++] = drafts[i];
+            if (drafts[i] == eos_token) break;
+        }
+        DS4_MTP_KEEP_ACCEPTED(committed);
+        s->checkpoint_valid = true;
+        s->mtp_draft_valid = false;
+        ds4_session_dspark_capture_note_checkpoint(s);
+        if (mtp_conf_log) {
+            fprintf(stderr,
+                    "ds4: mtp conf distributed drafted=%u committed=%u margin=%.6f\n",
+                    verify_n,
+                    committed,
+                    mtp_last_margin);
+        }
+        if (mtp_timing) {
+            fprintf(stderr,
+                    "ds4: mtp timing distributed drafted=%u committed=%u draft=%.3f ms verify=%.3f ms total=%.3f ms\n",
+                    verify_n,
+                    committed,
+                    (mtp_t_after_draft - mtp_t0) * 1000.0,
+                    (now_sec() - mtp_t_after_draft) * 1000.0,
+                    (now_sec() - mtp_t0) * 1000.0);
+        }
+        return n_accept;
+    }
+
     if (!strict_mtp && draft_n == 2 && mtp_margin_threshold > 0.0f) {
         if (!mtp_conf_log) {
             float v0 = 0.0f, v1 = 0.0f;
@@ -66217,18 +67506,21 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
      * decode kernels, while the generic N=2 batch graph uses full-F32
      * activations and loses the paired and HC-expand decode fusions. Running
      * the exact two-row verifier reuses those Q8 kernels and is faster.
-     * DS4_MTP_BATCH_VERIFY remains an explicit diagnostic rollback to the
-     * generic batch verifier.
+     * A truthy DS4_MTP_BATCH_VERIFY remains an explicit diagnostic rollback
+     * to the generic batch verifier outside strict/quality mode. Strict mode
+     * must retain exact greedy-token semantics regardless of diagnostics.
      */
 #ifdef DS4_ROCM_BUILD
     const bool prefer_decode2_exact = true;
 #else
     const bool prefer_decode2_exact = false;
 #endif
+    const bool mtp_batch_verify =
+        glm_graph_env_truthy(getenv("DS4_MTP_BATCH_VERIFY"));
     const bool use_decode2_exact =
         draft_n == 2 &&
         (strict_mtp || prefer_decode2_exact) &&
-        getenv("DS4_MTP_BATCH_VERIFY") == NULL;
+        (strict_mtp || !mtp_batch_verify);
     if (use_decode2_exact) {
         ds4_spec_frontier frontier;
         memset(&frontier, 0, sizeof(frontier));
@@ -66308,7 +67600,15 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
         if (have_frontier) {
             s->checkpoint.len = start;
             ds4_session_dspark_capture_invalidate(s);
-            (void)spec_frontier_restore(&frontier, s);
+            if (!spec_frontier_restore(&frontier, s)) {
+                snprintf(err, errlen, "MTP decode2 verifier rollback failed");
+                s->checkpoint_valid = false;
+                DS4_MTP_KEEP_ACCEPTED(0);
+                spec_frontier_free(&frontier);
+                free(row0_logits);
+                free(row_logits);
+                return -1;
+            }
         }
         spec_frontier_free(&frontier);
         free(row0_logits);
@@ -66563,7 +67863,15 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
         s->checkpoint.len = start;
         ds4_session_dspark_capture_invalidate(s);
         if (have_frontier) {
-            (void)spec_frontier_restore(&frontier, s);
+            if (!spec_frontier_restore(&frontier, s)) {
+                snprintf(err, errlen, "MTP verifier rollback failed");
+                s->checkpoint_valid = false;
+                DS4_MTP_KEEP_ACCEPTED(0);
+                spec_frontier_free(&frontier);
+                free(row_logits);
+                free(row_tops);
+                return -1;
+            }
         } else if (!verifier_may_have_mutated) {
             /* Snapshot setup failed before the verifier touched Metal state.
              * Fall through to the exact sequential verifier below. */
@@ -66682,6 +67990,14 @@ void ds4_session_invalidate(ds4_session *s) {
     s->mtp_draft_valid = false;
     ds4_session_dspark_capture_invalidate(s);
 #ifndef DS4_NO_GPU
+    if (!ds4_session_is_cpu(s) && !ds4_session_is_glm(s)) {
+        s->graph.spec_capture_prefixes = s->slice_spec_pending
+            ? s->slice_spec_saved_capture
+            : false;
+    }
+    s->slice_spec_pending = false;
+    s->slice_spec_capture_prefixes = false;
+    spec_frontier_free(&s->slice_spec_frontier);
     ds4_session_glm_reset_dense_cache(s);
 #endif
 }
@@ -66697,6 +68013,14 @@ void ds4_session_rewind(ds4_session *s, int pos) {
     s->mtp_draft_valid = false;
     ds4_session_dspark_capture_invalidate(s);
 #ifndef DS4_NO_GPU
+    if (!ds4_session_is_cpu(s) && !ds4_session_is_glm(s)) {
+        s->graph.spec_capture_prefixes = s->slice_spec_pending
+            ? s->slice_spec_saved_capture
+            : false;
+    }
+    s->slice_spec_pending = false;
+    s->slice_spec_capture_prefixes = false;
+    spec_frontier_free(&s->slice_spec_frontier);
     ds4_session_glm_cap_dense_cache(s);
 #endif
 }

--- a/ds4.h
+++ b/ds4.h
@@ -77,6 +77,14 @@ typedef struct {
     bool set;
 } ds4_distributed_layers;
 
+typedef enum {
+    /* Preserve the pre-v3 behavior unless transport selection is explicit. */
+    DS4_DIST_TRANSPORT_DEFAULT = 0,
+    DS4_DIST_TRANSPORT_AUTO,
+    DS4_DIST_TRANSPORT_TCP,
+    DS4_DIST_TRANSPORT_NHI,
+} ds4_distributed_transport;
+
 typedef struct {
     ds4_distributed_role role;
     ds4_distributed_layers layers;
@@ -87,6 +95,8 @@ typedef struct {
     uint32_t prefill_chunk;
     uint32_t prefill_window;
     uint32_t activation_bits;
+    ds4_distributed_transport transport;
+    const char *nhi_device;
     bool replay_check;
     bool debug;
 } ds4_distributed_options;
@@ -425,6 +435,30 @@ const ds4_tokens *ds4_session_tokens(ds4_session *s);
 
 /* Low-level graph slice entry points used by distributed inference.  The
  * transport/session routing logic lives in ds4_distributed.c. */
+typedef struct {
+    const void *input_hc_device;
+    uint64_t input_hc_bytes;
+    void *output_hc_device;
+    uint64_t output_hc_bytes;
+    void *logits_device;
+    uint64_t logits_bytes;
+    uint32_t flags;
+} ds4_layer_slice_device_io;
+
+enum {
+    DS4_LAYER_SLICE_DIRECT_INPUT_HC  = 1u << 0,
+    DS4_LAYER_SLICE_DIRECT_OUTPUT_HC = 1u << 1,
+    DS4_LAYER_SLICE_DIRECT_LOGITS    = 1u << 2,
+};
+
+enum {
+    /* Distributed callers may discard canonical graph copies only when the
+     * next operation is guaranteed to overwrite them before any read. The
+     * externally bound output remains valid and synchronized. */
+    DS4_LAYER_SLICE_DEVICE_IO_DISCARD_OUTPUT_HC_STATE = 1u << 0,
+    DS4_LAYER_SLICE_DEVICE_IO_DISCARD_LOGITS_STATE    = 1u << 1,
+};
+
 int ds4_session_layer_slice_reset(ds4_session *s, char *err, size_t errlen);
 int ds4_session_eval_layer_slice(ds4_session *s,
                                  const int *tokens,
@@ -438,12 +472,71 @@ int ds4_session_eval_layer_slice(ds4_session *s,
                                  float *logits,
                                  char *err,
                                  size_t errlen);
+/* ROCm single-device decode may bind externally owned mapped device spans to
+ * the first/last graph tensors. Each device span must alias the same backing
+ * bytes as its corresponding mandatory host pointer; input, output, and
+ * logits spans must not overlap one another. Host pointers are used as the
+ * byte-identical fallback whenever a requested span is ineligible.
+ * direct_used receives DS4_LAYER_SLICE_DIRECT_* bits only after successful
+ * synchronized evaluation. DISCARD_* flags leave the corresponding canonical
+ * graph tensor stale and are valid only when the caller proves it is dead
+ * until overwritten. */
+int ds4_session_eval_layer_slice_device_io(
+                                 ds4_session *s,
+                                 const int *tokens,
+                                 uint32_t n_tokens,
+                                 uint32_t pos0,
+                                 uint32_t layer_start,
+                                 uint32_t layer_end,
+                                 const float *input_hc,
+                                 float *output_hc,
+                                 bool output_logits,
+                                 float *logits,
+                                 const ds4_layer_slice_device_io *device_io,
+                                 uint32_t *direct_used,
+                                 char *err,
+                                 size_t errlen);
 int ds4_session_eval_output_head_from_hc(ds4_session *s,
                                          const float *hidden_hc,
                                          uint32_t n_tokens,
                                          float *logits,
                                          char *err,
                                          size_t errlen);
+/* Evaluate the locally loaded output head for every hidden-state row.  The
+ * caller provides n_tokens * n_vocab floats in row_logits.  selected_row is
+ * also installed as the session's current hidden state for subsequent MTP or
+ * decode work. */
+int ds4_session_eval_output_heads_from_hc(ds4_session *s,
+                                          const float *hidden_hc,
+                                          uint32_t n_tokens,
+                                          uint32_t selected_row,
+                                          float *row_logits,
+                                          char *err,
+                                          size_t errlen);
+/* Install one row from an inter-node hidden-state batch without recomputing
+ * the output head. */
+int ds4_session_select_hidden_state_from_hc(ds4_session *s,
+                                            const float *hidden_hc,
+                                            uint32_t n_tokens,
+                                            uint32_t selected_row,
+                                            char *err,
+                                            size_t errlen);
+
+/* Transactional frontier helpers for a tiny batched layer-slice verifier.
+ * begin snapshots the current slice and enables intermediate-prefix capture;
+ * commit keeps keep_n rows from the batch evaluated since begin (a full batch
+ * simply finalizes it), while rollback restores the original slice timeline. */
+int ds4_session_speculative_begin(ds4_session *s,
+                                  bool capture_prefixes,
+                                  char *err,
+                                  size_t errlen);
+int ds4_session_speculative_commit(ds4_session *s,
+                                   uint32_t keep_n,
+                                   char *err,
+                                   size_t errlen);
+int ds4_session_speculative_rollback(ds4_session *s,
+                                     char *err,
+                                     size_t errlen);
 
 /* Disk KV payload helpers.  HTTP/agent code owns the outer file header and
  * persistence policy; the engine owns the DS4-specific serialized graph state. */

--- a/ds4_bench.c
+++ b/ds4_bench.c
@@ -24,9 +24,11 @@
 #include <time.h>
 
 #define DS4_BENCH_DEFAULT_SNAPSHOT_MAX_BYTES (UINT64_C(1) << 30)
+#define DS4_BENCH_SPEC_ACCEPT_CAP 17
 
 typedef struct {
     const char *model_path;
+    const char *mtp_path;
     const char *prompt_path;
     const char *chat_prompt_path;
     const char *system;
@@ -41,6 +43,7 @@ typedef struct {
     int ctx_alloc;
     int step_incr;
     int gen_tokens;
+    int mtp_draft_tokens;
     int power_percent;
     uint32_t prefill_chunk;
     uint32_t ssd_streaming_cache_experts;
@@ -49,6 +52,7 @@ typedef struct {
     uint32_t ssd_streaming_preload_experts;
     uint64_t simulate_used_memory_bytes;
     double step_mul;
+    float mtp_margin;
     const char *dump_frontier_logits_dir;
     ds4_dist_options dist;
     bool warm_weights;
@@ -58,6 +62,7 @@ typedef struct {
     bool ssd_streaming_full_layers_set;
     bool cuda_tensor_parallel;
     bool show_output;
+    bool mtp_options_set;
 } bench_config;
 
 static double bench_now_sec(void) {
@@ -91,6 +96,14 @@ static double bytes_to_gib(uint64_t bytes) {
 
 static void usage(FILE *fp, const char *topic) {
     ds4_help_print(fp, DS4_HELP_BENCH, topic);
+    if (!topic || !strcmp(topic, "all") || !strcmp(topic, "runtime") ||
+        !strcmp(topic, "benchmark")) {
+        fprintf(fp,
+                "MTP Decode\n"
+                "  --mtp FILE                 Optional MTP support GGUF used for speculative greedy decode.\n"
+                "  --mtp-draft N              Maximum autoregressive MTP draft tokens. Default: 1\n"
+                "  --mtp-margin F             Verifier confidence margin, 0..1000. Default: 3\n\n");
+    }
 }
 
 static int parse_int(const char *s, const char *opt) {
@@ -206,7 +219,9 @@ static bench_config parse_options(int argc, char **argv) {
         .ctx_max = 32768,
         .step_incr = 2048,
         .gen_tokens = 128,
+        .mtp_draft_tokens = 1,
         .step_mul = 1.0,
+        .mtp_margin = 3.0f,
     };
 
     for (int i = 1; i < argc; i++) {
@@ -236,6 +251,20 @@ static bench_config parse_options(int argc, char **argv) {
 
         if (!strcmp(arg, "-m") || !strcmp(arg, "--model")) {
             c.model_path = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--mtp")) {
+            c.mtp_path = need_arg(&i, argc, argv, arg);
+            c.mtp_options_set = true;
+        } else if (!strcmp(arg, "--mtp-draft")) {
+            c.mtp_draft_tokens = parse_int(need_arg(&i, argc, argv, arg), arg);
+            c.mtp_options_set = true;
+        } else if (!strcmp(arg, "--mtp-margin")) {
+            const double v = parse_double_arg(need_arg(&i, argc, argv, arg), arg);
+            if (v < 0.0 || v > 1000.0) {
+                fprintf(stderr, "ds4-bench: invalid value for %s: %.17g\n", arg, v);
+                exit(2);
+            }
+            c.mtp_margin = (float)v;
+            c.mtp_options_set = true;
         } else if (!strcmp(arg, "--prompt-file")) {
             c.prompt_path = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--chat-prompt-file")) {
@@ -576,10 +605,13 @@ int main(int argc, char **argv) {
 
     ds4_engine_options opt = {
         .model_path = cfg.model_path,
+        .mtp_path = cfg.mtp_path,
         .backend = cfg.backend,
         .n_threads = cfg.threads,
         .context_size = cfg.ctx_alloc,
         .prefill_chunk = cfg.prefill_chunk,
+        .mtp_draft_tokens = cfg.mtp_draft_tokens,
+        .mtp_margin = cfg.mtp_margin,
         .ssd_streaming_cache_experts = cfg.ssd_streaming_cache_experts,
         .ssd_streaming_cache_bytes = cfg.ssd_streaming_cache_bytes,
         .ssd_streaming_full_layers = cfg.ssd_streaming_full_layers,
@@ -615,6 +647,27 @@ int main(int argc, char **argv) {
                 &engine, &opt, &gpu_cfg) != 0) return 1;
     } else if (ds4_engine_open(&engine, &opt) != 0) {
         return 1;
+    }
+    const int effective_mtp_draft = ds4_engine_mtp_draft_tokens(engine);
+    const bool mtp_disabled_by_env = getenv("DS4_MTP_SPEC_DISABLE") != NULL;
+    const bool mtp_active = effective_mtp_draft > 1 && !mtp_disabled_by_env;
+    if (cfg.mtp_options_set) {
+        if (mtp_active) {
+            fprintf(stderr,
+                    "ds4-bench: MTP speculative greedy decode enabled "
+                    "(effective draft=%d, margin=%.3g)\n",
+                    effective_mtp_draft,
+                    (double)cfg.mtp_margin);
+        } else if (mtp_disabled_by_env && effective_mtp_draft > 1) {
+            fprintf(stderr,
+                    "ds4-bench: MTP support loaded but speculation is disabled by "
+                    "DS4_MTP_SPEC_DISABLE\n");
+        } else {
+            fprintf(stderr,
+                    "ds4-bench: MTP speculative decode is inactive "
+                    "(effective draft=%d; provide support with --mtp and set --mtp-draft above 1)\n",
+                    effective_mtp_draft);
+        }
     }
     log_context_memory(opt.backend,
                        cfg.ctx_alloc,
@@ -668,7 +721,14 @@ int main(int argc, char **argv) {
             return 1;
         }
     }
-    fprintf(out, "ctx_tokens,prefill_tokens,prefill_tps,gen_tokens,gen_tps,gen_first_ms,gen_steady_tokens,gen_steady_tps,kvcache_bytes\n");
+    fprintf(out, "ctx_tokens,prefill_tokens,prefill_tps,gen_tokens,gen_tps,gen_first_ms,gen_steady_tokens,gen_steady_tps,kvcache_bytes");
+    if (cfg.mtp_options_set) {
+        fprintf(out,
+                ",gen_cycles,gen_first_chunk_tokens,mtp_committed_tokens,"
+                "mtp_accepted_extras,mtp_max_committed_chunk,mtp_extra_slots,"
+                "mtp_slot_acceptance_pct,mtp_eos_recoveries");
+    }
+    fputc('\n', out);
     fflush(out);
 
     const int eos = ds4_token_eos(engine);
@@ -729,15 +789,27 @@ int main(int argc, char **argv) {
             }
         }
 
-        const double gen_t0 = bench_now_sec();
         double gen_first_sec = 0.0;
         double gen_steady_sec = 0.0;
         int gen_done = 0;
-        int *gen_token_buf = cfg.show_output && cfg.gen_tokens > 0
+        int gen_cycles = 0;
+        int gen_first_chunk_tokens = 0;
+        int mtp_accepted_extras = 0;
+        int mtp_max_committed_chunk = 0;
+        int mtp_extra_slots = 0;
+        int mtp_eos_recoveries = 0;
+        bool mtp_acceptance_defensible = true;
+        int *gen_token_buf = (cfg.show_output || mtp_active) && cfg.gen_tokens > 0
             ? malloc((size_t)cfg.gen_tokens * sizeof(gen_token_buf[0]))
             : NULL;
+        if ((cfg.show_output || mtp_active) && cfg.gen_tokens > 0 && !gen_token_buf) {
+            fprintf(stderr, "ds4-bench: out of memory recording generated tokens\n");
+            rc = 1;
+            break;
+        }
+        const double gen_t0 = bench_now_sec();
         int gen_token_count = 0;
-        for (int i = 0; i < cfg.gen_tokens; i++) {
+        while (gen_done < cfg.gen_tokens) {
             if (ds4_session_pos(session) + 1 >= ds4_session_ctx(session)) {
                 fprintf(stderr, "ds4-bench: generation would exceed allocated context at frontier %d\n", frontier);
                 rc = 1;
@@ -749,17 +821,130 @@ int main(int argc, char **argv) {
                 rc = 1;
                 break;
             }
+
+            int committed[DS4_BENCH_SPEC_ACCEPT_CAP];
+            int committed_n = 1;
+            int accepted_extras_this_cycle = 0;
+            const int remaining = cfg.gen_tokens - gen_done;
             const double token_t0 = bench_now_sec();
-            if (ds4_session_eval(session, token, err, sizeof(err)) != 0) {
-                fprintf(stderr, "ds4-bench: decode at frontier %d failed: %s\n", frontier, err);
-                rc = 1;
-                break;
+            if (mtp_active) {
+                int extra_slots = effective_mtp_draft;
+                if (extra_slots > remaining - 1) extra_slots = remaining - 1;
+                if (extra_slots > DS4_BENCH_SPEC_ACCEPT_CAP - 1) {
+                    extra_slots = DS4_BENCH_SPEC_ACCEPT_CAP - 1;
+                }
+                if (extra_slots > 0) mtp_extra_slots += extra_slots;
+
+                committed_n = ds4_session_eval_speculative_argmax(
+                        session,
+                        token,
+                        remaining,
+                        eos,
+                        committed,
+                        DS4_BENCH_SPEC_ACCEPT_CAP,
+                        err,
+                        sizeof(err));
+                if (committed_n <= 0 || committed_n > remaining ||
+                    committed_n > DS4_BENCH_SPEC_ACCEPT_CAP) {
+                    if (committed_n < 0) {
+                        fprintf(stderr,
+                                "ds4-bench: speculative decode at frontier %d failed: %s\n",
+                                frontier,
+                                err);
+                    } else {
+                        fprintf(stderr,
+                                "ds4-bench: speculative decode at frontier %d returned invalid token count %d\n",
+                                frontier,
+                                committed_n);
+                    }
+                    rc = 1;
+                    break;
+                }
+
+                int eos_index = -1;
+                for (int i = 0; i < committed_n; i++) {
+                    if (committed[i] == eos) {
+                        eos_index = i;
+                        break;
+                    }
+                }
+                if (eos_index >= 0) {
+                    /* The benchmark historically excludes EOS and always emits
+                     * exactly --gen-tokens tokens. Rebuild the state immediately
+                     * before the accepted EOS, then evaluate the non-EOS runner. */
+                    const int canonical_len = frontier + gen_token_count + eos_index;
+                    int *canonical_v = malloc((size_t)canonical_len * sizeof(canonical_v[0]));
+                    if (!canonical_v) {
+                        fprintf(stderr, "ds4-bench: out of memory recovering from speculative EOS\n");
+                        rc = 1;
+                        break;
+                    }
+                    memcpy(canonical_v,
+                           prefix.v,
+                           (size_t)frontier * sizeof(canonical_v[0]));
+                    memcpy(canonical_v + frontier,
+                           gen_token_buf,
+                           (size_t)gen_token_count * sizeof(canonical_v[0]));
+                    memcpy(canonical_v + frontier + gen_token_count,
+                           committed,
+                           (size_t)eos_index * sizeof(canonical_v[0]));
+                    ds4_tokens canonical = {
+                        .v = canonical_v,
+                        .len = canonical_len,
+                        .cap = canonical_len,
+                    };
+                    if (ds4_session_sync(session, &canonical, err, sizeof(err)) != 0) {
+                        fprintf(stderr,
+                                "ds4-bench: speculative EOS recovery at frontier %d failed: %s\n",
+                                frontier,
+                                err);
+                        free(canonical_v);
+                        rc = 1;
+                        break;
+                    }
+                    free(canonical_v);
+
+                    const int non_eos = ds4_session_argmax_excluding(session, eos);
+                    if (non_eos < 0 ||
+                        ds4_session_eval(session, non_eos, err, sizeof(err)) != 0) {
+                        fprintf(stderr,
+                                "ds4-bench: non-EOS decode recovery at frontier %d failed: %s\n",
+                                frontier,
+                                non_eos < 0 ? "no non-EOS token" : err);
+                        rc = 1;
+                        break;
+                    }
+                    committed[eos_index] = non_eos;
+                    committed_n = eos_index + 1;
+                    accepted_extras_this_cycle = eos_index > 1 ? eos_index - 1 : 0;
+                    mtp_eos_recoveries++;
+                    mtp_acceptance_defensible = false;
+                } else {
+                    accepted_extras_this_cycle = committed_n - 1;
+                }
+            } else {
+                committed[0] = token;
+                if (ds4_session_eval(session, token, err, sizeof(err)) != 0) {
+                    fprintf(stderr, "ds4-bench: decode at frontier %d failed: %s\n", frontier, err);
+                    rc = 1;
+                    break;
+                }
             }
             const double token_t1 = bench_now_sec();
-            if (i == 0) gen_first_sec = token_t1 - token_t0;
+            if (gen_cycles == 0) {
+                gen_first_sec = token_t1 - token_t0;
+                gen_first_chunk_tokens = committed_n;
+            }
             else gen_steady_sec += token_t1 - token_t0;
-            if (gen_token_buf) gen_token_buf[gen_token_count++] = token;
-            gen_done++;
+            for (int i = 0; i < committed_n; i++) {
+                if (gen_token_buf) gen_token_buf[gen_token_count++] = committed[i];
+            }
+            gen_done += committed_n;
+            gen_cycles++;
+            mtp_accepted_extras += accepted_extras_this_cycle;
+            if (committed_n > mtp_max_committed_chunk) {
+                mtp_max_committed_chunk = committed_n;
+            }
         }
         const double gen_t1 = bench_now_sec();
         if (cfg.show_output && gen_token_buf && gen_token_count > 0) {
@@ -795,9 +980,11 @@ int main(int argc, char **argv) {
         }
 
         const double gen_sec = gen_t1 - gen_t0;
-        const int gen_steady_tokens = gen_done > 1 ? gen_done - 1 : 0;
+        const int gen_steady_tokens = gen_done > gen_first_chunk_tokens
+            ? gen_done - gen_first_chunk_tokens
+            : 0;
         fprintf(out,
-                "%d,%d,%.2f,%d,%.2f,%.3f,%d,%.2f,%llu\n",
+                "%d,%d,%.2f,%d,%.2f,%.3f,%d,%.2f,%llu",
                 frontier,
                 prefill_tokens,
                 prefill_sec > 0.0 ? (double)prefill_tokens / prefill_sec : 0.0,
@@ -807,7 +994,45 @@ int main(int argc, char **argv) {
                 gen_steady_tokens,
                 gen_steady_sec > 0.0 ? (double)gen_steady_tokens / gen_steady_sec : 0.0,
                 (unsigned long long)(have_snapshot ? snap.len : 0));
+        if (cfg.mtp_options_set) {
+            fprintf(out,
+                    ",%d,%d,%d,%d,%d,%d,",
+                    gen_cycles,
+                    gen_first_chunk_tokens,
+                    gen_done,
+                    mtp_accepted_extras,
+                    mtp_max_committed_chunk,
+                    mtp_extra_slots);
+            if (mtp_acceptance_defensible && mtp_extra_slots > 0) {
+                fprintf(out,
+                        "%.2f",
+                        100.0 * (double)mtp_accepted_extras / (double)mtp_extra_slots);
+            }
+            fprintf(out, ",%d", mtp_eos_recoveries);
+        }
+        fputc('\n', out);
         fflush(out);
+
+        if (cfg.mtp_options_set) {
+            fprintf(stderr,
+                    "ds4-bench: mtp[ctx=%d] active=%s cycles=%d committed=%d "
+                    "accepted-extras=%d max-chunk=%d slots=%d slot-acceptance=",
+                    frontier,
+                    mtp_active ? "yes" : "no",
+                    gen_cycles,
+                    gen_done,
+                    mtp_accepted_extras,
+                    mtp_max_committed_chunk,
+                    mtp_extra_slots);
+            if (mtp_acceptance_defensible && mtp_extra_slots > 0) {
+                fprintf(stderr,
+                        "%.2f%%",
+                        100.0 * (double)mtp_accepted_extras / (double)mtp_extra_slots);
+            } else {
+                fputs("n/a", stderr);
+            }
+            fprintf(stderr, " eos-recoveries=%d\n", mtp_eos_recoveries);
+        }
 
         previous = frontier;
         if (frontier >= cfg.ctx_max) break;

--- a/ds4_dist_v3.c
+++ b/ds4_dist_v3.c
@@ -1,0 +1,407 @@
+/* Standalone DS4 distributed protocol v3 negotiation and frame helpers. */
+
+#include "ds4_dist_v3.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+
+typedef char ds4_dist_v3_hello_ext_size_check[
+    sizeof(ds4_dist_v3_hello_ext) == DS4_DIST_V3_HELLO_EXT_BYTES ? 1 : -1];
+typedef char ds4_dist_v3_hello_ack_size_check[
+    sizeof(ds4_dist_v3_hello_ack) == DS4_DIST_V3_HELLO_ACK_BYTES ? 1 : -1];
+typedef char ds4_dist_v3_hello_ready_size_check[
+    sizeof(ds4_dist_v3_hello_ready) == DS4_DIST_V3_HELLO_READY_BYTES ? 1 : -1];
+
+static int v3_fail(int error, char *err, size_t errlen, const char *message) {
+    errno = error;
+    if (err && errlen != 0) snprintf(err, errlen, "%s", message);
+    return -1;
+}
+
+static int v3_add_u32(uint32_t a, uint32_t b, uint32_t *out) {
+    if (!out) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (a > UINT32_MAX - b) {
+        errno = EOVERFLOW;
+        return -1;
+    }
+    *out = a + b;
+    return 0;
+}
+
+static int v3_mode_valid(uint32_t mode) {
+    return mode == DS4_TRANSPORT_BULK_NONE ||
+           mode == DS4_TRANSPORT_BULK_TCP_INLINE ||
+           mode == DS4_TRANSPORT_BULK_NHI_OOB;
+}
+
+static int v3_policy_valid(uint32_t policy) {
+    return policy == DS4_DIST_V3_POLICY_AUTO ||
+           policy == DS4_DIST_V3_POLICY_REQUIRE_NHI;
+}
+
+#define DS4_DIST_V3_CAP_NHI_OPTIONAL \
+    (DS4_DIST_V3_CAP_NHI_CPU_COPY_V1 | DS4_DIST_V3_CAP_NHI_TAGGED_V1)
+
+static int v3_nhi_geometry_valid(
+        uint32_t frame_size,
+        uint32_t ring_size,
+        uint32_t max_payload) {
+    uint64_t capacity;
+    if (frame_size == 0 || ring_size < 2u || max_payload == 0) return 0;
+    capacity = (uint64_t)(ring_size - 1u) * frame_size;
+    return capacity > DS4_TRANSPORT_BULK_DESC_BYTES &&
+        max_payload <= capacity - DS4_TRANSPORT_BULK_DESC_BYTES;
+}
+
+void ds4_dist_v3_u64_to_halves(uint64_t value, uint32_t *hi, uint32_t *lo) {
+    if (hi) *hi = (uint32_t)(value >> 32);
+    if (lo) *lo = (uint32_t)value;
+}
+
+uint64_t ds4_dist_v3_u64_from_halves(uint32_t hi, uint32_t lo) {
+    return ((uint64_t)hi << 32) | (uint64_t)lo;
+}
+
+void ds4_dist_v3_hello_ext_to_wire(
+        ds4_dist_v3_hello_ext *wire,
+        const ds4_dist_v3_hello_ext *host) {
+    ds4_dist_v3_hello_ext value;
+    if (!wire || !host) return;
+    value = *host;
+    value.protocol_min = htonl(value.protocol_min);
+    value.protocol_max = htonl(value.protocol_max);
+    value.capabilities = htonl(value.capabilities);
+    value.transport_policy = htonl(value.transport_policy);
+    value.nhi_frame_size = htonl(value.nhi_frame_size);
+    value.nhi_ring_size = htonl(value.nhi_ring_size);
+    value.nhi_max_payload = htonl(value.nhi_max_payload);
+    value.reserved = htonl(value.reserved);
+    *wire = value;
+}
+
+void ds4_dist_v3_hello_ext_from_wire(
+        ds4_dist_v3_hello_ext *host,
+        const ds4_dist_v3_hello_ext *wire) {
+    ds4_dist_v3_hello_ext value;
+    if (!host || !wire) return;
+    value = *wire;
+    value.protocol_min = ntohl(value.protocol_min);
+    value.protocol_max = ntohl(value.protocol_max);
+    value.capabilities = ntohl(value.capabilities);
+    value.transport_policy = ntohl(value.transport_policy);
+    value.nhi_frame_size = ntohl(value.nhi_frame_size);
+    value.nhi_ring_size = ntohl(value.nhi_ring_size);
+    value.nhi_max_payload = ntohl(value.nhi_max_payload);
+    value.reserved = ntohl(value.reserved);
+    *host = value;
+}
+
+void ds4_dist_v3_hello_ack_to_wire(
+        ds4_dist_v3_hello_ack *wire,
+        const ds4_dist_v3_hello_ack *host) {
+    ds4_dist_v3_hello_ack value;
+    uint32_t i;
+    if (!wire || !host) return;
+    value = *host;
+    value.protocol_version = htonl(value.protocol_version);
+    value.coordinator_caps = htonl(value.coordinator_caps);
+    value.selected_caps = htonl(value.selected_caps);
+    value.selected_transport = htonl(value.selected_transport);
+    value.generation_hi = htonl(value.generation_hi);
+    value.generation_lo = htonl(value.generation_lo);
+    value.nhi_frame_size = htonl(value.nhi_frame_size);
+    value.nhi_ring_size = htonl(value.nhi_ring_size);
+    value.nhi_max_payload = htonl(value.nhi_max_payload);
+    for (i = 0; i < 3u; i++) value.reserved[i] = htonl(value.reserved[i]);
+    *wire = value;
+}
+
+void ds4_dist_v3_hello_ack_from_wire(
+        ds4_dist_v3_hello_ack *host,
+        const ds4_dist_v3_hello_ack *wire) {
+    ds4_dist_v3_hello_ack value;
+    uint32_t i;
+    if (!host || !wire) return;
+    value = *wire;
+    value.protocol_version = ntohl(value.protocol_version);
+    value.coordinator_caps = ntohl(value.coordinator_caps);
+    value.selected_caps = ntohl(value.selected_caps);
+    value.selected_transport = ntohl(value.selected_transport);
+    value.generation_hi = ntohl(value.generation_hi);
+    value.generation_lo = ntohl(value.generation_lo);
+    value.nhi_frame_size = ntohl(value.nhi_frame_size);
+    value.nhi_ring_size = ntohl(value.nhi_ring_size);
+    value.nhi_max_payload = ntohl(value.nhi_max_payload);
+    for (i = 0; i < 3u; i++) value.reserved[i] = ntohl(value.reserved[i]);
+    *host = value;
+}
+
+void ds4_dist_v3_hello_ready_to_wire(
+        ds4_dist_v3_hello_ready *wire,
+        const ds4_dist_v3_hello_ready *host) {
+    ds4_dist_v3_hello_ready value;
+    uint32_t i;
+    if (!wire || !host) return;
+    value = *host;
+    value.protocol_version = htonl(value.protocol_version);
+    value.selected_transport = htonl(value.selected_transport);
+    value.generation_hi = htonl(value.generation_hi);
+    value.generation_lo = htonl(value.generation_lo);
+    for (i = 0; i < 2u; i++) value.reserved[i] = htonl(value.reserved[i]);
+    *wire = value;
+}
+
+void ds4_dist_v3_hello_ready_from_wire(
+        ds4_dist_v3_hello_ready *host,
+        const ds4_dist_v3_hello_ready *wire) {
+    ds4_dist_v3_hello_ready value;
+    uint32_t i;
+    if (!host || !wire) return;
+    value = *wire;
+    value.protocol_version = ntohl(value.protocol_version);
+    value.selected_transport = ntohl(value.selected_transport);
+    value.generation_hi = ntohl(value.generation_hi);
+    value.generation_lo = ntohl(value.generation_lo);
+    for (i = 0; i < 2u; i++) value.reserved[i] = ntohl(value.reserved[i]);
+    *host = value;
+}
+
+int ds4_dist_v3_hello_ext_validate(
+        const ds4_dist_v3_hello_ext *hello,
+        char *err,
+        size_t errlen) {
+    uint32_t nhi_bits;
+    if (err && errlen != 0) err[0] = '\0';
+    if (!hello)
+        return v3_fail(EINVAL, err, errlen, "missing v3 HELLO extension");
+    if (hello->protocol_min > DS4_DIST_V3_PROTOCOL_VERSION ||
+        hello->protocol_max < DS4_DIST_V3_PROTOCOL_VERSION ||
+        hello->protocol_min > hello->protocol_max)
+        return v3_fail(EPROTONOSUPPORT, err, errlen, "v3 HELLO has no supported protocol revision");
+    if (!v3_policy_valid(hello->transport_policy))
+        return v3_fail(EPROTO, err, errlen, "v3 HELLO has an invalid transport policy");
+    if (hello->reserved != 0)
+        return v3_fail(EPROTO, err, errlen, "v3 HELLO reserved field is nonzero");
+    if ((hello->capabilities & DS4_DIST_V3_CAP_BULK_DESC_V1) == 0)
+        return v3_fail(EPROTONOSUPPORT, err, errlen, "v3 HELLO lacks bulk descriptor support");
+
+    nhi_bits = hello->capabilities & DS4_DIST_V3_CAP_NHI_OPTIONAL;
+    if (nhi_bits != 0 && nhi_bits != DS4_DIST_V3_CAP_NHI_OPTIONAL)
+        return v3_fail(EPROTONOSUPPORT, err, errlen, "v3 HELLO advertises an incomplete NHI capability bundle");
+    if ((hello->capabilities & DS4_DIST_V3_CAP_NHI_V1) ==
+        DS4_DIST_V3_CAP_NHI_V1) {
+        if (!v3_nhi_geometry_valid(hello->nhi_frame_size,
+                                   hello->nhi_ring_size,
+                                   hello->nhi_max_payload))
+            return v3_fail(EPROTO, err, errlen, "v3 HELLO has invalid NHI geometry");
+    } else if (hello->nhi_frame_size != 0 || hello->nhi_ring_size != 0 ||
+               hello->nhi_max_payload != 0) {
+        return v3_fail(EPROTO, err, errlen, "v3 HELLO has NHI geometry without NHI capability");
+    }
+    if (hello->transport_policy == DS4_DIST_V3_POLICY_REQUIRE_NHI &&
+        (hello->capabilities & DS4_DIST_V3_CAP_NHI_V1) !=
+            DS4_DIST_V3_CAP_NHI_V1)
+        return v3_fail(EPROTONOSUPPORT, err, errlen, "v3 HELLO requires unavailable NHI capability");
+    return 0;
+}
+
+int ds4_dist_v3_hello_ack_validate(
+        const ds4_dist_v3_hello_ack *ack,
+        const ds4_dist_v3_hello_ext *local_offer,
+        char *err,
+        size_t errlen) {
+    uint64_t generation;
+    uint32_t common_caps;
+    uint32_t i;
+    if (err && errlen != 0) err[0] = '\0';
+    if (!ack || !local_offer)
+        return v3_fail(EINVAL, err, errlen, "missing v3 HELLO ACK validation parameters");
+    if (ds4_dist_v3_hello_ext_validate(local_offer, err, errlen) != 0) return -1;
+    if (ack->protocol_version != DS4_DIST_V3_PROTOCOL_VERSION)
+        return v3_fail(EPROTONOSUPPORT, err, errlen, "v3 HELLO ACK selected an unsupported revision");
+    for (i = 0; i < 3u; i++) {
+        if (ack->reserved[i] != 0)
+            return v3_fail(EPROTO, err, errlen, "v3 HELLO ACK reserved field is nonzero");
+    }
+    generation = ds4_dist_v3_u64_from_halves(ack->generation_hi,
+                                              ack->generation_lo);
+    if (generation == 0)
+        return v3_fail(EPROTO, err, errlen, "v3 HELLO ACK has a zero generation");
+    if ((ack->coordinator_caps & DS4_DIST_V3_CAP_BULK_DESC_V1) == 0 ||
+        ((ack->coordinator_caps & DS4_DIST_V3_CAP_NHI_OPTIONAL) != 0 &&
+         (ack->coordinator_caps & DS4_DIST_V3_CAP_NHI_OPTIONAL) !=
+             DS4_DIST_V3_CAP_NHI_OPTIONAL))
+        return v3_fail(EPROTONOSUPPORT, err, errlen, "v3 HELLO ACK advertises invalid coordinator capabilities");
+    common_caps = local_offer->capabilities & ack->coordinator_caps;
+    if ((ack->selected_caps & ~common_caps) != 0 ||
+        (ack->selected_caps & DS4_DIST_V3_CAP_BULK_DESC_V1) == 0)
+        return v3_fail(EPROTO, err, errlen, "v3 HELLO ACK selected unsupported capabilities");
+
+    if (ack->selected_transport == DS4_DIST_V3_TRANSPORT_TCP) {
+        if (local_offer->transport_policy == DS4_DIST_V3_POLICY_REQUIRE_NHI)
+            return v3_fail(EPROTONOSUPPORT, err, errlen, "v3 HELLO ACK downgraded required NHI to TCP");
+        if (ack->nhi_frame_size != 0 || ack->nhi_ring_size != 0 ||
+            ack->nhi_max_payload != 0)
+            return v3_fail(EPROTO, err, errlen, "v3 TCP ACK contains NHI geometry");
+        if ((ack->selected_caps &
+             (DS4_DIST_V3_CAP_NHI_CPU_COPY_V1 |
+              DS4_DIST_V3_CAP_NHI_TAGGED_V1)) != 0)
+            return v3_fail(EPROTO, err, errlen, "v3 TCP ACK selected NHI capabilities");
+        return 0;
+    }
+    if (ack->selected_transport != DS4_DIST_V3_TRANSPORT_NHI)
+        return v3_fail(EPROTO, err, errlen, "v3 HELLO ACK selected an invalid transport");
+    if ((ack->selected_caps & DS4_DIST_V3_CAP_NHI_V1) != DS4_DIST_V3_CAP_NHI_V1)
+        return v3_fail(EPROTO, err, errlen, "v3 NHI ACK lacks the complete capability bundle");
+    if (ack->nhi_frame_size != local_offer->nhi_frame_size ||
+        ack->nhi_ring_size > local_offer->nhi_ring_size ||
+        ack->nhi_max_payload > local_offer->nhi_max_payload ||
+        !v3_nhi_geometry_valid(ack->nhi_frame_size,
+                               ack->nhi_ring_size,
+                               ack->nhi_max_payload))
+        return v3_fail(EPROTO, err, errlen, "v3 HELLO ACK has incompatible NHI geometry");
+    return 0;
+}
+
+int ds4_dist_v3_hello_ready_validate(
+        const ds4_dist_v3_hello_ready *ready,
+        const ds4_dist_v3_hello_ack *ack,
+        char *err,
+        size_t errlen) {
+    uint64_t ready_generation;
+    uint64_t ack_generation;
+    uint32_t i;
+    if (err && errlen != 0) err[0] = '\0';
+    if (!ready || !ack)
+        return v3_fail(EINVAL, err, errlen, "missing v3 HELLO READY validation parameters");
+    if (ready->protocol_version != DS4_DIST_V3_PROTOCOL_VERSION ||
+        ready->protocol_version != ack->protocol_version)
+        return v3_fail(EPROTONOSUPPORT, err, errlen, "v3 HELLO READY protocol mismatch");
+    if ((ready->selected_transport != DS4_DIST_V3_TRANSPORT_TCP &&
+         ready->selected_transport != DS4_DIST_V3_TRANSPORT_NHI) ||
+        ready->selected_transport != ack->selected_transport)
+        return v3_fail(EPROTO, err, errlen, "v3 HELLO READY transport mismatch");
+    ready_generation = ds4_dist_v3_u64_from_halves(ready->generation_hi,
+                                                    ready->generation_lo);
+    ack_generation = ds4_dist_v3_u64_from_halves(ack->generation_hi,
+                                                  ack->generation_lo);
+    if (ready_generation == 0 || ack_generation == 0 ||
+        ready_generation != ack_generation)
+        return v3_fail(EPROTO, err, errlen, "v3 HELLO READY generation mismatch");
+    for (i = 0; i < 2u; i++) {
+        if (ready->reserved[i] != 0)
+            return v3_fail(EPROTO, err, errlen, "v3 HELLO READY reserved field is nonzero");
+    }
+    return 0;
+}
+
+int ds4_dist_v3_negotiate(
+        const ds4_dist_v3_hello_ext *worker,
+        const ds4_dist_v3_hello_ext *coordinator,
+        uint64_t generation,
+        ds4_dist_v3_hello_ack *ack,
+        char *err,
+        size_t errlen) {
+    uint32_t common_caps;
+    int both_nhi;
+    if (err && errlen != 0) err[0] = '\0';
+    if (!worker || !coordinator || !ack || generation == 0)
+        return v3_fail(EINVAL, err, errlen, "missing v3 negotiation parameters");
+    if (ds4_dist_v3_hello_ext_validate(worker, err, errlen) != 0 ||
+        ds4_dist_v3_hello_ext_validate(coordinator, err, errlen) != 0)
+        return -1;
+
+    common_caps = worker->capabilities & coordinator->capabilities;
+    both_nhi = (common_caps & DS4_DIST_V3_CAP_NHI_V1) ==
+        DS4_DIST_V3_CAP_NHI_V1 &&
+        worker->nhi_frame_size == coordinator->nhi_frame_size;
+    if (!both_nhi &&
+        (worker->transport_policy == DS4_DIST_V3_POLICY_REQUIRE_NHI ||
+         coordinator->transport_policy == DS4_DIST_V3_POLICY_REQUIRE_NHI))
+        return v3_fail(EPROTONOSUPPORT, err, errlen, "required v3 NHI transport cannot be negotiated");
+
+    *ack = (ds4_dist_v3_hello_ack){0};
+    ack->protocol_version = DS4_DIST_V3_PROTOCOL_VERSION;
+    ack->coordinator_caps = coordinator->capabilities;
+    ack->selected_caps = common_caps & DS4_DIST_V3_CAP_BULK_DESC_V1;
+    ds4_dist_v3_u64_to_halves(generation,
+                              &ack->generation_hi, &ack->generation_lo);
+    if (both_nhi) {
+        uint32_t ring_size = worker->nhi_ring_size < coordinator->nhi_ring_size
+            ? worker->nhi_ring_size : coordinator->nhi_ring_size;
+        uint32_t max_payload = worker->nhi_max_payload < coordinator->nhi_max_payload
+            ? worker->nhi_max_payload : coordinator->nhi_max_payload;
+        ack->selected_transport = DS4_DIST_V3_TRANSPORT_NHI;
+        ack->selected_caps |= DS4_DIST_V3_CAP_NHI_V1;
+        ack->nhi_frame_size = worker->nhi_frame_size;
+        ack->nhi_ring_size = ring_size;
+        ack->nhi_max_payload = max_payload;
+    } else {
+        ack->selected_transport = DS4_DIST_V3_TRANSPORT_TCP;
+    }
+    return ds4_dist_v3_hello_ack_validate(ack, worker, err, errlen);
+}
+
+int ds4_dist_v3_work_frame_sizes(
+        uint32_t token_bytes,
+        uint32_t route_bytes,
+        uint32_t bulk_payload_bytes,
+        uint32_t mode,
+        uint32_t *control_bytes,
+        uint32_t *frame_bytes) {
+    uint32_t control;
+    uint32_t total;
+    if (!control_bytes || !frame_bytes || !v3_mode_valid(mode) ||
+        (mode == DS4_TRANSPORT_BULK_NONE && bulk_payload_bytes != 0) ||
+        (mode != DS4_TRANSPORT_BULK_NONE && bulk_payload_bytes == 0)) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (v3_add_u32(DS4_DIST_V3_WORK_FIXED_BYTES,
+                   DS4_TRANSPORT_BULK_DESC_BYTES, &control) != 0 ||
+        v3_add_u32(control, token_bytes, &control) != 0 ||
+        v3_add_u32(control, route_bytes, &control) != 0)
+        return -1;
+    total = control;
+    if (mode == DS4_TRANSPORT_BULK_TCP_INLINE &&
+        v3_add_u32(total, bulk_payload_bytes, &total) != 0)
+        return -1;
+    *control_bytes = control;
+    *frame_bytes = total;
+    return 0;
+}
+
+int ds4_dist_v3_result_frame_sizes(
+        uint32_t telemetry_bytes,
+        uint32_t control_payload_bytes,
+        uint32_t bulk_payload_bytes,
+        uint32_t mode,
+        uint32_t *control_bytes,
+        uint32_t *frame_bytes) {
+    uint32_t control;
+    uint32_t total;
+    if (!control_bytes || !frame_bytes || !v3_mode_valid(mode) ||
+        (mode == DS4_TRANSPORT_BULK_NONE && bulk_payload_bytes != 0) ||
+        (mode != DS4_TRANSPORT_BULK_NONE &&
+         (bulk_payload_bytes == 0 || control_payload_bytes != 0))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (v3_add_u32(DS4_DIST_V3_RESULT_FIXED_BYTES,
+                   DS4_TRANSPORT_BULK_DESC_BYTES, &control) != 0 ||
+        v3_add_u32(control, telemetry_bytes, &control) != 0 ||
+        v3_add_u32(control, control_payload_bytes, &control) != 0)
+        return -1;
+    total = control;
+    if (mode == DS4_TRANSPORT_BULK_TCP_INLINE &&
+        v3_add_u32(total, bulk_payload_bytes, &total) != 0)
+        return -1;
+    *control_bytes = control;
+    *frame_bytes = total;
+    return 0;
+}

--- a/ds4_dist_v3.h
+++ b/ds4_dist_v3.h
@@ -1,0 +1,154 @@
+#ifndef DS4_DIST_V3_H
+#define DS4_DIST_V3_H
+
+/* Standalone negotiation and frame-layout helpers for DS4 distributed v3.
+ * The common DS4E frame header stays in ds4_distributed.c. Bulk descriptor
+ * ownership, encoding, sequencing, and transport validation live in
+ * ds4_transport.[ch]; this module deliberately uses that canonical record.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "ds4_transport.h"
+
+#define DS4_DIST_V3_PROTOCOL_VERSION 3u
+
+/* v2 currently uses message types 1..10. */
+#define DS4_DIST_MSG_HELLO_V3  11u
+#define DS4_DIST_MSG_HELLO_ACK 12u
+#define DS4_DIST_MSG_HELLO_READY 13u
+
+#define DS4_DIST_V3_CAP_BULK_DESC_V1    0x00000001u
+#define DS4_DIST_V3_CAP_NHI_CPU_COPY_V1 0x00000002u
+#define DS4_DIST_V3_CAP_NHI_TAGGED_V1   0x00000004u
+#define DS4_DIST_V3_CAP_NHI_V1 \
+    (DS4_DIST_V3_CAP_BULK_DESC_V1 | \
+     DS4_DIST_V3_CAP_NHI_CPU_COPY_V1 | \
+     DS4_DIST_V3_CAP_NHI_TAGGED_V1)
+
+#define DS4_DIST_V3_HELLO_EXT_BYTES     32u
+#define DS4_DIST_V3_HELLO_ACK_BYTES     48u
+#define DS4_DIST_V3_HELLO_READY_BYTES   24u
+#define DS4_DIST_V3_WORK_FIXED_BYTES    84u
+#define DS4_DIST_V3_RESULT_FIXED_BYTES  40u
+
+typedef enum {
+    DS4_DIST_V3_POLICY_AUTO = 0,
+    DS4_DIST_V3_POLICY_REQUIRE_NHI = 1,
+} ds4_dist_v3_transport_policy;
+
+typedef enum {
+    DS4_DIST_V3_TRANSPORT_TCP = 1,
+    DS4_DIST_V3_TRANSPORT_NHI = 2,
+} ds4_dist_v3_transport_kind;
+
+/* Appended to the existing v2 HELLO fixed record in a HELLO_V3 payload. */
+typedef struct {
+    uint32_t protocol_min;
+    uint32_t protocol_max;
+    uint32_t capabilities;
+    uint32_t transport_policy;
+    uint32_t nhi_frame_size;
+    uint32_t nhi_ring_size;
+    uint32_t nhi_max_payload;
+    uint32_t reserved;
+} ds4_dist_v3_hello_ext;
+
+typedef struct {
+    uint32_t protocol_version;
+    uint32_t coordinator_caps;
+    uint32_t selected_caps;
+    uint32_t selected_transport;
+    uint32_t generation_hi;
+    uint32_t generation_lo;
+    uint32_t nhi_frame_size;
+    uint32_t nhi_ring_size;
+    uint32_t nhi_max_payload;
+    uint32_t reserved[3];
+} ds4_dist_v3_hello_ack;
+
+/* Sent by the worker only after it has installed the ACK-selected link. The
+ * coordinator must not publish the worker or dispatch WORK before receiving
+ * and validating this barrier. */
+typedef struct {
+    uint32_t protocol_version;
+    uint32_t selected_transport;
+    uint32_t generation_hi;
+    uint32_t generation_lo;
+    uint32_t reserved[2];
+} ds4_dist_v3_hello_ready;
+
+void ds4_dist_v3_u64_to_halves(uint64_t value, uint32_t *hi, uint32_t *lo);
+uint64_t ds4_dist_v3_u64_from_halves(uint32_t hi, uint32_t lo);
+
+void ds4_dist_v3_hello_ext_to_wire(
+        ds4_dist_v3_hello_ext *wire,
+        const ds4_dist_v3_hello_ext *host);
+void ds4_dist_v3_hello_ext_from_wire(
+        ds4_dist_v3_hello_ext *host,
+        const ds4_dist_v3_hello_ext *wire);
+void ds4_dist_v3_hello_ack_to_wire(
+        ds4_dist_v3_hello_ack *wire,
+        const ds4_dist_v3_hello_ack *host);
+void ds4_dist_v3_hello_ack_from_wire(
+        ds4_dist_v3_hello_ack *host,
+        const ds4_dist_v3_hello_ack *wire);
+void ds4_dist_v3_hello_ready_to_wire(
+        ds4_dist_v3_hello_ready *wire,
+        const ds4_dist_v3_hello_ready *host);
+void ds4_dist_v3_hello_ready_from_wire(
+        ds4_dist_v3_hello_ready *host,
+        const ds4_dist_v3_hello_ready *wire);
+
+/* Validate a host-order offer or ACK. Unknown advertised capability bits are
+ * ignored. Selected bits must be a supported subset of both peers' offers.
+ */
+int ds4_dist_v3_hello_ext_validate(
+        const ds4_dist_v3_hello_ext *hello,
+        char *err,
+        size_t errlen);
+int ds4_dist_v3_hello_ack_validate(
+        const ds4_dist_v3_hello_ack *ack,
+        const ds4_dist_v3_hello_ext *local_offer,
+        char *err,
+        size_t errlen);
+int ds4_dist_v3_hello_ready_validate(
+        const ds4_dist_v3_hello_ready *ready,
+        const ds4_dist_v3_hello_ack *ack,
+        char *err,
+        size_t errlen);
+
+/* Construct the host-order ACK selected from two already validated offers.
+ * generation must be nonzero. NHI is selected only if both sides advertise
+ * the complete NHI v1 bundle and have compatible geometry. AUTO otherwise
+ * selects v3 TCP; REQUIRE_NHI rejects instead.
+ */
+int ds4_dist_v3_negotiate(
+        const ds4_dist_v3_hello_ext *worker,
+        const ds4_dist_v3_hello_ext *coordinator,
+        uint64_t generation,
+        ds4_dist_v3_hello_ack *ack,
+        char *err,
+        size_t errlen);
+
+/* Frame sizes exclude the common 12-byte DS4E frame header. control_bytes is
+ * the number of bytes retained on TCP when mode is NHI_OOB. Descriptors are
+ * always present and use the canonical DS4_TRANSPORT_BULK_DESC_BYTES size.
+ */
+int ds4_dist_v3_work_frame_sizes(
+        uint32_t token_bytes,
+        uint32_t route_bytes,
+        uint32_t bulk_payload_bytes,
+        uint32_t mode,
+        uint32_t *control_bytes,
+        uint32_t *frame_bytes);
+int ds4_dist_v3_result_frame_sizes(
+        uint32_t telemetry_bytes,
+        uint32_t control_payload_bytes,
+        uint32_t bulk_payload_bytes,
+        uint32_t mode,
+        uint32_t *control_bytes,
+        uint32_t *frame_bytes);
+
+#endif

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -14,10 +14,16 @@
  */
 
 #include "ds4_distributed.h"
+#include "ds4_dist_v3.h"
+#include "ds4_transport.h"
+#ifdef DS4_TEST_HOOKS
+#include "ds4_transport_internal.h"
+#endif
 
 #include <arpa/inet.h>
 #include <errno.h>
 #include <float.h>
+#include <fcntl.h>
 #include <math.h>
 #include <netdb.h>
 #include <net/if.h>
@@ -41,7 +47,9 @@
  * Protocol Constants And Wire Records
  * ========================================================================= */
 
-#define DS4_DIST_MAGIC 0x44533444u /* DS4D */
+#define DS4_DIST_PROTOCOL_VERSION 2u
+#define DS4_DIST_MAGIC_V1 0x44533444u /* DS4D */
+#define DS4_DIST_MAGIC 0x44533445u /* DS4E: wire protocol v2 */
 #define DS4_DIST_MSG_HELLO 1u
 #define DS4_DIST_MSG_ERROR 2u
 #define DS4_DIST_MSG_WORK 3u
@@ -51,14 +59,18 @@
 #define DS4_DIST_MSG_SNAPSHOT_CHUNK 7u
 #define DS4_DIST_MSG_SNAPSHOT_DONE 8u
 #define DS4_DIST_MSG_SNAPSHOT_LOAD_BEGIN 9u
+#define DS4_DIST_MSG_SESSION_DESTROY 10u
 #define DS4_DIST_MAX_MODEL_NAME 127u
 #define DS4_DIST_WORK_F_INPUT_HC 0x00000001u
 #define DS4_DIST_WORK_F_OUTPUT_LOGITS 0x00000002u
 #define DS4_DIST_WORK_F_RESET_SESSION 0x00000004u
 #define DS4_DIST_WORK_F_ACK_ONLY 0x00000008u
+#define DS4_DIST_WORK_F_SPECULATIVE 0x00000010u
+#define DS4_DIST_WORK_F_SPEC_COMMIT 0x00000020u
 #define DS4_DIST_WORK_F_VALID_MASK \
     (DS4_DIST_WORK_F_INPUT_HC | DS4_DIST_WORK_F_OUTPUT_LOGITS | \
-     DS4_DIST_WORK_F_RESET_SESSION | DS4_DIST_WORK_F_ACK_ONLY)
+     DS4_DIST_WORK_F_RESET_SESSION | DS4_DIST_WORK_F_ACK_ONLY | \
+     DS4_DIST_WORK_F_SPECULATIVE | DS4_DIST_WORK_F_SPEC_COMMIT)
 #define DS4_DIST_RESULT_ACK 0u
 #define DS4_DIST_RESULT_HIDDEN_STATE 1u
 #define DS4_DIST_RESULT_LOGITS 2u
@@ -68,6 +80,7 @@
 #define DS4_DIST_RECV_TRANSPORT_ERROR 1
 #define DS4_DIST_RECV_REMOTE_ERROR 2
 #define DS4_DIST_SNAPSHOT_CHUNK_BYTES (8u * 1024u * 1024u)
+#define DS4_DIST_MAX_ROUTE_BYTES (1024u * 1024u)
 
 typedef struct {
     uint32_t magic;
@@ -109,7 +122,11 @@ typedef struct {
     uint32_t route_count;
     uint32_t route_index;
     uint32_t route_bytes;
+    uint32_t spec_keep_tokens;
 } ds4_dist_work_fixed;
+
+typedef char ds4_dist_work_v3_size_check[
+    sizeof(ds4_dist_work_fixed) == DS4_DIST_V3_WORK_FIXED_BYTES ? 1 : -1];
 
 typedef struct {
     uint32_t host_len;
@@ -195,6 +212,16 @@ typedef struct {
     uint32_t message_bytes;
 } ds4_dist_snapshot_done_fixed;
 
+typedef struct {
+    uint32_t model_id;
+    uint32_t session_hi;
+    uint32_t session_lo;
+    uint32_t request_hi;
+    uint32_t request_lo;
+    uint32_t layer_start;
+    uint32_t layer_end;
+} ds4_dist_session_destroy_fixed;
+
 /* =========================================================================
  * Runtime State
  * =========================================================================
@@ -207,6 +234,7 @@ typedef struct {
 
 typedef struct ds4_dist_worker_entry {
     int fd;
+    ds4_transport *transport;
     char peer_host[NI_MAXHOST];
     char peer_port[NI_MAXSERV];
     char model_name[DS4_DIST_MAX_MODEL_NAME + 1u];
@@ -219,8 +247,15 @@ typedef struct ds4_dist_worker_entry {
     uint32_t ctx_size;
     uint32_t n_layers;
     uint32_t listen_port;
+    uint32_t protocol_version;
+    uint64_t link_generation;
     struct ds4_dist_worker_entry *next;
 } ds4_dist_worker_entry;
+
+typedef struct ds4_dist_client_fd_entry {
+    int fd;
+    struct ds4_dist_client_fd_entry *next;
+} ds4_dist_client_fd_entry;
 
 typedef struct {
     ds4_engine *engine;
@@ -231,15 +266,21 @@ typedef struct {
     uint32_t ctx_size;
     bool local_has_output;
     bool local_can_output_head;
+    bool prefer_local_output_head;
     bool replay_check;
     bool debug;
     bool use_control_for_work;
     uint32_t prefill_chunk;
     uint32_t prefill_window;
     uint32_t activation_bits;
+    ds4_distributed_transport transport_policy;
+    const char *nhi_device;
     uint64_t generation;
+    uint64_t next_link_generation;
     pthread_mutex_t mu;
+    pthread_cond_t clients_cv;
     ds4_dist_worker_entry *workers;
+    ds4_dist_client_fd_entry *clients;
     bool shutting_down;
 } ds4_dist_coordinator_state;
 
@@ -270,7 +311,10 @@ typedef struct {
     uint32_t layer_end;
     bool has_output;
     int ctx_size;
+    uint64_t hidden_f32_values;
     int listen_fd;
+    ds4_distributed_transport transport_policy;
+    const char *nhi_device;
     pthread_mutex_t mu;
     ds4_dist_worker_session *sessions;
 } ds4_dist_worker_state;
@@ -289,6 +333,7 @@ typedef struct ds4_dist_worker_forwarder {
     char host[NI_MAXHOST];
     uint32_t port;
     int fd;
+    ds4_transport *transport;
     pthread_t tid;
     bool thread_started;
     pthread_mutex_t send_mu;
@@ -305,14 +350,33 @@ typedef struct ds4_dist_worker_forwarder {
 struct ds4_dist_worker_upstream {
     ds4_dist_worker_state *state;
     int fd;
+    ds4_transport *transport;
     pthread_mutex_t write_mu;
     pthread_mutex_t forward_mu;
     ds4_dist_worker_forwarder *forwarders;
 };
 
+typedef struct {
+    ds4_dist_work_fixed work;
+    ds4_transport_bulk_desc bulk_desc;
+    int *tokens;
+    void *input_hc_wire;
+    ds4_transport_lease *input_lease;
+    void *route_blob;
+    uint32_t frame_bytes;
+    bool v3;
+    uint64_t reject_request_id;
+    char reject_message[160];
+} ds4_dist_work_message;
+
+typedef struct {
+    ds4_transport_bulk_desc desc;
+    ds4_transport_lease *lease;
+    bool prepared;
+} ds4_dist_tx_bulk_plan;
+
 typedef struct ds4_dist_worker_job {
-    void *payload;
-    uint32_t bytes;
+    ds4_dist_work_message message;
     struct ds4_dist_worker_job *next;
 } ds4_dist_worker_job;
 
@@ -322,9 +386,14 @@ typedef struct {
     pthread_mutex_t mu;
     pthread_cond_t not_empty;
     pthread_cond_t not_full;
+    pthread_cond_t idle;
     ds4_dist_worker_job *head;
     ds4_dist_worker_job *tail;
     uint32_t queued;
+    uint32_t active;
+#ifdef DS4_TEST_HOOKS
+    uint32_t control_waiters;
+#endif
     uint32_t depth;
     bool closed;
     bool canceled;
@@ -351,12 +420,18 @@ typedef struct {
     uint32_t layer_end;
     uint32_t flags;
     int fd;
+    ds4_transport *transport;
 } ds4_dist_route_entry;
 
 typedef struct {
     ds4_dist_route_entry *entry;
     uint32_t count;
     void *blob;
+    /* Optional request variant that asks the final worker to run its output
+     * head.  Coordinator-owned MTP keeps the primary route in hidden-return
+     * mode for decode/speculation, while prefill can use this much smaller
+     * logits result instead of returning every final hidden-state row. */
+    void *output_blob;
     uint32_t blob_bytes;
 } ds4_dist_route_plan;
 
@@ -383,12 +458,19 @@ typedef struct {
     uint64_t tensor_bytes;
 } ds4_dist_kv_shard_file;
 
-struct ds4_dist_session {
+struct ds4_dist_coordinator {
     ds4_dist_coordinator_state state;
     int listen_fd;
     pthread_t accept_tid;
     bool accept_started;
     ds4_dist_accept_ctx accept_ctx;
+    pthread_mutex_t op_mu;
+    uint64_t next_session_id;
+};
+
+struct ds4_dist_session {
+    ds4_dist_coordinator *coordinator;
+    ds4_dist_coordinator_state *state;
     ds4_dist_route_plan plan;
     bool plan_ready;
     uint64_t plan_generation;
@@ -396,6 +478,11 @@ struct ds4_dist_session {
     uint64_t request_id;
     uint64_t snapshot_request_id;
 };
+
+/* Functional prefill progress is a durable-checkpoint boundary only when the
+ * local and every remote KV frontier (and logits) are aligned.  Pipelined
+ * progress intentionally leaves this false while work is in flight. */
+static __thread bool dist_progress_payload_save_safe;
 
 typedef struct {
     int id;
@@ -406,6 +493,7 @@ typedef struct {
 typedef struct {
     ds4_dist_coordinator_state *state;
     int fd;
+    ds4_transport *transport;
     ds4_session *progress_session;
     uint64_t first_request_id;
     uint64_t *expected_hashes;
@@ -445,6 +533,7 @@ typedef struct {
     const ds4_tokens *prompt;
     uint64_t session_id;
     int fd;
+    ds4_transport *transport;
     ds4_dist_prefill_send_slot *slots;
     uint32_t slot_count;
     uint32_t head;
@@ -482,10 +571,20 @@ static uint32_t dist_prefill_send_depth(uint32_t chunk_count) {
 
 static int dist_send_work_frame(
         int fd,
+        ds4_transport *transport,
         const ds4_dist_work_fixed *work,
         const int *tokens,
         const float *input_hc,
         const void *route_blob);
+static int dist_send_work_frame_prepared(
+        int fd,
+        ds4_transport *transport,
+        const ds4_dist_work_fixed *work,
+        const int *tokens,
+        const float *input_hc,
+        const void *route_blob,
+        const ds4_transport_bulk_desc *prepared_desc,
+        ds4_transport_lease *tx_lease);
 static int dist_write_full(int fd, const void *buf, size_t len);
 static int dist_send_snapshot_file_chunks(
         int fd,
@@ -505,10 +604,15 @@ static int dist_worker_handle_snapshot_load(
         ds4_dist_worker_state *state,
         ds4_dist_worker_upstream *upstream,
         uint32_t bytes);
-static void dist_worker_upstream_init(
+static int dist_worker_handle_session_destroy(
+        ds4_dist_worker_state *state,
+        ds4_dist_worker_upstream *upstream,
+        uint32_t bytes);
+static int dist_worker_upstream_init(
         ds4_dist_worker_upstream *upstream,
         ds4_dist_worker_state *state,
-        int fd);
+        int fd,
+        ds4_transport *transport);
 static void dist_worker_upstream_destroy(ds4_dist_worker_upstream *upstream);
 static int dist_worker_upstream_send_work_error(
         ds4_dist_worker_upstream *upstream,
@@ -753,6 +857,65 @@ static bool dist_decode_profile_enabled(void) {
     return getenv("DS4_DIST_DECODE_PROFILE") != NULL;
 }
 
+enum {
+    DS4_DIST_NHI_DIRECT_RX = 1u << 0,
+    DS4_DIST_NHI_DIRECT_TX = 1u << 1,
+};
+
+/* Experimental graph binding is deliberately separate from mapped leases:
+ * mapped leases alone still use the established host-staged tensor copies.
+ * tx and rx may be qualified independently before enabling both directions. */
+static uint32_t dist_nhi_direct_slot_mode(void) {
+    const char *value = getenv("DS4_DIST_NHI_DIRECT_SLOTS");
+    if (!value || !value[0] || strcmp(value, "0") == 0 ||
+        strcmp(value, "off") == 0)
+        return 0;
+    if (strcmp(value, "tx") == 0) return DS4_DIST_NHI_DIRECT_TX;
+    if (strcmp(value, "rx") == 0) return DS4_DIST_NHI_DIRECT_RX;
+    if (strcmp(value, "1") == 0 || strcmp(value, "on") == 0 ||
+        strcmp(value, "both") == 0)
+        return DS4_DIST_NHI_DIRECT_RX | DS4_DIST_NHI_DIRECT_TX;
+    static int warned = 0;
+    if (!__atomic_exchange_n(&warned, 1, __ATOMIC_RELAXED)) {
+        fprintf(stderr,
+                "ds4: ignoring invalid DS4_DIST_NHI_DIRECT_SLOTS=%s "
+                "(expected off, tx, rx, or both)\n",
+                value);
+    }
+    return 0;
+}
+
+static bool dist_nhi_direct_slot_trace_enabled(void) {
+    const char *value = getenv("DS4_DIST_NHI_DIRECT_TRACE");
+    return value && value[0] && strcmp(value, "0") != 0 &&
+        strcmp(value, "off") != 0;
+}
+
+/* Qualification-only mode. The distributed call sites below assert GPU
+ * quiescence at lease handoff and may leave graph outputs stale when their
+ * next operation provably overwrites them. Transport integrity, sequence,
+ * generation, descriptor, and DMA ownership checks remain enabled. */
+static bool dist_nhi_unsafe_fast_enabled(void) {
+    const char *value = getenv("DS4_DIST_NHI_UNSAFE_FAST");
+    const bool enabled = value &&
+        (!strcmp(value, "1") || !strcmp(value, "true") ||
+         !strcmp(value, "yes") || !strcmp(value, "on"));
+    static int warned = 0;
+    if (enabled && !__atomic_exchange_n(&warned, 1, __ATOMIC_RELAXED)) {
+        fprintf(stderr,
+                "ds4: WARNING: DS4_DIST_NHI_UNSAFE_FAST enabled; "
+                "caller-proven GPU fences and dead graph-state copies are skipped\n");
+    }
+    return enabled;
+}
+
+static int dist_mapped_lease_commit_after_gpu_quiesce(
+        ds4_transport_lease *lease) {
+    return dist_nhi_unsafe_fast_enabled()
+        ? ds4_transport_lease_commit_gpu_quiesced(lease)
+        : ds4_transport_lease_commit(lease);
+}
+
 static bool dist_parse_positive_u32(
         const char *s,
         const char *name,
@@ -923,7 +1086,7 @@ static float dist_f8_e4m3_to_f32(uint8_t h) {
 }
 
 static int dist_write_activation_payload(
-        int fd,
+        ds4_transport *transport,
         const float *src,
         uint64_t values,
         uint32_t bits) {
@@ -934,7 +1097,7 @@ static int dist_write_activation_payload(
     if (bits == 32u) {
         uint32_t bytes = 0;
         if (!dist_activation_wire_bytes(bits, values, &bytes)) return -1;
-        return dist_write_full(fd, src, bytes);
+        return ds4_transport_send_bulk(transport, src, bytes);
     }
 
     const uint64_t max_values = 1024u * 1024u;
@@ -953,7 +1116,7 @@ static int dist_write_activation_payload(
             uint8_t *dst = buf;
             for (uint64_t i = 0; i < n; i++) dst[i] = dist_f32_to_f8_e4m3(src[done + i]);
         }
-        if (dist_write_full(fd, buf, (size_t)n * (size_t)(bits / 8u)) != 0) {
+        if (ds4_transport_send_bulk(transport, buf, (size_t)n * (size_t)(bits / 8u)) != 0) {
             rc = -1;
             break;
         }
@@ -961,6 +1124,146 @@ static int dist_write_activation_payload(
     }
     free(buf);
     return rc;
+}
+
+/* v3 names one logical tensor with one descriptor. Pack reduced-width
+ * activations contiguously so one descriptor always maps to one transport
+ * message (and therefore one NHI SUBMIT_TX). */
+static int dist_pack_activation_payload(
+        const float *src,
+        uint64_t values,
+        uint32_t bits,
+        const void **wire,
+        void **owned,
+        uint32_t *wire_bytes) {
+    if (wire) *wire = NULL;
+    if (owned) *owned = NULL;
+    if (wire_bytes) *wire_bytes = 0;
+    bits = dist_activation_bits_or_default(bits);
+    uint32_t bytes = 0;
+    if (!src || values == 0 ||
+        !dist_activation_wire_bytes(bits, values, &bytes))
+        return -1;
+    if (bits == 32u) {
+        if (wire) *wire = src;
+        if (wire_bytes) *wire_bytes = bytes;
+        return 0;
+    }
+    void *buf = malloc(bytes);
+    if (!buf) return -1;
+    if (bits == 16u) {
+        uint16_t *dst = buf;
+        for (uint64_t i = 0; i < values; i++) dst[i] = dist_f32_to_f16(src[i]);
+    } else if (bits == 8u) {
+        uint8_t *dst = buf;
+        for (uint64_t i = 0; i < values; i++) dst[i] = dist_f32_to_f8_e4m3(src[i]);
+    } else {
+        free(buf);
+        return -1;
+    }
+    if (wire) *wire = buf;
+    if (owned) *owned = buf;
+    if (wire_bytes) *wire_bytes = bytes;
+    return 0;
+}
+
+static bool dist_transport_uses_v3(const ds4_transport *transport) {
+    return transport && ds4_transport_generation(transport) != 0;
+}
+
+static void dist_bulk_none_desc(
+        const ds4_transport *transport,
+        uint64_t session_id,
+        uint64_t request_id,
+        ds4_transport_bulk_desc *desc) {
+    memset(desc, 0, sizeof(*desc));
+    desc->mode = DS4_TRANSPORT_BULK_NONE;
+    desc->generation = ds4_transport_generation(transport);
+    desc->session_id = session_id;
+    desc->request_id = request_id;
+}
+
+static int dist_validate_bulk_none_desc(
+        const ds4_transport *transport,
+        const ds4_transport_bulk_desc *desc,
+        uint64_t session_id,
+        uint64_t request_id) {
+    if (!transport || !desc ||
+        desc->mode != DS4_TRANSPORT_BULK_NONE || desc->kind != 0 ||
+        desc->generation != ds4_transport_generation(transport) ||
+        desc->sequence != 0 || desc->session_id != session_id ||
+        desc->request_id != request_id || desc->payload_bytes != 0 ||
+        desc->element_bits != 0 || desc->frame_count != 0 ||
+        desc->flags != 0 || desc->reserved[0] != 0 ||
+        desc->reserved[1] != 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    return 0;
+}
+
+/* Prepare a direct mapped TX slot only for 32-bit OOB tensors. A wrapped
+ * payload returns ENOTSUP from the backend; the prepared descriptor is kept
+ * so the ordinary NHI copy path can send the same sequence later. */
+static int dist_tx_bulk_plan_prepare(
+        ds4_transport *transport,
+        uint32_t kind,
+        uint64_t session_id,
+        uint64_t request_id,
+        uint32_t payload_bytes,
+        uint32_t element_bits,
+        ds4_dist_tx_bulk_plan *plan,
+        char *err,
+        size_t errlen) {
+    if (!plan) return -1;
+    memset(plan, 0, sizeof(*plan));
+    if (!transport || element_bits != 32u || payload_bytes == 0 ||
+        !dist_transport_uses_v3(transport) ||
+        !ds4_transport_can_oob(transport, payload_bytes) ||
+        !ds4_transport_mapped_leases_supported(transport))
+        return 0;
+    if (ds4_transport_prepare_bulk(transport, kind, session_id, request_id,
+                                   payload_bytes, element_bits, &plan->desc,
+                                   err, errlen) != 0)
+        return -1;
+    plan->prepared = true;
+    if (plan->desc.mode != DS4_TRANSPORT_BULK_NHI_OOB) {
+        if (errlen) snprintf(err, errlen,
+                             "mapped TX lease did not prepare an OOB descriptor");
+        errno = EPROTO;
+        return -1;
+    }
+    if (ds4_transport_tx_lease_acquire(transport, &plan->desc,
+                                       &plan->lease, err, errlen) == 0)
+        return 1;
+    if (errno == ENOTSUP) return 0;
+    return -1;
+}
+
+static const ds4_transport_bulk_desc *dist_tx_bulk_plan_desc(
+        const ds4_dist_tx_bulk_plan *plan) {
+    return plan && plan->prepared ? &plan->desc : NULL;
+}
+
+static void dist_tx_bulk_plan_abort(
+        ds4_transport *transport,
+        ds4_dist_tx_bulk_plan *plan) {
+    if (!plan || !plan->prepared) return;
+    if (plan->lease) {
+        (void)ds4_transport_lease_abort(plan->lease);
+        ds4_transport_lease_release(plan->lease);
+    } else if (transport && ds4_transport_control_fd(transport) >= 0) {
+        /* A wrap fallback has no lease through which to roll back the already
+         * prepared sequence. Abandon this generation if production fails. */
+        shutdown(ds4_transport_control_fd(transport), SHUT_RDWR);
+    }
+    memset(plan, 0, sizeof(*plan));
+}
+
+static void dist_tx_bulk_plan_release(ds4_dist_tx_bulk_plan *plan) {
+    if (!plan) return;
+    if (plan->lease) ds4_transport_lease_release(plan->lease);
+    memset(plan, 0, sizeof(*plan));
 }
 
 static int dist_decode_activation_payload(
@@ -1079,33 +1382,11 @@ static int dist_set_socket_low_latency(int fd) {
 #endif
 
 static int dist_write_full(int fd, const void *buf, size_t len) {
-    const unsigned char *p = buf;
-    while (len > 0) {
-        ssize_t n = send(fd, p, len, 0);
-        if (n < 0) {
-            if (errno == EINTR) continue;
-            return -1;
-        }
-        if (n == 0) return -1;
-        p += (size_t)n;
-        len -= (size_t)n;
-    }
-    return 0;
+    return ds4_transport_tcp_write(fd, buf, len);
 }
 
 static int dist_read_full(int fd, void *buf, size_t len) {
-    unsigned char *p = buf;
-    while (len > 0) {
-        ssize_t n = recv(fd, p, len, 0);
-        if (n < 0) {
-            if (errno == EINTR) continue;
-            return -1;
-        }
-        if (n == 0) return 0;
-        p += (size_t)n;
-        len -= (size_t)n;
-    }
-    return 1;
+    return ds4_transport_tcp_read(fd, buf, len);
 }
 
 static bool dist_connect_trace_enabled(void) {
@@ -1144,7 +1425,16 @@ static int dist_read_frame_header(int fd, uint32_t *type, uint32_t *bytes, char 
 
     uint32_t magic = ntohl(h.magic);
     if (magic != DS4_DIST_MAGIC) {
-        if (errlen) snprintf(err, errlen, "bad frame magic 0x%08x", magic);
+        if (errlen) {
+            if (magic == DS4_DIST_MAGIC_V1) {
+                snprintf(err,
+                         errlen,
+                         "distributed protocol version mismatch: peer uses v1, local requires v%u",
+                         DS4_DIST_PROTOCOL_VERSION);
+            } else {
+                snprintf(err, errlen, "bad frame magic 0x%08x", magic);
+            }
+        }
         return -1;
     }
 
@@ -1325,7 +1615,65 @@ static int dist_bind_connect_interface(int fd, int family, const char *ifname, i
     return 0;
 }
 
-static int dist_connect_endpoint_once(const char *host, int port, int *last_errno, char *err, size_t errlen) {
+static int dist_connect_socket(
+        int fd,
+        const struct sockaddr *addr,
+        socklen_t addrlen,
+        int timeout_ms) {
+    if (timeout_ms <= 0) return connect(fd, addr, addrlen);
+
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) != 0) return -1;
+
+    int rc = connect(fd, addr, addrlen);
+    int saved_errno = errno;
+    if (rc != 0 && saved_errno == EINPROGRESS) {
+        const double deadline = dist_now_sec() + (double)timeout_ms / 1000.0;
+        for (;;) {
+            double remaining = deadline - dist_now_sec();
+            if (remaining <= 0.0) {
+                saved_errno = ETIMEDOUT;
+                break;
+            }
+            int wait_ms = (int)ceil(remaining * 1000.0);
+            struct pollfd pfd = {
+                .fd = fd,
+                .events = POLLOUT,
+                .revents = 0,
+            };
+            int poll_rc = poll(&pfd, 1, wait_ms);
+            if (poll_rc < 0 && errno == EINTR) continue;
+            if (poll_rc <= 0) {
+                saved_errno = poll_rc == 0 ? ETIMEDOUT : errno;
+                break;
+            }
+            socklen_t error_len = sizeof(saved_errno);
+            if (getsockopt(fd, SOL_SOCKET, SO_ERROR,
+                           &saved_errno, &error_len) != 0) {
+                saved_errno = errno;
+            }
+            rc = saved_errno == 0 ? 0 : -1;
+            break;
+        }
+    } else if (rc != 0) {
+        rc = -1;
+    }
+
+    if (fcntl(fd, F_SETFL, flags) != 0 && rc == 0) {
+        rc = -1;
+        saved_errno = errno;
+    }
+    if (rc != 0) errno = saved_errno;
+    return rc;
+}
+
+static int dist_connect_endpoint_once(
+        const char *host,
+        int port,
+        int timeout_ms,
+        int *last_errno,
+        char *err,
+        size_t errlen) {
     char portbuf[16];
     snprintf(portbuf, sizeof(portbuf), "%d", port);
     if (last_errno) *last_errno = 0;
@@ -1408,7 +1756,8 @@ static int dist_connect_endpoint_once(const char *host, int port, int *last_errn
                 }
             }
         }
-        if (connect(fd, ai->ai_addr, ai->ai_addrlen) == 0) {
+        if (dist_connect_socket(fd, ai->ai_addr, ai->ai_addrlen,
+                                timeout_ms) == 0) {
             if (trace) {
                 struct sockaddr_storage local_ss;
                 socklen_t local_len = sizeof(local_ss);
@@ -1443,7 +1792,8 @@ static int dist_connect_endpoint_once(const char *host, int port, int *last_errn
 static int dist_connect_endpoint(const char *host, int port, char *err, size_t errlen) {
     int last_errno = 0;
     for (int attempt = 0; attempt < 200; attempt++) {
-        int fd = dist_connect_endpoint_once(host, port, &last_errno, err, errlen);
+        int fd = dist_connect_endpoint_once(host, port, 0,
+                                            &last_errno, err, errlen);
         if (fd >= 0) return fd;
         if (!dist_connect_errno_retryable(last_errno)) break;
         struct timespec ts = {0, 25 * 1000 * 1000};
@@ -1555,6 +1905,7 @@ static void dist_work_from_wire(ds4_dist_work_fixed *w) {
     w->route_count = ntohl(w->route_count);
     w->route_index = ntohl(w->route_index);
     w->route_bytes = ntohl(w->route_bytes);
+    w->spec_keep_tokens = ntohl(w->spec_keep_tokens);
 }
 
 static void dist_work_to_wire(ds4_dist_work_fixed *w) {
@@ -1578,6 +1929,7 @@ static void dist_work_to_wire(ds4_dist_work_fixed *w) {
     w->route_count = htonl(w->route_count);
     w->route_index = htonl(w->route_index);
     w->route_bytes = htonl(w->route_bytes);
+    w->spec_keep_tokens = htonl(w->spec_keep_tokens);
 }
 
 static void dist_route_from_wire(ds4_dist_route_fixed *r) {
@@ -1722,6 +2074,26 @@ static void dist_snapshot_done_from_wire(ds4_dist_snapshot_done_fixed *s) {
     s->message_bytes = ntohl(s->message_bytes);
 }
 
+static void dist_session_destroy_to_wire(ds4_dist_session_destroy_fixed *s) {
+    s->model_id = htonl(s->model_id);
+    s->session_hi = htonl(s->session_hi);
+    s->session_lo = htonl(s->session_lo);
+    s->request_hi = htonl(s->request_hi);
+    s->request_lo = htonl(s->request_lo);
+    s->layer_start = htonl(s->layer_start);
+    s->layer_end = htonl(s->layer_end);
+}
+
+static void dist_session_destroy_from_wire(ds4_dist_session_destroy_fixed *s) {
+    s->model_id = ntohl(s->model_id);
+    s->session_hi = ntohl(s->session_hi);
+    s->session_lo = ntohl(s->session_lo);
+    s->request_hi = ntohl(s->request_hi);
+    s->request_lo = ntohl(s->request_lo);
+    s->layer_start = ntohl(s->layer_start);
+    s->layer_end = ntohl(s->layer_end);
+}
+
 static void dist_telemetry_to_wire(ds4_dist_telemetry_fixed *t) {
     t->layer_start = htonl(t->layer_start);
     t->layer_end = htonl(t->layer_end);
@@ -1759,7 +2131,13 @@ static uint32_t dist_usec_since(double t0, double t1) {
  * Worker Registration
  * ========================================================================= */
 
-static int dist_send_hello(ds4_engine *engine, const ds4_dist_options *opt, int ctx_size, uint32_t listen_port, int fd) {
+static int dist_send_hello(
+        ds4_engine *engine,
+        const ds4_dist_options *opt,
+        int ctx_size,
+        uint32_t listen_port,
+        int fd,
+        const ds4_dist_v3_hello_ext *v3_ext) {
     uint32_t n_layers = (uint32_t)ds4_engine_layer_count(engine);
     const char *model_name = ds4_engine_model_name(engine);
     if (!model_name) model_name = "unknown";
@@ -1782,22 +2160,46 @@ static int dist_send_hello(ds4_engine *engine, const ds4_dist_options *opt, int 
     dist_hello_to_wire(&wire);
 
     uint32_t bytes = (uint32_t)sizeof(wire) + (uint32_t)model_name_len;
-    if (dist_write_frame_header(fd, DS4_DIST_MSG_HELLO, bytes) != 0) return -1;
+    if (v3_ext) bytes += (uint32_t)sizeof(*v3_ext);
+    if (dist_write_frame_header(fd,
+                                v3_ext ? DS4_DIST_MSG_HELLO_V3
+                                       : DS4_DIST_MSG_HELLO,
+                                bytes) != 0) return -1;
     if (dist_write_full(fd, &wire, sizeof(wire)) != 0) return -1;
+    if (v3_ext) {
+        ds4_dist_v3_hello_ext ext_wire;
+        ds4_dist_v3_hello_ext_to_wire(&ext_wire, v3_ext);
+        if (dist_write_full(fd, &ext_wire, sizeof(ext_wire)) != 0) return -1;
+    }
     if (model_name_len && dist_write_full(fd, model_name, model_name_len) != 0) return -1;
     return 0;
 }
 
-static int dist_recv_hello(int fd, ds4_dist_hello_fixed *hello, char *model_name, size_t model_name_cap, char *err, size_t errlen) {
+static int dist_recv_hello(
+        int fd,
+        ds4_dist_hello_fixed *hello,
+        ds4_dist_v3_hello_ext *v3_ext,
+        bool *is_v3,
+        char *model_name,
+        size_t model_name_cap,
+        char *err,
+        size_t errlen) {
+    if (v3_ext) memset(v3_ext, 0, sizeof(*v3_ext));
+    if (is_v3) *is_v3 = false;
     uint32_t type = 0, bytes = 0;
     int rc = dist_read_frame_header(fd, &type, &bytes, err, errlen);
     if (rc <= 0) return rc;
-    if (type != DS4_DIST_MSG_HELLO) {
+    if (type != DS4_DIST_MSG_HELLO && type != DS4_DIST_MSG_HELLO_V3) {
         if (errlen) snprintf(err, errlen, "expected HELLO frame, got type %u", type);
         dist_discard_bytes(fd, bytes);
         return -1;
     }
-    if (bytes < sizeof(*hello) || bytes > sizeof(*hello) + DS4_DIST_MAX_MODEL_NAME) {
+    const bool got_v3 = type == DS4_DIST_MSG_HELLO_V3;
+    const uint32_t ext_bytes = got_v3
+        ? (uint32_t)sizeof(ds4_dist_v3_hello_ext) : 0u;
+    const uint64_t min_bytes = (uint64_t)sizeof(*hello) + ext_bytes;
+    const uint64_t max_bytes = min_bytes + DS4_DIST_MAX_MODEL_NAME;
+    if ((uint64_t)bytes < min_bytes || (uint64_t)bytes > max_bytes) {
         if (errlen) snprintf(err, errlen, "invalid HELLO payload length %u", bytes);
         dist_discard_bytes(fd, bytes);
         return -1;
@@ -1809,6 +2211,13 @@ static int dist_recv_hello(int fd, ds4_dist_hello_fixed *hello, char *model_name
     dist_hello_from_wire(&wire);
 
     uint32_t remaining = bytes - (uint32_t)sizeof(wire);
+    if (got_v3) {
+        ds4_dist_v3_hello_ext ext_wire;
+        rc = dist_read_full(fd, &ext_wire, sizeof(ext_wire));
+        if (rc <= 0) return rc == 0 ? 0 : -1;
+        if (v3_ext) ds4_dist_v3_hello_ext_from_wire(v3_ext, &ext_wire);
+        remaining -= (uint32_t)sizeof(ext_wire);
+    }
     if (wire.model_name_len != remaining || wire.model_name_len > DS4_DIST_MAX_MODEL_NAME) {
         if (errlen) snprintf(err, errlen, "invalid HELLO model name length %u", wire.model_name_len);
         dist_discard_bytes(fd, remaining);
@@ -1831,7 +2240,339 @@ static int dist_recv_hello(int fd, ds4_dist_hello_fixed *hello, char *model_name
     }
 
     *hello = wire;
+    if (is_v3) *is_v3 = got_v3;
     return 1;
+}
+
+static uint32_t dist_nhi_offer_max_payload(const ds4_transport *transport) {
+    if (!transport) return 0;
+    const size_t payload = ds4_transport_max_oob_bytes(transport);
+    return payload > UINT32_MAX ? UINT32_MAX : (uint32_t)payload;
+}
+
+static ds4_dist_v3_hello_ext dist_v3_local_offer(
+        ds4_distributed_transport policy,
+        const ds4_transport *nhi) {
+    ds4_dist_v3_hello_ext offer;
+    memset(&offer, 0, sizeof(offer));
+    offer.protocol_min = DS4_DIST_V3_PROTOCOL_VERSION;
+    offer.protocol_max = DS4_DIST_V3_PROTOCOL_VERSION;
+    offer.capabilities = DS4_DIST_V3_CAP_BULK_DESC_V1;
+    offer.transport_policy = policy == DS4_DIST_TRANSPORT_NHI
+        ? DS4_DIST_V3_POLICY_REQUIRE_NHI : DS4_DIST_V3_POLICY_AUTO;
+    if (nhi) {
+        offer.capabilities |= DS4_DIST_V3_CAP_NHI_V1;
+        offer.nhi_frame_size = ds4_transport_frame_size(nhi);
+        offer.nhi_ring_size = ds4_transport_ring_size(nhi);
+        offer.nhi_max_payload = dist_nhi_offer_max_payload(nhi);
+    }
+    return offer;
+}
+
+static int dist_send_hello_ack(
+        int fd,
+        const ds4_dist_v3_hello_ack *ack) {
+    ds4_dist_v3_hello_ack wire;
+    ds4_dist_v3_hello_ack_to_wire(&wire, ack);
+    if (dist_write_frame_header(fd, DS4_DIST_MSG_HELLO_ACK,
+                                (uint32_t)sizeof(wire)) != 0)
+        return -1;
+    return dist_write_full(fd, &wire, sizeof(wire));
+}
+
+static int dist_recv_hello_ack(
+        int fd,
+        const ds4_dist_v3_hello_ext *local_offer,
+        ds4_dist_v3_hello_ack *ack,
+        char *err,
+        size_t errlen) {
+    uint32_t type = 0;
+    uint32_t bytes = 0;
+    int rc = dist_read_frame_header(fd, &type, &bytes, err, errlen);
+    if (rc <= 0) {
+        if (rc == 0 && errlen) snprintf(err, errlen, "peer closed before v3 HELLO ACK");
+        return rc;
+    }
+    if (type == DS4_DIST_MSG_ERROR) {
+        uint32_t n = bytes;
+        if (err && errlen) {
+            n = n < errlen - 1u ? n : (uint32_t)errlen - 1u;
+            rc = dist_read_full(fd, err, n);
+            if (rc <= 0) return rc;
+            err[n] = '\0';
+        } else {
+            n = 0;
+        }
+        if (bytes > n && dist_discard_bytes(fd, bytes - n) <= 0) return -1;
+        errno = EPROTONOSUPPORT;
+        return -2;
+    }
+    if (type != DS4_DIST_MSG_HELLO_ACK || bytes != sizeof(*ack)) {
+        (void)dist_discard_bytes(fd, bytes);
+        if (errlen) snprintf(err, errlen, "expected v3 HELLO ACK, got type %u length %u",
+                             type, bytes);
+        errno = EPROTO;
+        return -1;
+    }
+    ds4_dist_v3_hello_ack wire;
+    rc = dist_read_full(fd, &wire, sizeof(wire));
+    if (rc <= 0) return rc;
+    ds4_dist_v3_hello_ack_from_wire(ack, &wire);
+    return ds4_dist_v3_hello_ack_validate(ack, local_offer, err, errlen) == 0
+        ? 1 : -1;
+}
+
+static int dist_send_hello_ready(
+        int fd,
+        const ds4_dist_v3_hello_ack *ack) {
+    ds4_dist_v3_hello_ready ready;
+    ds4_dist_v3_hello_ready wire;
+    memset(&ready, 0, sizeof(ready));
+    ready.protocol_version = ack->protocol_version;
+    ready.selected_transport = ack->selected_transport;
+    ready.generation_hi = ack->generation_hi;
+    ready.generation_lo = ack->generation_lo;
+    ds4_dist_v3_hello_ready_to_wire(&wire, &ready);
+    if (dist_write_frame_header(fd, DS4_DIST_MSG_HELLO_READY,
+                                (uint32_t)sizeof(wire)) != 0)
+        return -1;
+    return dist_write_full(fd, &wire, sizeof(wire));
+}
+
+static int dist_recv_hello_ready(
+        int fd,
+        const ds4_dist_v3_hello_ack *ack,
+        char *err,
+        size_t errlen) {
+    uint32_t type = 0;
+    uint32_t bytes = 0;
+    int rc = dist_read_frame_header(fd, &type, &bytes, err, errlen);
+    if (rc <= 0) {
+        if (rc == 0 && errlen)
+            snprintf(err, errlen, "peer closed before v3 HELLO READY");
+        return rc;
+    }
+    if (type != DS4_DIST_MSG_HELLO_READY ||
+        bytes != DS4_DIST_V3_HELLO_READY_BYTES) {
+        (void)dist_discard_bytes(fd, bytes);
+        if (errlen)
+            snprintf(err, errlen,
+                     "expected v3 HELLO READY, got type %u length %u",
+                     type, bytes);
+        errno = EPROTO;
+        return -1;
+    }
+    ds4_dist_v3_hello_ready wire;
+    ds4_dist_v3_hello_ready ready;
+    rc = dist_read_full(fd, &wire, sizeof(wire));
+    if (rc <= 0) return rc;
+    ds4_dist_v3_hello_ready_from_wire(&ready, &wire);
+    return ds4_dist_v3_hello_ready_validate(&ready, ack, err, errlen) == 0
+        ? 1 : -1;
+}
+
+static uint64_t dist_coordinator_next_link_generation(
+        ds4_dist_coordinator_state *state) {
+    pthread_mutex_lock(&state->mu);
+    if (state->next_link_generation == 0) {
+        struct timespec realtime;
+        struct timespec monotonic;
+        clock_gettime(CLOCK_REALTIME, &realtime);
+        clock_gettime(CLOCK_MONOTONIC, &monotonic);
+        uint64_t seed = ((uint64_t)realtime.tv_sec << 32) ^
+            (uint64_t)realtime.tv_nsec ^
+            ((uint64_t)monotonic.tv_sec << 17) ^
+            (uint64_t)monotonic.tv_nsec ^
+            ((uint64_t)(uint32_t)getpid() << 7) ^
+            (uint64_t)(uintptr_t)state;
+        if (seed == 0 || seed == UINT64_MAX) seed = 1;
+        state->next_link_generation = seed;
+    }
+    state->next_link_generation++;
+    if (state->next_link_generation == 0)
+        state->next_link_generation = 1;
+    const uint64_t generation = state->next_link_generation;
+    pthread_mutex_unlock(&state->mu);
+    return generation;
+}
+
+static ds4_transport *dist_coordinator_negotiate_v3(
+        ds4_dist_coordinator_state *state,
+        int fd,
+        const ds4_dist_v3_hello_ext *worker_offer,
+        char *err,
+        size_t errlen) {
+    ds4_transport *candidate = NULL;
+    const bool try_nhi =
+        state->transport_policy == DS4_DIST_TRANSPORT_AUTO ||
+        state->transport_policy == DS4_DIST_TRANSPORT_NHI;
+    if (try_nhi && state->nhi_device) {
+        candidate = ds4_transport_nhi_dup(fd, state->nhi_device, err, errlen);
+        if (!candidate) {
+            if (state->debug) {
+                fprintf(stderr,
+                        "ds4: distributed coordinator: NHI candidate %s unavailable: %s\n",
+                        state->nhi_device,
+                        err && err[0] ? err : strerror(errno));
+            }
+        }
+    }
+
+    ds4_dist_v3_hello_ext local_offer =
+        dist_v3_local_offer(state->transport_policy, candidate);
+    const uint64_t generation = dist_coordinator_next_link_generation(state);
+    ds4_dist_v3_hello_ack ack;
+    if (ds4_dist_v3_negotiate(worker_offer, &local_offer, generation,
+                              &ack, err, errlen) != 0) {
+        ds4_transport_release(candidate);
+        return NULL;
+    }
+
+    ds4_transport *selected = NULL;
+    if (ack.selected_transport == DS4_DIST_V3_TRANSPORT_NHI) {
+        if (!candidate ||
+            ds4_transport_configure_link(candidate, generation,
+                                         worker_offer->nhi_frame_size,
+                                         worker_offer->nhi_ring_size,
+                                         err, errlen) != 0) {
+            ds4_transport_release(candidate);
+            candidate = NULL;
+            /* AUTO can still select descriptor-framed TCP, but the decision
+             * is made before ACK and before any OOB descriptor is visible. */
+            if (state->transport_policy == DS4_DIST_TRANSPORT_NHI)
+                return NULL;
+            local_offer = dist_v3_local_offer(DS4_DIST_TRANSPORT_AUTO, NULL);
+            if (ds4_dist_v3_negotiate(worker_offer, &local_offer, generation,
+                                      &ack, err, errlen) != 0)
+                return NULL;
+        } else {
+            selected = candidate;
+            candidate = NULL;
+        }
+    }
+    if (!selected) {
+        ds4_transport_release(candidate);
+        selected = ds4_transport_tcp_dup(fd, err, errlen);
+        if (!selected) return NULL;
+        if (ds4_transport_configure_link(selected, generation, 0, 0,
+                                         err, errlen) != 0) {
+            ds4_transport_release(selected);
+            return NULL;
+        }
+    }
+
+    if (dist_send_hello_ack(fd, &ack) != 0) {
+        if (errlen) snprintf(err, errlen, "failed to send v3 HELLO ACK: %s",
+                             strerror(errno));
+        ds4_transport_release(selected);
+        return NULL;
+    }
+    if (dist_recv_hello_ready(fd, &ack, err, errlen) != 1) {
+        ds4_transport_release(selected);
+        return NULL;
+    }
+    return selected;
+}
+
+static ds4_transport *dist_worker_negotiate_link(
+        ds4_engine *engine,
+        const ds4_dist_options *opt,
+        int ctx_size,
+        uint32_t listen_port,
+        int fd,
+        bool use_v3,
+        bool suppress_nhi,
+        bool *legacy_retry,
+        bool *v3_tcp_retry,
+        char *err,
+        size_t errlen) {
+    if (legacy_retry) *legacy_retry = false;
+    if (v3_tcp_retry) *v3_tcp_retry = false;
+    if (!use_v3) {
+        if (dist_send_hello(engine, opt, ctx_size, listen_port, fd, NULL) != 0) {
+            if (errlen) snprintf(err, errlen, "failed to send v2 HELLO: %s",
+                                 strerror(errno));
+            return NULL;
+        }
+        return ds4_transport_tcp_create(fd, err, errlen);
+    }
+
+    ds4_transport *candidate = NULL;
+    if (opt->nhi_device && !suppress_nhi) {
+        candidate = ds4_transport_nhi_create(fd, opt->nhi_device, err, errlen);
+        if (!candidate && opt->transport == DS4_DIST_TRANSPORT_NHI)
+            return NULL;
+        if (!candidate) {
+            fprintf(stderr,
+                    "ds4: distributed worker: NHI candidate %s unavailable: %s; offering v3 TCP\n",
+                    opt->nhi_device,
+                    err && err[0] ? err : strerror(errno));
+        }
+    }
+    ds4_dist_v3_hello_ext offer = dist_v3_local_offer(opt->transport, candidate);
+    if (ds4_dist_v3_hello_ext_validate(&offer, err, errlen) != 0) {
+        ds4_transport_release(candidate);
+        return NULL;
+    }
+    if (dist_send_hello(engine, opt, ctx_size, listen_port, fd, &offer) != 0) {
+        if (errlen) snprintf(err, errlen, "failed to send v3 HELLO: %s",
+                             strerror(errno));
+        ds4_transport_release(candidate);
+        return NULL;
+    }
+
+    ds4_dist_v3_hello_ack ack;
+    const int ack_rc = dist_recv_hello_ack(fd, &offer, &ack, err, errlen);
+    if (ack_rc != 1) {
+        if (legacy_retry && opt->transport == DS4_DIST_TRANSPORT_AUTO &&
+            ack_rc != -2)
+            *legacy_retry = true;
+        ds4_transport_release(candidate);
+        return NULL;
+    }
+    const uint64_t generation = ds4_dist_v3_u64_from_halves(
+        ack.generation_hi, ack.generation_lo);
+    ds4_transport *selected = NULL;
+    if (ack.selected_transport == DS4_DIST_V3_TRANSPORT_NHI) {
+        if (!candidate) {
+            if (errlen) snprintf(err, errlen,
+                                 "v3 peer selected NHI without a local NHI endpoint");
+            errno = EPROTO;
+            return NULL;
+        }
+        if (ds4_transport_configure_link(candidate, generation,
+                                         ack.nhi_frame_size,
+                                         ack.nhi_ring_size,
+                                         err, errlen) != 0) {
+            ds4_transport_release(candidate);
+            if (v3_tcp_retry &&
+                opt->transport == DS4_DIST_TRANSPORT_AUTO)
+                *v3_tcp_retry = true;
+            return NULL;
+        }
+        selected = candidate;
+    } else {
+        ds4_transport_release(candidate);
+        selected = ds4_transport_tcp_create(fd, err, errlen);
+        if (!selected) return NULL;
+        if (ds4_transport_configure_link(selected, generation, 0, 0,
+                                         err, errlen) != 0) {
+            ds4_transport_release(selected);
+            return NULL;
+        }
+    }
+    if (dist_send_hello_ready(fd, &ack) != 0) {
+        if (errlen)
+            snprintf(err, errlen, "failed to send v3 HELLO READY: %s",
+                     strerror(errno));
+        ds4_transport_release(selected);
+        return NULL;
+    }
+    fprintf(stderr,
+            "ds4: distributed worker: negotiated protocol v3 transport=%s generation=%llu\n",
+            ds4_transport_name(selected),
+            (unsigned long long)generation);
+    return selected;
 }
 
 static void dist_coordinator_report_plan(ds4_dist_coordinator_state *state);
@@ -1853,20 +2594,98 @@ static bool dist_coordinator_debug_enabled(const ds4_dist_coordinator_state *sta
  * hidden state so the coordinator can run its local output head.
  */
 
-static void dist_coordinator_add_worker(
+static bool dist_coordinator_track_client(
+        ds4_dist_coordinator_state *state,
+        int fd) {
+    ds4_dist_client_fd_entry *entry = calloc(1, sizeof(*entry));
+    if (!entry) return false;
+    entry->fd = fd;
+
+    pthread_mutex_lock(&state->mu);
+    if (state->shutting_down) {
+        pthread_mutex_unlock(&state->mu);
+        free(entry);
+        return false;
+    }
+    entry->next = state->clients;
+    state->clients = entry;
+    pthread_mutex_unlock(&state->mu);
+    return true;
+}
+
+static void dist_coordinator_untrack_client(
+        ds4_dist_coordinator_state *state,
+        int fd) {
+    pthread_mutex_lock(&state->mu);
+    ds4_dist_client_fd_entry **link = &state->clients;
+    while (*link) {
+        ds4_dist_client_fd_entry *entry = *link;
+        if (entry->fd == fd) {
+            *link = entry->next;
+            free(entry);
+            break;
+        }
+        link = &entry->next;
+    }
+    pthread_cond_broadcast(&state->clients_cv);
+    pthread_mutex_unlock(&state->mu);
+}
+
+static void dist_coordinator_shutdown_clients(
+        ds4_dist_coordinator_state *state) {
+    pthread_mutex_lock(&state->mu);
+    state->shutting_down = true;
+    for (ds4_dist_client_fd_entry *it = state->clients; it; it = it->next) {
+        if (it->fd >= 0) shutdown(it->fd, SHUT_RDWR);
+    }
+    pthread_mutex_unlock(&state->mu);
+}
+
+static void dist_coordinator_wait_for_clients(
+        ds4_dist_coordinator_state *state) {
+    pthread_mutex_lock(&state->mu);
+    while (state->clients) {
+        pthread_cond_wait(&state->clients_cv, &state->mu);
+    }
+    pthread_mutex_unlock(&state->mu);
+}
+
+static void *dist_coordinator_client_done(
+        ds4_dist_coordinator_state *state,
+        int fd) {
+    /* Remove the fd from the coordinator-owned set before closing it.  This
+     * avoids an fd-reuse race where a newly accepted socket gets the same
+     * integer while the old tracking node is still present.  After untracking,
+     * this thread must not access state again. */
+    dist_coordinator_untrack_client(state, fd);
+    close(fd);
+    return NULL;
+}
+
+static bool dist_coordinator_add_worker(
         ds4_dist_coordinator_state *state,
         int fd,
         const char *peer_host,
         const char *peer_port,
         const ds4_dist_hello_fixed *hello,
-        const char *model_name) {
+        const char *model_name,
+        ds4_transport *prepared_transport,
+        uint32_t protocol_version) {
     ds4_dist_worker_entry *entry = calloc(1, sizeof(*entry));
     if (!entry) {
         DIST_COORD_DEBUG(state, "ds4: distributed coordinator: out of memory while registering worker\n");
-        return;
+        return false;
     }
 
     entry->fd = fd;
+    entry->transport = prepared_transport
+        ? ds4_transport_retain(prepared_transport)
+        : ds4_transport_tcp_dup(fd, NULL, 0);
+    if (!entry->transport) {
+        free(entry);
+        DIST_COORD_DEBUG(state, "ds4: distributed coordinator: failed to create persistent worker transport\n");
+        return false;
+    }
     snprintf(entry->peer_host, sizeof(entry->peer_host), "%s", peer_host);
     snprintf(entry->peer_port, sizeof(entry->peer_port), "%s", peer_port);
     snprintf(entry->model_name, sizeof(entry->model_name), "%s", model_name ? model_name : "unknown");
@@ -1879,12 +2698,17 @@ static void dist_coordinator_add_worker(
     entry->ctx_size = hello->ctx_size;
     entry->n_layers = hello->n_layers;
     entry->listen_port = hello->listen_port;
+    entry->protocol_version = protocol_version;
+    entry->link_generation = prepared_transport
+        ? ds4_transport_generation(prepared_transport) : 0;
 
+    ds4_dist_worker_entry *stale = NULL;
     pthread_mutex_lock(&state->mu);
     if (state->shutting_down) {
         pthread_mutex_unlock(&state->mu);
+        ds4_transport_release(entry->transport);
         free(entry);
-        return;
+        return false;
     }
     ds4_dist_worker_entry **link = &state->workers;
     while (*link) {
@@ -1903,7 +2727,9 @@ static void dist_coordinator_add_worker(
                              old->layer_start,
                              old->layer_end,
                              old->has_output ? "+output" : "");
-            free(old);
+            shutdown(old->fd, SHUT_RDWR);
+            old->next = stale;
+            stale = old;
             continue;
         }
         link = &old->next;
@@ -1913,21 +2739,32 @@ static void dist_coordinator_add_worker(
     state->generation++;
     pthread_mutex_unlock(&state->mu);
 
+    while (stale) {
+        ds4_dist_worker_entry *next = stale->next;
+        ds4_transport_release(stale->transport);
+        free(stale);
+        stale = next;
+    }
+
     char layer_end[32];
-    if (entry->has_output) snprintf(layer_end, sizeof(layer_end), "output");
-    else snprintf(layer_end, sizeof(layer_end), "%u", entry->layer_end);
+    if (hello->has_output) snprintf(layer_end, sizeof(layer_end), "output");
+    else snprintf(layer_end, sizeof(layer_end), "%u", hello->layer_end);
     DIST_COORD_DEBUG(state,
-                     "ds4: distributed coordinator: registered worker %s:%s data_port=%u model_id=%u quant=Q%u layers=%u:%s hidden=%u ctx=%u\n",
-                     entry->peer_host,
-                     entry->peer_port,
-                     entry->listen_port,
-                     entry->model_id,
-                     entry->quant_bits,
-                     entry->layer_start,
+                     "ds4: distributed coordinator: registered worker %s:%s data_port=%u model_id=%u quant=Q%u layers=%u:%s hidden=%u ctx=%u protocol=v%u transport=%s generation=%llu\n",
+                     peer_host,
+                     peer_port,
+                     hello->listen_port,
+                     hello->model_id,
+                     hello->quant_bits,
+                     hello->layer_start,
                      layer_end,
-                     entry->has_hidden,
-                     entry->ctx_size);
+                     hello->has_hidden,
+                     hello->ctx_size,
+                     entry->protocol_version,
+                     ds4_transport_name(entry->transport),
+                     (unsigned long long)entry->link_generation);
     if (dist_coordinator_debug_enabled(state)) dist_coordinator_report_plan(state);
+    return true;
 }
 
 static int dist_worker_route_cmp(const void *a, const void *b) {
@@ -1945,9 +2782,13 @@ static bool dist_worker_route_candidate_ok(
         const ds4_dist_coordinator_state *state,
         const ds4_dist_worker_entry *w,
         uint32_t last) {
-    const bool needs_hidden = w->layer_end < last || !w->has_output;
+    const bool needs_hidden =
+        w->layer_end < last || !w->has_output ||
+        (state->prefer_local_output_head && w->layer_end >= last);
     if (needs_hidden && !w->has_hidden) return false;
-    if (w->layer_end >= last && !w->has_output && !state->local_can_output_head) return false;
+    if (w->layer_end >= last &&
+        (state->prefer_local_output_head || !w->has_output) &&
+        !state->local_can_output_head) return false;
     return true;
 }
 
@@ -2081,10 +2922,11 @@ static void dist_coordinator_report_plan(ds4_dist_coordinator_state *state) {
 static void dist_route_plan_free(ds4_dist_route_plan *plan) {
     if (!plan) return;
     for (uint32_t i = 0; i < plan->count; i++) {
-        if (plan->entry[i].fd >= 0) close(plan->entry[i].fd);
+        ds4_transport_release(plan->entry[i].transport);
     }
     free(plan->entry);
     free(plan->blob);
+    free(plan->output_blob);
     memset(plan, 0, sizeof(*plan));
 }
 
@@ -2093,16 +2935,19 @@ static bool dist_route_entry_matches_worker(
         const ds4_dist_worker_entry *worker) {
     const bool route_has_output = (route->flags & DS4_DIST_ROUTE_F_OUTPUT_LOGITS) != 0;
     return route->port == worker->listen_port &&
+           route->transport == worker->transport &&
            strcmp(route->host, worker->peer_host) == 0 &&
            route->layer_start == worker->layer_start &&
            route->layer_end == worker->layer_end &&
-           route_has_output == (worker->has_output != 0);
+           (!route_has_output || worker->has_output != 0) &&
+           (route_has_output || worker->has_hidden != 0);
 }
 
 static void dist_coordinator_forget_route_workers(
         ds4_dist_coordinator_state *state,
         const ds4_dist_route_plan *plan) {
     bool removed_any = false;
+    ds4_dist_worker_entry *removed = NULL;
     pthread_mutex_lock(&state->mu);
     for (uint32_t i = 0; i < plan->count; i++) {
         ds4_dist_worker_entry **link = &state->workers;
@@ -2113,7 +2958,7 @@ static void dist_coordinator_forget_route_workers(
                 continue;
             }
             *link = entry->next;
-            close(entry->fd);
+            shutdown(entry->fd, SHUT_RDWR);
             DIST_COORD_DEBUG(state,
                              "ds4: distributed coordinator: forgot failed route worker %s:%u layers=%u:%u%s\n",
                              plan->entry[i].host,
@@ -2121,13 +2966,21 @@ static void dist_coordinator_forget_route_workers(
                              entry->layer_start,
                              entry->layer_end,
                              entry->has_output ? "+output" : "");
-            free(entry);
+            entry->next = removed;
+            removed = entry;
             removed_any = true;
             break;
         }
     }
     if (removed_any) state->generation++;
     pthread_mutex_unlock(&state->mu);
+
+    while (removed) {
+        ds4_dist_worker_entry *next = removed->next;
+        ds4_transport_release(removed->transport);
+        free(removed);
+        removed = next;
+    }
 
     if (removed_any && dist_coordinator_debug_enabled(state)) dist_coordinator_report_plan(state);
 }
@@ -2195,6 +3048,52 @@ static bool dist_route_plan_append_return_upstream(
     dist_route_return_to_wire(&fixed);
     memcpy((uint8_t *)plan->blob + old_bytes, &fixed, sizeof(fixed));
     plan->blob_bytes = new_bytes;
+    return true;
+}
+
+static bool dist_route_plan_make_output_variant(
+        ds4_dist_route_plan *plan,
+        char *err,
+        size_t errlen) {
+    if (!plan || plan->count == 0 || !plan->blob || plan->blob_bytes == 0) {
+        if (errlen) snprintf(err, errlen, "invalid route output variant");
+        return false;
+    }
+    void *blob = malloc(plan->blob_bytes);
+    if (!blob) {
+        if (errlen) snprintf(err, errlen, "out of memory building route output variant");
+        return false;
+    }
+    memcpy(blob, plan->blob, plan->blob_bytes);
+
+    uint8_t *p = blob;
+    uint32_t remaining = plan->blob_bytes;
+    for (uint32_t i = 0; i < plan->count; i++) {
+        if (remaining < sizeof(ds4_dist_route_fixed)) {
+            free(blob);
+            if (errlen) snprintf(err, errlen, "invalid route output variant payload");
+            return false;
+        }
+        ds4_dist_route_fixed fixed;
+        memcpy(&fixed, p, sizeof(fixed));
+        dist_route_from_wire(&fixed);
+        if (fixed.host_len > remaining - (uint32_t)sizeof(fixed)) {
+            free(blob);
+            if (errlen) snprintf(err, errlen, "invalid route output variant host");
+            return false;
+        }
+        if (i + 1u == plan->count) {
+            fixed.flags |= DS4_DIST_ROUTE_F_OUTPUT_LOGITS;
+            ds4_dist_route_fixed wire = fixed;
+            dist_route_to_wire(&wire);
+            memcpy(p, &wire, sizeof(wire));
+        }
+        const uint32_t entry_bytes = (uint32_t)sizeof(fixed) + fixed.host_len;
+        p += entry_bytes;
+        remaining -= entry_bytes;
+    }
+    free(plan->output_blob);
+    plan->output_blob = blob;
     return true;
 }
 
@@ -2267,18 +3166,13 @@ static bool dist_coordinator_build_route_plan(
         entry.port = w->listen_port;
         entry.layer_start = w->layer_start;
         entry.layer_end = w->layer_end;
-        entry.flags = w->has_output ? DS4_DIST_ROUTE_F_OUTPUT_LOGITS : 0u;
+        const bool final_local_output =
+            state->prefer_local_output_head && w->layer_end >= last;
+        entry.flags = w->has_output && !final_local_output
+            ? DS4_DIST_ROUTE_F_OUTPUT_LOGITS : 0u;
+        entry.transport = ds4_transport_retain(w->transport);
         if (state->use_control_for_work && plan->count == 0) {
-            entry.fd = dup(w->fd);
-            if (entry.fd < 0) {
-                pthread_mutex_unlock(&state->mu);
-                free(workers);
-                free(path);
-                dist_route_plan_free(plan);
-                if (errlen) snprintf(err, errlen, "failed to duplicate first-hop worker connection: %s", strerror(errno));
-                return false;
-            }
-            dist_set_socket_low_latency(entry.fd);
+            entry.fd = ds4_transport_control_fd(entry.transport);
         }
 
         ds4_dist_route_entry *new_entries = realloc(plan->entry, (size_t)(plan->count + 1u) * sizeof(plan->entry[0]));
@@ -2286,7 +3180,7 @@ static bool dist_coordinator_build_route_plan(
             pthread_mutex_unlock(&state->mu);
             free(workers);
             free(path);
-            if (entry.fd >= 0) close(entry.fd);
+            ds4_transport_release(entry.transport);
             dist_route_plan_free(plan);
             if (errlen) snprintf(err, errlen, "out of memory building route entries");
             return false;
@@ -2301,11 +3195,37 @@ static bool dist_coordinator_build_route_plan(
             return false;
         }
     }
+    const bool final_can_output =
+        path_len != 0 && path[path_len - 1u]->has_output != 0;
     if (generation) *generation = state->generation;
     pthread_mutex_unlock(&state->mu);
     free(workers);
     free(path);
+    if (plan->count > 1u) {
+        bool has_v3_link = false;
+        for (i = 0; i < plan->count; i++) {
+            if (dist_transport_uses_v3(plan->entry[i].transport)) {
+                has_v3_link = true;
+                break;
+            }
+        }
+        if (has_v3_link) {
+            dist_route_plan_free(plan);
+            if (errlen) {
+                snprintf(err, errlen,
+                         "distributed v3/NHI currently supports one remote worker link");
+            }
+            return false;
+        }
+    }
     if (plan->count != 0 && !dist_route_plan_append_return_upstream(plan, err, errlen)) {
+        dist_route_plan_free(plan);
+        return false;
+    }
+    if (final_can_output && plan->count != 0 &&
+        (plan->entry[plan->count - 1u].flags &
+         DS4_DIST_ROUTE_F_OUTPUT_LOGITS) == 0 &&
+        !dist_route_plan_make_output_variant(plan, err, errlen)) {
         dist_route_plan_free(plan);
         return false;
     }
@@ -2329,6 +3249,31 @@ static bool dist_coordinator_ensure_route(
     return dist_coordinator_build_route_plan(state, plan, generation, err, errlen);
 }
 
+static bool dist_coordinator_wait_for_route(
+        ds4_dist_coordinator_state *state,
+        ds4_dist_route_plan *plan,
+        uint64_t *generation,
+        double timeout_sec,
+        char *err,
+        size_t errlen) {
+    const double deadline = dist_now_sec() + timeout_sec;
+    do {
+        if (dist_coordinator_ensure_route(state,
+                                          plan,
+                                          generation,
+                                          err,
+                                          errlen)) {
+            return true;
+        }
+        struct timespec pause = {
+            .tv_sec = 0,
+            .tv_nsec = 100 * 1000 * 1000,
+        };
+        nanosleep(&pause, NULL);
+    } while (dist_now_sec() < deadline);
+    return false;
+}
+
 static uint64_t dist_coordinator_generation(ds4_dist_coordinator_state *state) {
     if (!state) return 0;
     pthread_mutex_lock(&state->mu);
@@ -2341,29 +3286,37 @@ static uint64_t dist_coordinator_generation(ds4_dist_coordinator_state *state) {
  * Coordinator Work Dispatch
  * ========================================================================= */
 
-static int dist_recv_result_alloc(
+static int dist_recv_result_alloc_leased(
         int fd,
+        ds4_transport *transport,
         const ds4_dist_coordinator_state *state,
         uint64_t request_id,
         uint32_t *kind,
         uint64_t *result_hash,
         void **payload,
         uint32_t *payload_bytes,
+        ds4_transport_lease **payload_lease,
         char *err,
         size_t errlen) {
     *payload = NULL;
     *payload_bytes = 0;
     *kind = 0;
     if (result_hash) *result_hash = 0;
+    if (payload_lease) *payload_lease = NULL;
+    const bool v3 = dist_transport_uses_v3(transport);
 
     uint32_t type = 0, bytes = 0;
     int rc = dist_read_frame_header(fd, &type, &bytes, err, errlen);
     if (rc <= 0) {
+        if (v3) shutdown(fd, SHUT_RDWR);
         if (rc == 0 && errlen) snprintf(err, errlen, "distributed worker closed connection");
         return 1;
     }
     if (type != DS4_DIST_MSG_RESULT || bytes < sizeof(ds4_dist_result_fixed)) {
-        dist_discard_bytes(fd, bytes);
+        if (v3)
+            shutdown(fd, SHUT_RDWR);
+        else
+            dist_discard_bytes(fd, bytes);
         if (errlen) snprintf(err, errlen, "distributed worker returned invalid frame");
         return 1;
     }
@@ -2378,26 +3331,96 @@ static int dist_recv_result_alloc(
     const uint64_t got_request = dist_u64_from_halves(result.request_hi, result.request_lo);
     const uint64_t got_hash = dist_u64_from_halves(result.result_hash_hi,
                                                   result.result_hash_lo);
-    const uint32_t body_bytes = bytes - (uint32_t)sizeof(result);
+    uint32_t body_bytes = bytes - (uint32_t)sizeof(result);
+    ds4_transport_bulk_desc bulk_desc;
+    memset(&bulk_desc, 0, sizeof(bulk_desc));
+    if (v3) {
+        if (body_bytes < sizeof(ds4_transport_bulk_desc_wire)) {
+            shutdown(fd, SHUT_RDWR);
+            if (errlen) snprintf(err, errlen,
+                                 "distributed v3 result is missing its bulk descriptor");
+            return 1;
+        }
+        ds4_transport_bulk_desc_wire desc_wire;
+        rc = dist_read_full(fd, &desc_wire, sizeof(desc_wire));
+        if (rc <= 0 ||
+            ds4_transport_bulk_desc_decode(&desc_wire, &bulk_desc) != 0) {
+            shutdown(fd, SHUT_RDWR);
+            if (errlen) snprintf(err, errlen,
+                                 "failed to read distributed v3 result descriptor");
+            return 1;
+        }
+        body_bytes -= (uint32_t)sizeof(desc_wire);
+    }
+    const bool payload_is_bulk = result.status == 0 &&
+        result.payload_bytes != 0 &&
+        (result.result_kind == DS4_DIST_RESULT_HIDDEN_STATE ||
+         result.result_kind == DS4_DIST_RESULT_LOGITS);
+    uint32_t tcp_payload_bytes = result.payload_bytes;
+    if (v3 && payload_is_bulk &&
+        bulk_desc.mode == DS4_TRANSPORT_BULK_NHI_OOB)
+        tcp_payload_bytes = 0;
     if (result.telemetry_bytes % (uint32_t)sizeof(ds4_dist_telemetry_fixed) != 0 ||
         result.telemetry_count != result.telemetry_bytes / (uint32_t)sizeof(ds4_dist_telemetry_fixed) ||
         result.telemetry_bytes > body_bytes ||
-        result.payload_bytes != body_bytes - result.telemetry_bytes) {
-        dist_discard_bytes(fd, body_bytes);
+        tcp_payload_bytes != body_bytes - result.telemetry_bytes) {
+        if (v3)
+            shutdown(fd, SHUT_RDWR);
+        else
+            dist_discard_bytes(fd, body_bytes);
         if (errlen) snprintf(err, errlen, "distributed result telemetry metadata mismatch");
         return 1;
     }
     if (got_request != request_id) {
-        dist_discard_bytes(fd, bytes - (uint32_t)sizeof(result));
+        if (v3)
+            shutdown(fd, SHUT_RDWR);
+        else
+            dist_discard_bytes(fd, body_bytes);
         if (errlen) snprintf(err, errlen, "distributed result metadata mismatch");
         return 1;
+    }
+
+    if (v3) {
+        int desc_rc = 0;
+        if (!payload_is_bulk) {
+            desc_rc = dist_validate_bulk_none_desc(transport, &bulk_desc,
+                                                   0, request_id);
+        } else {
+            const uint32_t bulk_kind =
+                result.result_kind == DS4_DIST_RESULT_HIDDEN_STATE
+                    ? DS4_TRANSPORT_BULK_RESULT_HIDDEN
+                    : DS4_TRANSPORT_BULK_RESULT_LOGITS;
+            if (bulk_desc.mode == DS4_TRANSPORT_BULK_TCP_INLINE) {
+                desc_rc = ds4_transport_validate_inline_desc(
+                    &bulk_desc, bulk_kind, 0, request_id,
+                    result.payload_bytes, result.payload_bits,
+                    err, errlen);
+            } else if (bulk_desc.mode == DS4_TRANSPORT_BULK_NHI_OOB) {
+                desc_rc = ds4_transport_validate_oob_desc(
+                    transport, &bulk_desc, bulk_kind, 0, request_id,
+                    result.payload_bytes, result.payload_bits,
+                    err, errlen);
+            } else {
+                desc_rc = -1;
+                errno = EPROTO;
+            }
+        }
+        if (desc_rc != 0) {
+            shutdown(fd, SHUT_RDWR);
+            if (errlen && !err[0]) snprintf(err, errlen,
+                                            "invalid distributed v3 result descriptor");
+            return 1;
+        }
     }
 
     if (result.telemetry_bytes != 0) {
         if (dist_coordinator_debug_enabled(state)) {
             ds4_dist_telemetry_fixed *telemetry = malloc(result.telemetry_bytes);
             if (!telemetry) {
-                dist_discard_bytes(fd, result.telemetry_bytes);
+                if (v3)
+                    shutdown(fd, SHUT_RDWR);
+                else
+                    dist_discard_bytes(fd, body_bytes);
                 if (errlen) snprintf(err, errlen, "out of memory reading distributed telemetry");
                 return 1;
             }
@@ -2432,18 +3455,52 @@ static int dist_recv_result_alloc(
     }
 
     void *buf = NULL;
+    ds4_transport_lease *lease = NULL;
     if (result.payload_bytes != 0) {
-        buf = malloc(result.payload_bytes);
-        if (!buf) {
-            dist_discard_bytes(fd, result.payload_bytes);
-            if (errlen) snprintf(err, errlen, "out of memory reading distributed result");
-            return 1;
+        const bool try_mapped = payload_lease && v3 && payload_is_bulk &&
+            result.payload_bits == 32u &&
+            bulk_desc.mode == DS4_TRANSPORT_BULK_NHI_OOB &&
+            ds4_transport_mapped_leases_supported(transport);
+        if (try_mapped) {
+            if (ds4_transport_rx_lease_acquire(transport, &bulk_desc, &lease,
+                                               err, errlen) == 0) {
+                buf = ds4_transport_lease_host_ptr(lease);
+            } else if (errno != ENOTSUP) {
+                shutdown(fd, SHUT_RDWR);
+                if (errlen && !err[0])
+                    snprintf(err, errlen,
+                             "failed to acquire mapped distributed result");
+                return 1;
+            }
         }
-        rc = dist_read_full(fd, buf, result.payload_bytes);
-        if (rc <= 0) {
-            free(buf);
-            if (errlen) snprintf(err, errlen, "failed to read distributed result payload");
-            return 1;
+        if (!buf) {
+            buf = malloc(result.payload_bytes);
+            if (!buf) {
+                if (v3)
+                    shutdown(fd, SHUT_RDWR);
+                else
+                    dist_discard_bytes(fd, result.payload_bytes);
+                if (errlen)
+                    snprintf(err, errlen,
+                             "out of memory reading distributed result");
+                return 1;
+            }
+            if (v3 && payload_is_bulk) {
+                rc = ds4_transport_recv_bulk_desc(transport, &bulk_desc,
+                                                  buf, result.payload_bytes);
+            } else {
+                rc = payload_is_bulk
+                    ? ds4_transport_recv_bulk(transport, buf,
+                                              result.payload_bytes)
+                    : dist_read_full(fd, buf, result.payload_bytes);
+            }
+            if (rc <= 0) {
+                free(buf);
+                if (errlen)
+                    snprintf(err, errlen,
+                             "failed to read distributed result payload");
+                return 1;
+            }
         }
     }
 
@@ -2457,7 +3514,10 @@ static int dist_recv_result_alloc(
                 snprintf(err, errlen, "distributed worker returned an error");
             }
         }
-        free(buf);
+        if (lease)
+            ds4_transport_lease_release(lease);
+        else
+            free(buf);
         return DS4_DIST_RECV_REMOTE_ERROR;
     }
 
@@ -2473,11 +3533,24 @@ static int dist_recv_result_alloc(
                                            &uses_wire,
                                            err,
                                            errlen) != 0) {
-            free(buf);
+            if (lease)
+                ds4_transport_lease_release(lease);
+            else
+                free(buf);
             return 1;
         }
         if (!uses_wire) {
-            free(buf);
+            if (lease) {
+                if (dist_mapped_lease_commit_after_gpu_quiesce(lease) != 0) {
+                    ds4_transport_lease_release(lease);
+                    free(decoded);
+                    return 1;
+                }
+                ds4_transport_lease_release(lease);
+                lease = NULL;
+            } else {
+                free(buf);
+            }
             buf = decoded;
         }
         result.payload_bytes = decoded_bytes;
@@ -2487,6 +3560,44 @@ static int dist_recv_result_alloc(
     if (result_hash) *result_hash = got_hash;
     *payload = buf;
     *payload_bytes = result.payload_bytes;
+    if (payload_lease) *payload_lease = lease;
+    return 0;
+}
+
+static int dist_recv_result_alloc(
+        int fd,
+        ds4_transport *transport,
+        const ds4_dist_coordinator_state *state,
+        uint64_t request_id,
+        uint32_t *kind,
+        uint64_t *result_hash,
+        void **payload,
+        uint32_t *payload_bytes,
+        char *err,
+        size_t errlen) {
+    return dist_recv_result_alloc_leased(fd, transport, state, request_id,
+                                         kind, result_hash, payload,
+                                         payload_bytes, NULL, err, errlen);
+}
+
+static int dist_result_payload_release(
+        void *payload,
+        ds4_transport_lease *lease,
+        char *err,
+        size_t errlen) {
+    if (!lease) {
+        free(payload);
+        return 0;
+    }
+    const int rc = dist_mapped_lease_commit_after_gpu_quiesce(lease);
+    ds4_transport_lease_release(lease);
+    if (rc != 0) {
+        if (errlen)
+            snprintf(err, errlen,
+                     "failed to release mapped distributed result: %s",
+                     strerror(errno));
+        return 1;
+    }
     return 0;
 }
 
@@ -2494,6 +3605,7 @@ static int dist_coordinator_send_remote_work_on_fd(
         ds4_dist_coordinator_state *state,
         const ds4_dist_route_plan *plan,
         int fd,
+        ds4_transport *transport,
         const int *tokens,
         uint32_t n_tokens,
         uint32_t pos0,
@@ -2503,8 +3615,12 @@ static int dist_coordinator_send_remote_work_on_fd(
         uint64_t result_hash,
         bool reset_session,
         bool ack_only,
+        bool prefer_remote_logits,
+        uint32_t extra_flags,
+        uint32_t spec_keep_tokens,
         const float *hidden_hc,
         uint32_t hidden_hc_bytes,
+        const ds4_dist_tx_bulk_plan *tx_plan,
         char *err,
         size_t errlen) {
     if (plan->count == 0) {
@@ -2524,14 +3640,23 @@ static int dist_coordinator_send_remote_work_on_fd(
     work.n_tokens = n_tokens;
     work.layer_start = first->layer_start;
     work.layer_end = first->layer_end;
-    work.flags = DS4_DIST_WORK_F_INPUT_HC;
+    const bool spec_commit = (extra_flags & DS4_DIST_WORK_F_SPEC_COMMIT) != 0;
+    const bool use_output_variant =
+        prefer_remote_logits && plan->output_blob != NULL;
+    const void *route_blob = use_output_variant
+        ? plan->output_blob : plan->blob;
+    work.flags = extra_flags;
+    if (!spec_commit) work.flags |= DS4_DIST_WORK_F_INPUT_HC;
     if (reset_session) work.flags |= DS4_DIST_WORK_F_RESET_SESSION;
     if (ack_only) work.flags |= DS4_DIST_WORK_F_ACK_ONLY;
-    if ((first->flags & DS4_DIST_ROUTE_F_OUTPUT_LOGITS) != 0) {
+    if (!spec_commit &&
+        ((first->flags & DS4_DIST_ROUTE_F_OUTPUT_LOGITS) != 0 ||
+         (use_output_variant && plan->count == 1u))) {
         work.flags |= DS4_DIST_WORK_F_OUTPUT_LOGITS;
     }
     uint32_t wire_hidden_hc_bytes = 0;
-    if (!dist_activation_wire_bytes_from_f32_bytes(state->activation_bits,
+    if (!spec_commit &&
+        !dist_activation_wire_bytes_from_f32_bytes(state->activation_bits,
                                                    hidden_hc_bytes,
                                                    &wire_hidden_hc_bytes)) {
         if (errlen) snprintf(err, errlen, "invalid distributed hidden-state size");
@@ -2543,8 +3668,11 @@ static int dist_coordinator_send_remote_work_on_fd(
     work.route_count = plan->count;
     work.route_index = 0;
     work.route_bytes = plan->blob_bytes;
+    work.spec_keep_tokens = spec_keep_tokens;
 
-    if (dist_send_work_frame(fd, &work, tokens, hidden_hc, plan->blob) != 0) {
+    if (dist_send_work_frame_prepared(
+            fd, transport, &work, tokens, hidden_hc, route_blob,
+            dist_tx_bulk_plan_desc(tx_plan), tx_plan ? tx_plan->lease : NULL) != 0) {
         if (errlen) snprintf(err, errlen, "failed to send distributed work");
         return 1;
     }
@@ -2556,6 +3684,7 @@ static int dist_coordinator_eval_remote_on_fd(
         ds4_session *session,
         const ds4_dist_route_plan *plan,
         int fd,
+        ds4_transport *transport,
         const int *tokens,
         uint32_t n_tokens,
         uint32_t pos0,
@@ -2564,17 +3693,24 @@ static int dist_coordinator_eval_remote_on_fd(
         uint64_t prefix_hash,
         uint64_t expected_result_hash,
         bool reset_session,
+        bool prefer_remote_logits,
+        uint32_t extra_flags,
         const float *hidden_hc,
         uint32_t hidden_hc_bytes,
+        const ds4_dist_tx_bulk_plan *tx_plan,
         float *logits,
+        float *row_logits,
+        float **hidden_rows_out,
         char *err,
         size_t errlen) {
+    if (hidden_rows_out) *hidden_rows_out = NULL;
     const bool profile = dist_decode_profile_enabled() && n_tokens == 1;
     const double total_t0 = profile ? dist_now_sec() : 0.0;
     const double send_t0 = profile ? dist_now_sec() : 0.0;
     int rc = dist_coordinator_send_remote_work_on_fd(state,
                                                      plan,
                                                      fd,
+                                                     transport,
                                                      tokens,
                                                      n_tokens,
                                                      pos0,
@@ -2584,25 +3720,25 @@ static int dist_coordinator_eval_remote_on_fd(
                                                      expected_result_hash,
                                                      reset_session,
                                                      false,
+                                                     prefer_remote_logits,
+                                                     extra_flags,
+                                                     0,
                                                      hidden_hc,
                                                      hidden_hc_bytes,
+                                                     tx_plan,
                                                      err,
                                                      errlen);
     const double send_t1 = profile ? dist_now_sec() : 0.0;
     uint32_t kind = 0, payload_bytes = 0;
     uint64_t result_hash = 0;
     void *payload = NULL;
+    ds4_transport_lease *payload_lease = NULL;
     if (rc == 0) {
         const double recv_t0 = profile ? dist_now_sec() : 0.0;
-        rc = dist_recv_result_alloc(fd,
-                                    state,
-                                    request_id,
-                                    &kind,
-                                    &result_hash,
-                                    &payload,
-                                    &payload_bytes,
-                                    err,
-                                    errlen);
+        rc = dist_recv_result_alloc_leased(
+            fd, transport, state, request_id, &kind, &result_hash,
+            &payload, &payload_bytes,
+            hidden_rows_out ? NULL : &payload_lease, err, errlen);
         const double recv_t1 = profile ? dist_now_sec() : 0.0;
         if (profile) {
             fprintf(stderr,
@@ -2617,7 +3753,7 @@ static int dist_coordinator_eval_remote_on_fd(
     }
     if (rc != 0) return rc;
     if (result_hash != expected_result_hash) {
-        free(payload);
+        (void)dist_result_payload_release(payload, payload_lease, NULL, 0);
         if (errlen) snprintf(err, errlen, "distributed result prefix hash mismatch");
         return 1;
     }
@@ -2626,7 +3762,8 @@ static int dist_coordinator_eval_remote_on_fd(
     if (kind == DS4_DIST_RESULT_LOGITS && payload_bytes == logits_bytes) {
         const double copy_t0 = profile ? dist_now_sec() : 0.0;
         memcpy(logits, payload, logits_bytes);
-        free(payload);
+        const int release_rc = dist_result_payload_release(
+            payload, payload_lease, err, errlen);
         if (profile) {
             const double copy_t1 = dist_now_sec();
             fprintf(stderr,
@@ -2635,17 +3772,41 @@ static int dist_coordinator_eval_remote_on_fd(
                     (copy_t1 - copy_t0) * 1000.0,
                     (copy_t1 - total_t0) * 1000.0);
         }
-        return 0;
+        return release_rc;
     }
     if (kind == DS4_DIST_RESULT_HIDDEN_STATE && payload_bytes == hidden_hc_bytes) {
         const double head_t0 = profile ? dist_now_sec() : 0.0;
-        int head_rc = ds4_session_eval_output_head_from_hc(session,
+        int head_rc;
+        if (row_logits) {
+            head_rc = ds4_session_eval_output_heads_from_hc(session,
+                                                            payload,
+                                                            n_tokens,
+                                                            n_tokens - 1u,
+                                                            row_logits,
+                                                            err,
+                                                            errlen);
+            if (head_rc == 0 && logits) {
+                const uint64_t row_values =
+                    (uint64_t)ds4_engine_vocab_size(state->engine);
+                memcpy(logits,
+                       row_logits + (uint64_t)(n_tokens - 1u) * row_values,
+                       row_values * sizeof(float));
+            }
+        } else {
+            head_rc = ds4_session_eval_output_head_from_hc(session,
                                                            payload,
                                                            n_tokens,
                                                            logits,
                                                            err,
                                                            errlen);
-        free(payload);
+        }
+        if (head_rc == 0 && hidden_rows_out) {
+            *hidden_rows_out = payload;
+        } else {
+            const int release_rc = dist_result_payload_release(
+                payload, payload_lease, err, errlen);
+            if (head_rc == 0 && release_rc != 0) head_rc = release_rc;
+        }
         if (profile) {
             const double head_t1 = dist_now_sec();
             fprintf(stderr,
@@ -2658,11 +3819,11 @@ static int dist_coordinator_eval_remote_on_fd(
         return head_rc;
     }
     if (kind == DS4_DIST_RESULT_HIDDEN_STATE) {
-        free(payload);
+        (void)dist_result_payload_release(payload, payload_lease, NULL, 0);
         if (errlen) snprintf(err, errlen, "distributed route returned invalid hidden-state size");
         return 1;
     }
-    free(payload);
+    (void)dist_result_payload_release(payload, payload_lease, NULL, 0);
     if (errlen) snprintf(err, errlen, "distributed route did not return logits or hidden-state");
     return 1;
 }
@@ -2677,6 +3838,7 @@ static int dist_coordinator_eval_span(
         uint64_t session_id,
         uint64_t request_id,
         bool reset_session,
+        bool prefer_remote_logits,
         float *logits,
         char *err,
         size_t errlen) {
@@ -2703,17 +3865,34 @@ static int dist_coordinator_eval_span(
     }
     const uint64_t result_hash = dist_token_hash_update_span(prefix_hash, tokens, n_tokens);
     const uint32_t hidden_bytes = (uint32_t)hidden_bytes64;
+    ds4_dist_tx_bulk_plan tx_plan;
+    memset(&tx_plan, 0, sizeof(tx_plan));
+    if (plan->count == 1u &&
+        dist_tx_bulk_plan_prepare(
+            plan->entry[0].transport,
+            DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+            session_id, request_id, hidden_bytes,
+            state->activation_bits, &tx_plan, err, errlen) < 0) {
+        dist_tx_bulk_plan_abort(plan->entry[0].transport, &tx_plan);
+        return 1;
+    }
     float *hidden = NULL;
     if (plan->count != 0) {
-        hidden = malloc(hidden_bytes);
+        hidden = tx_plan.lease
+            ? ds4_transport_lease_host_ptr(tx_plan.lease)
+            : malloc(hidden_bytes);
         if (!hidden) {
+            dist_tx_bulk_plan_abort(plan->entry[0].transport, &tx_plan);
             if (errlen) snprintf(err, errlen, "out of memory allocating coordinator hidden-state");
             return 1;
         }
     }
+    const bool hidden_mapped = tx_plan.lease != NULL;
     if (reset_session &&
         ds4_session_layer_slice_reset(session, err, errlen) != 0) {
-        free(hidden);
+        if (!tx_plan.lease) free(hidden);
+        if (plan->count != 0)
+            dist_tx_bulk_plan_abort(plan->entry[0].transport, &tx_plan);
         return 1;
     }
 
@@ -2724,25 +3903,66 @@ static int dist_coordinator_eval_span(
         remote_fd = first->fd;
         if (remote_fd < 0) {
             if (errlen) snprintf(err, errlen, "distributed route has no live first-hop connection");
-            free(hidden);
+            if (!tx_plan.lease) free(hidden);
+            dist_tx_bulk_plan_abort(plan->entry[0].transport, &tx_plan);
             return 1;
         }
     }
 
     const double local_t0 = profile ? dist_now_sec() : 0.0;
-    int rc = ds4_session_eval_layer_slice(session,
-                                          tokens,
-                                          n_tokens,
-                                          pos0,
-                                          state->local_start,
-                                          state->local_end,
-                                          NULL,
-                                          local_logits ? NULL : hidden,
-                                          local_logits,
-                                          local_logits ? logits : NULL,
-                                          err,
-                                          errlen);
+    uint32_t local_direct_used = 0;
+    ds4_layer_slice_device_io local_device_io;
+    memset(&local_device_io, 0, sizeof(local_device_io));
+    const uint32_t direct_mode = dist_nhi_direct_slot_mode();
+    if (!local_logits && tx_plan.lease &&
+        (direct_mode & DS4_DIST_NHI_DIRECT_TX) != 0) {
+        local_device_io.output_hc_device =
+            ds4_transport_lease_device_ptr(tx_plan.lease);
+        local_device_io.output_hc_bytes =
+            ds4_transport_lease_bytes(tx_plan.lease);
+        if (dist_nhi_unsafe_fast_enabled()) {
+            local_device_io.flags |=
+                DS4_LAYER_SLICE_DEVICE_IO_DISCARD_OUTPUT_HC_STATE;
+        }
+    }
+    int rc = local_device_io.output_hc_device
+        ? ds4_session_eval_layer_slice_device_io(
+              session,
+              tokens,
+              n_tokens,
+              pos0,
+              state->local_start,
+              state->local_end,
+              NULL,
+              hidden,
+              false,
+              NULL,
+              &local_device_io,
+              &local_direct_used,
+              err,
+              errlen)
+        : ds4_session_eval_layer_slice(session,
+                                       tokens,
+                                       n_tokens,
+                                       pos0,
+                                       state->local_start,
+                                       state->local_end,
+                                       NULL,
+                                       local_logits ? NULL : hidden,
+                                       local_logits,
+                                       local_logits ? logits : NULL,
+                                       err,
+                                       errlen);
     const double local_t1 = profile ? dist_now_sec() : 0.0;
+    if (dist_nhi_direct_slot_trace_enabled() && n_tokens == 1) {
+        fprintf(stderr,
+                "ds4: dist direct-slot: role=coordinator request=%llu pos=%u mode=%u tx_lease=%u used=0x%x\n",
+                (unsigned long long)request_id,
+                pos0,
+                direct_mode,
+                tx_plan.lease ? 1u : 0u,
+                local_direct_used);
+    }
     double remote_t0 = 0.0, remote_t1 = 0.0;
     if (rc == 0 && plan->count != 0) {
         remote_t0 = profile ? dist_now_sec() : 0.0;
@@ -2750,6 +3970,7 @@ static int dist_coordinator_eval_span(
                                                 session,
                                                 plan,
                                                 remote_fd,
+                                                plan->entry[0].transport,
                                                 tokens,
                                                 n_tokens,
                                                 pos0,
@@ -2758,17 +3979,26 @@ static int dist_coordinator_eval_span(
                                                 prefix_hash,
                                                 result_hash,
                                                 reset_session,
+                                                prefer_remote_logits,
+                                                0,
                                                 hidden,
                                                 hidden_bytes,
+                                                &tx_plan,
                                                 logits,
+                                                NULL,
+                                                NULL,
                                                 err,
                                                 errlen);
         remote_t1 = profile ? dist_now_sec() : 0.0;
     }
+    if (rc != 0 && tx_plan.prepared)
+        dist_tx_bulk_plan_abort(plan->entry[0].transport, &tx_plan);
+    else
+        dist_tx_bulk_plan_release(&tx_plan);
     if (profile) {
         const double span_t1 = dist_now_sec();
         fprintf(stderr,
-                "ds4: dist decode profile: span request=%llu pos=%u layers=%u:%u local=%.3fms remote=%.3fms total=%.3fms hidden=%.2fMiB rc=%d\n",
+                "ds4: dist decode profile: span request=%llu pos=%u layers=%u:%u local=%.3fms remote=%.3fms total=%.3fms hidden=%.2fMiB direct=0x%x rc=%d\n",
                 (unsigned long long)request_id,
                 pos0,
                 state->local_start,
@@ -2777,9 +4007,211 @@ static int dist_coordinator_eval_span(
                 (remote_t1 - remote_t0) * 1000.0,
                 (span_t1 - span_t0) * 1000.0,
                 (double)hidden_bytes / (1024.0 * 1024.0),
+                local_direct_used,
                 rc);
     }
+    if (!hidden_mapped) free(hidden);
+    return rc;
+}
+
+/* Run a tiny target-model verifier across every distributed layer slice.
+ * Each slice keeps a transaction open until the coordinator sends the
+ * accepted prefix length with dist_coordinator_commit_speculative(). */
+static int dist_coordinator_eval_speculative_span(
+        ds4_dist_coordinator_state *state,
+        ds4_session *session,
+        const ds4_dist_route_plan *plan,
+        const int *tokens,
+        uint32_t n_tokens,
+        uint32_t pos0,
+        uint64_t session_id,
+        uint64_t request_id,
+        float *row_logits,
+        float **hidden_rows_out,
+        char *err,
+        size_t errlen) {
+    if (!state || !session || !plan || !tokens || n_tokens == 0 || !row_logits) {
+        if (errlen) snprintf(err, errlen, "invalid distributed speculative span");
+        return 1;
+    }
+    if (plan->count == 0) {
+        if (errlen) snprintf(err, errlen,
+                             "distributed speculative verification requires a remote layer slice");
+        return 1;
+    }
+    if (!state->local_can_output_head) {
+        if (errlen) snprintf(err, errlen,
+                             "distributed MTP requires the coordinator output head");
+        return 1;
+    }
+
+    uint64_t prefix_hash = 0;
+    if (dist_session_token_hash_prefix(session, pos0, &prefix_hash, err, errlen) != 0) {
+        return 1;
+    }
+    const uint64_t result_hash =
+        dist_token_hash_update_span(prefix_hash, tokens, n_tokens);
+    const uint64_t hc_values = ds4_engine_hidden_f32_values(state->engine);
+    const uint64_t hidden_bytes64 =
+        (uint64_t)n_tokens * hc_values * sizeof(float);
+    if (hidden_bytes64 > UINT32_MAX) {
+        if (errlen) snprintf(err, errlen,
+                             "distributed speculative hidden-state span is too large");
+        return 1;
+    }
+    const uint32_t hidden_bytes = (uint32_t)hidden_bytes64;
+    float *hidden = malloc(hidden_bytes);
+    if (!hidden) {
+        if (errlen) snprintf(err, errlen,
+                             "out of memory allocating speculative hidden states");
+        return 1;
+    }
+
+    int rc = ds4_session_speculative_begin(session, true, err, errlen);
+    if (rc == 0) {
+        rc = ds4_session_eval_layer_slice(session,
+                                          tokens,
+                                          n_tokens,
+                                          pos0,
+                                          state->local_start,
+                                          state->local_end,
+                                          NULL,
+                                          hidden,
+                                          false,
+                                          NULL,
+                                          err,
+                                          errlen);
+    }
+    if (rc == 0) {
+        const int remote_fd = plan->entry[0].fd;
+        if (remote_fd < 0) {
+            if (errlen) snprintf(err, errlen,
+                                 "distributed speculative route has no first-hop connection");
+            rc = 1;
+        } else {
+            rc = dist_coordinator_eval_remote_on_fd(
+                state,
+                session,
+                plan,
+                remote_fd,
+                plan->entry[0].transport,
+                tokens,
+                n_tokens,
+                pos0,
+                session_id,
+                request_id,
+                prefix_hash,
+                result_hash,
+                false,
+                false,
+                DS4_DIST_WORK_F_SPECULATIVE,
+                hidden,
+                hidden_bytes,
+                NULL,
+                NULL,
+                row_logits,
+                hidden_rows_out,
+                err,
+                errlen);
+        }
+    }
+    if (rc != 0) {
+        char rollback_err[256] = "";
+        if (ds4_session_speculative_rollback(session,
+                                             rollback_err,
+                                             sizeof(rollback_err)) != 0 &&
+            errlen && !err[0]) {
+            snprintf(err, errlen, "%s", rollback_err[0]
+                                         ? rollback_err
+                                         : "distributed speculative rollback failed");
+        }
+    }
     free(hidden);
+    return rc;
+}
+
+static int dist_coordinator_commit_speculative(
+        ds4_dist_coordinator_state *state,
+        ds4_session *session,
+        const ds4_dist_route_plan *plan,
+        const int *tokens,
+        uint32_t n_tokens,
+        uint32_t keep_tokens,
+        uint32_t pos0,
+        uint64_t session_id,
+        uint64_t request_id,
+        char *err,
+        size_t errlen) {
+    if (!state || !session || !plan || !tokens || n_tokens == 0 ||
+        keep_tokens == 0 || keep_tokens > n_tokens) {
+        if (errlen) snprintf(err, errlen, "invalid distributed speculative commit");
+        return 1;
+    }
+
+    uint64_t prefix_hash = 0;
+    if (dist_session_token_hash_prefix(session, pos0, &prefix_hash, err, errlen) != 0) {
+        return 1;
+    }
+    const uint64_t result_hash =
+        dist_token_hash_update_span(prefix_hash, tokens, n_tokens);
+    const uint64_t committed_hash =
+        dist_token_hash_update_span(prefix_hash, tokens, keep_tokens);
+
+    int rc = 0;
+    if (plan->count != 0) {
+        const int remote_fd = plan->entry[0].fd;
+        rc = dist_coordinator_send_remote_work_on_fd(
+            state,
+            plan,
+            remote_fd,
+            plan->entry[0].transport,
+            tokens,
+            n_tokens,
+            pos0,
+            session_id,
+            request_id,
+            prefix_hash,
+            result_hash,
+            false,
+            true,
+            false,
+            DS4_DIST_WORK_F_SPEC_COMMIT,
+            keep_tokens,
+            NULL,
+            0,
+            NULL,
+            err,
+            errlen);
+        uint32_t kind = 0, payload_bytes = 0;
+        uint64_t got_hash = 0;
+        void *payload = NULL;
+        if (rc == 0) {
+            rc = dist_recv_result_alloc(remote_fd,
+                                        plan->entry[0].transport,
+                                        state,
+                                        request_id,
+                                        &kind,
+                                        &got_hash,
+                                        &payload,
+                                        &payload_bytes,
+                                        err,
+                                        errlen);
+        }
+        if (rc == 0 &&
+            (kind != DS4_DIST_RESULT_ACK || payload_bytes != 0 ||
+             got_hash != committed_hash)) {
+            if (errlen) snprintf(err, errlen,
+                                 "invalid distributed speculative commit acknowledgement");
+            rc = 1;
+        }
+        free(payload);
+    }
+    if (rc == 0) {
+        rc = ds4_session_speculative_commit(session,
+                                            keep_tokens,
+                                            err,
+                                            errlen);
+    }
     return rc;
 }
 
@@ -2965,7 +4397,12 @@ static int dist_coordinator_rebuild_from_transcript(
         dist_coordinator_forget_route_workers(state, plan);
         dist_route_plan_free(plan);
         uint64_t generation = 0;
-        if (!dist_coordinator_ensure_route(state, plan, &generation, err, errlen)) return 1;
+        if (!dist_coordinator_wait_for_route(state,
+                                             plan,
+                                             &generation,
+                                             5.0,
+                                             err,
+                                             errlen)) return 1;
         if (plan_generation) *plan_generation = generation;
     } else if (plan->count == 0) {
         uint64_t generation = 0;
@@ -3055,7 +4492,8 @@ static int dist_write_logprobs_dump(
         if (dist_coordinator_eval_span(state, session, plan,
                                        &token, 1, token_pos,
                                        session_id, (*request_id)++,
-                                       false, logits, err, sizeof(err)) != 0) {
+                                       false, false,
+                                       logits, err, sizeof(err)) != 0) {
             fprintf(stderr,
                     "ds4: distributed decode failed while dumping logprobs: %s\n",
                     err);
@@ -3106,6 +4544,7 @@ static int dist_prefill_sender_init(
         const ds4_tokens *prompt,
         uint64_t session_id,
         int fd,
+        ds4_transport *transport,
         uint32_t chunk_count,
         uint32_t max_hidden_bytes,
         char *err,
@@ -3116,6 +4555,7 @@ static int dist_prefill_sender_init(
     sender->prompt = prompt;
     sender->session_id = session_id;
     sender->fd = fd;
+    sender->transport = transport;
     sender->slot_count = dist_prefill_send_depth(chunk_count);
     pthread_mutex_init(&sender->mu, NULL);
     pthread_cond_init(&sender->can_enqueue, NULL);
@@ -3222,6 +4662,7 @@ static void *dist_prefill_sender_main(void *arg) {
         int rc = dist_coordinator_send_remote_work_on_fd(sender->state,
                                                          sender->plan,
                                                          sender->fd,
+                                                         sender->transport,
                                                          sender->prompt->v + slot->pos,
                                                          slot->n_tokens,
                                                          slot->pos,
@@ -3231,8 +4672,12 @@ static void *dist_prefill_sender_main(void *arg) {
                                                          slot->result_hash,
                                                          slot->reset_session,
                                                          slot->ack_only,
+                                                         true,
+                                                         0,
+                                                         0,
                                                          slot->hidden,
                                                          slot->hidden_bytes,
+                                                         NULL,
                                                          send_err,
                                                          sizeof(send_err));
         const double send_t1 = dist_now_sec();
@@ -3243,7 +4688,12 @@ static void *dist_prefill_sender_main(void *arg) {
                                                         slot->hidden_bytes,
                                                         &slot_hidden_wire_bytes);
         sender->send_sec += send_t1 - send_t0;
-        sender->send_bytes += (uint64_t)sizeof(ds4_dist_work_fixed) +
+        const uint64_t fixed_and_desc_bytes =
+            dist_transport_uses_v3(sender->transport)
+                ? (uint64_t)sizeof(ds4_dist_work_fixed) +
+                  DS4_TRANSPORT_BULK_DESC_BYTES
+                : (uint64_t)sizeof(ds4_dist_work_fixed);
+        sender->send_bytes += fixed_and_desc_bytes +
                               (uint64_t)slot->n_tokens * sizeof(uint32_t) +
                               (uint64_t)slot_hidden_wire_bytes +
                               sender->plan->blob_bytes;
@@ -3357,6 +4807,7 @@ static void *dist_prefill_result_reader_main(void *arg) {
         uint64_t result_hash = 0;
         void *payload = NULL;
         int recv_rc = dist_recv_result_alloc(reader->fd,
+                                             reader->transport,
                                              reader->state,
                                              request_id,
                                              &kind,
@@ -3507,7 +4958,10 @@ static void dist_report_prefill_progress(ds4_session *session, uint32_t current,
     if (!session) return;
     if (current > (uint32_t)INT_MAX) current = (uint32_t)INT_MAX;
     if (total > (uint32_t)INT_MAX) total = (uint32_t)INT_MAX;
+    const bool old_save_safe = dist_progress_payload_save_safe;
+    dist_progress_payload_save_safe = true;
     ds4_session_report_progress(session, "prefill_chunk", (int)current, (int)total);
+    dist_progress_payload_save_safe = old_save_safe;
 }
 
 static int dist_coordinator_prefill_prompt_pipelined(
@@ -3558,6 +5012,7 @@ static int dist_coordinator_prefill_prompt_pipelined(
                                  prompt,
                                  session_id,
                                  plan->entry[0].fd,
+                                 plan->entry[0].transport,
                                  chunk_count,
                                  max_hidden_bytes,
                                  err,
@@ -3570,6 +5025,7 @@ static int dist_coordinator_prefill_prompt_pipelined(
     memset(&reader, 0, sizeof(reader));
     reader.state = state;
     reader.fd = plan->entry[0].fd;
+    reader.transport = plan->entry[0].transport;
     reader.progress_session = session;
     reader.first_request_id = *request_id;
     reader.count = chunk_count;
@@ -3815,7 +5271,8 @@ static int dist_coordinator_prefill_prompt(
         int eval_rc = dist_coordinator_eval_span(state, session, plan,
                                                  prompt->v + pos, chunk, pos,
                                                  session_id, (*request_id)++,
-                                                 pos == 0, logits, err, errlen);
+                                                 pos == 0, true,
+                                                 logits, err, errlen);
         if (eval_rc != 0) {
             return eval_rc;
         }
@@ -4054,7 +5511,8 @@ static int dist_run_coordinator_generation(
         int decode_rc = dist_coordinator_eval_span(state, session, &plan,
                                                    &token, 1, token_pos,
                                                    session_id, request_id++,
-                                                   false, logits, err, sizeof(err));
+                                                   false, false,
+                                                   logits, err, sizeof(err));
         if (decode_rc != 0) {
             fprintf(stderr, "\nds4: distributed decode failed: %s\n", err);
             if (dist_coordinator_rebuild_from_transcript(state,
@@ -4108,6 +5566,7 @@ static void dist_coordinator_remove_worker(ds4_dist_coordinator_state *state, in
                              entry->layer_end,
                              entry->has_output ? "+output" : "");
             pthread_mutex_unlock(&state->mu);
+            ds4_transport_release(entry->transport);
             free(entry);
             if (dist_coordinator_debug_enabled(state)) dist_coordinator_report_plan(state);
             return;
@@ -4154,21 +5613,22 @@ static void *dist_coordinator_client_main(void *arg) {
     free(ctx);
 
     ds4_dist_hello_fixed hello;
+    ds4_dist_v3_hello_ext hello_v3;
+    bool is_v3 = false;
     char model_name[DS4_DIST_MAX_MODEL_NAME + 1u];
     char err[256];
-    int rc = dist_recv_hello(fd, &hello, model_name, sizeof(model_name), err, sizeof(err));
+    int rc = dist_recv_hello(fd, &hello, &hello_v3, &is_v3,
+                             model_name, sizeof(model_name), err, sizeof(err));
     if (rc <= 0) {
         if (rc < 0) DIST_COORD_DEBUG(state, "ds4: distributed coordinator: bad HELLO from %s:%s: %s\n", peer_host, peer_port, err);
-        close(fd);
-        return NULL;
+        return dist_coordinator_client_done(state, fd);
     }
 
     if (hello.model_id != state->model_id) {
         snprintf(err, sizeof(err), "model id mismatch: worker=%u coordinator=%u", hello.model_id, state->model_id);
         DIST_COORD_DEBUG(state, "ds4: distributed coordinator: rejecting %s:%s: %s\n", peer_host, peer_port, err);
         dist_send_error(fd, err);
-        close(fd);
-        return NULL;
+        return dist_coordinator_client_done(state, fd);
     }
     const char *expected_model_name = ds4_engine_model_name(state->engine);
     if (!expected_model_name) expected_model_name = "unknown";
@@ -4180,43 +5640,37 @@ static void *dist_coordinator_client_main(void *arg) {
                  expected_model_name);
         DIST_COORD_DEBUG(state, "ds4: distributed coordinator: rejecting %s:%s: %s\n", peer_host, peer_port, err);
         dist_send_error(fd, err);
-        close(fd);
-        return NULL;
+        return dist_coordinator_client_done(state, fd);
     }
     if (hello.n_layers != state->n_layers) {
         snprintf(err, sizeof(err), "layer count mismatch: worker=%u coordinator=%u", hello.n_layers, state->n_layers);
         DIST_COORD_DEBUG(state, "ds4: distributed coordinator: rejecting %s:%s: %s\n", peer_host, peer_port, err);
         dist_send_error(fd, err);
-        close(fd);
-        return NULL;
+        return dist_coordinator_client_done(state, fd);
     }
     if (hello.quant_bits != 2u && hello.quant_bits != 4u) {
         snprintf(err, sizeof(err), "unsupported worker quant profile Q%u", hello.quant_bits);
         DIST_COORD_DEBUG(state, "ds4: distributed coordinator: rejecting %s:%s: %s\n", peer_host, peer_port, err);
         dist_send_error(fd, err);
-        close(fd);
-        return NULL;
+        return dist_coordinator_client_done(state, fd);
     }
     if (hello.has_output > 1u) {
         snprintf(err, sizeof(err), "invalid worker output-head flag %u", hello.has_output);
         DIST_COORD_DEBUG(state, "ds4: distributed coordinator: rejecting %s:%s: %s\n", peer_host, peer_port, err);
         dist_send_error(fd, err);
-        close(fd);
-        return NULL;
+        return dist_coordinator_client_done(state, fd);
     }
     if (hello.has_hidden > 1u) {
         snprintf(err, sizeof(err), "invalid worker hidden-state flag %u", hello.has_hidden);
         DIST_COORD_DEBUG(state, "ds4: distributed coordinator: rejecting %s:%s: %s\n", peer_host, peer_port, err);
         dist_send_error(fd, err);
-        close(fd);
-        return NULL;
+        return dist_coordinator_client_done(state, fd);
     }
     if (hello.layer_start >= hello.n_layers || hello.layer_end >= hello.n_layers || hello.layer_end < hello.layer_start) {
         snprintf(err, sizeof(err), "invalid worker layer range %u:%u for %u layers", hello.layer_start, hello.layer_end, hello.n_layers);
         DIST_COORD_DEBUG(state, "ds4: distributed coordinator: rejecting %s:%s: %s\n", peer_host, peer_port, err);
         dist_send_error(fd, err);
-        close(fd);
-        return NULL;
+        return dist_coordinator_client_done(state, fd);
     }
     if (hello.has_output && hello.layer_end + 1u != hello.n_layers) {
         snprintf(err,
@@ -4227,8 +5681,7 @@ static void *dist_coordinator_client_main(void *arg) {
                  hello.n_layers);
         DIST_COORD_DEBUG(state, "ds4: distributed coordinator: rejecting %s:%s: %s\n", peer_host, peer_port, err);
         dist_send_error(fd, err);
-        close(fd);
-        return NULL;
+        return dist_coordinator_client_done(state, fd);
     }
     if (state->ctx_size != 0 && hello.ctx_size < state->ctx_size) {
         snprintf(err,
@@ -4238,18 +5691,51 @@ static void *dist_coordinator_client_main(void *arg) {
                  state->ctx_size);
         DIST_COORD_DEBUG(state, "ds4: distributed coordinator: rejecting %s:%s: %s\n", peer_host, peer_port, err);
         dist_send_error(fd, err);
-        close(fd);
-        return NULL;
+        return dist_coordinator_client_done(state, fd);
     }
     if (hello.listen_port == 0 || hello.listen_port > 65535u) {
         snprintf(err, sizeof(err), "invalid worker data listen port %u", hello.listen_port);
         DIST_COORD_DEBUG(state, "ds4: distributed coordinator: rejecting %s:%s: %s\n", peer_host, peer_port, err);
         dist_send_error(fd, err);
-        close(fd);
-        return NULL;
+        return dist_coordinator_client_done(state, fd);
     }
 
-    dist_coordinator_add_worker(state, fd, peer_host, peer_port, &hello, model_name);
+    ds4_transport *prepared_transport = NULL;
+    uint32_t protocol_version = DS4_DIST_PROTOCOL_VERSION;
+    if (is_v3) {
+        if (ds4_dist_v3_hello_ext_validate(&hello_v3, err, sizeof(err)) != 0) {
+            DIST_COORD_DEBUG(state,
+                             "ds4: distributed coordinator: rejecting v3 HELLO from %s:%s: %s\n",
+                             peer_host, peer_port, err);
+            dist_send_error(fd, err);
+            return dist_coordinator_client_done(state, fd);
+        }
+        prepared_transport = dist_coordinator_negotiate_v3(
+            state, fd, &hello_v3, err, sizeof(err));
+        if (!prepared_transport) {
+            DIST_COORD_DEBUG(state,
+                             "ds4: distributed coordinator: v3 negotiation with %s:%s failed: %s\n",
+                             peer_host, peer_port,
+                             err[0] ? err : strerror(errno));
+            dist_send_error(fd, err[0] ? err : "v3 transport negotiation failed");
+            return dist_coordinator_client_done(state, fd);
+        }
+        protocol_version = DS4_DIST_V3_PROTOCOL_VERSION;
+    } else if (state->transport_policy == DS4_DIST_TRANSPORT_NHI) {
+        snprintf(err, sizeof(err),
+                 "coordinator requires v3 NHI but worker sent a v2 HELLO");
+        dist_send_error(fd, err);
+        return dist_coordinator_client_done(state, fd);
+    }
+
+    if (!dist_coordinator_add_worker(state, fd, peer_host, peer_port,
+                                     &hello, model_name, prepared_transport,
+                                     protocol_version)) {
+        ds4_transport_release(prepared_transport);
+        dist_send_error(fd, "failed to create persistent worker transport");
+        return dist_coordinator_client_done(state, fd);
+    }
+    ds4_transport_release(prepared_transport);
 
     if (state->use_control_for_work) {
         dist_coordinator_monitor_worker_fd(state, fd, peer_host, peer_port);
@@ -4273,8 +5759,7 @@ static void *dist_coordinator_client_main(void *arg) {
     }
 
     dist_coordinator_remove_worker(state, fd);
-    close(fd);
-    return NULL;
+    return dist_coordinator_client_done(state, fd);
 }
 
 static void *dist_coordinator_accept_main(void *arg) {
@@ -4294,9 +5779,15 @@ static void *dist_coordinator_accept_main(void *arg) {
         }
         dist_set_socket_low_latency(fd);
 
+        if (!dist_coordinator_track_client(state, fd)) {
+            close(fd);
+            continue;
+        }
+
         ds4_dist_client_ctx *ctx = calloc(1, sizeof(*ctx));
         if (!ctx) {
             DIST_COORD_DEBUG(state, "ds4: distributed coordinator: out of memory accepting worker\n");
+            dist_coordinator_untrack_client(state, fd);
             close(fd);
             continue;
         }
@@ -4313,6 +5804,7 @@ static void *dist_coordinator_accept_main(void *arg) {
         pthread_t tid;
         if (pthread_create(&tid, NULL, dist_coordinator_client_main, ctx) != 0) {
             DIST_COORD_DEBUG(state, "ds4: distributed coordinator: pthread_create failed\n");
+            dist_coordinator_untrack_client(state, fd);
             close(fd);
             free(ctx);
             continue;
@@ -4334,10 +5826,10 @@ static int dist_session_ensure_route(ds4_dist_session *d, char *err, size_t errl
         if (errlen) snprintf(err, errlen, "missing distributed session");
         return 1;
     }
-    uint64_t generation = dist_coordinator_generation(&d->state);
+    uint64_t generation = dist_coordinator_generation(d->state);
     if (d->plan_ready && d->plan_generation == generation) return 0;
     dist_route_plan_free(&d->plan);
-    if (!dist_coordinator_ensure_route(&d->state, &d->plan, &generation, err, errlen)) {
+    if (!dist_coordinator_ensure_route(d->state, &d->plan, &generation, err, errlen)) {
         d->plan_ready = false;
         d->plan_generation = 0;
         return 1;
@@ -4878,8 +6370,8 @@ static void dist_kv_route_shard(
         const ds4_dist_route_entry **entry) {
     if (entry) *entry = NULL;
     if (shard == 0) {
-        if (layer_start) *layer_start = d->state.local_start;
-        if (layer_end) *layer_end = d->state.local_end;
+        if (layer_start) *layer_start = d->state->local_start;
+        if (layer_end) *layer_end = d->state->local_end;
         return;
     }
     const ds4_dist_route_entry *e = &d->plan.entry[shard - 1u];
@@ -4892,25 +6384,25 @@ static int dist_kv_route_validate(
         const ds4_dist_session *d,
         char *err,
         size_t errlen) {
-    if (!d || d->state.n_layers == 0 ||
-        d->state.local_start != 0 ||
-        d->state.local_end >= d->state.n_layers) {
+    if (!d || d->state->n_layers == 0 ||
+        d->state->local_start != 0 ||
+        d->state->local_end >= d->state->n_layers) {
         if (errlen) snprintf(err, errlen, "distributed KV route does not start at layer 0");
         return 1;
     }
-    uint32_t prev = d->state.local_end;
+    uint32_t prev = d->state->local_end;
     for (uint32_t i = 0; i < d->plan.count; i++) {
         const ds4_dist_route_entry *e = &d->plan.entry[i];
         if (prev == UINT32_MAX ||
             e->layer_start != prev + 1u ||
             e->layer_end < e->layer_start ||
-            e->layer_end >= d->state.n_layers) {
+            e->layer_end >= d->state->n_layers) {
             if (errlen) snprintf(err, errlen, "distributed KV route is not contiguous");
             return 1;
         }
         prev = e->layer_end;
     }
-    if (prev + 1u != d->state.n_layers) {
+    if (prev + 1u != d->state->n_layers) {
         if (errlen) snprintf(err, errlen, "distributed KV route does not cover all layers");
         return 1;
     }
@@ -4940,7 +6432,7 @@ static int dist_save_remote_shard_to_file(
 
     ds4_dist_snapshot_req_fixed req;
     memset(&req, 0, sizeof(req));
-    req.model_id = d->state.model_id;
+    req.model_id = d->state->model_id;
     dist_u64_to_halves(d->session_id, &req.session_hi, &req.session_lo);
     dist_u64_to_halves(request_id, &req.request_hi, &req.request_lo);
     dist_u64_to_halves(token_hash, &req.token_hash_hi, &req.token_hash_lo);
@@ -4972,7 +6464,7 @@ static int dist_save_remote_shard_to_file(
     uint64_t got_session = dist_u64_from_halves(begin.session_hi, begin.session_lo);
     uint64_t got_request = dist_u64_from_halves(begin.request_hi, begin.request_lo);
     uint64_t got_hash = dist_u64_from_halves(begin.token_hash_hi, begin.token_hash_lo);
-    if (begin.model_id != d->state.model_id ||
+    if (begin.model_id != d->state->model_id ||
         got_session != d->session_id ||
         got_request != request_id ||
         got_hash != token_hash ||
@@ -5019,7 +6511,7 @@ static int dist_prepare_shard_from_session_payload(
         goto cleanup;
     for (uint32_t il = layer_start; il <= layer_end; il++) {
         uint64_t layer_bytes = 0;
-        if (!dist_kv_layer_tensor_bytes(d->state.engine, layout, il,
+        if (!dist_kv_layer_tensor_bytes(d->state->engine, layout, il,
                                         n_comp[il], n_index_comp[il],
                                         &layer_bytes)) {
             if (errlen) snprintf(err, errlen, "distributed KV layer byte count overflow");
@@ -5057,7 +6549,7 @@ static int dist_load_remote_shard_from_payload(
 
     ds4_dist_snapshot_begin_fixed begin;
     memset(&begin, 0, sizeof(begin));
-    begin.model_id = d->state.model_id;
+    begin.model_id = d->state->model_id;
     dist_u64_to_halves(d->session_id, &begin.session_hi, &begin.session_lo);
     dist_u64_to_halves(request_id, &begin.request_hi, &begin.request_lo);
     dist_u64_to_halves(token_hash, &begin.token_hash_hi, &begin.token_hash_lo);
@@ -5085,21 +6577,301 @@ cleanup:
     return rc;
 }
 
+static int dist_destroy_remote_session_on_entry(
+        ds4_dist_session *d,
+        const ds4_dist_route_entry *entry,
+        uint64_t request_id,
+        char *err,
+        size_t errlen) {
+    /* Registered workers already have their data listener up.  Cleanup is
+     * best-effort, so avoid the multi-second startup retry loop here. */
+    const int cleanup_timeout_ms = 2000;
+    int last_errno = 0;
+    int fd = dist_connect_endpoint_once(entry->host, (int)entry->port,
+                                        cleanup_timeout_ms,
+                                        &last_errno, err, errlen);
+    if (fd < 0) return 1;
+    struct timeval cleanup_timeout = {
+        .tv_sec = cleanup_timeout_ms / 1000,
+        .tv_usec = (cleanup_timeout_ms % 1000) * 1000,
+    };
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO,
+                   &cleanup_timeout, sizeof(cleanup_timeout)) != 0 ||
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO,
+                   &cleanup_timeout, sizeof(cleanup_timeout)) != 0) {
+        if (errlen) {
+            snprintf(err, errlen,
+                     "failed to set distributed session destroy timeout");
+        }
+        close(fd);
+        return 1;
+    }
+    ds4_transport *transport = ds4_transport_tcp_create(fd, err, errlen);
+    if (!transport) {
+        close(fd);
+        return 1;
+    }
+
+    ds4_dist_session_destroy_fixed destroy;
+    memset(&destroy, 0, sizeof(destroy));
+    destroy.model_id = d->state->model_id;
+    dist_u64_to_halves(d->session_id,
+                       &destroy.session_hi,
+                       &destroy.session_lo);
+    dist_u64_to_halves(request_id,
+                       &destroy.request_hi,
+                       &destroy.request_lo);
+    destroy.layer_start = entry->layer_start;
+    destroy.layer_end = entry->layer_end;
+
+    ds4_dist_session_destroy_fixed wire = destroy;
+    dist_session_destroy_to_wire(&wire);
+    int rc = 1;
+    if (dist_write_frame_header(fd, DS4_DIST_MSG_SESSION_DESTROY,
+                                (uint32_t)sizeof(wire)) != 0 ||
+        dist_write_full(fd, &wire, sizeof(wire)) != 0) {
+        if (errlen) {
+            snprintf(err, errlen,
+                     "failed to send distributed session destroy request");
+        }
+        goto cleanup;
+    }
+
+    uint32_t kind = 0;
+    uint64_t result_hash = 0;
+    void *payload = NULL;
+    uint32_t payload_bytes = 0;
+    rc = dist_recv_result_alloc(fd, transport, d->state, request_id, &kind,
+                                &result_hash, &payload, &payload_bytes,
+                                err, errlen);
+    free(payload);
+    if (rc != 0) goto cleanup;
+    if (kind != DS4_DIST_RESULT_ACK || result_hash != 0 ||
+        payload_bytes != 0) {
+        if (errlen) {
+            snprintf(err, errlen,
+                     "distributed worker returned invalid session destroy acknowledgement");
+        }
+        rc = 1;
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    ds4_transport_release(transport);
+    close(fd);
+    return rc;
+}
+
+static bool dist_destroy_target_matches(
+        const ds4_dist_route_entry *a,
+        const ds4_dist_route_entry *b) {
+    return a->port == b->port &&
+           a->layer_start == b->layer_start &&
+           a->layer_end == b->layer_end &&
+           strcmp(a->host, b->host) == 0;
+}
+
+static int dist_session_destroy_remote_locked(
+        ds4_dist_session *d,
+        char *err,
+        size_t errlen) {
+    if (!d) return 0;
+
+    /* A route can be replaced after a worker joins or leaves.  Workers from an
+     * older route may still hold this session even though they are no longer in
+     * d->plan, so include every currently registered data endpoint.  A worker
+     * whose control connection is already gone clears all sessions itself. */
+    uint32_t registered_count = 0;
+    pthread_mutex_lock(&d->state->mu);
+    for (ds4_dist_worker_entry *it = d->state->workers; it; it = it->next) {
+        registered_count++;
+    }
+    ds4_dist_route_entry *registered = registered_count
+        ? calloc(registered_count, sizeof(*registered)) : NULL;
+    if (registered) {
+        uint32_t i = 0;
+        for (ds4_dist_worker_entry *it = d->state->workers;
+             it && i < registered_count; it = it->next, i++) {
+            snprintf(registered[i].host, sizeof(registered[i].host), "%s",
+                     it->peer_host);
+            registered[i].port = it->listen_port;
+            registered[i].layer_start = it->layer_start;
+            registered[i].layer_end = it->layer_end;
+            registered[i].fd = -1;
+        }
+    }
+    pthread_mutex_unlock(&d->state->mu);
+
+    int result = 0;
+    char first_error[256] = "";
+    for (uint32_t i = 0; i < d->plan.count; i++) {
+        uint64_t request_id = d->snapshot_request_id++;
+        if (request_id == 0) request_id = d->snapshot_request_id++;
+        char entry_error[256] = "";
+        if (dist_destroy_remote_session_on_entry(d, &d->plan.entry[i],
+                                                 request_id,
+                                                 entry_error,
+                                                 sizeof(entry_error)) != 0) {
+            result = 1;
+            if (!first_error[0]) {
+                snprintf(first_error, sizeof(first_error), "%s",
+                         entry_error[0] ? entry_error
+                                        : "remote session destroy failed");
+            }
+        }
+    }
+    if (registered_count != 0 && !registered) {
+        result = 1;
+        snprintf(first_error, sizeof(first_error),
+                 "out of memory enumerating distributed session destroy targets");
+    }
+    for (uint32_t i = 0; registered && i < registered_count; i++) {
+        bool duplicate = false;
+        for (uint32_t j = 0; j < d->plan.count; j++) {
+            if (dist_destroy_target_matches(&registered[i], &d->plan.entry[j])) {
+                duplicate = true;
+                break;
+            }
+        }
+        for (uint32_t j = 0; !duplicate && j < i; j++) {
+            if (dist_destroy_target_matches(&registered[i], &registered[j])) {
+                duplicate = true;
+            }
+        }
+        if (duplicate) continue;
+
+        uint64_t request_id = d->snapshot_request_id++;
+        if (request_id == 0) request_id = d->snapshot_request_id++;
+        char entry_error[256] = "";
+        if (dist_destroy_remote_session_on_entry(d, &registered[i],
+                                                 request_id,
+                                                 entry_error,
+                                                 sizeof(entry_error)) != 0) {
+            result = 1;
+            if (!first_error[0]) {
+                snprintf(first_error, sizeof(first_error), "%s",
+                         entry_error[0] ? entry_error
+                                        : "remote session destroy failed");
+            }
+        }
+    }
+    free(registered);
+    if (result != 0 && errlen) {
+        snprintf(err, errlen, "%s", first_error);
+    }
+    return result;
+}
+
 /* =========================================================================
  * Coordinator KV Payload API
  * ========================================================================= */
 
-int ds4_dist_session_save_payload(
+typedef enum {
+    DS4_DIST_OP_NONE = 0,
+    DS4_DIST_OP_ROUTE,
+    DS4_DIST_OP_SYNC,
+    DS4_DIST_OP_EVAL,
+    DS4_DIST_OP_VERIFY,
+    DS4_DIST_OP_SAVE,
+    DS4_DIST_OP_LOAD,
+    DS4_DIST_OP_DESTROY,
+} ds4_dist_operation_kind;
+
+typedef struct {
+    bool owns_lock;
+    bool reentrant_save;
+} ds4_dist_operation_guard;
+
+/* The progress callback is synchronous and is allowed to save the KV payload
+ * for the session whose sync is currently running.  A plain non-recursive
+ * mutex deadlocks in that path, while making the mutex recursive would also
+ * permit unsafe eval/sync re-entry.  Track the active operation per thread so
+ * only the one callback-safe case bypasses the coordinator lock. */
+static __thread ds4_dist_coordinator *dist_active_coordinator;
+static __thread ds4_dist_session *dist_active_session;
+static __thread ds4_dist_operation_kind dist_active_operation;
+static __thread bool dist_reentrant_save_active;
+
+static int dist_session_operation_begin(
+        ds4_dist_session *d,
+        ds4_dist_operation_kind kind,
+        bool allow_reentrant_save,
+        ds4_dist_operation_guard *guard,
+        char *err,
+        size_t errlen) {
+    if (guard) memset(guard, 0, sizeof(*guard));
+    if (!d || !d->coordinator || !guard) {
+        if (errlen) snprintf(err, errlen, "missing distributed session");
+        return 1;
+    }
+
+    if (dist_active_coordinator) {
+        if (allow_reentrant_save &&
+            kind == DS4_DIST_OP_SAVE &&
+            dist_active_operation == DS4_DIST_OP_SYNC &&
+            dist_active_coordinator == d->coordinator &&
+            dist_active_session == d &&
+            dist_progress_payload_save_safe &&
+            !dist_reentrant_save_active) {
+            dist_reentrant_save_active = true;
+            guard->reentrant_save = true;
+            return 0;
+        }
+        if (errlen) {
+            snprintf(err, errlen,
+                     "distributed coordinator operation cannot be re-entered");
+        }
+        return 1;
+    }
+
+    pthread_mutex_lock(&d->coordinator->op_mu);
+    dist_active_coordinator = d->coordinator;
+    dist_active_session = d;
+    dist_active_operation = kind;
+    guard->owns_lock = true;
+    return 0;
+}
+
+static void dist_session_operation_end(
+        ds4_dist_session *d,
+        ds4_dist_operation_guard *guard) {
+    if (!guard) return;
+    if (guard->reentrant_save) {
+        dist_reentrant_save_active = false;
+        guard->reentrant_save = false;
+        return;
+    }
+    if (!guard->owns_lock) return;
+    dist_active_operation = DS4_DIST_OP_NONE;
+    dist_active_session = NULL;
+    dist_active_coordinator = NULL;
+    guard->owns_lock = false;
+    pthread_mutex_unlock(&d->coordinator->op_mu);
+}
+
+static int dist_session_save_payload_locked(
         ds4_dist_session *d,
         ds4_session *owner,
         FILE *fp,
+        bool route_already_active,
         char *err,
         size_t errlen) {
     if (!d || !owner || !fp) {
         if (errlen) snprintf(err, errlen, "invalid distributed payload save");
         return 1;
     }
-    if (dist_session_ensure_route(d, err, errlen) != 0) return 1;
+    if (route_already_active) {
+        if (!d->plan_ready || d->plan.count == 0) {
+            if (errlen) {
+                snprintf(err, errlen,
+                         "distributed route is unavailable during progress save");
+            }
+            return 1;
+        }
+    } else if (dist_session_ensure_route(d, err, errlen) != 0) {
+        return 1;
+    }
     if (dist_kv_route_validate(d, err, errlen) != 0) return 1;
 
     const ds4_tokens *tokens = ds4_session_tokens(owner);
@@ -5109,7 +6881,7 @@ int ds4_dist_session_save_payload(
     }
     const uint32_t token_count = (uint32_t)tokens->len;
     const uint64_t token_hash = dist_token_hash_prefix(tokens->v, token_count);
-    const uint32_t vocab = (uint32_t)ds4_engine_vocab_size(d->state.engine);
+    const uint32_t vocab = (uint32_t)ds4_engine_vocab_size(d->state->engine);
     float *logits = malloc((size_t)vocab * sizeof(logits[0]));
     if (!logits) {
         if (errlen) snprintf(err, errlen, "out of memory saving distributed logits");
@@ -5123,8 +6895,8 @@ int ds4_dist_session_save_payload(
 
     const uint32_t shard_count = dist_kv_route_shard_count(d);
     ds4_dist_kv_shard_file *shards = calloc(shard_count, sizeof(shards[0]));
-    uint32_t *n_comp = calloc(d->state.n_layers, sizeof(n_comp[0]));
-    uint32_t *n_index_comp = calloc(d->state.n_layers, sizeof(n_index_comp[0]));
+    uint32_t *n_comp = calloc(d->state->n_layers, sizeof(n_comp[0]));
+    uint32_t *n_index_comp = calloc(d->state->n_layers, sizeof(n_index_comp[0]));
     if (!shards || !n_comp || !n_index_comp) {
         free(logits);
         free(shards);
@@ -5163,7 +6935,7 @@ int ds4_dist_session_save_payload(
             if (errlen) snprintf(err, errlen, "distributed KV shard is empty");
             goto cleanup;
         }
-        if (dist_kv_parse_layer_payload(d->state.engine,
+        if (dist_kv_parse_layer_payload(d->state->engine,
                                         shards[shard].fp,
                                         shards[shard].bytes,
                                         layer_start,
@@ -5178,7 +6950,7 @@ int ds4_dist_session_save_payload(
             goto cleanup;
     }
     if (!layout_set || layout.token_count != token_count ||
-        layout.n_layers != d->state.n_layers ||
+        layout.n_layers != d->state->n_layers ||
         layout.vocab != vocab) {
         if (errlen) snprintf(err, errlen, "distributed KV shard metadata mismatch");
         goto cleanup;
@@ -5222,7 +6994,7 @@ cleanup:
     return rc;
 }
 
-int ds4_dist_session_load_payload(
+static int dist_session_load_payload_locked(
         ds4_dist_session *d,
         ds4_session *owner,
         FILE *fp,
@@ -5260,11 +7032,11 @@ int ds4_dist_session_load_payload(
         .vocab = h[11],
         .raw_live = h[12],
     };
-    if (layout.n_layers != d->state.n_layers ||
+    if (layout.n_layers != d->state->n_layers ||
         layout.ctx > (uint32_t)ds4_session_ctx(owner) ||
         layout.token_count >= (uint32_t)ds4_session_ctx(owner) ||
-        layout.vocab != (uint32_t)ds4_engine_vocab_size(d->state.engine) ||
-        !dist_kv_raw_live_valid(d->state.engine, &layout)) {
+        layout.vocab != (uint32_t)ds4_engine_vocab_size(d->state->engine) ||
+        !dist_kv_raw_live_valid(d->state->engine, &layout)) {
         if (errlen) snprintf(err, errlen, "DS4 KV payload does not match current distributed runtime");
         return 1;
     }
@@ -5292,7 +7064,7 @@ int ds4_dist_session_load_payload(
             return 1;
         }
         if (tok > (uint32_t)INT_MAX ||
-            tok >= (uint32_t)ds4_engine_vocab_size(d->state.engine)) {
+            tok >= (uint32_t)ds4_engine_vocab_size(d->state->engine)) {
             free(tokens);
             free(logits);
             free(n_comp);
@@ -5390,6 +7162,42 @@ cleanup:
     return rc;
 }
 
+int ds4_dist_session_save_payload(
+        ds4_dist_session *d,
+        ds4_session *owner,
+        FILE *fp,
+        char *err,
+        size_t errlen) {
+    ds4_dist_operation_guard guard;
+    if (dist_session_operation_begin(d, DS4_DIST_OP_SAVE, true, &guard,
+                                     err, errlen) != 0) {
+        return 1;
+    }
+    int rc = dist_session_save_payload_locked(d, owner, fp,
+                                              guard.reentrant_save,
+                                              err, errlen);
+    dist_session_operation_end(d, &guard);
+    return rc;
+}
+
+int ds4_dist_session_load_payload(
+        ds4_dist_session *d,
+        ds4_session *owner,
+        FILE *fp,
+        uint64_t payload_bytes,
+        char *err,
+        size_t errlen) {
+    ds4_dist_operation_guard guard;
+    if (dist_session_operation_begin(d, DS4_DIST_OP_LOAD, false, &guard,
+                                     err, errlen) != 0) {
+        return 1;
+    }
+    int rc = dist_session_load_payload_locked(d, owner, fp, payload_bytes,
+                                              err, errlen);
+    dist_session_operation_end(d, &guard);
+    return rc;
+}
+
 /* =========================================================================
  * Coordinator Session API
  * =========================================================================
@@ -5399,8 +7207,106 @@ cleanup:
  * selects these calls when the owning session has a coordinator attached.
  */
 
+static int dist_shared_coordinator_create(
+        ds4_dist_coordinator **out,
+        ds4_engine *engine,
+        const ds4_dist_options *opt,
+        int ctx_size,
+        char *err,
+        size_t errlen) {
+    int listen_fd = dist_open_listener(opt->listen_host, opt->listen_port,
+                                       err, errlen);
+    if (listen_fd < 0) return 1;
+
+    ds4_dist_coordinator *coordinator = calloc(1, sizeof(*coordinator));
+    if (!coordinator) {
+        close(listen_fd);
+        if (errlen) snprintf(err, errlen,
+                             "out of memory creating distributed coordinator");
+        return 1;
+    }
+
+    coordinator->listen_fd = listen_fd;
+    coordinator->state.engine = engine;
+    coordinator->state.model_id = (uint32_t)ds4_engine_model_id(engine);
+    coordinator->state.n_layers = (uint32_t)ds4_engine_layer_count(engine);
+    coordinator->state.local_start = opt->layers.start;
+    coordinator->state.local_end =
+        dist_resolved_layer_end(opt, coordinator->state.n_layers);
+    coordinator->state.ctx_size = ctx_size > 0 ? (uint32_t)ctx_size : 0u;
+    coordinator->state.local_has_output = opt->layers.has_output;
+    coordinator->state.local_can_output_head = ds4_engine_has_output_head(engine);
+    coordinator->state.prefer_local_output_head = ds4_engine_has_mtp(engine);
+    coordinator->state.replay_check = opt->replay_check;
+    coordinator->state.debug = opt->debug;
+    coordinator->state.use_control_for_work = true;
+    coordinator->state.prefill_chunk = opt->prefill_chunk;
+    coordinator->state.prefill_window = opt->prefill_window;
+    coordinator->state.activation_bits =
+        dist_activation_bits_or_default(opt->activation_bits);
+    coordinator->state.transport_policy = opt->transport;
+    coordinator->state.nhi_device = opt->nhi_device;
+    if (pthread_mutex_init(&coordinator->state.mu, NULL) != 0) {
+        close(listen_fd);
+        free(coordinator);
+        if (errlen) snprintf(err, errlen,
+                             "failed to initialize distributed coordinator registry");
+        return 1;
+    }
+    if (pthread_cond_init(&coordinator->state.clients_cv, NULL) != 0) {
+        close(listen_fd);
+        pthread_mutex_destroy(&coordinator->state.mu);
+        free(coordinator);
+        if (errlen) snprintf(err, errlen,
+                             "failed to initialize distributed coordinator client tracking");
+        return 1;
+    }
+    if (pthread_mutex_init(&coordinator->op_mu, NULL) != 0) {
+        close(listen_fd);
+        pthread_cond_destroy(&coordinator->state.clients_cv);
+        pthread_mutex_destroy(&coordinator->state.mu);
+        free(coordinator);
+        if (errlen) snprintf(err, errlen,
+                             "failed to initialize distributed coordinator operation lock");
+        return 1;
+    }
+    coordinator->next_session_id = dist_make_session_id(coordinator);
+
+    char local_end[32];
+    if (opt->layers.has_output) snprintf(local_end, sizeof(local_end), "output");
+    else snprintf(local_end, sizeof(local_end), "%u", opt->layers.end);
+    DIST_COORD_DEBUG(&coordinator->state,
+                     "ds4: distributed coordinator API: listening on %s:%d model_id=%u layers=%u local=%u:%s activation_bits=%u\n",
+                     opt->listen_host,
+                     opt->listen_port,
+                     coordinator->state.model_id,
+                     coordinator->state.n_layers,
+                     opt->layers.start,
+                     local_end,
+                     coordinator->state.activation_bits);
+
+    coordinator->accept_ctx.state = &coordinator->state;
+    coordinator->accept_ctx.listen_fd = listen_fd;
+    if (pthread_create(&coordinator->accept_tid, NULL,
+                       dist_coordinator_accept_main,
+                       &coordinator->accept_ctx) != 0) {
+        close(listen_fd);
+        pthread_mutex_destroy(&coordinator->op_mu);
+        pthread_cond_destroy(&coordinator->state.clients_cv);
+        pthread_mutex_destroy(&coordinator->state.mu);
+        free(coordinator);
+        if (errlen) snprintf(err, errlen,
+                             "failed to start distributed coordinator accept loop");
+        return 1;
+    }
+    coordinator->accept_started = true;
+    *out = coordinator;
+    return 0;
+}
+
 int ds4_dist_session_create(
         ds4_dist_session **out,
+        ds4_dist_coordinator **shared,
         ds4_engine *engine,
         const ds4_dist_options *opt,
         ds4_session *owner,
@@ -5408,7 +7314,7 @@ int ds4_dist_session_create(
         char *err,
         size_t errlen) {
     (void)owner;
-    if (!out || !engine || !opt) {
+    if (!out || !shared || !engine || !opt) {
         if (errlen) snprintf(err, errlen, "missing distributed session parameters");
         return 1;
     }
@@ -5418,95 +7324,123 @@ int ds4_dist_session_create(
         return 1;
     }
     if (dist_validate_options(opt, err, errlen) != 0) return 1;
-
-    int listen_fd = dist_open_listener(opt->listen_host, opt->listen_port, err, errlen);
-    if (listen_fd < 0) return 1;
-
-    ds4_dist_session *d = calloc(1, sizeof(*d));
-    if (!d) {
-        close(listen_fd);
-        if (errlen) snprintf(err, errlen, "out of memory creating distributed session");
+    if (ds4_engine_has_mtp(engine) && !ds4_engine_has_output_head(engine)) {
+        if (errlen) snprintf(err, errlen,
+                             "distributed MTP requires an output head in the coordinator model");
         return 1;
     }
 
-    d->listen_fd = listen_fd;
-    d->state.engine = engine;
-    d->state.model_id = (uint32_t)ds4_engine_model_id(engine);
-    d->state.n_layers = (uint32_t)ds4_engine_layer_count(engine);
-    d->state.local_start = opt->layers.start;
-    d->state.local_end = dist_resolved_layer_end(opt, d->state.n_layers);
-    d->state.ctx_size = ctx_size > 0 ? (uint32_t)ctx_size : 0u;
-    d->state.local_has_output = opt->layers.has_output;
-    d->state.local_can_output_head = ds4_engine_has_output_head(engine);
-    d->state.replay_check = opt->replay_check;
-    d->state.debug = opt->debug;
-    d->state.use_control_for_work = true;
-    d->state.prefill_chunk = opt->prefill_chunk;
-    d->state.prefill_window = opt->prefill_window;
-    d->state.activation_bits = dist_activation_bits_or_default(opt->activation_bits);
-    pthread_mutex_init(&d->state.mu, NULL);
-    d->session_id = dist_make_session_id(d);
+    if (!*shared &&
+        dist_shared_coordinator_create(shared, engine, opt, ctx_size,
+                                       err, errlen) != 0) {
+        return 1;
+    }
+    ds4_dist_coordinator *coordinator = *shared;
+    const uint32_t requested_ctx = ctx_size > 0 ? (uint32_t)ctx_size : 0u;
+    if (!coordinator || coordinator->state.engine != engine ||
+        coordinator->state.ctx_size != requested_ctx) {
+        if (errlen) snprintf(err, errlen,
+                             "distributed sessions sharing an engine must use the same context size");
+        return 1;
+    }
+
+    ds4_dist_session *d = calloc(1, sizeof(*d));
+    if (!d) {
+        if (errlen) snprintf(err, errlen, "out of memory creating distributed session");
+        return 1;
+    }
+    d->coordinator = coordinator;
+    d->state = &coordinator->state;
+    pthread_mutex_lock(&coordinator->op_mu);
+    d->session_id = ++coordinator->next_session_id;
+    if (d->session_id == 0) d->session_id = ++coordinator->next_session_id;
+    pthread_mutex_unlock(&coordinator->op_mu);
     d->request_id = 1;
     /* KV snapshots use separate data connections and can run while pipelined
      * WORK results are outstanding.  Keep them out of the WORK request-id stream
      * so progress callbacks cannot perturb the reader's contiguous expectations. */
     d->snapshot_request_id = UINT64_C(1) << 63;
 
-    char local_end[32];
-    if (opt->layers.has_output) snprintf(local_end, sizeof(local_end), "output");
-    else snprintf(local_end, sizeof(local_end), "%u", opt->layers.end);
-    DIST_COORD_DEBUG(&d->state,
-                     "ds4: distributed coordinator API: listening on %s:%d model_id=%u layers=%u local=%u:%s activation_bits=%u\n",
+    DIST_COORD_DEBUG(d->state,
+                     "ds4: distributed coordinator API: session=%llu sharing %s:%d\n",
+                     (unsigned long long)d->session_id,
                      opt->listen_host,
-                     opt->listen_port,
-                     d->state.model_id,
-                     d->state.n_layers,
-                     opt->layers.start,
-                     local_end,
-                     d->state.activation_bits);
-
-    d->accept_ctx.state = &d->state;
-    d->accept_ctx.listen_fd = listen_fd;
-    if (pthread_create(&d->accept_tid, NULL, dist_coordinator_accept_main, &d->accept_ctx) != 0) {
-        close(listen_fd);
-        pthread_mutex_destroy(&d->state.mu);
-        free(d);
-        if (errlen) snprintf(err, errlen, "failed to start distributed coordinator accept loop");
-        return 1;
-    }
-    pthread_detach(d->accept_tid);
-    d->accept_started = true;
+                     opt->listen_port);
     *out = d;
     return 0;
 }
 
 void ds4_dist_session_free(ds4_dist_session *d) {
     if (!d) return;
-    if (d->listen_fd >= 0) {
-        shutdown(d->listen_fd, SHUT_RDWR);
-        close(d->listen_fd);
-        d->listen_fd = -1;
+    ds4_dist_operation_guard guard;
+    char err[256] = "";
+    if (dist_session_operation_begin(d, DS4_DIST_OP_DESTROY, false, &guard,
+                                     err, sizeof(err)) != 0) {
+        /* ds4_session_free() has a void API and will immediately free the
+         * owner after this call.  Returning here would therefore leak d while
+         * the outer sync keeps using a freed owner.  Self-destruction from a
+         * callback is unsupported; fail deterministically instead of allowing
+         * memory corruption.  Ordinary cross-thread destruction waits. */
+        fprintf(stderr,
+                "ds4: fatal: distributed session cannot be freed from its own callback: %s\n",
+                err[0] ? err : "operation is active");
+        abort();
+    }
+    if (dist_session_destroy_remote_locked(d, err, sizeof(err)) != 0) {
+        DIST_COORD_DEBUG(d->state,
+                         "ds4: distributed coordinator: session=%llu remote cleanup failed: %s\n",
+                         (unsigned long long)d->session_id,
+                         err[0] ? err : "unknown error");
     }
     dist_route_plan_free(&d->plan);
-    pthread_mutex_lock(&d->state.mu);
-    d->state.shutting_down = true;
-    for (ds4_dist_worker_entry *it = d->state.workers; it; it = it->next) {
-        if (it->fd >= 0) shutdown(it->fd, SHUT_RDWR);
-    }
-    pthread_mutex_unlock(&d->state.mu);
-    /* Client threads are detached and remove their registry entries after the
-     * socket closes. Keep this small coordinator object process-lifetime to
-     * avoid racing those threads during application shutdown. */
+    dist_session_operation_end(d, &guard);
+    free(d);
 }
 
-int ds4_dist_session_route_ready(ds4_dist_session *d, char *err, size_t errlen) {
+void ds4_dist_coordinator_free(ds4_dist_coordinator *coordinator) {
+    if (!coordinator) return;
+    pthread_mutex_lock(&coordinator->op_mu);
+    dist_coordinator_shutdown_clients(&coordinator->state);
+    if (coordinator->listen_fd >= 0) {
+        shutdown(coordinator->listen_fd, SHUT_RDWR);
+        close(coordinator->listen_fd);
+        coordinator->listen_fd = -1;
+    }
+    if (coordinator->accept_started) {
+        pthread_join(coordinator->accept_tid, NULL);
+        coordinator->accept_started = false;
+    }
+    dist_coordinator_wait_for_clients(&coordinator->state);
+
+    /* Every tracked client removes its worker entry before untracking.  Drain
+     * defensively in case a registration allocation or protocol failure left
+     * a registry-only node behind. */
+    pthread_mutex_lock(&coordinator->state.mu);
+    ds4_dist_worker_entry *workers = coordinator->state.workers;
+    coordinator->state.workers = NULL;
+    pthread_mutex_unlock(&coordinator->state.mu);
+    while (workers) {
+        ds4_dist_worker_entry *next = workers->next;
+        ds4_transport_release(workers->transport);
+        free(workers);
+        workers = next;
+    }
+    pthread_mutex_unlock(&coordinator->op_mu);
+    pthread_mutex_destroy(&coordinator->op_mu);
+    pthread_cond_destroy(&coordinator->state.clients_cv);
+    pthread_mutex_destroy(&coordinator->state.mu);
+    free(coordinator);
+}
+
+static int dist_session_route_ready_locked(
+        ds4_dist_session *d, char *err, size_t errlen) {
     if (!d) {
         if (errlen) snprintf(err, errlen, "missing distributed session");
         return -1;
     }
 
     ds4_dist_route_plan probe = {0};
-    if (!dist_coordinator_build_route_plan(&d->state, &probe, NULL, err, errlen)) {
+    if (!dist_coordinator_build_route_plan(d->state, &probe, NULL, err, errlen)) {
         return 0;
     }
     dist_route_plan_free(&probe);
@@ -5514,7 +7448,7 @@ int ds4_dist_session_route_ready(ds4_dist_session *d, char *err, size_t errlen) 
     return 1;
 }
 
-int ds4_dist_session_sync(
+static int dist_session_sync_locked(
         ds4_dist_session *d,
         ds4_session *owner,
         const ds4_tokens *checkpoint,
@@ -5536,13 +7470,13 @@ int ds4_dist_session_sync(
         if (checkpoint->len == prompt->len) return 0;
 
         uint32_t chunk_cap = 0;
-        if (dist_coordinator_prefill_chunk_cap(&d->state, owner, &chunk_cap, err, errlen) != 0) {
+        if (dist_coordinator_prefill_chunk_cap(d->state, owner, &chunk_cap, err, errlen) != 0) {
             return 1;
         }
         const uint32_t pos0 = (uint32_t)checkpoint->len;
         const uint32_t suffix = (uint32_t)prompt->len - pos0;
-        if (dist_coordinator_can_pipeline_prefill(&d->state, &d->plan, owner, suffix, chunk_cap)) {
-            int prefill_rc = dist_coordinator_prefill_prompt_pipelined(&d->state,
+        if (dist_coordinator_can_pipeline_prefill(d->state, &d->plan, owner, suffix, chunk_cap)) {
+            int prefill_rc = dist_coordinator_prefill_prompt_pipelined(d->state,
                                                                        owner,
                                                                        &d->plan,
                                                                        prompt,
@@ -5556,7 +7490,7 @@ int ds4_dist_session_sync(
                                                                        err,
                                                                        errlen);
             if (prefill_rc != 0) {
-                if (dist_coordinator_rebuild_from_transcript(&d->state,
+                if (dist_coordinator_rebuild_from_transcript(d->state,
                                                              owner,
                                                              &d->plan,
                                                              prompt,
@@ -5580,7 +7514,7 @@ int ds4_dist_session_sync(
         while (pos < (uint32_t)prompt->len) {
             const uint32_t remaining = (uint32_t)prompt->len - pos;
             const uint32_t chunk = remaining < chunk_cap ? remaining : chunk_cap;
-            int eval_rc = dist_coordinator_eval_span(&d->state,
+            int eval_rc = dist_coordinator_eval_span(d->state,
                                                      owner,
                                                      &d->plan,
                                                      prompt->v + pos,
@@ -5589,11 +7523,12 @@ int ds4_dist_session_sync(
                                                      d->session_id,
                                                      d->request_id++,
                                                      false,
+                                                     true,
                                                      logits,
                                                      err,
                                                      errlen);
             if (eval_rc != 0) {
-                if (dist_coordinator_rebuild_from_transcript(&d->state,
+                if (dist_coordinator_rebuild_from_transcript(d->state,
                                                              owner,
                                                              &d->plan,
                                                              prompt,
@@ -5617,7 +7552,7 @@ int ds4_dist_session_sync(
         return 0;
     }
 
-    int prefill_rc = dist_coordinator_prefill_prompt(&d->state,
+    int prefill_rc = dist_coordinator_prefill_prompt(d->state,
                                                      owner,
                                                      &d->plan,
                                                      prompt,
@@ -5627,7 +7562,7 @@ int ds4_dist_session_sync(
                                                      err,
                                                      errlen);
     if (prefill_rc != 0) {
-        if (dist_coordinator_rebuild_from_transcript(&d->state,
+        if (dist_coordinator_rebuild_from_transcript(d->state,
                                                      owner,
                                                      &d->plan,
                                                      prompt,
@@ -5647,7 +7582,7 @@ int ds4_dist_session_sync(
     return 0;
 }
 
-int ds4_dist_session_eval(
+static int dist_session_eval_locked(
         ds4_dist_session *d,
         ds4_session *owner,
         const ds4_tokens *checkpoint,
@@ -5661,7 +7596,7 @@ int ds4_dist_session_eval(
     }
     if (dist_session_ensure_route(d, err, errlen) != 0) return 1;
 
-    int rc = dist_coordinator_eval_span(&d->state,
+    int rc = dist_coordinator_eval_span(d->state,
                                         owner,
                                         &d->plan,
                                         &token,
@@ -5670,6 +7605,7 @@ int ds4_dist_session_eval(
                                         d->session_id,
                                         d->request_id++,
                                         false,
+                                        false,
                                         logits,
                                         err,
                                         errlen);
@@ -5677,7 +7613,7 @@ int ds4_dist_session_eval(
         ds4_tokens transcript = {0};
         ds4_tokens_copy(&transcript, checkpoint);
         ds4_tokens_push(&transcript, token);
-        if (dist_coordinator_rebuild_from_transcript(&d->state,
+        if (dist_coordinator_rebuild_from_transcript(d->state,
                                                      owner,
                                                      &d->plan,
                                                      &transcript,
@@ -5700,12 +7636,224 @@ int ds4_dist_session_eval(
     return rc;
 }
 
+static int dist_session_verify_greedy_locked(
+        ds4_dist_session *d,
+        ds4_session *owner,
+        const ds4_tokens *checkpoint,
+        const int *drafts,
+        uint32_t draft_n,
+        uint32_t *committed,
+        float *logits,
+        char *err,
+        size_t errlen) {
+    if (!d || !owner || !checkpoint || checkpoint->len < 0 || !drafts ||
+        draft_n == 0 || draft_n > DS4_DIST_SPEC_MAX_DRAFT_TOKENS ||
+        !committed || !logits) {
+        if (errlen) snprintf(err, errlen,
+                             "invalid distributed speculative verification request");
+        return 1;
+    }
+    *committed = 0;
+    if (!d->state->prefer_local_output_head || !d->state->local_can_output_head) {
+        if (errlen) snprintf(err, errlen,
+                             "distributed speculative verification requires coordinator-owned MTP and output head");
+        return 1;
+    }
+    if (dist_session_ensure_route(d, err, errlen) != 0) return 1;
+
+    ds4_tokens base = {0};
+    ds4_tokens_copy(&base, checkpoint);
+    const uint32_t pos0 = (uint32_t)base.len;
+    const uint64_t rows =
+        (uint64_t)draft_n * (uint64_t)ds4_engine_vocab_size(d->state->engine);
+    if (rows > SIZE_MAX / sizeof(float)) {
+        ds4_tokens_free(&base);
+        if (errlen) snprintf(err, errlen,
+                             "distributed speculative logits allocation is too large");
+        return 1;
+    }
+    float *row_logits = malloc((size_t)rows * sizeof(float));
+    if (!row_logits) {
+        ds4_tokens_free(&base);
+        if (errlen) snprintf(err, errlen,
+                             "out of memory allocating distributed speculative logits");
+        return 1;
+    }
+
+    float *final_hidden_rows = NULL;
+    int rc = dist_coordinator_eval_speculative_span(d->state,
+                                                    owner,
+                                                    &d->plan,
+                                                    drafts,
+                                                    draft_n,
+                                                    pos0,
+                                                    d->session_id,
+                                                    d->request_id++,
+                                                    row_logits,
+                                                    &final_hidden_rows,
+                                                    err,
+                                                    errlen);
+    uint32_t keep = 1;
+    const uint32_t vocab = (uint32_t)ds4_engine_vocab_size(d->state->engine);
+    if (rc == 0) {
+        for (uint32_t i = 1; i < draft_n; i++) {
+            const int target = dist_logits_argmax(
+                row_logits + (uint64_t)(i - 1u) * vocab,
+                (int)vocab);
+            if (target != drafts[i]) break;
+            keep++;
+        }
+        if (keep < draft_n) {
+            rc = ds4_session_select_hidden_state_from_hc(
+                owner,
+                final_hidden_rows,
+                draft_n,
+                keep - 1u,
+                err,
+                errlen);
+        }
+    }
+    if (rc == 0) {
+        rc = dist_coordinator_commit_speculative(d->state,
+                                                 owner,
+                                                 &d->plan,
+                                                 drafts,
+                                                 draft_n,
+                                                 keep,
+                                                 pos0,
+                                                 d->session_id,
+                                                 d->request_id++,
+                                                 err,
+                                                 errlen);
+    }
+    if (rc == 0) {
+        memcpy(logits,
+               row_logits + (uint64_t)(keep - 1u) * vocab,
+               (uint64_t)vocab * sizeof(float));
+        *committed = keep;
+        free(final_hidden_rows);
+        free(row_logits);
+        ds4_tokens_free(&base);
+        return 0;
+    }
+
+    char cause[256] = "distributed speculative verification failed";
+    if (err && errlen && err[0]) snprintf(cause, sizeof(cause), "%s", err);
+    char rollback_err[256] = "";
+    (void)ds4_session_speculative_rollback(owner,
+                                           rollback_err,
+                                           sizeof(rollback_err));
+    if (dist_coordinator_rebuild_from_transcript(d->state,
+                                                 owner,
+                                                 &d->plan,
+                                                 &base,
+                                                 d->session_id,
+                                                 &d->request_id,
+                                                 logits,
+                                                 &d->plan_generation,
+                                                 true,
+                                                 rollback_err,
+                                                 sizeof(rollback_err)) != 0) {
+        d->plan_ready = false;
+        d->plan_generation = 0;
+        if (errlen) snprintf(err, errlen,
+                             "%s; distributed rollback replay failed: %s",
+                             cause,
+                             rollback_err[0] ? rollback_err : "unknown error");
+    } else if (errlen) {
+        snprintf(err, errlen, "%s; restored committed prefix", cause);
+        d->plan_ready = true;
+    }
+    free(final_hidden_rows);
+    free(row_logits);
+    ds4_tokens_free(&base);
+    return 1;
+}
+
+int ds4_dist_session_route_ready(ds4_dist_session *d,
+                                 char *err,
+                                 size_t errlen) {
+    ds4_dist_operation_guard guard;
+    if (dist_session_operation_begin(d, DS4_DIST_OP_ROUTE, false, &guard,
+                                     err, errlen) != 0) {
+        return -1;
+    }
+    int rc = dist_session_route_ready_locked(d, err, errlen);
+    dist_session_operation_end(d, &guard);
+    return rc;
+}
+
+int ds4_dist_session_sync(
+        ds4_dist_session *d,
+        ds4_session *owner,
+        const ds4_tokens *checkpoint,
+        const ds4_tokens *prompt,
+        float *logits,
+        char *err,
+        size_t errlen) {
+    ds4_dist_operation_guard guard;
+    if (dist_session_operation_begin(d, DS4_DIST_OP_SYNC, false, &guard,
+                                     err, errlen) != 0) {
+        return 1;
+    }
+    int rc = dist_session_sync_locked(d, owner, checkpoint, prompt, logits,
+                                      err, errlen);
+    dist_session_operation_end(d, &guard);
+    return rc;
+}
+
+int ds4_dist_session_eval(
+        ds4_dist_session *d,
+        ds4_session *owner,
+        const ds4_tokens *checkpoint,
+        int token,
+        float *logits,
+        char *err,
+        size_t errlen) {
+    ds4_dist_operation_guard guard;
+    if (dist_session_operation_begin(d, DS4_DIST_OP_EVAL, false, &guard,
+                                     err, errlen) != 0) {
+        return 1;
+    }
+    int rc = dist_session_eval_locked(d, owner, checkpoint, token, logits,
+                                      err, errlen);
+    dist_session_operation_end(d, &guard);
+    return rc;
+}
+
+int ds4_dist_session_verify_greedy(
+        ds4_dist_session *d,
+        ds4_session *owner,
+        const ds4_tokens *checkpoint,
+        const int *drafts,
+        uint32_t draft_n,
+        uint32_t *committed,
+        float *logits,
+        char *err,
+        size_t errlen) {
+    ds4_dist_operation_guard guard;
+    if (dist_session_operation_begin(d, DS4_DIST_OP_VERIFY, false, &guard,
+                                     err, errlen) != 0) {
+        return 1;
+    }
+    int rc = dist_session_verify_greedy_locked(d, owner, checkpoint, drafts,
+                                               draft_n, committed, logits,
+                                               err, errlen);
+    dist_session_operation_end(d, &guard);
+    return rc;
+}
+
 /* =========================================================================
  * Standalone Coordinator Entrypoint
  * ========================================================================= */
 
 static int dist_run_coordinator(ds4_engine *engine, const ds4_dist_options *opt, const ds4_dist_generation_options *gen) {
     char err[256];
+    if (ds4_engine_has_mtp(engine) && !ds4_engine_has_output_head(engine)) {
+        fprintf(stderr,
+                "ds4: distributed coordinator: MTP requires a local output head\n");
+        return 1;
+    }
     int listen_fd = dist_open_listener(opt->listen_host, opt->listen_port, err, sizeof(err));
     if (listen_fd < 0) {
         fprintf(stderr, "ds4: distributed coordinator: %s\n", err);
@@ -5722,13 +7870,28 @@ static int dist_run_coordinator(ds4_engine *engine, const ds4_dist_options *opt,
     state.ctx_size = gen && gen->ctx_size > 0 ? (uint32_t)gen->ctx_size : 0u;
     state.local_has_output = opt->layers.has_output;
     state.local_can_output_head = ds4_engine_has_output_head(engine);
+    state.prefer_local_output_head = ds4_engine_has_mtp(engine);
     state.replay_check = opt->replay_check;
     state.debug = opt->debug;
     state.use_control_for_work = gen && gen->prompt;
     state.prefill_chunk = opt->prefill_chunk;
     state.prefill_window = opt->prefill_window;
     state.activation_bits = dist_activation_bits_or_default(opt->activation_bits);
-    pthread_mutex_init(&state.mu, NULL);
+    state.transport_policy = opt->transport;
+    state.nhi_device = opt->nhi_device;
+    if (pthread_mutex_init(&state.mu, NULL) != 0) {
+        fprintf(stderr,
+                "ds4: distributed coordinator: failed to initialize registry lock\n");
+        close(listen_fd);
+        return 1;
+    }
+    if (pthread_cond_init(&state.clients_cv, NULL) != 0) {
+        fprintf(stderr,
+                "ds4: distributed coordinator: failed to initialize client tracking\n");
+        pthread_mutex_destroy(&state.mu);
+        close(listen_fd);
+        return 1;
+    }
 
     char local_end[32];
     if (opt->layers.has_output) snprintf(local_end, sizeof(local_end), "output");
@@ -5749,6 +7912,12 @@ static int dist_run_coordinator(ds4_engine *engine, const ds4_dist_options *opt,
     };
     if (!gen || !gen->prompt) {
         dist_coordinator_accept_main(&accept_ctx);
+        dist_coordinator_shutdown_clients(&state);
+        shutdown(listen_fd, SHUT_RDWR);
+        close(listen_fd);
+        dist_coordinator_wait_for_clients(&state);
+        pthread_cond_destroy(&state.clients_cv);
+        pthread_mutex_destroy(&state.mu);
         return 0;
     }
 
@@ -5756,20 +7925,32 @@ static int dist_run_coordinator(ds4_engine *engine, const ds4_dist_options *opt,
     if (pthread_create(&accept_tid, NULL, dist_coordinator_accept_main, &accept_ctx) != 0) {
         fprintf(stderr, "ds4: distributed coordinator: pthread_create failed for accept loop\n");
         close(listen_fd);
+        pthread_cond_destroy(&state.clients_cv);
+        pthread_mutex_destroy(&state.mu);
         return 1;
     }
-    pthread_detach(accept_tid);
 
-    return dist_run_coordinator_generation(&state, gen);
+    int rc = dist_run_coordinator_generation(&state, gen);
+    dist_coordinator_shutdown_clients(&state);
+    shutdown(listen_fd, SHUT_RDWR);
+    close(listen_fd);
+    pthread_join(accept_tid, NULL);
+    dist_coordinator_wait_for_clients(&state);
+    pthread_cond_destroy(&state.clients_cv);
+    pthread_mutex_destroy(&state.mu);
+    return rc;
 }
 
 /* =========================================================================
  * Worker Control Loop And Result Frames
  * ========================================================================= */
 
-static int dist_worker_read_loop(ds4_dist_worker_state *state, int fd) {
+static int dist_worker_read_loop(
+        ds4_dist_worker_state *state,
+        int fd,
+        ds4_transport *transport) {
     ds4_dist_worker_upstream upstream;
-    dist_worker_upstream_init(&upstream, state, fd);
+    if (dist_worker_upstream_init(&upstream, state, fd, transport) != 0) return 1;
     int loop_rc = 0;
 
     for (;;) {
@@ -5820,6 +8001,14 @@ static int dist_worker_read_loop(ds4_dist_worker_state *state, int fd) {
             }
             continue;
         }
+        if (type == DS4_DIST_MSG_SESSION_DESTROY) {
+            rc = dist_worker_handle_session_destroy(state, &upstream, bytes);
+            if (rc <= 0) {
+                loop_rc = rc == 0 ? 0 : 1;
+                break;
+            }
+            continue;
+        }
         rc = dist_discard_bytes(fd, bytes);
         if (rc <= 0) {
             loop_rc = rc == 0 ? 0 : 1;
@@ -5837,8 +8026,9 @@ static int dist_worker_read_loop(ds4_dist_worker_state *state, int fd) {
     return loop_rc;
 }
 
-static int dist_send_work_result(
+static int dist_send_work_result_prepared(
         int fd,
+        ds4_transport *transport,
         uint64_t request_id,
         uint64_t result_hash,
         uint32_t status,
@@ -5847,7 +8037,10 @@ static int dist_send_work_result(
         const ds4_dist_telemetry_fixed *telemetry,
         uint32_t telemetry_count,
         const void *payload,
-        uint32_t payload_bytes) {
+        uint32_t payload_bytes,
+        bool allow_oob,
+        const ds4_transport_bulk_desc *prepared_desc,
+        ds4_transport_lease *tx_lease) {
     if (payload_bytes != 0 && !payload) return -1;
     if (telemetry_count != 0 && !telemetry) return -1;
     uint32_t wire_payload_bytes = payload_bytes;
@@ -5869,10 +8062,6 @@ static int dist_send_work_result(
         (uint64_t)telemetry_count * sizeof(ds4_dist_telemetry_fixed);
     if (telemetry_bytes64 > UINT32_MAX) return -1;
     const uint32_t telemetry_bytes = (uint32_t)telemetry_bytes64;
-    const uint64_t frame_bytes = sizeof(ds4_dist_result_fixed) +
-                                 telemetry_bytes64 +
-                                 (uint64_t)wire_payload_bytes;
-    if (frame_bytes > UINT32_MAX) return -1;
 
     ds4_dist_result_fixed r;
     dist_u64_to_halves(request_id, &r.request_hi, &r.request_lo);
@@ -5886,6 +8075,142 @@ static int dist_send_work_result(
     r.payload_bytes = wire_payload_bytes;
     r.payload_bits = payload_bits;
 
+    if (dist_transport_uses_v3(transport)) {
+        const bool is_bulk = status == 0 && wire_payload_bytes != 0 &&
+            (result_kind == DS4_DIST_RESULT_HIDDEN_STATE ||
+             result_kind == DS4_DIST_RESULT_LOGITS);
+        const void *bulk_wire = NULL;
+        void *bulk_owned = NULL;
+        uint32_t bulk_bytes = 0;
+        ds4_transport_bulk_desc desc;
+        bool local_desc_prepared = false;
+        if (is_bulk) {
+            if (result_kind == DS4_DIST_RESULT_HIDDEN_STATE) {
+                if (dist_pack_activation_payload(payload, hidden_values,
+                                                 payload_bits, &bulk_wire,
+                                                 &bulk_owned,
+                                                 &bulk_bytes) != 0 ||
+                    bulk_bytes != wire_payload_bytes) {
+                    free(bulk_owned);
+                    return -1;
+                }
+            } else {
+                bulk_wire = payload;
+                bulk_bytes = payload_bytes;
+            }
+            const uint32_t bulk_kind =
+                result_kind == DS4_DIST_RESULT_HIDDEN_STATE
+                    ? DS4_TRANSPORT_BULK_RESULT_HIDDEN
+                    : DS4_TRANSPORT_BULK_RESULT_LOGITS;
+            if (prepared_desc) {
+                desc = *prepared_desc;
+                const int desc_rc = desc.mode == DS4_TRANSPORT_BULK_NHI_OOB
+                    ? ds4_transport_validate_oob_desc(
+                          transport, &desc, bulk_kind, 0, request_id,
+                          bulk_bytes, payload_bits, NULL, 0)
+                    : ds4_transport_validate_inline_desc(
+                          &desc, bulk_kind, 0, request_id,
+                          bulk_bytes, payload_bits, NULL, 0);
+                if (desc_rc != 0) {
+                    free(bulk_owned);
+                    return -1;
+                }
+            } else if (ds4_transport_prepare_bulk(
+                           transport, bulk_kind, 0, request_id,
+                           bulk_bytes, payload_bits, &desc,
+                           NULL, 0) != 0) {
+                free(bulk_owned);
+                return -1;
+            } else {
+                local_desc_prepared = true;
+            }
+            if (!allow_oob && desc.mode == DS4_TRANSPORT_BULK_NHI_OOB) {
+                desc.mode = DS4_TRANSPORT_BULK_TCP_INLINE;
+                desc.frame_count = 0;
+            }
+        } else {
+            if (prepared_desc || tx_lease) return -1;
+            dist_bulk_none_desc(transport, 0, request_id, &desc);
+        }
+
+        if (tx_lease &&
+            (!prepared_desc || desc.mode != DS4_TRANSPORT_BULK_NHI_OOB ||
+             ds4_transport_lease_host_ptr(tx_lease) != bulk_wire ||
+             ds4_transport_lease_bytes(tx_lease) != bulk_bytes)) {
+            free(bulk_owned);
+            errno = EINVAL;
+            return -1;
+        }
+
+        const uint32_t control_payload_bytes = is_bulk ? 0u : wire_payload_bytes;
+        uint32_t control_bytes = 0;
+        uint32_t frame_bytes = 0;
+        if (ds4_dist_v3_result_frame_sizes(telemetry_bytes,
+                                           control_payload_bytes,
+                                           bulk_bytes,
+                                           desc.mode,
+                                           &control_bytes,
+                                           &frame_bytes) != 0) {
+            if (local_desc_prepared) shutdown(fd, SHUT_RDWR);
+            free(bulk_owned);
+            return -1;
+        }
+        (void)control_bytes;
+        ds4_transport_bulk_desc_wire desc_wire;
+        if (ds4_transport_bulk_desc_encode(&desc, &desc_wire) != 0) {
+            if (local_desc_prepared) shutdown(fd, SHUT_RDWR);
+            free(bulk_owned);
+            return -1;
+        }
+        ds4_dist_result_fixed result_wire = r;
+        dist_result_to_wire(&result_wire);
+        int rc = -1;
+        bool lease_control_mark_attempted = false;
+        if (dist_write_frame_header(fd, DS4_DIST_MSG_RESULT, frame_bytes) != 0 ||
+            dist_write_full(fd, &result_wire, sizeof(result_wire)) != 0 ||
+            dist_write_full(fd, &desc_wire, sizeof(desc_wire)) != 0)
+            goto v3_result_done;
+        for (uint32_t i = 0; i < telemetry_count; i++) {
+            ds4_dist_telemetry_fixed tw = telemetry[i];
+            dist_telemetry_to_wire(&tw);
+            if (dist_write_full(fd, &tw, sizeof(tw)) != 0)
+                goto v3_result_done;
+        }
+        if (control_payload_bytes != 0 &&
+            dist_write_full(fd, payload, control_payload_bytes) != 0)
+            goto v3_result_done;
+        if (bulk_bytes != 0) {
+            if (tx_lease) {
+                lease_control_mark_attempted = true;
+                if (ds4_transport_tx_lease_mark_control_sent(tx_lease) != 0 ||
+                    dist_mapped_lease_commit_after_gpu_quiesce(tx_lease) != 0)
+                    goto v3_result_done;
+            } else if (ds4_transport_send_bulk_desc(
+                           transport, &desc, bulk_wire, bulk_bytes) != 0) {
+                goto v3_result_done;
+            }
+        }
+        rc = 1;
+v3_result_done:
+        if (rc < 0) {
+            const int saved = errno ? errno : EIO;
+            /* A control write was attempted. Make a mapped lease irreversible
+             * before caller cleanup so its prepared sequence cannot roll back,
+             * even if the peer saw only a prefix of the frame. */
+            if (tx_lease && !lease_control_mark_attempted)
+                (void)ds4_transport_tx_lease_mark_control_sent(tx_lease);
+            shutdown(fd, SHUT_RDWR);
+            errno = saved;
+        }
+        free(bulk_owned);
+        return rc;
+    }
+
+    const uint64_t frame_bytes = sizeof(ds4_dist_result_fixed) +
+                                 telemetry_bytes64 +
+                                 (uint64_t)wire_payload_bytes;
+    if (frame_bytes > UINT32_MAX) return -1;
+
     ds4_dist_result_fixed wire = r;
     dist_result_to_wire(&wire);
     if (dist_write_frame_header(fd, DS4_DIST_MSG_RESULT, (uint32_t)frame_bytes) != 0) return -1;
@@ -5896,18 +8221,49 @@ static int dist_send_work_result(
         if (dist_write_full(fd, &tw, sizeof(tw)) != 0) return -1;
     }
     if (status == 0 && result_kind == DS4_DIST_RESULT_HIDDEN_STATE && wire_payload_bytes != 0) {
-        if (dist_write_activation_payload(fd, payload, hidden_values, payload_bits) != 0) return -1;
-    } else if (payload_bytes && payload && dist_write_full(fd, payload, payload_bytes) != 0) {
-        return -1;
+        if (dist_write_activation_payload(transport, payload, hidden_values, payload_bits) != 0) return -1;
+    } else if (payload_bytes && payload) {
+        const bool payload_is_bulk = status == 0 &&
+            result_kind == DS4_DIST_RESULT_LOGITS;
+        if (payload_is_bulk) {
+            if (ds4_transport_send_bulk(transport, payload, payload_bytes) != 0)
+                return -1;
+        } else if (dist_write_full(fd, payload, payload_bytes) != 0) {
+            return -1;
+        }
     }
     return 1;
 }
 
-static int dist_send_work_error(int fd, uint64_t request_id, const char *msg) {
+static int dist_send_work_result(
+        int fd,
+        ds4_transport *transport,
+        uint64_t request_id,
+        uint64_t result_hash,
+        uint32_t status,
+        uint32_t result_kind,
+        uint32_t payload_bits,
+        const ds4_dist_telemetry_fixed *telemetry,
+        uint32_t telemetry_count,
+        const void *payload,
+        uint32_t payload_bytes,
+        bool allow_oob) {
+    return dist_send_work_result_prepared(
+        fd, transport, request_id, result_hash, status, result_kind,
+        payload_bits, telemetry, telemetry_count, payload, payload_bytes,
+        allow_oob, NULL, NULL);
+}
+
+static int dist_send_work_error(
+        int fd,
+        ds4_transport *transport,
+        uint64_t request_id,
+        const char *msg) {
     if (!msg) msg = "distributed work failed";
     size_t len = strlen(msg);
     if (len > UINT32_MAX) len = UINT32_MAX;
-    return dist_send_work_result(fd, request_id, 0, 1, 0, 0, NULL, 0, msg, (uint32_t)len);
+    return dist_send_work_result(fd, transport, request_id, 0, 1, 0, 0,
+                                 NULL, 0, msg, (uint32_t)len, false);
 }
 
 static int dist_send_snapshot_begin(
@@ -6228,12 +8584,15 @@ static bool dist_route_validate_blob(
     return true;
 }
 
-static int dist_send_work_frame(
+static int dist_send_work_frame_prepared(
         int fd,
+        ds4_transport *transport,
         const ds4_dist_work_fixed *work,
         const int *tokens,
         const float *input_hc,
-        const void *route_blob) {
+        const void *route_blob,
+        const ds4_transport_bulk_desc *prepared_desc,
+        ds4_transport_lease *tx_lease) {
     if (!work || !tokens || work->n_tokens == 0) return -1;
     const uint64_t token_bytes = (uint64_t)work->n_tokens * sizeof(uint32_t);
     if (token_bytes > UINT32_MAX || work->token_bytes != (uint32_t)token_bytes) return -1;
@@ -6245,6 +8604,132 @@ static int dist_send_work_frame(
                                                 work->input_hc_bytes,
                                                 &input_hc_values))
         return -1;
+    if (dist_transport_uses_v3(transport)) {
+        const uint64_t session_id = dist_u64_from_halves(
+            work->session_hi, work->session_lo);
+        const uint64_t request_id = dist_u64_from_halves(
+            work->request_hi, work->request_lo);
+        ds4_transport_bulk_desc desc;
+        const void *bulk_wire = NULL;
+        void *bulk_owned = NULL;
+        uint32_t bulk_bytes = 0;
+        bool local_desc_prepared = false;
+        if (work->input_hc_bytes != 0) {
+            if (dist_pack_activation_payload(input_hc, input_hc_values,
+                                             work->input_hc_bits,
+                                             &bulk_wire, &bulk_owned,
+                                             &bulk_bytes) != 0 ||
+                bulk_bytes != work->input_hc_bytes) {
+                free(bulk_owned);
+                return -1;
+            }
+            if (prepared_desc) {
+                desc = *prepared_desc;
+                const int desc_rc = desc.mode == DS4_TRANSPORT_BULK_NHI_OOB
+                    ? ds4_transport_validate_oob_desc(
+                          transport, &desc,
+                          DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+                          session_id, request_id, bulk_bytes,
+                          dist_activation_bits_or_default(work->input_hc_bits),
+                          NULL, 0)
+                    : ds4_transport_validate_inline_desc(
+                          &desc, DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+                          session_id, request_id, bulk_bytes,
+                          dist_activation_bits_or_default(work->input_hc_bits),
+                          NULL, 0);
+                if (desc_rc != 0) {
+                    free(bulk_owned);
+                    return -1;
+                }
+            } else if (ds4_transport_prepare_bulk(
+                           transport, DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+                           session_id, request_id, bulk_bytes,
+                           dist_activation_bits_or_default(work->input_hc_bits),
+                           &desc, NULL, 0) != 0) {
+                free(bulk_owned);
+                return -1;
+            } else {
+                local_desc_prepared = true;
+            }
+            /* One NHI endpoint represents one coordinator/worker route. A
+             * multi-hop route remains descriptor-framed but inline. */
+            if (work->route_count != 1u &&
+                desc.mode == DS4_TRANSPORT_BULK_NHI_OOB) {
+                desc.mode = DS4_TRANSPORT_BULK_TCP_INLINE;
+                desc.frame_count = 0;
+            }
+        } else {
+            if (prepared_desc || tx_lease) return -1;
+            dist_bulk_none_desc(transport, session_id, request_id, &desc);
+        }
+
+        if (tx_lease &&
+            (!prepared_desc || desc.mode != DS4_TRANSPORT_BULK_NHI_OOB ||
+             ds4_transport_lease_host_ptr(tx_lease) != bulk_wire ||
+             ds4_transport_lease_bytes(tx_lease) != bulk_bytes)) {
+            free(bulk_owned);
+            errno = EINVAL;
+            return -1;
+        }
+
+        uint32_t control_bytes = 0;
+        uint32_t frame_bytes = 0;
+        if (ds4_dist_v3_work_frame_sizes(work->token_bytes,
+                                         work->route_bytes,
+                                         bulk_bytes,
+                                         desc.mode,
+                                         &control_bytes,
+                                         &frame_bytes) != 0) {
+            if (local_desc_prepared) shutdown(fd, SHUT_RDWR);
+            free(bulk_owned);
+            return -1;
+        }
+        (void)control_bytes;
+        ds4_transport_bulk_desc_wire desc_wire;
+        if (ds4_transport_bulk_desc_encode(&desc, &desc_wire) != 0) {
+            if (local_desc_prepared) shutdown(fd, SHUT_RDWR);
+            free(bulk_owned);
+            return -1;
+        }
+        ds4_dist_work_fixed work_wire = *work;
+        dist_work_to_wire(&work_wire);
+        int rc = -1;
+        bool lease_control_mark_attempted = false;
+        if (dist_write_frame_header(fd, DS4_DIST_MSG_WORK, frame_bytes) != 0 ||
+            dist_write_full(fd, &work_wire, sizeof(work_wire)) != 0 ||
+            dist_write_full(fd, &desc_wire, sizeof(desc_wire)) != 0)
+            goto v3_done;
+        for (uint32_t i = 0; i < work->n_tokens; i++) {
+            uint32_t token = htonl((uint32_t)tokens[i]);
+            if (dist_write_full(fd, &token, sizeof(token)) != 0)
+                goto v3_done;
+        }
+        if (work->route_bytes &&
+            dist_write_full(fd, route_blob, work->route_bytes) != 0)
+            goto v3_done;
+        if (bulk_bytes != 0) {
+            if (tx_lease) {
+                lease_control_mark_attempted = true;
+                if (ds4_transport_tx_lease_mark_control_sent(tx_lease) != 0 ||
+                    dist_mapped_lease_commit_after_gpu_quiesce(tx_lease) != 0)
+                    goto v3_done;
+            } else if (ds4_transport_send_bulk_desc(
+                           transport, &desc, bulk_wire, bulk_bytes) != 0) {
+                goto v3_done;
+            }
+        }
+        rc = 0;
+v3_done:
+        if (rc < 0) {
+            const int saved = errno ? errno : EIO;
+            if (tx_lease && !lease_control_mark_attempted)
+                (void)ds4_transport_tx_lease_mark_control_sent(tx_lease);
+            shutdown(fd, SHUT_RDWR);
+            errno = saved;
+        }
+        free(bulk_owned);
+        return rc;
+    }
     const uint64_t frame_bytes = sizeof(ds4_dist_work_fixed) +
                                  (uint64_t)work->token_bytes +
                                  work->input_hc_bytes +
@@ -6259,14 +8744,49 @@ static int dist_send_work_frame(
         uint32_t t = htonl((uint32_t)tokens[i]);
         if (dist_write_full(fd, &t, sizeof(t)) != 0) return -1;
     }
-    if (work->input_hc_bytes &&
-        dist_write_activation_payload(fd,
-                                      input_hc,
-                                      input_hc_values,
-                                      work->input_hc_bits) != 0)
-        return -1;
+    if (work->input_hc_bytes) {
+        if (dist_write_activation_payload(transport,
+                                          input_hc,
+                                          input_hc_values,
+                                          work->input_hc_bits) != 0)
+            return -1;
+    }
     if (work->route_bytes && dist_write_full(fd, route_blob, work->route_bytes) != 0) return -1;
     return 0;
+}
+
+static int dist_send_work_frame(
+        int fd,
+        ds4_transport *transport,
+        const ds4_dist_work_fixed *work,
+        const int *tokens,
+        const float *input_hc,
+        const void *route_blob) {
+    return dist_send_work_frame_prepared(fd, transport, work, tokens,
+                                         input_hc, route_blob, NULL, NULL);
+}
+
+static int dist_worker_upstream_send_work_result_prepared(
+        ds4_dist_worker_upstream *upstream,
+        uint64_t request_id,
+        uint64_t result_hash,
+        uint32_t status,
+        uint32_t result_kind,
+        uint32_t payload_bits,
+        const ds4_dist_telemetry_fixed *telemetry,
+        uint32_t telemetry_count,
+        const void *payload,
+        uint32_t payload_bytes,
+        bool allow_oob,
+        const ds4_dist_tx_bulk_plan *tx_plan) {
+    pthread_mutex_lock(&upstream->write_mu);
+    int rc = dist_send_work_result_prepared(
+        upstream->fd, upstream->transport, request_id, result_hash,
+        status, result_kind, payload_bits, telemetry, telemetry_count,
+        payload, payload_bytes, allow_oob,
+        dist_tx_bulk_plan_desc(tx_plan), tx_plan ? tx_plan->lease : NULL);
+    pthread_mutex_unlock(&upstream->write_mu);
+    return rc;
 }
 
 static int dist_worker_upstream_send_work_result(
@@ -6279,20 +8799,12 @@ static int dist_worker_upstream_send_work_result(
         const ds4_dist_telemetry_fixed *telemetry,
         uint32_t telemetry_count,
         const void *payload,
-        uint32_t payload_bytes) {
-    pthread_mutex_lock(&upstream->write_mu);
-    int rc = dist_send_work_result(upstream->fd,
-                                   request_id,
-                                   result_hash,
-                                   status,
-                                   result_kind,
-                                   payload_bits,
-                                   telemetry,
-                                   telemetry_count,
-                                   payload,
-                                   payload_bytes);
-    pthread_mutex_unlock(&upstream->write_mu);
-    return rc;
+        uint32_t payload_bytes,
+        bool allow_oob) {
+    return dist_worker_upstream_send_work_result_prepared(
+        upstream, request_id, result_hash, status, result_kind,
+        payload_bits, telemetry, telemetry_count, payload, payload_bytes,
+        allow_oob, NULL);
 }
 
 static int dist_worker_upstream_send_work_error(
@@ -6300,20 +8812,36 @@ static int dist_worker_upstream_send_work_error(
         uint64_t request_id,
         const char *msg) {
     pthread_mutex_lock(&upstream->write_mu);
-    int rc = dist_send_work_error(upstream->fd, request_id, msg);
+    int rc = dist_send_work_error(upstream->fd, upstream->transport,
+                                  request_id, msg);
     pthread_mutex_unlock(&upstream->write_mu);
     return rc;
 }
 
-static void dist_worker_upstream_init(
+static int dist_worker_upstream_init(
         ds4_dist_worker_upstream *upstream,
         ds4_dist_worker_state *state,
-        int fd) {
+        int fd,
+        ds4_transport *transport) {
     memset(upstream, 0, sizeof(*upstream));
     upstream->state = state;
     upstream->fd = fd;
-    pthread_mutex_init(&upstream->write_mu, NULL);
-    pthread_mutex_init(&upstream->forward_mu, NULL);
+    upstream->transport = transport
+        ? ds4_transport_retain(transport)
+        : ds4_transport_tcp_create(fd, NULL, 0);
+    if (!upstream->transport) return -1;
+    if (pthread_mutex_init(&upstream->write_mu, NULL) != 0) {
+        ds4_transport_release(upstream->transport);
+        upstream->transport = NULL;
+        return -1;
+    }
+    if (pthread_mutex_init(&upstream->forward_mu, NULL) != 0) {
+        pthread_mutex_destroy(&upstream->write_mu);
+        ds4_transport_release(upstream->transport);
+        upstream->transport = NULL;
+        return -1;
+    }
+    return 0;
 }
 
 static bool dist_worker_forwarder_enqueue_request(
@@ -6600,15 +9128,23 @@ static void *dist_worker_forwarder_relay_main(void *arg) {
             }
         }
 
+        const bool payload_is_bulk = result.status == 0 &&
+            (result.result_kind == DS4_DIST_RESULT_HIDDEN_STATE ||
+             result.result_kind == DS4_DIST_RESULT_LOGITS);
         remaining = result.payload_bytes;
         while (write_rc == 0 && remaining > 0) {
             uint32_t n = remaining < 1024u * 1024u ? remaining : 1024u * 1024u;
-            rc = dist_read_full(fd, buf, n);
+            rc = payload_is_bulk
+                ? ds4_transport_recv_bulk(forwarder->transport, buf, n)
+                : dist_read_full(fd, buf, n);
             if (rc <= 0) {
                 write_rc = -1;
                 break;
             }
-            if (dist_write_full(upstream->fd, buf, n) != 0) {
+            int payload_write_rc = payload_is_bulk
+                ? ds4_transport_send_bulk(upstream->transport, buf, n)
+                : dist_write_full(upstream->fd, buf, n);
+            if (payload_write_rc != 0) {
                 write_rc = -1;
                 break;
             }
@@ -6662,14 +9198,46 @@ static ds4_dist_worker_forwarder *dist_worker_get_forwarder(
     snprintf(forwarder->host, sizeof(forwarder->host), "%s", host);
     forwarder->port = port;
     forwarder->fd = fd;
+    forwarder->transport = ds4_transport_tcp_create(fd, err, errlen);
+    if (!forwarder->transport) {
+        close(fd);
+        free(forwarder);
+        pthread_mutex_unlock(&upstream->forward_mu);
+        return NULL;
+    }
     forwarder->pending_depth = dist_worker_forward_window();
-    pthread_mutex_init(&forwarder->send_mu, NULL);
-    pthread_mutex_init(&forwarder->queue_mu, NULL);
-    pthread_cond_init(&forwarder->queue_not_full, NULL);
+    if (pthread_mutex_init(&forwarder->send_mu, NULL) != 0) {
+        ds4_transport_release(forwarder->transport);
+        close(fd);
+        free(forwarder);
+        pthread_mutex_unlock(&upstream->forward_mu);
+        if (errlen) snprintf(err, errlen, "failed to initialize worker-to-worker sender lock");
+        return NULL;
+    }
+    if (pthread_mutex_init(&forwarder->queue_mu, NULL) != 0) {
+        pthread_mutex_destroy(&forwarder->send_mu);
+        ds4_transport_release(forwarder->transport);
+        close(fd);
+        free(forwarder);
+        pthread_mutex_unlock(&upstream->forward_mu);
+        if (errlen) snprintf(err, errlen, "failed to initialize worker-to-worker queue lock");
+        return NULL;
+    }
+    if (pthread_cond_init(&forwarder->queue_not_full, NULL) != 0) {
+        pthread_mutex_destroy(&forwarder->queue_mu);
+        pthread_mutex_destroy(&forwarder->send_mu);
+        ds4_transport_release(forwarder->transport);
+        close(fd);
+        free(forwarder);
+        pthread_mutex_unlock(&upstream->forward_mu);
+        if (errlen) snprintf(err, errlen, "failed to initialize worker-to-worker queue condition");
+        return NULL;
+    }
     if (pthread_create(&forwarder->tid, NULL, dist_worker_forwarder_relay_main, forwarder) != 0) {
         pthread_cond_destroy(&forwarder->queue_not_full);
         pthread_mutex_destroy(&forwarder->queue_mu);
         pthread_mutex_destroy(&forwarder->send_mu);
+        ds4_transport_release(forwarder->transport);
         close(fd);
         free(forwarder);
         pthread_mutex_unlock(&upstream->forward_mu);
@@ -6702,6 +9270,7 @@ static void dist_worker_upstream_destroy(ds4_dist_worker_upstream *upstream) {
     while (forwarders) {
         ds4_dist_worker_forwarder *next = forwarders->next;
         if (forwarders->thread_started) pthread_join(forwarders->tid, NULL);
+        ds4_transport_release(forwarders->transport);
         if (forwarders->fd >= 0) close(forwarders->fd);
         dist_worker_forwarder_clear_requests(forwarders);
         pthread_cond_destroy(&forwarders->queue_not_full);
@@ -6713,6 +9282,7 @@ static void dist_worker_upstream_destroy(ds4_dist_worker_upstream *upstream) {
 
     pthread_mutex_destroy(&upstream->forward_mu);
     pthread_mutex_destroy(&upstream->write_mu);
+    ds4_transport_release(upstream->transport);
 }
 
 static int dist_forward_work_to_next(
@@ -6736,19 +9306,30 @@ static int dist_forward_work_to_next(
     forwarded.layer_start = next->layer_start;
     forwarded.layer_end = next->layer_end;
     forwarded.route_index = work->route_index + 1u;
-    forwarded.flags |= DS4_DIST_WORK_F_INPUT_HC;
-    forwarded.input_hc_bits = dist_activation_bits_or_default(work->input_hc_bits);
-    if (!dist_activation_wire_bytes_from_f32_bytes(forwarded.input_hc_bits,
-                                                   hidden_hc_bytes,
-                                                   &forwarded.input_hc_bytes)) {
-        return dist_worker_upstream_send_work_error(upstream,
-                                                    request_id,
-                                                    "invalid forwarded hidden-state size");
-    }
-    if ((next->flags & DS4_DIST_ROUTE_F_OUTPUT_LOGITS) != 0) {
-        forwarded.flags |= DS4_DIST_WORK_F_OUTPUT_LOGITS;
+    const bool spec_commit =
+        (forwarded.flags & DS4_DIST_WORK_F_SPEC_COMMIT) != 0;
+    if (spec_commit) {
+        forwarded.flags &= ~(DS4_DIST_WORK_F_INPUT_HC |
+                             DS4_DIST_WORK_F_OUTPUT_LOGITS);
+        forwarded.flags |= DS4_DIST_WORK_F_ACK_ONLY;
+        forwarded.input_hc_bytes = 0;
+        forwarded.input_hc_bits = dist_activation_bits_or_default(
+            work->input_hc_bits);
     } else {
-        forwarded.flags &= ~DS4_DIST_WORK_F_OUTPUT_LOGITS;
+        forwarded.flags |= DS4_DIST_WORK_F_INPUT_HC;
+        forwarded.input_hc_bits = dist_activation_bits_or_default(work->input_hc_bits);
+        if (!dist_activation_wire_bytes_from_f32_bytes(forwarded.input_hc_bits,
+                                                       hidden_hc_bytes,
+                                                       &forwarded.input_hc_bytes)) {
+            return dist_worker_upstream_send_work_error(upstream,
+                                                        request_id,
+                                                        "invalid forwarded hidden-state size");
+        }
+        if ((next->flags & DS4_DIST_ROUTE_F_OUTPUT_LOGITS) != 0) {
+            forwarded.flags |= DS4_DIST_WORK_F_OUTPUT_LOGITS;
+        } else {
+            forwarded.flags &= ~DS4_DIST_WORK_F_OUTPUT_LOGITS;
+        }
     }
 
     pthread_mutex_lock(&forwarder->send_mu);
@@ -6767,7 +9348,8 @@ static int dist_forward_work_to_next(
                forwarded.n_tokens,
                forwarded.pos0,
                forwarded.input_hc_bytes);
-    int rc = dist_send_work_frame(forwarder->fd, &forwarded, tokens, hidden_hc, route_blob);
+    int rc = dist_send_work_frame(forwarder->fd, forwarder->transport,
+                                  &forwarded, tokens, hidden_hc, route_blob);
     const double send_t1 = dist_now_sec();
     dist_worker_forwarder_note_send_done(forwarder,
                                          request_id,
@@ -6846,17 +9428,67 @@ static uint32_t dist_worker_clear_sessions(ds4_dist_worker_state *state) {
     return n;
 }
 
-typedef struct {
-    const uint8_t *p;
-    uint32_t remaining;
-} ds4_dist_mem_reader;
+static int dist_worker_handle_session_destroy(
+        ds4_dist_worker_state *state,
+        ds4_dist_worker_upstream *upstream,
+        uint32_t bytes) {
+    ds4_dist_session_destroy_fixed destroy;
+    if (bytes != sizeof(destroy)) {
+        dist_discard_bytes(upstream->fd, bytes);
+        return dist_worker_upstream_send_work_error(
+            upstream, 0, "invalid distributed session destroy request");
+    }
 
-static int dist_mem_read(ds4_dist_mem_reader *r, void *dst, uint32_t len) {
-    if (!r || len > r->remaining) return -1;
-    if (len != 0) memcpy(dst, r->p, len);
-    r->p += len;
-    r->remaining -= len;
-    return 1;
+    int rc = dist_read_full(upstream->fd, &destroy, sizeof(destroy));
+    if (rc <= 0) return rc == 0 ? 0 : -1;
+    dist_session_destroy_from_wire(&destroy);
+    const uint64_t request_id = dist_u64_from_halves(destroy.request_hi,
+                                                     destroy.request_lo);
+    const uint64_t session_id = dist_u64_from_halves(destroy.session_hi,
+                                                     destroy.session_lo);
+    if (destroy.model_id != state->model_id ||
+        destroy.layer_start != state->layer_start ||
+        destroy.layer_end != state->layer_end ||
+        request_id == 0 || session_id == 0) {
+        return dist_worker_upstream_send_work_error(
+            upstream, request_id,
+            "session destroy request does not match worker state");
+    }
+
+    ds4_dist_worker_session *removed = NULL;
+    pthread_mutex_lock(&state->mu);
+    ds4_dist_worker_session **link = &state->sessions;
+    while (*link) {
+        if ((*link)->session_id == session_id) {
+            removed = *link;
+            *link = removed->next;
+            removed->next = NULL;
+            break;
+        }
+        link = &(*link)->next;
+    }
+    pthread_mutex_unlock(&state->mu);
+
+    if (removed) {
+        ds4_session_free(removed->session);
+        free(removed);
+        DIST_DEBUG("destroyed worker session=%llu layers=%u:%u",
+                   (unsigned long long)session_id,
+                   state->layer_start,
+                   state->layer_end);
+    }
+    /* Idempotent acknowledgement lets a coordinator safely retry cleanup. */
+    return dist_worker_upstream_send_work_result(upstream,
+                                                 request_id,
+                                                 0,
+                                                 0,
+                                                 DS4_DIST_RESULT_ACK,
+                                                 0,
+                                                 NULL,
+                                                 0,
+                                                 NULL,
+                                                 0,
+                                                 false);
 }
 
 static int dist_temp_file(const char *prefix, char *path, size_t path_len, FILE **fp_out) {
@@ -7168,40 +9800,352 @@ static int dist_worker_handle_snapshot_load(
  * Worker Layer Execution
  * ========================================================================= */
 
-static int dist_worker_process_work_payload(
+enum {
+    DS4_DIST_WORK_RECV_READY = 1,
+    DS4_DIST_WORK_RECV_REJECTED = 2,
+};
+
+static void dist_work_message_free(ds4_dist_work_message *message) {
+    if (!message) return;
+    free(message->tokens);
+    if (message->input_lease)
+        ds4_transport_lease_release(message->input_lease);
+    else
+        free(message->input_hc_wire);
+    free(message->route_blob);
+    memset(message, 0, sizeof(*message));
+}
+
+static int dist_work_message_commit_input_lease(
+        ds4_dist_work_message *message) {
+    if (!message || !message->input_lease) return 0;
+    int rc = dist_mapped_lease_commit_after_gpu_quiesce(
+        message->input_lease);
+    ds4_transport_lease_release(message->input_lease);
+    message->input_lease = NULL;
+    message->input_hc_wire = NULL;
+    return rc;
+}
+
+/* Once a mapped RX lease has been acquired, the descriptor and OOB event are
+ * structurally valid and belong to this generation. A semantic rejection must
+ * therefore consume/repost that event before notifying the peer; releasing an
+ * active RX lease would correctly treat it as an unsafe abort and poison the
+ * otherwise healthy link. */
+static int dist_worker_reject_received_work(
+        ds4_dist_worker_upstream *upstream,
+        ds4_dist_work_message *message,
+        uint64_t request_id,
+        const char *error_message) {
+    if (dist_work_message_commit_input_lease(message) != 0) return -1;
+    return dist_worker_upstream_send_work_error(upstream, request_id,
+                                                 error_message);
+}
+
+static int dist_worker_reject_work(
+        ds4_dist_worker_upstream *upstream,
+        uint32_t unread_bytes,
+        ds4_dist_work_message *work,
+        uint64_t request_id,
+        const char *message) {
+    if (unread_bytes != 0 &&
+        dist_discard_bytes(upstream->fd, unread_bytes) <= 0)
+        return -1;
+    work->reject_request_id = request_id;
+    snprintf(work->reject_message, sizeof(work->reject_message), "%s", message);
+    return DS4_DIST_WORK_RECV_REJECTED;
+}
+
+static int dist_worker_reject_typed_work(
+        ds4_dist_worker_upstream *upstream,
+        uint32_t unread_bytes,
+        ds4_dist_work_message *work,
+        uint64_t request_id,
+        const char *message) {
+    if (work && work->v3) {
+        /* A malformed v3 WORK cannot be made recoverable with a raw TCP drain:
+         * a sequenced descriptor would leave rx_sequence behind, while an OOB
+         * sender may already have produced an event. Abandon the generation. */
+        shutdown(upstream->fd, SHUT_RDWR);
+        errno = EPROTO;
+        return -1;
+    }
+    return dist_worker_reject_work(upstream, unread_bytes, work,
+                                   request_id, message);
+}
+
+/* Read one v2 WORK frame into typed ownership. The wire order remains exactly
+ * fixed | tokens | hidden-state | route, but bulk bytes now flow through the
+ * persistent transport rather than a temporary whole-frame allocation. */
+static int dist_worker_recv_work_message(
         ds4_dist_worker_state *state,
         ds4_dist_worker_upstream *upstream,
-        const void *payload,
-        uint32_t bytes) {
-    uint64_t request_id = 0;
-    char err[256];
-    if (bytes < sizeof(ds4_dist_work_fixed)) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "truncated distributed WORK frame");
+        uint32_t bytes,
+        ds4_dist_work_message *message) {
+    memset(message, 0, sizeof(*message));
+    message->frame_bytes = bytes;
+    message->v3 = dist_transport_uses_v3(upstream->transport);
+    const uint32_t fixed_bytes = (uint32_t)sizeof(ds4_dist_work_fixed);
+    if (bytes < fixed_bytes) {
+        if (message->v3) {
+            shutdown(upstream->fd, SHUT_RDWR);
+            errno = EPROTO;
+            return -1;
+        }
+        return dist_worker_reject_work(upstream, bytes, message, 0,
+                                       "truncated distributed WORK frame");
     }
 
-    ds4_dist_mem_reader reader = {
-        .p = payload,
-        .remaining = bytes,
-    };
-    ds4_dist_work_fixed work;
-    int rc = dist_mem_read(&reader, &work, (uint32_t)sizeof(work));
-    if (rc <= 0) return -1;
-    dist_work_from_wire(&work);
+    ds4_dist_work_fixed wire;
+    int rc = dist_read_full(upstream->fd, &wire, sizeof(wire));
+    if (rc <= 0) return rc == 0 ? 0 : -1;
+    message->work = wire;
+    dist_work_from_wire(&message->work);
+    const ds4_dist_work_fixed *work = &message->work;
+    const uint64_t request_id =
+        dist_u64_from_halves(work->request_hi, work->request_lo);
+    const uint64_t session_id =
+        dist_u64_from_halves(work->session_hi, work->session_lo);
+    uint32_t unread = bytes - fixed_bytes;
+    if (message->v3) {
+        if (unread < sizeof(ds4_transport_bulk_desc_wire)) {
+            shutdown(upstream->fd, SHUT_RDWR);
+            errno = EPROTO;
+            return -1;
+        }
+        ds4_transport_bulk_desc_wire desc_wire;
+        rc = dist_read_full(upstream->fd, &desc_wire, sizeof(desc_wire));
+        if (rc <= 0) return rc == 0 ? 0 : -1;
+        unread -= (uint32_t)sizeof(desc_wire);
+        if (ds4_transport_bulk_desc_decode(&desc_wire,
+                                           &message->bulk_desc) != 0) {
+            shutdown(upstream->fd, SHUT_RDWR);
+            return -1;
+        }
+    }
+
+    if (message->v3 && work->route_count != 1u) {
+        return dist_worker_reject_typed_work(
+            upstream, unread, message, request_id,
+            "distributed v3 currently supports one remote worker link");
+    }
+
+    const uint64_t token_bytes_expected =
+        (uint64_t)work->n_tokens * sizeof(uint32_t);
+    uint64_t body_bytes_expected = token_bytes_expected + work->route_bytes;
+    if (!message->v3 ||
+        message->bulk_desc.mode == DS4_TRANSPORT_BULK_TCP_INLINE)
+        body_bytes_expected += work->input_hc_bytes;
+    if (token_bytes_expected > UINT32_MAX ||
+        work->token_bytes != (uint32_t)token_bytes_expected ||
+        body_bytes_expected != unread) {
+        return dist_worker_reject_typed_work(
+            upstream, unread, message, request_id,
+            "invalid distributed WORK payload sizes");
+    }
+    if (work->n_tokens == 0 ||
+        work->pos0 > (uint32_t)state->ctx_size ||
+        work->n_tokens > (uint32_t)state->ctx_size - work->pos0) {
+        return dist_worker_reject_typed_work(
+            upstream, unread, message, request_id,
+            "WORK token span exceeds worker context");
+    }
+    if (work->route_bytes > DS4_DIST_MAX_ROUTE_BYTES) {
+        return dist_worker_reject_typed_work(
+            upstream, unread, message, request_id,
+            "distributed WORK route metadata is too large");
+    }
+
+    const bool input_hc_present =
+        (work->flags & DS4_DIST_WORK_F_INPUT_HC) != 0;
+    if (!input_hc_present && work->input_hc_bytes != 0) {
+        return dist_worker_reject_typed_work(
+            upstream, unread, message, request_id,
+            "WORK frame has hidden bytes without input flag");
+    }
+    if (input_hc_present) {
+        const uint64_t hc_values = state->hidden_f32_values;
+        const uint64_t expected_values = (uint64_t)work->n_tokens * hc_values;
+        const uint32_t input_hc_bits =
+            dist_activation_bits_or_default(work->input_hc_bits);
+        uint32_t expected_wire_bytes = 0;
+        if (!dist_activation_bits_valid(input_hc_bits) ||
+            !dist_activation_wire_bytes(input_hc_bits,
+                                        expected_values,
+                                        &expected_wire_bytes) ||
+            work->input_hc_bytes != expected_wire_bytes) {
+            return dist_worker_reject_typed_work(
+                upstream, unread, message, request_id,
+                "input hidden-state size does not match token span");
+        }
+    }
+
+    if (message->v3) {
+        int desc_rc = 0;
+        if (work->input_hc_bytes == 0) {
+            desc_rc = dist_validate_bulk_none_desc(
+                upstream->transport, &message->bulk_desc,
+                session_id, request_id);
+        } else if (message->bulk_desc.mode ==
+                   DS4_TRANSPORT_BULK_TCP_INLINE) {
+            desc_rc = ds4_transport_validate_inline_desc(
+                &message->bulk_desc,
+                DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+                session_id, request_id, work->input_hc_bytes,
+                dist_activation_bits_or_default(work->input_hc_bits),
+                NULL, 0);
+        } else if (message->bulk_desc.mode ==
+                   DS4_TRANSPORT_BULK_NHI_OOB &&
+                   work->route_count == 1u) {
+            desc_rc = ds4_transport_validate_oob_desc(
+                upstream->transport, &message->bulk_desc,
+                DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+                session_id, request_id, work->input_hc_bytes,
+                dist_activation_bits_or_default(work->input_hc_bits),
+                NULL, 0);
+        } else {
+            desc_rc = -1;
+            errno = EPROTO;
+        }
+        if (desc_rc != 0) {
+            shutdown(upstream->fd, SHUT_RDWR);
+            return -1;
+        }
+    }
+
+    message->tokens = malloc((size_t)work->n_tokens * sizeof(message->tokens[0]));
+    if (!message->tokens) {
+        shutdown(upstream->fd, SHUT_RDWR);
+        return -1;
+    }
+    bool invalid_token = false;
+    for (uint32_t i = 0; i < work->n_tokens; i++) {
+        uint32_t token_wire = 0;
+        rc = dist_read_full(upstream->fd, &token_wire, sizeof(token_wire));
+        if (rc <= 0) {
+            dist_work_message_free(message);
+            return -1;
+        }
+        const uint32_t token = ntohl(token_wire);
+        if (token > (uint32_t)INT_MAX) {
+            invalid_token = true;
+            message->tokens[i] = 0;
+        } else {
+            message->tokens[i] = (int)token;
+        }
+    }
+    unread -= work->token_bytes;
+
+    if (!message->v3 && work->input_hc_bytes != 0) {
+        message->input_hc_wire = malloc(work->input_hc_bytes);
+        if (!message->input_hc_wire) {
+            dist_work_message_free(message);
+            shutdown(upstream->fd, SHUT_RDWR);
+            return -1;
+        }
+        rc = ds4_transport_recv_bulk(upstream->transport,
+                                     message->input_hc_wire,
+                                     work->input_hc_bytes);
+        if (rc <= 0) {
+            dist_work_message_free(message);
+            return -1;
+        }
+        unread -= work->input_hc_bytes;
+    }
+
+    if (work->route_bytes != 0) {
+        message->route_blob = malloc(work->route_bytes);
+        if (!message->route_blob) {
+            dist_work_message_free(message);
+            shutdown(upstream->fd, SHUT_RDWR);
+            return -1;
+        }
+        rc = dist_read_full(upstream->fd, message->route_blob,
+                            work->route_bytes);
+        if (rc <= 0) {
+            dist_work_message_free(message);
+            return -1;
+        }
+        unread -= work->route_bytes;
+    }
+    if (message->v3 && invalid_token) {
+        int reject_rc = dist_worker_reject_typed_work(
+            upstream, unread, message, request_id,
+            "WORK token id is outside the model vocabulary");
+        if (reject_rc < 0) dist_work_message_free(message);
+        return reject_rc;
+    }
+    if (message->v3 && work->input_hc_bytes != 0) {
+        if (message->bulk_desc.mode == DS4_TRANSPORT_BULK_NHI_OOB &&
+            dist_activation_bits_or_default(work->input_hc_bits) == 32u &&
+            ds4_transport_mapped_leases_supported(upstream->transport)) {
+            rc = ds4_transport_rx_lease_acquire(
+                upstream->transport, &message->bulk_desc,
+                &message->input_lease, NULL, 0);
+            if (rc == 0) {
+                message->input_hc_wire =
+                    ds4_transport_lease_host_ptr(message->input_lease);
+            } else if (errno != ENOTSUP) {
+                dist_work_message_free(message);
+                return -1;
+            }
+        }
+        if (!message->input_lease) {
+            message->input_hc_wire = malloc(work->input_hc_bytes);
+            if (!message->input_hc_wire) {
+                dist_work_message_free(message);
+                shutdown(upstream->fd, SHUT_RDWR);
+                return -1;
+            }
+            rc = ds4_transport_recv_bulk_desc(upstream->transport,
+                                              &message->bulk_desc,
+                                              message->input_hc_wire,
+                                              work->input_hc_bytes);
+            if (rc <= 0) {
+                dist_work_message_free(message);
+                return -1;
+            }
+        }
+        if (message->bulk_desc.mode == DS4_TRANSPORT_BULK_TCP_INLINE)
+            unread -= work->input_hc_bytes;
+    }
+    if (unread != 0) {
+        dist_work_message_free(message);
+        shutdown(upstream->fd, SHUT_RDWR);
+        return -1;
+    }
+    if (invalid_token) {
+        dist_work_message_free(message);
+        return dist_worker_reject_work(
+            upstream, 0, message, request_id,
+            "WORK token id is outside the model vocabulary");
+    }
+    return DS4_DIST_WORK_RECV_READY;
+}
+
+static int dist_worker_process_work_message(
+        ds4_dist_worker_state *state,
+        ds4_dist_worker_upstream *upstream,
+        ds4_dist_work_message *message) {
+    char err[256];
+    ds4_dist_work_fixed work = message->work;
+    const uint32_t bytes = message->frame_bytes;
     const uint64_t session_id = dist_u64_from_halves(work.session_hi, work.session_lo);
-    request_id = dist_u64_from_halves(work.request_hi, work.request_lo);
+    const uint64_t request_id = dist_u64_from_halves(work.request_hi, work.request_lo);
     const uint64_t work_prefix_hash = dist_u64_from_halves(work.prefix_hash_hi,
                                                            work.prefix_hash_lo);
     const uint64_t work_result_hash = dist_u64_from_halves(work.result_hash_hi,
                                                            work.result_hash_lo);
     const bool profile = dist_decode_profile_enabled() && work.n_tokens == 1;
     const double total_t0 = profile ? dist_now_sec() : 0.0;
-    DIST_DEBUG("worker work request=%llu layers=%u:%u tokens=%u pos=%u flags=0x%x token_bytes=%u input_hc=%u/%ub route_count=%u route_index=%u route_bytes=%u",
+    DIST_DEBUG("worker work request=%llu layers=%u:%u tokens=%u pos=%u flags=0x%x keep=%u token_bytes=%u input_hc=%u/%ub route_count=%u route_index=%u route_bytes=%u",
                (unsigned long long)request_id,
                work.layer_start,
                work.layer_end,
                work.n_tokens,
                work.pos0,
                work.flags,
+               work.spec_keep_tokens,
                work.token_bytes,
                work.input_hc_bytes,
                work.input_hc_bits,
@@ -7209,79 +10153,134 @@ static int dist_worker_process_work_payload(
                work.route_index,
                work.route_bytes);
 
-    const uint32_t remaining = bytes - (uint32_t)sizeof(work);
+    const uint32_t descriptor_bytes = message->v3
+        ? (uint32_t)sizeof(ds4_transport_bulk_desc_wire) : 0u;
+    const uint32_t metadata_bytes = (uint32_t)sizeof(ds4_dist_work_fixed);
+    if (bytes < metadata_bytes + descriptor_bytes) {
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "truncated distributed WORK metadata");
+    }
+    const uint32_t remaining = bytes - metadata_bytes - descriptor_bytes;
     const uint64_t token_bytes_expected = (uint64_t)work.n_tokens * sizeof(uint32_t);
-    const uint64_t payload_bytes_expected =
-        (uint64_t)work.token_bytes + work.input_hc_bytes + work.route_bytes;
+    uint64_t payload_bytes_expected =
+        (uint64_t)work.token_bytes + work.route_bytes;
+    if (!message->v3 ||
+        message->bulk_desc.mode == DS4_TRANSPORT_BULK_TCP_INLINE)
+        payload_bytes_expected += work.input_hc_bytes;
     if ((uint64_t)work.token_bytes != token_bytes_expected ||
         payload_bytes_expected != remaining) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "invalid distributed WORK payload sizes");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "invalid distributed WORK payload sizes");
     }
     if (work.route_count == 0) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "WORK frame is missing distributed route");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "WORK frame is missing distributed route");
     }
     if (work.route_index >= work.route_count) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "invalid distributed WORK route metadata");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "invalid distributed WORK route metadata");
     }
     if (work.model_id != state->model_id) {
         snprintf(err, sizeof(err), "model id mismatch: work=%u worker=%u", work.model_id, state->model_id);
-        return dist_worker_upstream_send_work_error(upstream, request_id, err);
+        return dist_worker_reject_received_work(upstream, message,
+                                                request_id, err);
     }
     if (work.layer_start != state->layer_start || work.layer_end != state->layer_end) {
         snprintf(err, sizeof(err), "worker is assigned layers %u:%u but request asked for %u:%u",
                  state->layer_start, state->layer_end, work.layer_start, work.layer_end);
-        return dist_worker_upstream_send_work_error(upstream, request_id, err);
+        return dist_worker_reject_received_work(upstream, message,
+                                                request_id, err);
     }
     if ((work.flags & ~DS4_DIST_WORK_F_VALID_MASK) != 0) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "invalid distributed WORK flags");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id, "invalid distributed WORK flags");
     }
     if (work.n_tokens == 0) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "WORK frame has no tokens");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id, "WORK frame has no tokens");
     }
     if (work.pos0 > (uint32_t)state->ctx_size ||
         work.n_tokens > (uint32_t)state->ctx_size - work.pos0) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "WORK token span exceeds worker context");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "WORK token span exceeds worker context");
     }
 
     const bool output_logits = (work.flags & DS4_DIST_WORK_F_OUTPUT_LOGITS) != 0;
     const bool input_hc_present = (work.flags & DS4_DIST_WORK_F_INPUT_HC) != 0;
     const bool ack_only = (work.flags & DS4_DIST_WORK_F_ACK_ONLY) != 0;
-    if (input_hc_present && work.layer_start == 0) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "layer 0 WORK must not provide input hidden-state");
+    const bool speculative = (work.flags & DS4_DIST_WORK_F_SPECULATIVE) != 0;
+    const bool spec_commit = (work.flags & DS4_DIST_WORK_F_SPEC_COMMIT) != 0;
+    if (speculative && spec_commit) {
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "WORK cannot verify and commit speculation together");
     }
-    if (!input_hc_present && work.layer_start != 0) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "nonzero layer WORK requires input hidden-state");
+    if (spec_commit) {
+        if (!ack_only || input_hc_present || output_logits ||
+            (work.flags & DS4_DIST_WORK_F_RESET_SESSION) != 0 ||
+            work.spec_keep_tokens == 0 ||
+            work.spec_keep_tokens > work.n_tokens) {
+            return dist_worker_reject_received_work(
+                upstream, message, request_id,
+                "invalid speculative commit WORK metadata");
+        }
+    } else if (work.spec_keep_tokens != 0) {
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "non-commit WORK has speculative keep count");
+    }
+    if (speculative && (work.n_tokens > DS4_DIST_SPEC_MAX_DRAFT_TOKENS ||
+                        ack_only ||
+                        (work.flags & DS4_DIST_WORK_F_RESET_SESSION) != 0)) {
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "invalid speculative verify WORK metadata");
+    }
+    if (!spec_commit && input_hc_present && work.layer_start == 0) {
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "layer 0 WORK must not provide input hidden-state");
+    }
+    if (!spec_commit && !input_hc_present && work.layer_start != 0) {
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "nonzero layer WORK requires input hidden-state");
     }
     if (output_logits && !state->has_output) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "worker was not assigned the output head");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "worker was not assigned the output head");
     }
     const uint32_t n_layers = (uint32_t)ds4_engine_layer_count(state->engine);
     if (output_logits && work.layer_end + 1u != n_layers) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "WORK logits require final transformer layer");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "WORK logits require final transformer layer");
     }
 
-    int *tokens = malloc((size_t)work.n_tokens * sizeof(tokens[0]));
-    if (!tokens) {
-        return dist_worker_upstream_send_work_error(upstream, request_id, "out of memory reading WORK tokens");
-    }
+    int *tokens = message->tokens;
+    message->tokens = NULL;
     for (uint32_t i = 0; i < work.n_tokens; i++) {
-        uint32_t wire_token = 0;
-        rc = dist_mem_read(&reader, &wire_token, (uint32_t)sizeof(wire_token));
-        if (rc <= 0) {
-            free(tokens);
-            return -1;
-        }
-        uint32_t token = ntohl(wire_token);
+        uint32_t token = (uint32_t)tokens[i];
         if (token > (uint32_t)INT_MAX || token >= (uint32_t)ds4_engine_vocab_size(state->engine)) {
             free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, "WORK token id is outside the model vocabulary");
+            return dist_worker_reject_received_work(
+                upstream, message, request_id,
+                "WORK token id is outside the model vocabulary");
         }
         tokens[i] = (int)token;
     }
     if (dist_token_hash_update_span(work_prefix_hash, tokens, work.n_tokens) !=
         work_result_hash) {
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, "WORK token prefix hash metadata mismatch");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "WORK token prefix hash metadata mismatch");
     }
 
     const uint64_t hc_values = ds4_engine_hidden_f32_values(state->engine);
@@ -7289,13 +10288,15 @@ static int dist_worker_process_work_payload(
     const uint64_t expected_hc_bytes64 = expected_hc_values * sizeof(float);
     if (expected_hc_bytes64 > UINT32_MAX) {
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, "distributed hidden-state payload is too large");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "distributed hidden-state payload is too large");
     }
     const uint32_t expected_hc_bytes = (uint32_t)expected_hc_bytes64;
     const uint32_t input_hc_bits = dist_activation_bits_or_default(work.input_hc_bits);
 
     float *input_hc = NULL;
-    const void *input_hc_wire = NULL;
+    const void *input_hc_wire = message->input_hc_wire;
     if (input_hc_present) {
         uint32_t expected_hc_wire_bytes = 0;
         if (!dist_activation_bits_valid(input_hc_bits) ||
@@ -7303,13 +10304,17 @@ static int dist_worker_process_work_payload(
                                         expected_hc_values,
                                         &expected_hc_wire_bytes)) {
             free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, "invalid distributed activation width");
+            return dist_worker_reject_received_work(
+                upstream, message, request_id,
+                "invalid distributed activation width");
         }
         if (work.input_hc_bytes != expected_hc_wire_bytes) {
             free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, "input hidden-state size does not match token span");
+            return dist_worker_reject_received_work(
+                upstream, message, request_id,
+                "input hidden-state size does not match token span");
         }
-        if (work.input_hc_bytes > reader.remaining) {
+        if (work.input_hc_bytes != 0 && !input_hc_wire) {
             DIST_DEBUG("worker input hidden read failed request=%llu rc=%d bytes=%u",
                        (unsigned long long)request_id,
                        -1,
@@ -7317,34 +10322,19 @@ static int dist_worker_process_work_payload(
             free(tokens);
             return -1;
         }
-        input_hc_wire = reader.p;
-        reader.p += work.input_hc_bytes;
-        reader.remaining -= work.input_hc_bytes;
         DIST_DEBUG("worker input hidden read ok request=%llu bytes=%u bits=%u",
                    (unsigned long long)request_id,
                    work.input_hc_bytes,
                    input_hc_bits);
     } else if (work.input_hc_bytes != 0) {
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, "WORK frame has hidden bytes without input flag");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "WORK frame has hidden bytes without input flag");
     }
-    void *route_blob = NULL;
+    void *route_blob = message->route_blob;
+    message->route_blob = NULL;
     if (work.route_bytes != 0) {
-        route_blob = malloc(work.route_bytes);
-        if (!route_blob) {
-            free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, "out of memory reading distributed route");
-        }
-        rc = dist_mem_read(&reader, route_blob, work.route_bytes);
-        if (rc <= 0) {
-            DIST_DEBUG("worker route read failed request=%llu rc=%d bytes=%u",
-                       (unsigned long long)request_id,
-                       rc,
-                       work.route_bytes);
-            free(route_blob);
-            free(tokens);
-            return -1;
-        }
         DIST_DEBUG("worker route read ok request=%llu bytes=%u",
                    (unsigned long long)request_id,
                    work.route_bytes);
@@ -7360,38 +10350,47 @@ static int dist_worker_process_work_payload(
                                       err, sizeof(err))) {
             free(route_blob);
             free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, err);
+            return dist_worker_reject_received_work(upstream, message,
+                                                    request_id, err);
         }
         if (!dist_route_get_entry(route_blob, work.route_bytes, work.route_count,
                                   work.route_index, &current_route, err, sizeof(err))) {
             free(route_blob);
             free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, err);
+            return dist_worker_reject_received_work(upstream, message,
+                                                    request_id, err);
         }
         if (current_route.layer_start != work.layer_start ||
             current_route.layer_end != work.layer_end) {
             free(route_blob);
             free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, "WORK layer range does not match route entry");
+            return dist_worker_reject_received_work(
+                upstream, message, request_id,
+                "WORK layer range does not match route entry");
         }
         const bool route_output_logits = (current_route.flags & DS4_DIST_ROUTE_F_OUTPUT_LOGITS) != 0;
-        if (route_output_logits != output_logits) {
+        if (!spec_commit && route_output_logits != output_logits) {
             free(route_blob);
             free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, "WORK logits flag does not match route entry");
+            return dist_worker_reject_received_work(
+                upstream, message, request_id,
+                "WORK logits flag does not match route entry");
         }
         if (has_next &&
             !dist_route_get_entry(route_blob, work.route_bytes, work.route_count,
                                   work.route_index + 1u, &next_route, err, sizeof(err))) {
             free(route_blob);
             free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, err);
+            return dist_worker_reject_received_work(upstream, message,
+                                                    request_id, err);
         }
     }
-    if (has_next && output_logits) {
+    if (!spec_commit && has_next && output_logits) {
         free(route_blob);
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, "non-final route entry requested logits");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "non-final route entry requested logits");
     }
     if (has_route && !has_next) {
         ds4_dist_route_return ret;
@@ -7399,31 +10398,39 @@ static int dist_worker_process_work_payload(
                                           &ret, err, sizeof(err))) {
             free(route_blob);
             free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, err);
+            return dist_worker_reject_received_work(upstream, message,
+                                                    request_id, err);
         }
         if (ret.kind != DS4_DIST_ROUTE_RETURN_UPSTREAM) {
             free(route_blob);
             free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, "unsupported final result destination");
+            return dist_worker_reject_received_work(
+                upstream, message, request_id,
+                "unsupported final result destination");
         }
     }
 
-    const bool final_ack_only = ack_only && !has_next;
+    const bool final_ack_only = (ack_only || spec_commit) && !has_next;
     const bool local_output_logits = output_logits && !has_next && !final_ack_only;
-    const bool produce_hidden = !local_output_logits && !final_ack_only;
-    const uint32_t result_kind = final_ack_only
+    const bool produce_hidden = !spec_commit && !local_output_logits && !final_ack_only;
+    const uint32_t result_kind = (spec_commit || final_ack_only)
         ? DS4_DIST_RESULT_ACK
         : (local_output_logits ? DS4_DIST_RESULT_LOGITS : DS4_DIST_RESULT_HIDDEN_STATE);
-    const uint32_t result_bytes = final_ack_only
+    const uint32_t result_bytes = (spec_commit || final_ack_only)
         ? 0u
         : (local_output_logits
             ? (uint32_t)((uint64_t)ds4_engine_vocab_size(state->engine) * sizeof(float))
             : expected_hc_bytes);
     float *result = result_bytes ? malloc(result_bytes) : NULL;
+    ds4_dist_tx_bulk_plan result_tx_plan;
+    memset(&result_tx_plan, 0, sizeof(result_tx_plan));
+    bool result_mapped = false;
     if (result_bytes && !result) {
         free(route_blob);
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, "out of memory allocating distributed result");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "out of memory allocating distributed result");
     }
 
     const double decode_t0 = profile ? dist_now_sec() : 0.0;
@@ -7441,16 +10448,44 @@ static int dist_worker_process_work_payload(
         free(result);
         free(route_blob);
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, err);
+        return dist_worker_reject_received_work(upstream, message,
+                                                request_id, err);
     }
     if (input_hc_present && input_hc_decoded_bytes != expected_hc_bytes) {
         if (!input_hc_uses_wire) free(input_hc);
         free(result);
         free(route_blob);
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, "decoded input hidden-state size does not match token span");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "decoded input hidden-state size does not match token span");
     }
     const double decode_t1 = profile ? dist_now_sec() : 0.0;
+
+    const uint32_t result_payload_bits =
+        result_kind == DS4_DIST_RESULT_HIDDEN_STATE ? input_hc_bits : 32u;
+    if (!has_next && work.route_count == 1u && result_bytes != 0) {
+        int tx_plan_rc = dist_tx_bulk_plan_prepare(
+            upstream->transport,
+            result_kind == DS4_DIST_RESULT_HIDDEN_STATE
+                ? DS4_TRANSPORT_BULK_RESULT_HIDDEN
+                : DS4_TRANSPORT_BULK_RESULT_LOGITS,
+            0, request_id, result_bytes, result_payload_bits,
+            &result_tx_plan, err, sizeof(err));
+        if (tx_plan_rc < 0) {
+            if (!input_hc_uses_wire) free(input_hc);
+            free(result);
+            dist_tx_bulk_plan_abort(upstream->transport, &result_tx_plan);
+            free(route_blob);
+            free(tokens);
+            return -1;
+        }
+        if (result_tx_plan.lease) {
+            free(result);
+            result = ds4_transport_lease_host_ptr(result_tx_plan.lease);
+            result_mapped = true;
+        }
+    }
 
     const double lock_t0 = profile ? dist_now_sec() : 0.0;
     pthread_mutex_lock(&state->mu);
@@ -7459,19 +10494,23 @@ static int dist_worker_process_work_payload(
     if (!session) {
         pthread_mutex_unlock(&state->mu);
         if (!input_hc_uses_wire) free(input_hc);
-        free(result);
+        if (!result_mapped) free(result);
+        dist_tx_bulk_plan_abort(upstream->transport, &result_tx_plan);
         free(route_blob);
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, err);
+        return dist_worker_reject_received_work(upstream, message,
+                                                request_id, err);
     }
     if ((work.flags & DS4_DIST_WORK_F_RESET_SESSION) != 0 &&
         ds4_session_layer_slice_reset(session->session, err, sizeof(err)) != 0) {
         pthread_mutex_unlock(&state->mu);
         if (!input_hc_uses_wire) free(input_hc);
-        free(result);
+        if (!result_mapped) free(result);
+        dist_tx_bulk_plan_abort(upstream->transport, &result_tx_plan);
         free(route_blob);
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, err);
+        return dist_worker_reject_received_work(upstream, message,
+                                                request_id, err);
     }
     if ((work.flags & DS4_DIST_WORK_F_RESET_SESSION) != 0) {
         session->token_hash = DS4_DIST_TOKEN_HASH_INIT;
@@ -7481,24 +10520,100 @@ static int dist_worker_process_work_payload(
         if (!timeline || timeline->len < 0) {
             pthread_mutex_unlock(&state->mu);
             if (!input_hc_uses_wire) free(input_hc);
-            free(result);
+            if (!result_mapped) free(result);
+            dist_tx_bulk_plan_abort(upstream->transport, &result_tx_plan);
             free(route_blob);
             free(tokens);
-            return dist_worker_upstream_send_work_error(upstream, request_id, "worker session has no token timeline");
+            return dist_worker_reject_received_work(
+                upstream, message, request_id,
+                "worker session has no token timeline");
         }
         session->token_hash = dist_token_hash_prefix(timeline->v, (uint32_t)timeline->len);
         session->token_hash_valid = true;
     }
-    if (session->token_hash != work_prefix_hash) {
+    const uint64_t required_hash = spec_commit ? work_result_hash : work_prefix_hash;
+    if (session->token_hash != required_hash) {
         pthread_mutex_unlock(&state->mu);
         if (!input_hc_uses_wire) free(input_hc);
-        free(result);
+        if (!result_mapped) free(result);
+        dist_tx_bulk_plan_abort(upstream->transport, &result_tx_plan);
         free(route_blob);
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, "worker KV prefix hash mismatch");
+        return dist_worker_reject_received_work(
+            upstream,
+            message,
+            request_id,
+            spec_commit ? "worker speculative result hash mismatch"
+                        : "worker KV prefix hash mismatch");
     }
     const double eval_t0 = dist_now_sec();
-    int eval_rc = ds4_session_eval_layer_slice(session->session,
+    int eval_rc = 0;
+    uint32_t eval_direct_used = 0;
+    const uint32_t direct_mode = dist_nhi_direct_slot_mode();
+    ds4_layer_slice_device_io eval_device_io;
+    memset(&eval_device_io, 0, sizeof(eval_device_io));
+    if (!speculative && input_hc && message->input_lease &&
+        (direct_mode & DS4_DIST_NHI_DIRECT_RX) != 0) {
+        eval_device_io.input_hc_device =
+            ds4_transport_lease_device_ptr(message->input_lease);
+        eval_device_io.input_hc_bytes =
+            ds4_transport_lease_bytes(message->input_lease);
+    }
+    if (!speculative && result_tx_plan.lease &&
+        (direct_mode & DS4_DIST_NHI_DIRECT_TX) != 0) {
+        void *result_device =
+            ds4_transport_lease_device_ptr(result_tx_plan.lease);
+        const uint64_t result_device_bytes =
+            ds4_transport_lease_bytes(result_tx_plan.lease);
+        if (produce_hidden) {
+            eval_device_io.output_hc_device = result_device;
+            eval_device_io.output_hc_bytes = result_device_bytes;
+            if (dist_nhi_unsafe_fast_enabled()) {
+                eval_device_io.flags |=
+                    DS4_LAYER_SLICE_DEVICE_IO_DISCARD_OUTPUT_HC_STATE;
+            }
+        } else if (local_output_logits) {
+            eval_device_io.logits_device = result_device;
+            eval_device_io.logits_bytes = result_device_bytes;
+            if (dist_nhi_unsafe_fast_enabled()) {
+                eval_device_io.flags |=
+                    DS4_LAYER_SLICE_DEVICE_IO_DISCARD_LOGITS_STATE;
+            }
+        }
+    }
+    const bool use_device_io =
+        eval_device_io.input_hc_device || eval_device_io.output_hc_device ||
+        eval_device_io.logits_device;
+    if (spec_commit) {
+        eval_rc = ds4_session_speculative_commit(session->session,
+                                                 work.spec_keep_tokens,
+                                                 err,
+                                                 sizeof(err));
+    } else {
+        if (speculative) {
+            eval_rc = ds4_session_speculative_begin(session->session,
+                                                    true,
+                                                    err,
+                                                    sizeof(err));
+        }
+        if (eval_rc == 0) {
+            eval_rc = use_device_io
+                ? ds4_session_eval_layer_slice_device_io(
+                      session->session,
+                      tokens,
+                      work.n_tokens,
+                      work.pos0,
+                      work.layer_start,
+                      work.layer_end,
+                      input_hc,
+                      produce_hidden ? result : NULL,
+                      local_output_logits,
+                      local_output_logits ? result : NULL,
+                      &eval_device_io,
+                      &eval_direct_used,
+                      err,
+                      sizeof(err))
+                : ds4_session_eval_layer_slice(session->session,
                                                tokens,
                                                work.n_tokens,
                                                work.pos0,
@@ -7510,14 +10625,42 @@ static int dist_worker_process_work_payload(
                                                local_output_logits ? result : NULL,
                                                err,
                                                sizeof(err));
+        }
+        if (eval_rc != 0 && speculative) {
+            char rollback_err[256] = "";
+            (void)ds4_session_speculative_rollback(session->session,
+                                                   rollback_err,
+                                                   sizeof(rollback_err));
+        }
+    }
     const double eval_t1 = dist_now_sec();
+    const uint64_t response_hash = spec_commit
+        ? dist_token_hash_update_span(work_prefix_hash,
+                                      tokens,
+                                      work.spec_keep_tokens)
+        : work_result_hash;
     if (eval_rc == 0) {
-        session->token_hash = work_result_hash;
+        session->token_hash = spec_commit
+            ? dist_token_hash_update_span(work_prefix_hash,
+                                          tokens,
+                                          work.spec_keep_tokens)
+            : work_result_hash;
         session->token_hash_valid = true;
     } else {
         session->token_hash_valid = false;
     }
     pthread_mutex_unlock(&state->mu);
+    if (dist_nhi_direct_slot_trace_enabled() && work.n_tokens == 1) {
+        fprintf(stderr,
+                "ds4: dist direct-slot: role=worker request=%llu pos=%u mode=%u rx_lease=%u tx_lease=%u used=0x%x rc=%d\n",
+                (unsigned long long)request_id,
+                work.pos0,
+                direct_mode,
+                message->input_lease ? 1u : 0u,
+                result_tx_plan.lease ? 1u : 0u,
+                eval_direct_used,
+                eval_rc);
+    }
     DIST_DEBUG("worker eval request=%llu layers=%u:%u tokens=%u pos=%u has_next=%d output=%d rc=%d",
                (unsigned long long)request_id,
                work.layer_start,
@@ -7530,10 +10673,21 @@ static int dist_worker_process_work_payload(
 
     if (eval_rc != 0) {
         if (!input_hc_uses_wire) free(input_hc);
-        free(result);
+        if (!result_mapped) free(result);
+        dist_tx_bulk_plan_abort(upstream->transport, &result_tx_plan);
         free(route_blob);
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, err);
+        return dist_worker_reject_received_work(upstream, message,
+                                                request_id, err);
+    }
+
+    if (dist_work_message_commit_input_lease(message) != 0) {
+        if (!input_hc_uses_wire) free(input_hc);
+        if (!result_mapped) free(result);
+        dist_tx_bulk_plan_abort(upstream->transport, &result_tx_plan);
+        free(route_blob);
+        free(tokens);
+        return -1;
     }
 
     uint32_t result_wire_bytes = result_bytes;
@@ -7542,10 +10696,13 @@ static int dist_worker_process_work_payload(
                                                    result_bytes,
                                                    &result_wire_bytes)) {
         if (!input_hc_uses_wire) free(input_hc);
-        free(result);
+        if (!result_mapped) free(result);
+        dist_tx_bulk_plan_abort(upstream->transport, &result_tx_plan);
         free(route_blob);
         free(tokens);
-        return dist_worker_upstream_send_work_error(upstream, request_id, "invalid output hidden-state size");
+        return dist_worker_reject_received_work(
+            upstream, message, request_id,
+            "invalid output hidden-state size");
     }
 
     ds4_dist_telemetry_fixed telemetry = {
@@ -7573,21 +10730,15 @@ static int dist_worker_process_work_payload(
                                             &telemetry,
                                             route_blob);
     } else {
-        send_rc = dist_worker_upstream_send_work_result(upstream,
-                                                        request_id,
-                                                        work_result_hash,
-                                                        0,
-                                                        result_kind,
-                                                        result_kind == DS4_DIST_RESULT_HIDDEN_STATE ? input_hc_bits : 32u,
-                                                        &telemetry,
-                                                        1,
-                                                        result,
-                                                        result_bytes);
+        send_rc = dist_worker_upstream_send_work_result_prepared(
+            upstream, request_id, response_hash, 0, result_kind,
+            result_payload_bits, &telemetry, 1, result, result_bytes,
+            work.route_count == 1u, &result_tx_plan);
     }
     const double send_t1 = profile ? dist_now_sec() : 0.0;
     if (profile) {
         fprintf(stderr,
-                "ds4: dist decode profile: worker request=%llu pos=%u layers=%u:%u input_decode=%.3fms lock_wait=%.3fms eval=%.3fms send=%.3fms total=%.3fms input=%.2fMiB output=%.2fMiB rc=%d\n",
+                "ds4: dist decode profile: worker request=%llu pos=%u layers=%u:%u input_decode=%.3fms lock_wait=%.3fms eval=%.3fms send=%.3fms total=%.3fms input=%.2fMiB output=%.2fMiB direct=0x%x rc=%d\n",
                 (unsigned long long)request_id,
                 work.pos0,
                 work.layer_start,
@@ -7599,14 +10750,19 @@ static int dist_worker_process_work_payload(
                 (send_t1 - total_t0) * 1000.0,
                 (double)(work.token_bytes + work.input_hc_bytes) / (1024.0 * 1024.0),
                 (double)result_wire_bytes / (1024.0 * 1024.0),
+                eval_direct_used,
                 send_rc);
     }
     DIST_DEBUG("worker send complete request=%llu has_next=%d send_rc=%d",
                (unsigned long long)request_id,
                has_next ? 1 : 0,
                send_rc);
+    if (send_rc <= 0 && result_tx_plan.prepared)
+        dist_tx_bulk_plan_abort(upstream->transport, &result_tx_plan);
+    else
+        dist_tx_bulk_plan_release(&result_tx_plan);
     if (!input_hc_uses_wire) free(input_hc);
-    free(result);
+    if (!result_mapped) free(result);
     free(route_blob);
     free(tokens);
     return send_rc;
@@ -7616,18 +10772,18 @@ static int dist_worker_handle_work(
         ds4_dist_worker_state *state,
         ds4_dist_worker_upstream *upstream,
         uint32_t bytes) {
-    void *payload = malloc(bytes);
-    if (!payload) {
-        dist_discard_bytes(upstream->fd, bytes);
-        return dist_worker_upstream_send_work_error(upstream, 0, "out of memory reading distributed WORK frame");
+    ds4_dist_work_message message;
+    int rc = dist_worker_recv_work_message(state, upstream, bytes, &message);
+    if (rc == DS4_DIST_WORK_RECV_REJECTED) {
+        rc = dist_worker_upstream_send_work_error(upstream,
+                                                   message.reject_request_id,
+                                                   message.reject_message);
+        dist_work_message_free(&message);
+        return rc;
     }
-    int rc = dist_read_full(upstream->fd, payload, bytes);
-    if (rc <= 0) {
-        free(payload);
-        return rc == 0 ? 0 : -1;
-    }
-    rc = dist_worker_process_work_payload(state, upstream, payload, bytes);
-    free(payload);
+    if (rc <= 0) return rc;
+    rc = dist_worker_process_work_message(state, upstream, &message);
+    dist_work_message_free(&message);
     return rc;
 }
 
@@ -7637,11 +10793,11 @@ static int dist_worker_handle_work(
 
 static void dist_worker_job_free(ds4_dist_worker_job *job) {
     if (!job) return;
-    free(job->payload);
+    dist_work_message_free(&job->message);
     free(job);
 }
 
-static void dist_worker_job_queue_init(
+static int dist_worker_job_queue_init(
         ds4_dist_worker_job_queue *q,
         ds4_dist_worker_state *state,
         ds4_dist_worker_upstream *upstream) {
@@ -7649,9 +10805,23 @@ static void dist_worker_job_queue_init(
     q->state = state;
     q->upstream = upstream;
     q->depth = dist_worker_prefetch_depth();
-    pthread_mutex_init(&q->mu, NULL);
-    pthread_cond_init(&q->not_empty, NULL);
-    pthread_cond_init(&q->not_full, NULL);
+    if (pthread_mutex_init(&q->mu, NULL) != 0) return -1;
+    if (pthread_cond_init(&q->not_empty, NULL) != 0) {
+        pthread_mutex_destroy(&q->mu);
+        return -1;
+    }
+    if (pthread_cond_init(&q->not_full, NULL) != 0) {
+        pthread_cond_destroy(&q->not_empty);
+        pthread_mutex_destroy(&q->mu);
+        return -1;
+    }
+    if (pthread_cond_init(&q->idle, NULL) != 0) {
+        pthread_cond_destroy(&q->not_full);
+        pthread_cond_destroy(&q->not_empty);
+        pthread_mutex_destroy(&q->mu);
+        return -1;
+    }
+    return 0;
 }
 
 static void dist_worker_job_queue_clear_locked(ds4_dist_worker_job_queue *q) {
@@ -7670,6 +10840,7 @@ static void dist_worker_job_queue_destroy(ds4_dist_worker_job_queue *q) {
     pthread_mutex_lock(&q->mu);
     dist_worker_job_queue_clear_locked(q);
     pthread_mutex_unlock(&q->mu);
+    pthread_cond_destroy(&q->idle);
     pthread_cond_destroy(&q->not_full);
     pthread_cond_destroy(&q->not_empty);
     pthread_mutex_destroy(&q->mu);
@@ -7688,6 +10859,7 @@ static void dist_worker_job_queue_cancel(ds4_dist_worker_job_queue *q) {
     q->closed = true;
     q->canceled = true;
     dist_worker_job_queue_clear_locked(q);
+    pthread_cond_broadcast(&q->idle);
     pthread_cond_broadcast(&q->not_empty);
     pthread_cond_broadcast(&q->not_full);
     pthread_mutex_unlock(&q->mu);
@@ -7726,10 +10898,56 @@ static ds4_dist_worker_job *dist_worker_job_queue_pop(ds4_dist_worker_job_queue 
     q->head = job->next;
     if (!q->head) q->tail = NULL;
     q->queued--;
+    q->active++;
     job->next = NULL;
     pthread_cond_signal(&q->not_full);
     pthread_mutex_unlock(&q->mu);
     return job;
+}
+
+static bool dist_worker_job_queue_complete(
+        ds4_dist_worker_job_queue *q,
+        int rc) {
+    pthread_mutex_lock(&q->mu);
+    if (q->active != 0) q->active--;
+    if (rc <= 0) {
+        q->rc = rc == 0 ? 0 : 1;
+        q->closed = true;
+        q->canceled = true;
+        dist_worker_job_queue_clear_locked(q);
+        pthread_cond_broadcast(&q->not_empty);
+        pthread_cond_broadcast(&q->not_full);
+    }
+    const bool keep_running = rc > 0 && !q->canceled;
+    pthread_cond_broadcast(&q->idle);
+    pthread_mutex_unlock(&q->mu);
+    return keep_running;
+}
+
+/* A correctly ordered peer may send a control frame immediately after it has
+ * received the preceding RESULT, while the eval thread is in the tiny window
+ * between completing that write and publishing active=0. Wait out that
+ * handoff, but reject a control frame that overtakes work still in the FIFO. */
+static bool dist_worker_job_queue_prepare_control(ds4_dist_worker_job_queue *q) {
+    pthread_mutex_lock(&q->mu);
+    if (q->queued != 0) {
+        pthread_mutex_unlock(&q->mu);
+        return false;
+    }
+    int wait_rc = 0;
+    while (q->active != 0 && !q->canceled && wait_rc == 0) {
+#ifdef DS4_TEST_HOOKS
+        q->control_waiters++;
+        pthread_cond_broadcast(&q->idle);
+#endif
+        wait_rc = pthread_cond_wait(&q->idle, &q->mu);
+#ifdef DS4_TEST_HOOKS
+        q->control_waiters--;
+#endif
+    }
+    const bool ready = wait_rc == 0 && !q->canceled && q->queued == 0;
+    pthread_mutex_unlock(&q->mu);
+    return ready;
 }
 
 static void *dist_worker_prefetch_eval_main(void *arg) {
@@ -7737,16 +10955,19 @@ static void *dist_worker_prefetch_eval_main(void *arg) {
     for (;;) {
         ds4_dist_worker_job *job = dist_worker_job_queue_pop(q);
         if (!job) break;
-        int rc = dist_worker_process_work_payload(q->state,
+        int rc;
+        if (job->message.reject_message[0]) {
+            rc = dist_worker_upstream_send_work_error(
+                q->upstream,
+                job->message.reject_request_id,
+                job->message.reject_message);
+        } else {
+            rc = dist_worker_process_work_message(q->state,
                                                   q->upstream,
-                                                  job->payload,
-                                                  job->bytes);
+                                                  &job->message);
+        }
         dist_worker_job_free(job);
-        if (rc <= 0) {
-            pthread_mutex_lock(&q->mu);
-            q->rc = rc == 0 ? 0 : 1;
-            pthread_mutex_unlock(&q->mu);
-            dist_worker_job_queue_cancel(q);
+        if (!dist_worker_job_queue_complete(q, rc)) {
             shutdown(q->upstream->fd, SHUT_RDWR);
             break;
         }
@@ -7754,12 +10975,18 @@ static void *dist_worker_prefetch_eval_main(void *arg) {
     return NULL;
 }
 
-static int dist_worker_read_loop_prefetch(ds4_dist_worker_state *state, int fd) {
+static int dist_worker_read_loop_prefetch(
+        ds4_dist_worker_state *state,
+        int fd,
+        ds4_transport *transport) {
     ds4_dist_worker_upstream upstream;
-    dist_worker_upstream_init(&upstream, state, fd);
+    if (dist_worker_upstream_init(&upstream, state, fd, transport) != 0) return 1;
 
     ds4_dist_worker_job_queue queue;
-    dist_worker_job_queue_init(&queue, state, &upstream);
+    if (dist_worker_job_queue_init(&queue, state, &upstream) != 0) {
+        dist_worker_upstream_destroy(&upstream);
+        return 1;
+    }
 
     pthread_t eval_tid;
     if (pthread_create(&eval_tid, NULL, dist_worker_prefetch_eval_main, &queue) != 0) {
@@ -7801,20 +11028,15 @@ static int dist_worker_read_loop_prefetch(ds4_dist_worker_state *state, int fd) 
             ds4_dist_worker_job *job = calloc(1, sizeof(*job));
             if (!job) {
                 dist_discard_bytes(fd, bytes);
-                dist_worker_upstream_send_work_error(&upstream, 0, "out of memory queueing distributed WORK");
+                /* An immediate error could overtake results for queued WORK.
+                 * Make allocation failure terminal instead of reordering the
+                 * request/response stream. */
+                shutdown(fd, SHUT_RDWR);
                 loop_rc = 1;
                 break;
             }
-            job->payload = malloc(bytes);
-            job->bytes = bytes;
-            if (!job->payload) {
-                dist_worker_job_free(job);
-                dist_discard_bytes(fd, bytes);
-                dist_worker_upstream_send_work_error(&upstream, 0, "out of memory reading distributed WORK frame");
-                loop_rc = 1;
-                break;
-            }
-            rc = dist_read_full(fd, job->payload, bytes);
+            rc = dist_worker_recv_work_message(state, &upstream, bytes,
+                                               &job->message);
             if (rc <= 0) {
                 dist_worker_job_free(job);
                 loop_rc = rc == 0 ? 0 : 1;
@@ -7827,6 +11049,16 @@ static int dist_worker_read_loop_prefetch(ds4_dist_worker_state *state, int fd) 
             }
             continue;
         }
+        if (!dist_worker_job_queue_prepare_control(&queue)) {
+            /* Processing this request now would overtake WORK that has not
+             * completed, or the eval path has already failed. */
+            fprintf(stderr,
+                    "ds4: distributed worker: control frame %u arrived while WORK was pending\n",
+                    type);
+            shutdown(fd, SHUT_RDWR);
+            loop_rc = 1;
+            break;
+        }
         if (type == DS4_DIST_MSG_SNAPSHOT_SAVE_REQ) {
             rc = dist_worker_handle_snapshot_save(state, &upstream, bytes);
             if (rc <= 0) {
@@ -7837,6 +11069,14 @@ static int dist_worker_read_loop_prefetch(ds4_dist_worker_state *state, int fd) 
         }
         if (type == DS4_DIST_MSG_SNAPSHOT_LOAD_BEGIN) {
             rc = dist_worker_handle_snapshot_load(state, &upstream, bytes);
+            if (rc <= 0) {
+                loop_rc = rc == 0 ? 0 : 1;
+                break;
+            }
+            continue;
+        }
+        if (type == DS4_DIST_MSG_SESSION_DESTROY) {
+            rc = dist_worker_handle_session_destroy(state, &upstream, bytes);
             if (rc <= 0) {
                 loop_rc = rc == 0 ? 0 : 1;
                 break;
@@ -7876,8 +11116,8 @@ static void *dist_worker_data_client_main(void *arg) {
     free(ctx);
 
     int rc = getenv("DS4_DIST_DISABLE_WORKER_PREFETCH")
-        ? dist_worker_read_loop(state, fd)
-        : dist_worker_read_loop_prefetch(state, fd);
+        ? dist_worker_read_loop(state, fd, NULL)
+        : dist_worker_read_loop_prefetch(state, fd, NULL);
     if (rc != 0) {
         fprintf(stderr,
                 "ds4: distributed worker: data connection %s:%s closed after error\n",
@@ -7964,7 +11204,10 @@ static int dist_run_worker(ds4_engine *engine, const ds4_dist_options *opt, int 
     state.layer_end = dist_resolved_layer_end(opt, (uint32_t)ds4_engine_layer_count(engine));
     state.has_output = opt->layers.has_output;
     state.ctx_size = ctx_size;
+    state.hidden_f32_values = ds4_engine_hidden_f32_values(engine);
     state.listen_fd = listen_fd;
+    state.transport_policy = opt->transport;
+    state.nhi_device = opt->nhi_device;
     pthread_mutex_init(&state.mu, NULL);
 
     pthread_t data_tid;
@@ -7985,6 +11228,9 @@ static int dist_run_worker(ds4_engine *engine, const ds4_dist_options *opt, int 
             opt->coordinator_host,
             opt->coordinator_port);
 
+    bool legacy_v2 = opt->transport == DS4_DIST_TRANSPORT_DEFAULT ||
+                     opt->transport == DS4_DIST_TRANSPORT_TCP;
+    bool force_v3_tcp = false;
     for (;;) {
         int fd = dist_connect_endpoint(opt->coordinator_host, opt->coordinator_port, err, sizeof(err));
         if (fd < 0) {
@@ -7997,16 +11243,38 @@ static int dist_run_worker(ds4_engine *engine, const ds4_dist_options *opt, int 
         dist_peer_name(fd, peer_host, sizeof(peer_host), peer_port, sizeof(peer_port));
         fprintf(stderr, "ds4: distributed worker: connected to coordinator %s:%s\n", peer_host, peer_port);
 
-        if (dist_send_hello(engine, opt, ctx_size, listen_port, fd) != 0) {
-            fprintf(stderr, "ds4: distributed worker: failed to send HELLO: %s\n", strerror(errno));
+        bool retry_legacy = false;
+        bool retry_v3_tcp = false;
+        ds4_transport *transport = dist_worker_negotiate_link(
+            engine, opt, ctx_size, listen_port, fd, !legacy_v2,
+            force_v3_tcp, &retry_legacy, &retry_v3_tcp,
+            err, sizeof(err));
+        if (!transport) {
+            fprintf(stderr, "ds4: distributed worker: link negotiation failed: %s\n",
+                    err[0] ? err : strerror(errno));
             close(fd);
+            if (retry_legacy) {
+                legacy_v2 = true;
+                fprintf(stderr,
+                        "ds4: distributed worker: peer rejected v3 HELLO; retrying with exact v2 TCP framing\n");
+            } else if (retry_v3_tcp) {
+                force_v3_tcp = true;
+                fprintf(stderr,
+                        "ds4: distributed worker: NHI failed before activation; retrying protocol v3 over TCP\n");
+            }
             dist_sleep_reconnect();
             continue;
         }
 
-        int rc = getenv("DS4_DIST_DISABLE_WORKER_PREFETCH")
-            ? dist_worker_read_loop(&state, fd)
-            : dist_worker_read_loop_prefetch(&state, fd);
+        /* The first mapped-slot implementation deliberately holds at most
+         * one RX lease. Keep parsing and evaluation on one thread until a
+         * later multi-lease pipeline can preserve POST_RX order. */
+        const bool mapped_slots =
+            ds4_transport_mapped_leases_supported(transport) != 0;
+        int rc = getenv("DS4_DIST_DISABLE_WORKER_PREFETCH") || mapped_slots
+            ? dist_worker_read_loop(&state, fd, transport)
+            : dist_worker_read_loop_prefetch(&state, fd, transport);
+        ds4_transport_release(transport);
         close(fd);
         uint32_t dropped_sessions = dist_worker_clear_sessions(&state);
         if (dropped_sessions) {
@@ -8157,6 +11425,10 @@ void ds4_dist_usage(FILE *fp) {
         "      Coordinator max end-to-end prefill chunks in flight. Default: workers+2, capped at 8.\n"
         "  --dist-activation-bits N\n"
         "      Coordinator hidden-state transport width: 32, 16, or 8. Default: 32.\n"
+        "  --dist-transport MODE\n"
+        "      Bulk transport: tcp, auto, or nhi. Default: tcp.\n"
+        "  --dist-nhi-device PATH\n"
+        "      Local USB4STREAM zero-copy device, e.g. /dev/tbstream0.\n"
         "  --dist-replay-check\n"
         "      Coordinator diagnostic: reset and replay the prompt, then compare logits.\n"
         "  --debug\n"
@@ -8281,6 +11553,46 @@ ds4_dist_cli_parse_result ds4_dist_parse_cli_arg(
         opt->activation_bits = bits;
         return DS4_DIST_CLI_MATCHED;
     }
+    if (!strcmp(arg, "--dist-transport")) {
+        if (!opt) {
+            if (errlen) snprintf(err, errlen, "missing distributed options");
+            return DS4_DIST_CLI_ERROR;
+        }
+        if (opt->transport != DS4_DIST_TRANSPORT_DEFAULT) {
+            if (errlen) snprintf(err, errlen, "specify --dist-transport only once");
+            return DS4_DIST_CLI_ERROR;
+        }
+        const char *value = dist_cli_need_arg(index, argc, argv, arg, err, errlen);
+        if (!value) return DS4_DIST_CLI_ERROR;
+        if (!strcmp(value, "auto")) opt->transport = DS4_DIST_TRANSPORT_AUTO;
+        else if (!strcmp(value, "tcp")) opt->transport = DS4_DIST_TRANSPORT_TCP;
+        else if (!strcmp(value, "nhi")) opt->transport = DS4_DIST_TRANSPORT_NHI;
+        else {
+            if (errlen) snprintf(err, errlen,
+                                 "invalid distributed transport: %s (valid: tcp, auto, nhi)",
+                                 value);
+            return DS4_DIST_CLI_ERROR;
+        }
+        return DS4_DIST_CLI_MATCHED;
+    }
+    if (!strcmp(arg, "--dist-nhi-device")) {
+        if (!opt) {
+            if (errlen) snprintf(err, errlen, "missing distributed options");
+            return DS4_DIST_CLI_ERROR;
+        }
+        if (opt->nhi_device) {
+            if (errlen) snprintf(err, errlen, "specify --dist-nhi-device only once");
+            return DS4_DIST_CLI_ERROR;
+        }
+        const char *value = dist_cli_need_arg(index, argc, argv, arg, err, errlen);
+        if (!value) return DS4_DIST_CLI_ERROR;
+        if (!value[0]) {
+            if (errlen) snprintf(err, errlen, "--dist-nhi-device requires a nonempty path");
+            return DS4_DIST_CLI_ERROR;
+        }
+        opt->nhi_device = value;
+        return DS4_DIST_CLI_MATCHED;
+    }
     if (!strcmp(arg, "--dist-replay-check")) {
         if (!opt) {
             if (errlen) snprintf(err, errlen, "missing distributed options");
@@ -8310,7 +11622,9 @@ static int dist_validate_options(const ds4_dist_options *opt, char *err, size_t 
         if (opt->layers.set || opt->listen_host || opt->listen_port ||
             opt->coordinator_host || opt->coordinator_port ||
             opt->prefill_chunk != 0 || opt->prefill_window != 0 ||
-            opt->activation_bits != 0) {
+            opt->activation_bits != 0 ||
+            opt->transport != DS4_DIST_TRANSPORT_DEFAULT ||
+            opt->nhi_device) {
             if (errlen) snprintf(err, errlen, "distributed options require --role coordinator or --role worker");
             return 1;
         }
@@ -8329,6 +11643,25 @@ static int dist_validate_options(const ds4_dist_options *opt, char *err, size_t 
         if (errlen) snprintf(err, errlen, "--dist-activation-bits must be 32, 16, or 8");
         return 1;
     }
+    if (opt->transport < DS4_DIST_TRANSPORT_DEFAULT ||
+        opt->transport > DS4_DIST_TRANSPORT_NHI) {
+        if (errlen) snprintf(err, errlen, "invalid distributed transport selection");
+        return 1;
+    }
+    if (opt->transport == DS4_DIST_TRANSPORT_NHI && !opt->nhi_device) {
+        if (errlen) snprintf(err, errlen, "--dist-transport nhi requires --dist-nhi-device PATH");
+        return 1;
+    }
+    if (opt->transport == DS4_DIST_TRANSPORT_TCP && opt->nhi_device) {
+        if (errlen) snprintf(err, errlen, "--dist-nhi-device cannot be used with --dist-transport tcp");
+        return 1;
+    }
+#ifndef __linux__
+    if (opt->transport == DS4_DIST_TRANSPORT_NHI) {
+        if (errlen) snprintf(err, errlen, "--dist-transport nhi is available only on Linux");
+        return 1;
+    }
+#endif
 
     if (opt->role == DS4_DISTRIBUTED_COORDINATOR) {
         if (!opt->listen_host || opt->listen_port <= 0) {
@@ -8410,6 +11743,642 @@ static int dist_validate_layers_for_model(const ds4_dist_options *opt, uint32_t 
     }
     return 0;
 }
+
+#ifdef DS4_TEST_HOOKS
+typedef struct {
+    ds4_dist_worker_job_queue *queue;
+    bool ready;
+} ds4_dist_control_barrier_test;
+
+typedef struct {
+    unsigned char host[16];
+    ds4_transport_lease *active_rx;
+    uint32_t commits;
+    uint32_t aborts;
+} ds4_dist_mapped_reject_test_ctx;
+
+static int dist_test_mapped_supported(const ds4_transport *transport) {
+    return transport && transport->ctx != NULL;
+}
+
+static int dist_test_mapped_rx_acquire(
+        ds4_transport *transport,
+        const ds4_transport_bulk_desc *desc,
+        ds4_transport_lease *lease,
+        char *err,
+        size_t errlen) {
+    (void)err;
+    (void)errlen;
+    ds4_dist_mapped_reject_test_ctx *ctx = transport->ctx;
+    if (!ctx || ctx->active_rx || desc->payload_bytes > sizeof(ctx->host)) {
+        errno = ctx && ctx->active_rx ? EBUSY : EINVAL;
+        return -1;
+    }
+    ctx->active_rx = lease;
+    lease->host_ptr = ctx->host;
+    lease->device_ptr = ctx->host;
+    lease->bytes = desc->payload_bytes;
+    return 0;
+}
+
+static int dist_test_mapped_lease_commit(ds4_transport_lease *lease,
+                                         int gpu_quiesced) {
+    (void)gpu_quiesced;
+    ds4_dist_mapped_reject_test_ctx *ctx = lease->transport->ctx;
+    if (!ctx || lease->direction != DS4_TRANSPORT_LEASE_RX ||
+        ctx->active_rx != lease) {
+        errno = EINVAL;
+        return -1;
+    }
+    ctx->active_rx = NULL;
+    ctx->commits++;
+    return 0;
+}
+
+static int dist_test_mapped_lease_abort(ds4_transport_lease *lease) {
+    ds4_dist_mapped_reject_test_ctx *ctx = lease->transport->ctx;
+    if (!ctx || lease->direction != DS4_TRANSPORT_LEASE_RX ||
+        ctx->active_rx != lease) {
+        errno = EINVAL;
+        return -1;
+    }
+    ctx->active_rx = NULL;
+    ctx->aborts++;
+    errno = ECANCELED;
+    return -1;
+}
+
+static size_t dist_test_mapped_max_oob(const ds4_transport *transport) {
+    (void)transport;
+    return 4096u;
+}
+
+static const ds4_transport_ops dist_test_mapped_ops = {
+    .name = "test-mapped",
+    .caps = DS4_TRANSPORT_CAP_STREAM | DS4_TRANSPORT_CAP_ZEROCOPY,
+    .mapped_leases_supported = dist_test_mapped_supported,
+    .rx_lease_acquire = dist_test_mapped_rx_acquire,
+    .lease_commit = dist_test_mapped_lease_commit,
+    .lease_abort = dist_test_mapped_lease_abort,
+    .max_oob_bytes = dist_test_mapped_max_oob,
+};
+
+static void *dist_test_control_barrier_main(void *arg) {
+    ds4_dist_control_barrier_test *test = arg;
+    test->ready = dist_worker_job_queue_prepare_control(test->queue);
+    return NULL;
+}
+
+static int dist_test_v3_truncated_work_terminal(char *err, size_t errlen) {
+    int sv[2] = {-1, -1};
+    ds4_transport *transport = NULL;
+    ds4_dist_worker_upstream upstream;
+    bool upstream_ready = false;
+    int result = 1;
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+        if (errlen) snprintf(err, errlen, "truncated WORK socketpair failed");
+        goto done;
+    }
+    transport = ds4_transport_tcp_create(sv[1], err, errlen);
+    if (!transport ||
+        ds4_transport_configure_link(transport, 91u, 0, 0,
+                                     err, errlen) != 0)
+        goto done;
+    ds4_dist_worker_state state;
+    memset(&state, 0, sizeof(state));
+    if (dist_worker_upstream_init(&upstream, &state, sv[1], transport) != 0) {
+        if (errlen) snprintf(err, errlen,
+                             "truncated WORK upstream initialization failed");
+        goto done;
+    }
+    upstream_ready = true;
+    unsigned char body[sizeof(ds4_dist_work_fixed) - 1u];
+    memset(body, 0, sizeof(body));
+    if (dist_write_frame_header(sv[0], DS4_DIST_MSG_WORK,
+                                (uint32_t)sizeof(body)) != 0 ||
+        dist_write_full(sv[0], body, sizeof(body)) != 0) {
+        if (errlen) snprintf(err, errlen, "truncated WORK send failed");
+        goto done;
+    }
+    ds4_dist_work_message message;
+    if (dist_worker_recv_work_message(&state, &upstream,
+                                      (uint32_t)sizeof(body), &message) != -1) {
+        if (errlen) snprintf(err, errlen,
+                             "truncated v3 WORK did not terminate its generation");
+        dist_work_message_free(&message);
+        goto done;
+    }
+    uint32_t marker = 0;
+    /* Observe the shutdown from the peer. Linux may still expose bytes that
+     * were queued before SHUT_RDWR on the local endpoint. */
+    if (dist_read_full(sv[0], &marker, sizeof(marker)) != 0) {
+        if (errlen) snprintf(err, errlen,
+                             "truncated v3 WORK left its control link readable");
+        goto done;
+    }
+    result = 0;
+
+done:
+    if (upstream_ready) dist_worker_upstream_destroy(&upstream);
+    ds4_transport_release(transport);
+    if (sv[0] >= 0) close(sv[0]);
+    if (sv[1] >= 0) close(sv[1]);
+    return result;
+}
+
+static int dist_test_mapped_rx_semantic_reject(char *err, size_t errlen) {
+    int result = 1;
+    int sv[2] = {-1, -1};
+    ds4_transport *transport = NULL;
+    ds4_transport *peer = NULL;
+    ds4_dist_worker_upstream upstream;
+    bool upstream_ready = false;
+    ds4_dist_work_message message;
+    memset(&message, 0, sizeof(message));
+    ds4_dist_mapped_reject_test_ctx ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
+#define MAPPED_REJECT_FAIL(text) do { \
+    if (err && errlen) snprintf(err, errlen, "%s", (text)); \
+    goto done; \
+} while (0)
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0)
+        MAPPED_REJECT_FAIL("mapped rejection socketpair failed");
+    transport = ds4_transport_internal_create(
+        &dist_test_mapped_ops, sv[1], 0, &ctx, 4096u, 8u, err, errlen);
+    peer = ds4_transport_tcp_create(sv[0], err, errlen);
+    if (!transport || !peer)
+        MAPPED_REJECT_FAIL("mapped rejection transport creation failed");
+
+    const uint64_t generation = 0x66778899aabbccddull;
+    if (ds4_transport_configure_link(transport, generation, 0, 0,
+                                     err, errlen) != 0 ||
+        ds4_transport_configure_link(peer, generation, 0, 0,
+                                     err, errlen) != 0)
+        MAPPED_REJECT_FAIL("mapped rejection link configuration failed");
+
+    ds4_dist_worker_state state;
+    memset(&state, 0, sizeof(state));
+    state.model_id = 11u;
+    state.layer_start = 1u;
+    state.layer_end = 1u;
+    state.ctx_size = 16;
+    state.hidden_f32_values = 1u;
+    if (dist_worker_upstream_init(&upstream, &state, sv[1], transport) != 0)
+        MAPPED_REJECT_FAIL("mapped rejection upstream initialization failed");
+    upstream_ready = true;
+
+    const uint64_t session_id = 101u;
+    const uint64_t request_id = 202u;
+    ds4_dist_work_fixed work;
+    memset(&work, 0, sizeof(work));
+    work.model_id = 22u; /* Structurally valid, semantically wrong. */
+    dist_u64_to_halves(session_id, &work.session_hi, &work.session_lo);
+    dist_u64_to_halves(request_id, &work.request_hi, &work.request_lo);
+    work.n_tokens = 1u;
+    work.layer_start = state.layer_start;
+    work.layer_end = state.layer_end;
+    work.flags = DS4_DIST_WORK_F_INPUT_HC;
+    work.token_bytes = (uint32_t)sizeof(uint32_t);
+    work.input_hc_bytes = (uint32_t)sizeof(float);
+    work.input_hc_bits = 32u;
+    work.route_count = 1u;
+
+    ds4_transport_bulk_desc desc;
+    memset(&desc, 0, sizeof(desc));
+    desc.mode = DS4_TRANSPORT_BULK_NHI_OOB;
+    desc.kind = DS4_TRANSPORT_BULK_INPUT_HIDDEN;
+    desc.generation = generation;
+    desc.sequence = 1u;
+    desc.session_id = session_id;
+    desc.request_id = request_id;
+    desc.payload_bytes = work.input_hc_bytes;
+    desc.element_bits = 32u;
+    desc.frame_count = 1u;
+    ds4_transport_bulk_desc_wire desc_wire;
+    if (ds4_transport_bulk_desc_encode(&desc, &desc_wire) != 0)
+        MAPPED_REJECT_FAIL("mapped rejection descriptor encoding failed");
+    ds4_dist_work_fixed work_wire = work;
+    dist_work_to_wire(&work_wire);
+    const uint32_t frame_bytes = (uint32_t)sizeof(work_wire) +
+        (uint32_t)sizeof(desc_wire) + (uint32_t)sizeof(uint32_t);
+    const uint32_t token_wire = htonl(1u);
+    if (dist_write_frame_header(sv[0], DS4_DIST_MSG_WORK, frame_bytes) != 0 ||
+        dist_write_full(sv[0], &work_wire, sizeof(work_wire)) != 0 ||
+        dist_write_full(sv[0], &desc_wire, sizeof(desc_wire)) != 0 ||
+        dist_write_full(sv[0], &token_wire, sizeof(token_wire)) != 0)
+        MAPPED_REJECT_FAIL("mapped rejection WORK send failed");
+
+    uint32_t type = 0;
+    uint32_t bytes = 0;
+    char frame_err[128] = "";
+    if (dist_read_frame_header(sv[1], &type, &bytes,
+                               frame_err, sizeof(frame_err)) <= 0 ||
+        type != DS4_DIST_MSG_WORK || bytes != frame_bytes)
+        MAPPED_REJECT_FAIL("mapped rejection WORK header mismatch");
+    if (dist_worker_recv_work_message(&state, &upstream, bytes, &message) !=
+            DS4_DIST_WORK_RECV_READY || !message.input_lease ||
+        ctx.active_rx != message.input_lease)
+        MAPPED_REJECT_FAIL("mapped rejection RX lease acquisition failed");
+
+    if (dist_worker_process_work_message(&state, &upstream, &message) <= 0)
+        MAPPED_REJECT_FAIL("mapped rejection did not send a WORK error");
+    dist_work_message_free(&message);
+    if (ctx.commits != 1u || ctx.aborts != 0u || ctx.active_rx ||
+        ds4_transport_internal_error(transport) != 0)
+        MAPPED_REJECT_FAIL("semantic rejection poisoned its mapped RX lease");
+
+    ds4_dist_coordinator_state coordinator_state;
+    memset(&coordinator_state, 0, sizeof(coordinator_state));
+    uint32_t kind = UINT32_MAX;
+    uint64_t result_hash = UINT64_MAX;
+    void *payload = NULL;
+    uint32_t payload_bytes = UINT32_MAX;
+    char remote_err[128] = "";
+    if (dist_recv_result_alloc(sv[0], peer, &coordinator_state,
+                               request_id, &kind, &result_hash,
+                               &payload, &payload_bytes,
+                               remote_err, sizeof(remote_err)) !=
+            DS4_DIST_RECV_REMOTE_ERROR ||
+        strcmp(remote_err, "model id mismatch: work=22 worker=11") != 0)
+        MAPPED_REJECT_FAIL("mapped rejection WORK error mismatch");
+
+    desc.sequence = 2u;
+    desc.request_id++;
+    ds4_transport_lease *next_lease = NULL;
+    if (ds4_transport_rx_lease_acquire(transport, &desc, &next_lease,
+                                       frame_err, sizeof(frame_err)) != 0 ||
+        ds4_transport_lease_commit(next_lease) != 0) {
+        ds4_transport_lease_release(next_lease);
+        MAPPED_REJECT_FAIL("mapped rejection did not preserve RX sequence reuse");
+    }
+    ds4_transport_lease_release(next_lease);
+    if (ctx.commits != 2u || ctx.aborts != 0u ||
+        ds4_transport_internal_error(transport) != 0)
+        MAPPED_REJECT_FAIL("mapped rejection follow-up RX lease was not clean");
+
+    result = 0;
+
+done:
+    dist_work_message_free(&message);
+    if (upstream_ready) dist_worker_upstream_destroy(&upstream);
+    ds4_transport_release(peer);
+    ds4_transport_release(transport);
+    if (sv[0] >= 0) close(sv[0]);
+    if (sv[1] >= 0) close(sv[1]);
+#undef MAPPED_REJECT_FAIL
+    return result;
+}
+
+int ds4_dist_test_tcp_bulk_split(char *err, size_t errlen) {
+    int rc = 1;
+    int sv[2] = {-1, -1};
+    ds4_transport *sender = NULL;
+    ds4_dist_worker_upstream receiver;
+    bool receiver_ready = false;
+    ds4_dist_worker_job_queue reject_queue;
+    bool reject_queue_ready = false;
+    pthread_t reject_tid;
+    bool reject_thread_started = false;
+    ds4_dist_work_message message;
+    void *payload = NULL;
+    memset(&message, 0, sizeof(message));
+
+#define TEST_FAIL(text) do { \
+    if (err && errlen) snprintf(err, errlen, "%s", (text)); \
+    goto cleanup; \
+} while (0)
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0)
+        TEST_FAIL("socketpair failed");
+    sender = ds4_transport_tcp_create(sv[0], err, errlen);
+    if (!sender) goto cleanup;
+    ds4_dist_worker_state state;
+    memset(&state, 0, sizeof(state));
+    state.ctx_size = 16;
+    state.hidden_f32_values = 3;
+    ds4_dist_coordinator_state coordinator_state;
+    memset(&coordinator_state, 0, sizeof(coordinator_state));
+    if (dist_worker_upstream_init(&receiver, &state, sv[1], NULL) != 0)
+        TEST_FAIL("receiver transport initialization failed");
+    receiver_ready = true;
+
+    const int tokens[2] = {7, 11};
+    const float hidden[6] = {1.0f, -2.0f, 0.5f, 0.25f, -0.125f, 3.0f};
+    uint16_t hidden_wire[6];
+    for (size_t i = 0; i < sizeof(hidden) / sizeof(hidden[0]); i++)
+        hidden_wire[i] = dist_f32_to_f16(hidden[i]);
+    const uint8_t route[5] = {1, 3, 5, 7, 9};
+    ds4_dist_work_fixed work;
+    memset(&work, 0, sizeof(work));
+    work.flags = DS4_DIST_WORK_F_INPUT_HC;
+    work.n_tokens = 2;
+    work.token_bytes = sizeof(tokens);
+    work.input_hc_bytes = sizeof(hidden_wire);
+    work.route_count = 1;
+    work.route_bytes = sizeof(route);
+    work.input_hc_bits = 16;
+    const uint32_t work_bytes = (uint32_t)sizeof(work) +
+        work.token_bytes + work.input_hc_bytes + work.route_bytes;
+    const uint32_t marker1 = 0x13579bdfu;
+    if (dist_send_work_frame(sv[0], sender, &work, tokens, hidden, route) != 0 ||
+        dist_write_full(sv[0], &marker1, sizeof(marker1)) != 0)
+        TEST_FAIL("WORK send failed");
+
+    uint32_t type = 0, bytes = 0;
+    char frame_err[128] = "";
+    if (dist_read_frame_header(sv[1], &type, &bytes,
+                               frame_err, sizeof(frame_err)) <= 0 ||
+        type != DS4_DIST_MSG_WORK || bytes != work_bytes)
+        TEST_FAIL("WORK header mismatch");
+    if (dist_worker_recv_work_message(&state, &receiver, bytes, &message) !=
+        DS4_DIST_WORK_RECV_READY)
+        TEST_FAIL("typed WORK receive failed");
+    if (message.work.n_tokens != 2 || !message.tokens ||
+        message.tokens[0] != tokens[0] || message.tokens[1] != tokens[1] ||
+        !message.input_hc_wire ||
+        memcmp(message.input_hc_wire, hidden_wire, sizeof(hidden_wire)) != 0 ||
+        !message.route_blob || memcmp(message.route_blob, route, sizeof(route)) != 0)
+        TEST_FAIL("typed WORK contents mismatch");
+    dist_work_message_free(&message);
+    uint32_t got_marker = 0;
+    if (dist_read_full(sv[1], &got_marker, sizeof(got_marker)) <= 0 ||
+        got_marker != marker1)
+        TEST_FAIL("WORK left TCP stream misaligned");
+
+    const uint64_t request_id = 23;
+    const uint64_t result_hash = 29;
+    const uint32_t marker2 = 0x2468ace0u;
+    if (dist_send_work_result(sv[0], sender, request_id, result_hash,
+                              0, DS4_DIST_RESULT_HIDDEN_STATE, 16,
+                              NULL, 0, hidden, sizeof(hidden), false) <= 0 ||
+        dist_write_full(sv[0], &marker2, sizeof(marker2)) != 0)
+        TEST_FAIL("RESULT send failed");
+    uint32_t kind = UINT32_MAX;
+    uint64_t got_hash = 0;
+    uint32_t payload_bytes = UINT32_MAX;
+    if (dist_recv_result_alloc(sv[1], receiver.transport, &coordinator_state,
+                               request_id, &kind, &got_hash,
+                               &payload, &payload_bytes,
+                               frame_err, sizeof(frame_err)) != 0 ||
+        kind != DS4_DIST_RESULT_HIDDEN_STATE || got_hash != result_hash ||
+        !payload || payload_bytes != sizeof(hidden) ||
+        memcmp(payload, hidden, sizeof(hidden)) != 0)
+        TEST_FAIL("typed RESULT receive failed");
+    free(payload);
+    payload = NULL;
+    if (dist_read_full(sv[1], &got_marker, sizeof(got_marker)) <= 0 ||
+        got_marker != marker2)
+        TEST_FAIL("RESULT left TCP stream misaligned");
+
+    /* Errors are control data, not bulk. Passing NULL as the transport proves
+     * both sides keep the error payload on the TCP control path. */
+    const uint64_t error_request_id = 31;
+    const char error_text[] = "intentional split-test error";
+    const uint32_t marker3 = 0x55aa33ccu;
+    if (dist_send_work_result(sv[0], NULL, error_request_id, 0,
+                              1, DS4_DIST_RESULT_ACK, 0,
+                              NULL, 0, error_text,
+                              (uint32_t)strlen(error_text), false) <= 0 ||
+        dist_write_full(sv[0], &marker3, sizeof(marker3)) != 0)
+        TEST_FAIL("error RESULT send failed");
+    char remote_err[128] = "";
+    if (dist_recv_result_alloc(sv[1], NULL, &coordinator_state,
+                               error_request_id, &kind, &got_hash,
+                               &payload, &payload_bytes,
+                               remote_err, sizeof(remote_err)) !=
+            DS4_DIST_RECV_REMOTE_ERROR ||
+        strcmp(remote_err, error_text) != 0)
+        TEST_FAIL("error RESULT escaped the TCP control path");
+    if (dist_read_full(sv[1], &got_marker, sizeof(got_marker)) <= 0 ||
+        got_marker != marker3)
+        TEST_FAIL("error RESULT left TCP stream misaligned");
+
+    /* Prefetch must serialize parser rejections behind earlier jobs instead
+     * of letting the socket reader emit out-of-order RESULT frames. */
+    if (dist_worker_job_queue_init(&reject_queue, &state, &receiver) != 0)
+        TEST_FAIL("prefetch rejection queue initialization failed");
+    reject_queue_ready = true;
+    if (pthread_create(&reject_tid, NULL,
+                       dist_worker_prefetch_eval_main, &reject_queue) != 0)
+        TEST_FAIL("prefetch rejection thread creation failed");
+    reject_thread_started = true;
+    const uint64_t rejected_ids[2] = {41, 42};
+    for (size_t i = 0; i < sizeof(rejected_ids) / sizeof(rejected_ids[0]); i++) {
+        ds4_dist_work_fixed rejected_work;
+        memset(&rejected_work, 0, sizeof(rejected_work));
+        dist_u64_to_halves(rejected_ids[i],
+                           &rejected_work.request_hi,
+                           &rejected_work.request_lo);
+        ds4_dist_work_fixed rejected_wire = rejected_work;
+        dist_work_to_wire(&rejected_wire);
+        if (dist_write_frame_header(sv[0], DS4_DIST_MSG_WORK,
+                                    (uint32_t)sizeof(rejected_wire)) != 0 ||
+            dist_write_full(sv[0], &rejected_wire,
+                            sizeof(rejected_wire)) != 0)
+            TEST_FAIL("rejected WORK send failed");
+        if (dist_read_frame_header(sv[1], &type, &bytes,
+                                   frame_err, sizeof(frame_err)) <= 0 ||
+            type != DS4_DIST_MSG_WORK || bytes != sizeof(rejected_wire))
+            TEST_FAIL("rejected WORK header mismatch");
+        ds4_dist_worker_job *job = calloc(1, sizeof(*job));
+        if (!job)
+            TEST_FAIL("rejected WORK allocation failed");
+        int reject_rc = dist_worker_recv_work_message(&state, &receiver,
+                                                       bytes, &job->message);
+        if (reject_rc != DS4_DIST_WORK_RECV_REJECTED) {
+            dist_worker_job_free(job);
+            TEST_FAIL("malformed WORK was not staged as a rejection");
+        }
+        if (!dist_worker_job_queue_enqueue(&reject_queue, job)) {
+            dist_worker_job_free(job);
+            TEST_FAIL("rejected WORK enqueue failed");
+        }
+    }
+    dist_worker_job_queue_finish(&reject_queue);
+    for (size_t i = 0; i < sizeof(rejected_ids) / sizeof(rejected_ids[0]); i++) {
+        remote_err[0] = '\0';
+        if (dist_recv_result_alloc(sv[0], NULL, &coordinator_state,
+                                   rejected_ids[i], &kind, &got_hash,
+                                   &payload, &payload_bytes,
+                                   remote_err, sizeof(remote_err)) !=
+                DS4_DIST_RECV_REMOTE_ERROR ||
+            strcmp(remote_err,
+                   "WORK token span exceeds worker context") != 0)
+            TEST_FAIL("prefetch rejection RESULT order mismatch");
+    }
+    pthread_join(reject_tid, NULL);
+    reject_thread_started = false;
+
+    /* Model the post-RESULT scheduling window: control waits until the eval
+     * thread publishes active=0 instead of spuriously closing the socket. */
+    pthread_mutex_lock(&reject_queue.mu);
+    reject_queue.active = 1;
+    pthread_mutex_unlock(&reject_queue.mu);
+    ds4_dist_control_barrier_test barrier = {
+        .queue = &reject_queue,
+        .ready = false,
+    };
+    pthread_t barrier_tid;
+    if (pthread_create(&barrier_tid, NULL,
+                       dist_test_control_barrier_main, &barrier) != 0) {
+        pthread_mutex_lock(&reject_queue.mu);
+        reject_queue.active = 0;
+        pthread_cond_broadcast(&reject_queue.idle);
+        pthread_mutex_unlock(&reject_queue.mu);
+        TEST_FAIL("control barrier thread creation failed");
+    }
+    pthread_mutex_lock(&reject_queue.mu);
+    while (reject_queue.control_waiters == 0)
+        pthread_cond_wait(&reject_queue.idle, &reject_queue.mu);
+    reject_queue.active = 0;
+    pthread_cond_broadcast(&reject_queue.idle);
+    pthread_mutex_unlock(&reject_queue.mu);
+    pthread_join(barrier_tid, NULL);
+    if (!barrier.ready)
+        TEST_FAIL("control barrier rejected a completed WORK result");
+
+    dist_worker_job_queue_destroy(&reject_queue);
+    reject_queue_ready = false;
+
+    /* Once both sides configure a nonzero generation, the same persistent
+     * TCP link switches to v3 descriptor framing. TCP-inline bulk is still a
+     * useful equivalence oracle for the negotiated wire layout. */
+    const uint64_t v3_generation = 0x1122334455667788ull;
+    if (ds4_transport_configure_link(sender, v3_generation, 0, 0,
+                                     frame_err, sizeof(frame_err)) != 0 ||
+        ds4_transport_configure_link(receiver.transport, v3_generation, 0, 0,
+                                     frame_err, sizeof(frame_err)) != 0)
+        TEST_FAIL("v3 TCP transport configuration failed");
+
+    const uint64_t v3_session_id = 0x123456789abcdef0ull;
+    const uint64_t v3_request_id = 0xfedcba9876543210ull;
+    dist_u64_to_halves(v3_session_id, &work.session_hi, &work.session_lo);
+    dist_u64_to_halves(v3_request_id, &work.request_hi, &work.request_lo);
+    uint32_t v3_control_bytes = 0;
+    uint32_t v3_work_bytes = 0;
+    if (ds4_dist_v3_work_frame_sizes(work.token_bytes, work.route_bytes,
+                                     work.input_hc_bytes,
+                                     DS4_TRANSPORT_BULK_TCP_INLINE,
+                                     &v3_control_bytes,
+                                     &v3_work_bytes) != 0)
+        TEST_FAIL("v3 WORK size calculation failed");
+    const uint32_t marker4 = 0x0badf00du;
+    if (dist_send_work_frame(sv[0], sender, &work, tokens, hidden, route) != 0 ||
+        dist_write_full(sv[0], &marker4, sizeof(marker4)) != 0)
+        TEST_FAIL("v3 WORK send failed");
+    if (dist_read_frame_header(sv[1], &type, &bytes,
+                               frame_err, sizeof(frame_err)) <= 0 ||
+        type != DS4_DIST_MSG_WORK || bytes != v3_work_bytes ||
+        v3_control_bytes + work.input_hc_bytes != v3_work_bytes)
+        TEST_FAIL("v3 WORK header mismatch");
+    if (dist_worker_recv_work_message(&state, &receiver, bytes, &message) !=
+        DS4_DIST_WORK_RECV_READY)
+        TEST_FAIL("typed v3 WORK receive failed");
+    if (!message.v3 ||
+        message.bulk_desc.mode != DS4_TRANSPORT_BULK_TCP_INLINE ||
+        message.bulk_desc.kind != DS4_TRANSPORT_BULK_INPUT_HIDDEN ||
+        message.bulk_desc.generation != v3_generation ||
+        message.bulk_desc.sequence != 1u ||
+        message.bulk_desc.session_id != v3_session_id ||
+        message.bulk_desc.request_id != v3_request_id ||
+        !message.input_hc_wire ||
+        memcmp(message.input_hc_wire, hidden_wire, sizeof(hidden_wire)) != 0 ||
+        !message.route_blob || memcmp(message.route_blob, route, sizeof(route)) != 0)
+        TEST_FAIL("typed v3 WORK contents mismatch");
+    dist_work_message_free(&message);
+    if (dist_read_full(sv[1], &got_marker, sizeof(got_marker)) <= 0 ||
+        got_marker != marker4)
+        TEST_FAIL("v3 WORK left TCP stream misaligned");
+
+    const uint64_t v3_result_hash = 0x0102030405060708ull;
+    const uint32_t marker5 = 0xc001d00du;
+    if (dist_send_work_result(sv[0], sender, v3_request_id,
+                              v3_result_hash, 0,
+                              DS4_DIST_RESULT_HIDDEN_STATE, 16,
+                              NULL, 0, hidden, sizeof(hidden), false) <= 0 ||
+        dist_write_full(sv[0], &marker5, sizeof(marker5)) != 0)
+        TEST_FAIL("v3 RESULT send failed");
+    if (dist_recv_result_alloc(sv[1], receiver.transport, &coordinator_state,
+                               v3_request_id, &kind, &got_hash,
+                               &payload, &payload_bytes,
+                               frame_err, sizeof(frame_err)) != 0 ||
+        kind != DS4_DIST_RESULT_HIDDEN_STATE ||
+        got_hash != v3_result_hash || !payload ||
+        payload_bytes != sizeof(hidden) ||
+        memcmp(payload, hidden, sizeof(hidden)) != 0)
+        TEST_FAIL("typed v3 RESULT receive failed");
+    free(payload);
+    payload = NULL;
+    if (dist_read_full(sv[1], &got_marker, sizeof(got_marker)) <= 0 ||
+        got_marker != marker5)
+        TEST_FAIL("v3 RESULT left TCP stream misaligned");
+
+    ds4_dist_v3_hello_ack ready_ack;
+    memset(&ready_ack, 0, sizeof(ready_ack));
+    ready_ack.protocol_version = DS4_DIST_V3_PROTOCOL_VERSION;
+    ready_ack.selected_transport = DS4_DIST_V3_TRANSPORT_TCP;
+    ds4_dist_v3_u64_to_halves(v3_generation,
+                              &ready_ack.generation_hi,
+                              &ready_ack.generation_lo);
+    if (dist_send_hello_ready(sv[0], &ready_ack) != 0 ||
+        dist_recv_hello_ready(sv[1], &ready_ack,
+                              frame_err, sizeof(frame_err)) != 1)
+        TEST_FAIL("v3 HELLO READY barrier round-trip failed");
+
+    /* Once v3 is active, a structurally incomplete descriptor frame is
+     * generation-terminal: attempting to drain/reuse it could pair a later
+     * descriptor with an orphaned NHI event. */
+    ds4_dist_result_fixed truncated_result;
+    memset(&truncated_result, 0, sizeof(truncated_result));
+    dist_u64_to_halves(v3_request_id,
+                       &truncated_result.request_hi,
+                       &truncated_result.request_lo);
+    ds4_dist_result_fixed truncated_wire = truncated_result;
+    dist_result_to_wire(&truncated_wire);
+    if (dist_write_frame_header(sv[0], DS4_DIST_MSG_RESULT,
+                                (uint32_t)sizeof(truncated_wire)) != 0 ||
+        dist_write_full(sv[0], &truncated_wire,
+                        sizeof(truncated_wire)) != 0)
+        TEST_FAIL("truncated v3 RESULT send failed");
+    if (dist_recv_result_alloc(sv[1], receiver.transport, &coordinator_state,
+                               v3_request_id, &kind, &got_hash,
+                               &payload, &payload_bytes,
+                               frame_err, sizeof(frame_err)) != 1)
+        TEST_FAIL("truncated v3 RESULT was not rejected");
+    got_marker = 0;
+    if (dist_read_full(sv[0], &got_marker, sizeof(got_marker)) != 0)
+        TEST_FAIL("truncated v3 RESULT left its control link readable");
+
+    if (dist_test_v3_truncated_work_terminal(frame_err,
+                                             sizeof(frame_err)) != 0)
+        TEST_FAIL(frame_err[0] ? frame_err
+                               : "truncated v3 WORK terminal test failed");
+
+    if (dist_test_mapped_rx_semantic_reject(frame_err,
+                                            sizeof(frame_err)) != 0)
+        TEST_FAIL(frame_err[0] ? frame_err
+                               : "mapped RX semantic rejection test failed");
+
+    rc = 0;
+cleanup:
+    free(payload);
+    if (reject_thread_started) {
+        dist_worker_job_queue_cancel(&reject_queue);
+        pthread_join(reject_tid, NULL);
+    }
+    if (reject_queue_ready)
+        dist_worker_job_queue_destroy(&reject_queue);
+    dist_work_message_free(&message);
+    if (receiver_ready) dist_worker_upstream_destroy(&receiver);
+    ds4_transport_release(sender);
+    if (sv[0] >= 0) close(sv[0]);
+    if (sv[1] >= 0) close(sv[1]);
+#undef TEST_FAIL
+    return rc;
+}
+#endif
 
 int ds4_dist_run(ds4_engine *engine, const ds4_dist_options *opt, const ds4_dist_generation_options *gen) {
     if (!engine || !opt) {

--- a/ds4_distributed.h
+++ b/ds4_distributed.h
@@ -13,7 +13,13 @@
  * ds4_dist_run() directly.
  */
 typedef ds4_distributed_options ds4_dist_options;
+typedef struct ds4_dist_coordinator ds4_dist_coordinator;
 typedef struct ds4_dist_session ds4_dist_session;
+
+/* Four captured intermediate frontiers support a five-row verifier: any
+ * partial result keeps at most four rows, while a five-row full accept needs
+ * no intermediate restore. */
+#define DS4_DIST_SPEC_MAX_DRAFT_TOKENS 5u
 
 /* Options used by standalone `./ds4 --role coordinator -p ...` generation.
  * Interactive tools and the server go through the normal ds4_session API.
@@ -67,6 +73,7 @@ int ds4_dist_prepare_engine_options(
  */
 int ds4_dist_session_create(
         ds4_dist_session **out,
+        ds4_dist_coordinator **shared,
         ds4_engine *engine,
         const ds4_dist_options *opt,
         ds4_session *owner,
@@ -74,6 +81,7 @@ int ds4_dist_session_create(
         char *err,
         size_t errlen);
 void ds4_dist_session_free(ds4_dist_session *d);
+void ds4_dist_coordinator_free(ds4_dist_coordinator *coordinator);
 
 /* Returns 1 when the coordinator has full layer coverage, 0 when workers are
  * still missing, and -1 for configuration or internal errors.
@@ -100,6 +108,19 @@ int ds4_dist_session_eval(
         char *err,
         size_t errlen);
 
+/* Verify a coordinator-owned MTP draft block across all layer slices and
+ * atomically keep the greedy-accepted prefix. */
+int ds4_dist_session_verify_greedy(
+        ds4_dist_session *d,
+        ds4_session *owner,
+        const ds4_tokens *checkpoint,
+        const int *drafts,
+        uint32_t draft_n,
+        uint32_t *committed,
+        float *logits,
+        char *err,
+        size_t errlen);
+
 /* Save/load use the normal DSV4 payload format. The coordinator gathers or
  * pushes remote layer shards internally so saved files are topology-neutral.
  */
@@ -121,5 +142,11 @@ int ds4_dist_session_load_payload(
  * mode uses it for `./ds4 --role coordinator -p ...`.
  */
 int ds4_dist_run(ds4_engine *engine, const ds4_dist_options *opt, const ds4_dist_generation_options *gen);
+
+#ifdef DS4_TEST_HOOKS
+/* Deterministic socketpair coverage for persistent TCP WORK/RESULT bulk
+ * framing. Intended only for the test binary. */
+int ds4_dist_test_tcp_bulk_split(char *err, size_t errlen);
+#endif
 
 #endif

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -2,6 +2,7 @@
 #define DS4_GPU_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -47,6 +48,12 @@ void ds4_gpu_cleanup(void);
 ds4_gpu_tensor *ds4_gpu_tensor_alloc(uint64_t bytes);
 ds4_gpu_tensor *ds4_gpu_tensor_alloc_managed(uint64_t bytes);
 ds4_gpu_tensor *ds4_gpu_tensor_view(const ds4_gpu_tensor *base, uint64_t offset, uint64_t bytes);
+#ifdef DS4_ROCM_BUILD
+/* Wrap an externally owned ROCm device address without taking ownership of
+ * the allocation.  The caller must keep the backing mapping alive until all
+ * GPU work using the returned tensor has completed and the wrapper is freed. */
+ds4_gpu_tensor *ds4_gpu_tensor_wrap_external(void *device_ptr, uint64_t bytes);
+#endif
 void ds4_gpu_tensor_free(ds4_gpu_tensor *tensor);
 uint64_t ds4_gpu_tensor_bytes(const ds4_gpu_tensor *tensor);
 void *ds4_gpu_tensor_contents(ds4_gpu_tensor *tensor);
@@ -109,6 +116,95 @@ int ds4_gpu_tensor_read_after_selected_event(const ds4_gpu_tensor *tensor,
 #endif
 int ds4_gpu_end_commands(void);
 int ds4_gpu_synchronize(void);
+
+/* Low-overhead GPU timeline sampling.  begin records the first marker and
+ * mark appends another marker on the backend's primary (stream 0) timeline.
+ * collect returns the elapsed milliseconds between adjacent markers and
+ * consumes the sample, on success or failure.  At least one mark after begin
+ * is required.  The caller must collect only after an existing synchronization
+ * point has completed the sampled work; collection never adds a
+ * synchronization of its own.  discard is also nonblocking.
+ *
+ * The API is deliberately fail-open: zero means that profiling data is not
+ * available, and model execution must continue normally.  Profiling callers
+ * should invoke it only when an explicit diagnostic option is enabled.
+ */
+#define DS4_GPU_TIMING_MAX_MARKS 16u
+typedef struct ds4_gpu_timing_sample {
+    uint32_t slot;
+    uint32_t generation;
+    uint32_t mark_count;
+    uint32_t reserved;
+} ds4_gpu_timing_sample;
+
+#if defined(DS4_ROCM_BUILD) || defined(__HIP_PLATFORM_AMD__)
+int ds4_gpu_timing_begin(ds4_gpu_timing_sample *sample);
+int ds4_gpu_timing_mark(ds4_gpu_timing_sample *sample);
+int ds4_gpu_timing_collect(ds4_gpu_timing_sample *sample,
+                           float *segment_ms,
+                           uint32_t segment_capacity,
+                           uint32_t *segment_count);
+void ds4_gpu_timing_discard(ds4_gpu_timing_sample *sample);
+#else
+static inline void ds4_gpu_timing_discard(ds4_gpu_timing_sample *sample) {
+    if (!sample) return;
+    sample->slot = 0;
+    sample->generation = 0;
+    sample->mark_count = 0;
+    sample->reserved = 0;
+}
+static inline int ds4_gpu_timing_begin(ds4_gpu_timing_sample *sample) {
+    ds4_gpu_timing_discard(sample);
+    return 0;
+}
+static inline int ds4_gpu_timing_mark(ds4_gpu_timing_sample *sample) {
+    (void)sample;
+    return 0;
+}
+static inline int ds4_gpu_timing_collect(ds4_gpu_timing_sample *sample,
+                                         float *segment_ms,
+                                         uint32_t segment_capacity,
+                                         uint32_t *segment_count) {
+    (void)segment_ms;
+    (void)segment_capacity;
+    if (segment_count) *segment_count = 0;
+    ds4_gpu_timing_discard(sample);
+    return 0;
+}
+#endif
+
+/* ROCm mapped-host handoff helpers for driver-owned mmap() regions.  A
+ * successful registration pins/maps the complete range and returns the GPU
+ * address corresponding to host_ptr.  Call synchronize before transferring
+ * ownership between the GPU and an external DMA device.  Non-ROCm builds
+ * expose the same source-level API and report it unsupported.
+ */
+#if defined(DS4_ROCM_BUILD) || defined(__HIP_PLATFORM_AMD__)
+int ds4_gpu_host_mapping_supported(void);
+int ds4_gpu_host_register_mapped(void *host_ptr, uint64_t bytes,
+                                 void **device_ptr);
+int ds4_gpu_host_mapped_synchronize(const char *label);
+int ds4_gpu_host_unregister_mapped(void *host_ptr);
+#else
+static inline int ds4_gpu_host_mapping_supported(void) {
+    return 0;
+}
+static inline int ds4_gpu_host_register_mapped(void *host_ptr, uint64_t bytes,
+                                                void **device_ptr) {
+    (void)host_ptr;
+    (void)bytes;
+    if (device_ptr) *device_ptr = NULL;
+    return 0;
+}
+static inline int ds4_gpu_host_mapped_synchronize(const char *label) {
+    (void)label;
+    return 0;
+}
+static inline int ds4_gpu_host_unregister_mapped(void *host_ptr) {
+    (void)host_ptr;
+    return 0;
+}
+#endif
 
 int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size);
 int ds4_gpu_set_model_fd(int fd);

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -236,6 +236,8 @@ static void print_distributed(FILE *fp, const help_colors *c) {
     opt(fp, c, "--dist-prefill-chunk N", "Coordinator prefill pipeline chunk size. Default: session cap.");
     opt(fp, c, "--dist-prefill-window N", "Max prefill chunks in flight. Default: workers+2, capped at 8.");
     opt(fp, c, "--dist-activation-bits N", "Hidden-state transport width: 32, 16, or 8. Default: 32");
+    opt(fp, c, "--dist-transport MODE", "Bulk transport: tcp, auto, or nhi. Default: tcp.");
+    opt(fp, c, "--dist-nhi-device PATH", "Local /dev/tbstream device used by auto/nhi mode.");
     opt(fp, c, "--dist-replay-check", "Diagnostic: reset and replay prompt, then compare logits.");
     opt(fp, c, "--debug", "Print coordinator route/debug logs.");
     fputc('\n', fp);

--- a/ds4_tbstream_uapi.h
+++ b/ds4_tbstream_uapi.h
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+#ifndef DS4_TBSTREAM_UAPI_H
+#define DS4_TBSTREAM_UAPI_H
+
+/* Vendored userspace view of the zero-copy USB4STREAM UAPI deployed on the
+ * Strix Halo peers. Keep ioctl numbers and record widths synchronized with
+ * strix-rdma/kernel/zerocopy. */
+
+#include <stdint.h>
+#include <sys/ioctl.h>
+
+#define TBSTREAM_ZC_FRAME_SIZE 4096u
+
+struct tbstream_zc_info {
+    uint32_t ring_size;
+    uint32_t frame_size;
+    uint64_t tx_pool_offset;
+    uint64_t rx_pool_offset;
+};
+
+enum tbstream_zc_event_type {
+    TBSTREAM_ZC_EV_RX = 0,
+    TBSTREAM_ZC_EV_TX_DONE = 1,
+    TBSTREAM_ZC_EV_CLOSE = 2,
+};
+
+struct tbstream_zc_event {
+    uint32_t type;
+    uint32_t first;
+    uint32_t nframes;
+    uint32_t bytes;
+};
+
+struct tbstream_zc_tx {
+    uint32_t nframes;
+    uint32_t last_len;
+    uint32_t first;
+    uint32_t reserved;
+};
+
+struct tbstream_zc_reap {
+    uint32_t max;
+    uint32_t flags;
+    uint64_t events;
+};
+
+#define TBSTREAM_ZC_REAP_NONBLOCK 0x1u
+
+struct tbstream_zc_rx {
+    uint32_t nframes;
+    uint32_t flags;
+};
+
+#define TBSTREAM_ZC_RX_F_INTERRUPT_BOUNDARIES 0x1u
+
+#define TBSTREAM_ZC_MAGIC 0xb4
+#define TBSTREAM_ZC_ENABLE _IO(TBSTREAM_ZC_MAGIC, 0x00)
+#define TBSTREAM_ZC_GET_INFO \
+    _IOR(TBSTREAM_ZC_MAGIC, 0x01, struct tbstream_zc_info)
+#define TBSTREAM_ZC_SUBMIT_TX \
+    _IOWR(TBSTREAM_ZC_MAGIC, 0x02, struct tbstream_zc_tx)
+#define TBSTREAM_ZC_POST_RX \
+    _IOW(TBSTREAM_ZC_MAGIC, 0x03, uint32_t)
+#define TBSTREAM_ZC_REAP \
+    _IOWR(TBSTREAM_ZC_MAGIC, 0x04, struct tbstream_zc_reap)
+#define TBSTREAM_ZC_POST_RX_FLAGS \
+    _IOW(TBSTREAM_ZC_MAGIC, 0x05, struct tbstream_zc_rx)
+
+#endif

--- a/ds4_tp.c
+++ b/ds4_tp.c
@@ -437,6 +437,7 @@ int ds4_tp_adopt_distributed_options(
         return 0;
     }
     if (dist->prefill_chunk || dist->prefill_window || dist->activation_bits ||
+        dist->transport != DS4_DIST_TRANSPORT_DEFAULT || dist->nhi_device ||
         dist->replay_check || dist->debug) {
         tp_set_err(err, errlen,
                    "--dist-* and distributed debug options cannot be used with --tensor-parallel");

--- a/ds4_transport.c
+++ b/ds4_transport.c
@@ -1,0 +1,965 @@
+/* =========================================================================
+ * ds4_transport.c - Persistent boundary-tensor transport core.
+ * ========================================================================= */
+
+#include "ds4_transport_internal.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define DS4_NHI_ENVELOPE_BYTES 64u
+
+typedef char ds4_bulk_desc_must_be_64_bytes[
+    sizeof(ds4_transport_bulk_desc) == DS4_TRANSPORT_BULK_DESC_BYTES ? 1 : -1];
+typedef char ds4_bulk_desc_wire_must_be_64_bytes[
+    sizeof(ds4_transport_bulk_desc_wire) == DS4_TRANSPORT_BULK_DESC_BYTES ? 1 : -1];
+
+static void transport_set_err(char *err, size_t errlen, const char *message) {
+    if (err && errlen) snprintf(err, errlen, "%s", message);
+}
+
+static int bulk_kind_valid(uint32_t kind, uint32_t bits) {
+    switch (kind) {
+    case DS4_TRANSPORT_BULK_INPUT_HIDDEN:
+    case DS4_TRANSPORT_BULK_RESULT_HIDDEN:
+        return bits == 8u || bits == 16u || bits == 32u;
+    case DS4_TRANSPORT_BULK_RESULT_LOGITS:
+        return bits == 32u;
+    default:
+        return 0;
+    }
+}
+
+static int validate_expected_desc(
+        const ds4_transport_bulk_desc *desc,
+        uint32_t kind,
+        uint64_t session_id,
+        uint64_t request_id,
+        uint32_t payload_bytes,
+        uint32_t element_bits,
+        char *err,
+        size_t errlen) {
+    if (!desc || !bulk_kind_valid(kind, element_bits) || payload_bytes == 0u) {
+        transport_set_err(err, errlen, "invalid bulk descriptor expectation");
+        errno = EINVAL;
+        return -1;
+    }
+    if (desc->kind != kind || desc->session_id != session_id ||
+        desc->request_id != request_id ||
+        desc->payload_bytes != payload_bytes ||
+        desc->element_bits != element_bits) {
+        transport_set_err(err, errlen, "bulk descriptor metadata mismatch");
+        errno = EPROTO;
+        return -1;
+    }
+    if (!bulk_kind_valid(desc->kind, desc->element_bits) ||
+        desc->generation == 0 || desc->sequence == 0 || desc->flags != 0 ||
+        desc->reserved[0] != 0 || desc->reserved[1] != 0) {
+        transport_set_err(err, errlen, "invalid bulk descriptor fields");
+        errno = EPROTO;
+        return -1;
+    }
+    return 0;
+}
+
+int ds4_transport_tcp_write(int fd, const void *buf, size_t len) {
+    const unsigned char *p = buf;
+    if (len != 0 && !buf) {
+        errno = EINVAL;
+        return -1;
+    }
+    while (len > 0) {
+        int flags = 0;
+#ifdef MSG_NOSIGNAL
+        flags = MSG_NOSIGNAL;
+#endif
+        ssize_t n = send(fd, p, len, flags);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        if (n == 0) {
+            errno = EPIPE;
+            return -1;
+        }
+        p += (size_t)n;
+        len -= (size_t)n;
+    }
+    return 0;
+}
+
+int ds4_transport_tcp_read(int fd, void *buf, size_t len) {
+    unsigned char *p = buf;
+    if (len != 0 && !buf) {
+        errno = EINVAL;
+        return -1;
+    }
+    while (len > 0) {
+        ssize_t n = recv(fd, p, len, 0);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        if (n == 0) return 0;
+        p += (size_t)n;
+        len -= (size_t)n;
+    }
+    return 1;
+}
+
+static int tcp_send_bulk(ds4_transport *t, const void *buf, size_t len) {
+    return ds4_transport_tcp_write(t->control_fd, buf, len);
+}
+
+static int tcp_recv_bulk(ds4_transport *t, void *buf, size_t len) {
+    return ds4_transport_tcp_read(t->control_fd, buf, len);
+}
+
+static int tcp_configure(ds4_transport *t,
+                         uint32_t peer_frame_size,
+                         uint32_t peer_ring_size,
+                         char *err,
+                         size_t errlen) {
+    (void)t;
+    (void)peer_frame_size;
+    (void)peer_ring_size;
+    (void)err;
+    (void)errlen;
+    return 0;
+}
+
+static size_t tcp_max_oob_bytes(const ds4_transport *t) {
+    (void)t;
+    return 0;
+}
+
+static void tcp_close(ds4_transport *t) {
+    (void)t;
+}
+
+static const ds4_transport_ops tcp_ops = {
+    .name = "tcp",
+    .caps = DS4_TRANSPORT_CAP_STREAM,
+    .send_bulk = tcp_send_bulk,
+    .recv_bulk = tcp_recv_bulk,
+    .configure = tcp_configure,
+    .max_oob_bytes = tcp_max_oob_bytes,
+    .close = tcp_close,
+};
+
+ds4_transport *ds4_transport_internal_create(
+        const ds4_transport_ops *ops,
+        int control_fd,
+        int owns_control_fd,
+        void *ctx,
+        uint32_t local_frame_size,
+        uint32_t local_ring_size,
+        char *err,
+        size_t errlen) {
+    if (!ops || control_fd < 0) {
+        transport_set_err(err, errlen, "invalid transport creation arguments");
+        errno = EINVAL;
+        return NULL;
+    }
+    ds4_transport *t = calloc(1, sizeof(*t));
+    if (!t) {
+        transport_set_err(err, errlen, "out of memory creating transport");
+        return NULL;
+    }
+
+    int rc = pthread_mutex_init(&t->ref_mu, NULL);
+    if (rc != 0) goto fail_ref;
+    rc = pthread_mutex_init(&t->link_mu, NULL);
+    if (rc != 0) goto fail_link;
+    rc = pthread_mutex_init(&t->send_mu, NULL);
+    if (rc != 0) goto fail_send;
+    rc = pthread_mutex_init(&t->recv_mu, NULL);
+    if (rc != 0) goto fail_recv;
+
+    t->ops = ops;
+    t->control_fd = control_fd;
+    t->owns_control_fd = owns_control_fd;
+    t->ctx = ctx;
+    t->refs = 1;
+    t->local_frame_size = local_frame_size;
+    t->local_ring_size = local_ring_size;
+    t->tx_prepare_sequence = 1;
+    t->tx_send_sequence = 1;
+    t->rx_sequence = 1;
+#ifdef SO_NOSIGPIPE
+    {
+        int one = 1;
+        (void)setsockopt(control_fd, SOL_SOCKET, SO_NOSIGPIPE,
+                         &one, sizeof(one));
+    }
+#endif
+    return t;
+
+fail_recv:
+    pthread_mutex_destroy(&t->send_mu);
+fail_send:
+    pthread_mutex_destroy(&t->link_mu);
+fail_link:
+    pthread_mutex_destroy(&t->ref_mu);
+fail_ref:
+    free(t);
+    transport_set_err(err, errlen, "failed to initialize transport mutexes");
+    errno = rc;
+    return NULL;
+}
+
+static ds4_transport *tcp_create(int fd, int owns_fd,
+                                 char *err, size_t errlen) {
+    return ds4_transport_internal_create(&tcp_ops, fd, owns_fd, NULL,
+                                         0, 0, err, errlen);
+}
+
+ds4_transport *ds4_transport_tcp_create(int fd, char *err, size_t errlen) {
+    return tcp_create(fd, 0, err, errlen);
+}
+
+ds4_transport *ds4_transport_tcp_dup(int fd, char *err, size_t errlen) {
+    int copy = dup(fd);
+    if (copy < 0) {
+        transport_set_err(err, errlen, "failed to duplicate TCP transport fd");
+        return NULL;
+    }
+    ds4_transport *t = tcp_create(copy, 1, err, errlen);
+    if (!t) close(copy);
+    return t;
+}
+
+ds4_transport *ds4_transport_retain(ds4_transport *t) {
+    if (!t) return NULL;
+    pthread_mutex_lock(&t->ref_mu);
+    if (t->refs != UINT_MAX) t->refs++;
+    pthread_mutex_unlock(&t->ref_mu);
+    return t;
+}
+
+void ds4_transport_release(ds4_transport *t) {
+    if (!t) return;
+    pthread_mutex_lock(&t->ref_mu);
+    const int destroy = t->refs != 0 && --t->refs == 0;
+    pthread_mutex_unlock(&t->ref_mu);
+    if (!destroy) return;
+    if (t->ops && t->ops->close) t->ops->close(t);
+    if (t->owns_control_fd && t->control_fd >= 0) close(t->control_fd);
+    pthread_mutex_destroy(&t->recv_mu);
+    pthread_mutex_destroy(&t->send_mu);
+    pthread_mutex_destroy(&t->link_mu);
+    pthread_mutex_destroy(&t->ref_mu);
+    free(t);
+}
+
+int ds4_transport_control_fd(const ds4_transport *t) {
+    return t ? t->control_fd : -1;
+}
+
+void ds4_transport_internal_fail(ds4_transport *t, int error_code) {
+    if (!t) return;
+    if (error_code <= 0) error_code = EIO;
+    pthread_mutex_lock(&t->link_mu);
+    if (t->fatal_error == 0) t->fatal_error = error_code;
+    pthread_mutex_unlock(&t->link_mu);
+    if (t->control_fd >= 0) (void)shutdown(t->control_fd, SHUT_RDWR);
+}
+
+int ds4_transport_internal_error(const ds4_transport *t) {
+    if (!t) return EINVAL;
+    ds4_transport *mutable_t = (ds4_transport *)t;
+    pthread_mutex_lock(&mutable_t->link_mu);
+    int error_code = mutable_t->fatal_error;
+    pthread_mutex_unlock(&mutable_t->link_mu);
+    return error_code;
+}
+
+int ds4_transport_configure_link(
+        ds4_transport *t,
+        uint64_t generation,
+        uint32_t peer_frame_size,
+        uint32_t peer_ring_size,
+        char *err,
+        size_t errlen) {
+    if (!t || generation == 0) {
+        transport_set_err(err, errlen, "invalid transport link generation");
+        errno = EINVAL;
+        return -1;
+    }
+    pthread_mutex_lock(&t->link_mu);
+    if (t->fatal_error != 0) {
+        errno = t->fatal_error;
+        pthread_mutex_unlock(&t->link_mu);
+        transport_set_err(err, errlen, "transport link has failed");
+        return -1;
+    }
+    if (t->configured) {
+        const int same = t->generation == generation &&
+            t->peer_frame_size == peer_frame_size &&
+            t->peer_ring_size == peer_ring_size;
+        pthread_mutex_unlock(&t->link_mu);
+        if (same) return 0;
+        transport_set_err(err, errlen, "transport link is already configured");
+        errno = EBUSY;
+        return -1;
+    }
+    int rc = t->ops && t->ops->configure
+        ? t->ops->configure(t, peer_frame_size, peer_ring_size, err, errlen)
+        : 0;
+    if (rc == 0) {
+        t->generation = generation;
+        t->peer_frame_size = peer_frame_size;
+        t->peer_ring_size = peer_ring_size;
+        t->tx_prepare_sequence = 1;
+        t->tx_send_sequence = 1;
+        t->rx_sequence = 1;
+        t->configured = 1;
+    }
+    pthread_mutex_unlock(&t->link_mu);
+    return rc;
+}
+
+uint64_t ds4_transport_generation(const ds4_transport *t) {
+    if (!t) return 0;
+    ds4_transport *mutable_t = (ds4_transport *)t;
+    pthread_mutex_lock(&mutable_t->link_mu);
+    uint64_t generation = mutable_t->generation;
+    pthread_mutex_unlock(&mutable_t->link_mu);
+    return generation;
+}
+
+uint32_t ds4_transport_frame_size(const ds4_transport *t) {
+    return t ? t->local_frame_size : 0;
+}
+
+uint32_t ds4_transport_ring_size(const ds4_transport *t) {
+    return t ? t->local_ring_size : 0;
+}
+
+size_t ds4_transport_max_oob_bytes(const ds4_transport *t) {
+    if (!t || !t->ops || !t->ops->max_oob_bytes) return 0;
+    return t->ops->max_oob_bytes(t);
+}
+
+int ds4_transport_can_oob(const ds4_transport *t, size_t payload_bytes) {
+    if (!t || payload_bytes == 0 ||
+        (t->ops->caps & DS4_TRANSPORT_CAP_ZEROCOPY) == 0) return 0;
+    ds4_transport *mutable_t = (ds4_transport *)t;
+    pthread_mutex_lock(&mutable_t->link_mu);
+    const int configured = mutable_t->configured &&
+        mutable_t->generation != 0 && mutable_t->fatal_error == 0;
+    pthread_mutex_unlock(&mutable_t->link_mu);
+    if (!configured) return 0;
+    const size_t max_bytes = ds4_transport_max_oob_bytes(t);
+    return max_bytes != 0 && payload_bytes <= max_bytes;
+}
+
+int ds4_transport_prepare_bulk(
+        ds4_transport *t,
+        uint32_t kind,
+        uint64_t session_id,
+        uint64_t request_id,
+        uint32_t payload_bytes,
+        uint32_t element_bits,
+        ds4_transport_bulk_desc *desc,
+        char *err,
+        size_t errlen) {
+    if (!t || !desc || payload_bytes == 0 ||
+        !bulk_kind_valid(kind, element_bits)) {
+        transport_set_err(err, errlen, "invalid bulk descriptor request");
+        errno = EINVAL;
+        return -1;
+    }
+
+    memset(desc, 0, sizeof(*desc));
+    pthread_mutex_lock(&t->link_mu);
+    if (!t->configured || t->generation == 0 || t->fatal_error != 0 ||
+        t->tx_prepare_sequence == 0 || t->tx_prepare_sequence == UINT64_MAX) {
+        int saved = t->fatal_error ? t->fatal_error : EINVAL;
+        pthread_mutex_unlock(&t->link_mu);
+        transport_set_err(err, errlen, "transport link is not ready for bulk descriptors");
+        errno = saved;
+        return -1;
+    }
+    if (t->ops && t->ops->check_prepare && t->ops->check_prepare(t) != 0) {
+        int saved = errno ? errno : EIO;
+        pthread_mutex_unlock(&t->link_mu);
+        transport_set_err(err, errlen,
+                          "transport backend cannot prepare more bulk traffic");
+        errno = saved;
+        return -1;
+    }
+    desc->kind = kind;
+    desc->generation = t->generation;
+    desc->sequence = t->tx_prepare_sequence++;
+    desc->session_id = session_id;
+    desc->request_id = request_id;
+    desc->payload_bytes = payload_bytes;
+    desc->element_bits = element_bits;
+
+    const size_t max_oob = t->ops && t->ops->max_oob_bytes
+        ? t->ops->max_oob_bytes(t) : 0;
+    if ((t->ops->caps & DS4_TRANSPORT_CAP_ZEROCOPY) != 0 &&
+        max_oob != 0 && payload_bytes <= max_oob) {
+        const uint64_t total = (uint64_t)DS4_NHI_ENVELOPE_BYTES + payload_bytes;
+        desc->mode = DS4_TRANSPORT_BULK_NHI_OOB;
+        desc->frame_count = (uint32_t)((total + t->local_frame_size - 1u) /
+                                       t->local_frame_size);
+    } else {
+        desc->mode = DS4_TRANSPORT_BULK_TCP_INLINE;
+    }
+    pthread_mutex_unlock(&t->link_mu);
+    return 0;
+}
+
+int ds4_transport_validate_inline_desc(
+        const ds4_transport_bulk_desc *desc,
+        uint32_t kind,
+        uint64_t session_id,
+        uint64_t request_id,
+        uint32_t payload_bytes,
+        uint32_t element_bits,
+        char *err,
+        size_t errlen) {
+    if (validate_expected_desc(desc, kind, session_id, request_id,
+                               payload_bytes, element_bits, err, errlen) != 0)
+        return -1;
+    if (desc->mode != DS4_TRANSPORT_BULK_TCP_INLINE ||
+        desc->frame_count != 0) {
+        transport_set_err(err, errlen, "invalid inline bulk descriptor");
+        errno = EPROTO;
+        return -1;
+    }
+    return 0;
+}
+
+int ds4_transport_validate_oob_desc(
+        const ds4_transport *t,
+        const ds4_transport_bulk_desc *desc,
+        uint32_t kind,
+        uint64_t session_id,
+        uint64_t request_id,
+        uint32_t payload_bytes,
+        uint32_t element_bits,
+        char *err,
+        size_t errlen) {
+    if (!t || validate_expected_desc(desc, kind, session_id, request_id,
+                                     payload_bytes, element_bits,
+                                     err, errlen) != 0)
+        return -1;
+    if (desc->mode != DS4_TRANSPORT_BULK_NHI_OOB ||
+        (t->ops->caps & DS4_TRANSPORT_CAP_ZEROCOPY) == 0) {
+        transport_set_err(err, errlen, "invalid out-of-band bulk descriptor mode");
+        errno = EPROTO;
+        return -1;
+    }
+    ds4_transport *mutable_t = (ds4_transport *)t;
+    pthread_mutex_lock(&mutable_t->link_mu);
+    const uint64_t generation = mutable_t->generation;
+    const int configured = mutable_t->configured;
+    pthread_mutex_unlock(&mutable_t->link_mu);
+    const uint64_t total = (uint64_t)DS4_NHI_ENVELOPE_BYTES + payload_bytes;
+    const uint32_t frames = t->local_frame_size == 0 ? 0 :
+        (uint32_t)((total + t->local_frame_size - 1u) / t->local_frame_size);
+    if (!configured || desc->generation != generation || frames == 0 ||
+        desc->frame_count != frames || !ds4_transport_can_oob(t, payload_bytes)) {
+        transport_set_err(err, errlen, "out-of-band bulk descriptor geometry mismatch");
+        errno = EPROTO;
+        return -1;
+    }
+    return 0;
+}
+
+static void wire_put_u32(uint8_t *p, uint32_t value) {
+    value = htonl(value);
+    memcpy(p, &value, sizeof(value));
+}
+
+static uint32_t wire_get_u32(const uint8_t *p) {
+    uint32_t value;
+    memcpy(&value, p, sizeof(value));
+    return ntohl(value);
+}
+
+static void wire_put_u64(uint8_t *p, uint64_t value) {
+    wire_put_u32(p, (uint32_t)(value >> 32));
+    wire_put_u32(p + 4, (uint32_t)value);
+}
+
+static uint64_t wire_get_u64(const uint8_t *p) {
+    return ((uint64_t)wire_get_u32(p) << 32) | wire_get_u32(p + 4);
+}
+
+int ds4_transport_bulk_desc_encode(
+        const ds4_transport_bulk_desc *desc,
+        ds4_transport_bulk_desc_wire *wire) {
+    if (!desc || !wire) {
+        errno = EINVAL;
+        return -1;
+    }
+    wire_put_u32(wire->bytes + 0, desc->mode);
+    wire_put_u32(wire->bytes + 4, desc->kind);
+    wire_put_u64(wire->bytes + 8, desc->generation);
+    wire_put_u64(wire->bytes + 16, desc->sequence);
+    wire_put_u64(wire->bytes + 24, desc->session_id);
+    wire_put_u64(wire->bytes + 32, desc->request_id);
+    wire_put_u32(wire->bytes + 40, desc->payload_bytes);
+    wire_put_u32(wire->bytes + 44, desc->element_bits);
+    wire_put_u32(wire->bytes + 48, desc->frame_count);
+    wire_put_u32(wire->bytes + 52, desc->flags);
+    wire_put_u32(wire->bytes + 56, desc->reserved[0]);
+    wire_put_u32(wire->bytes + 60, desc->reserved[1]);
+    return 0;
+}
+
+int ds4_transport_bulk_desc_decode(
+        const ds4_transport_bulk_desc_wire *wire,
+        ds4_transport_bulk_desc *desc) {
+    if (!wire || !desc) {
+        errno = EINVAL;
+        return -1;
+    }
+    memset(desc, 0, sizeof(*desc));
+    desc->mode = wire_get_u32(wire->bytes + 0);
+    desc->kind = wire_get_u32(wire->bytes + 4);
+    desc->generation = wire_get_u64(wire->bytes + 8);
+    desc->sequence = wire_get_u64(wire->bytes + 16);
+    desc->session_id = wire_get_u64(wire->bytes + 24);
+    desc->request_id = wire_get_u64(wire->bytes + 32);
+    desc->payload_bytes = wire_get_u32(wire->bytes + 40);
+    desc->element_bits = wire_get_u32(wire->bytes + 44);
+    desc->frame_count = wire_get_u32(wire->bytes + 48);
+    desc->flags = wire_get_u32(wire->bytes + 52);
+    desc->reserved[0] = wire_get_u32(wire->bytes + 56);
+    desc->reserved[1] = wire_get_u32(wire->bytes + 60);
+    return 0;
+}
+
+int ds4_transport_send_bulk(ds4_transport *t, const void *buf, size_t len) {
+    if (!t || !t->ops || !t->ops->send_bulk || (len != 0 && !buf)) {
+        errno = EINVAL;
+        return -1;
+    }
+    pthread_mutex_lock(&t->send_mu);
+    int rc = t->ops->send_bulk(t, buf, len);
+    pthread_mutex_unlock(&t->send_mu);
+    return rc;
+}
+
+int ds4_transport_recv_bulk(ds4_transport *t, void *buf, size_t len) {
+    if (!t || !t->ops || !t->ops->recv_bulk || (len != 0 && !buf)) {
+        errno = EINVAL;
+        return -1;
+    }
+    pthread_mutex_lock(&t->recv_mu);
+    int rc = t->ops->recv_bulk(t, buf, len);
+    pthread_mutex_unlock(&t->recv_mu);
+    return rc;
+}
+
+static int validate_directional_desc(ds4_transport *t,
+                                     const ds4_transport_bulk_desc *desc,
+                                     size_t len,
+                                     int sending) {
+    if (!t || !desc || len != desc->payload_bytes ||
+        desc->payload_bytes == 0 ||
+        !bulk_kind_valid(desc->kind, desc->element_bits) ||
+        desc->flags != 0 || desc->reserved[0] != 0 ||
+        desc->reserved[1] != 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    pthread_mutex_lock(&t->link_mu);
+    const uint64_t expected = sending ? t->tx_send_sequence : t->rx_sequence;
+    const int valid = t->configured && t->fatal_error == 0 &&
+        desc->generation == t->generation && desc->sequence == expected;
+    int saved = t->fatal_error ? t->fatal_error : EPROTO;
+    pthread_mutex_unlock(&t->link_mu);
+    if (!valid) {
+        errno = saved;
+        return -1;
+    }
+    if (desc->mode == DS4_TRANSPORT_BULK_TCP_INLINE) {
+        if (desc->frame_count == 0) return 0;
+        errno = EPROTO;
+        return -1;
+    }
+    if (desc->mode == DS4_TRANSPORT_BULK_NHI_OOB)
+        return ds4_transport_validate_oob_desc(t, desc, desc->kind,
+                                               desc->session_id,
+                                               desc->request_id,
+                                               desc->payload_bytes,
+                                               desc->element_bits,
+                                               NULL, 0);
+    errno = EPROTO;
+    return -1;
+}
+
+int ds4_transport_send_bulk_desc(
+        ds4_transport *t,
+        const ds4_transport_bulk_desc *desc,
+        const void *buf,
+        size_t len) {
+    if (!t || !desc || (len != 0 && !buf)) {
+        errno = EINVAL;
+        return -1;
+    }
+    pthread_mutex_lock(&t->send_mu);
+    int rc = validate_directional_desc(t, desc, len, 1);
+    if (rc == 0) {
+        if (desc->mode == DS4_TRANSPORT_BULK_TCP_INLINE) {
+            rc = ds4_transport_tcp_write(t->control_fd, buf, len);
+        } else if (!t->ops || !t->ops->send_bulk_desc) {
+            errno = ENOTSUP;
+            rc = -1;
+        } else {
+            rc = t->ops->send_bulk_desc(t, desc, buf, len);
+        }
+    }
+    if (rc == 0) {
+        pthread_mutex_lock(&t->link_mu);
+        t->tx_send_sequence++;
+        pthread_mutex_unlock(&t->link_mu);
+    } else {
+        int saved = errno ? errno : EIO;
+        ds4_transport_internal_fail(t, saved);
+        errno = saved;
+    }
+    pthread_mutex_unlock(&t->send_mu);
+    return rc;
+}
+
+int ds4_transport_recv_bulk_desc(
+        ds4_transport *t,
+        const ds4_transport_bulk_desc *desc,
+        void *buf,
+        size_t len) {
+    if (!t || !desc || (len != 0 && !buf)) {
+        errno = EINVAL;
+        return -1;
+    }
+    pthread_mutex_lock(&t->recv_mu);
+    int rc = validate_directional_desc(t, desc, len, 0);
+    if (rc == 0) {
+        if (desc->mode == DS4_TRANSPORT_BULK_TCP_INLINE) {
+            rc = ds4_transport_tcp_read(t->control_fd, buf, len);
+        } else if (!t->ops || !t->ops->recv_bulk_desc) {
+            errno = ENOTSUP;
+            rc = -1;
+        } else {
+            rc = t->ops->recv_bulk_desc(t, desc, buf, len);
+        }
+    }
+    if (rc == 1) {
+        pthread_mutex_lock(&t->link_mu);
+        t->rx_sequence++;
+        pthread_mutex_unlock(&t->link_mu);
+    } else if (rc <= 0) {
+        int saved = rc == 0 ? ECONNRESET : (errno ? errno : EIO);
+        ds4_transport_internal_fail(t, saved);
+        errno = saved;
+    }
+    pthread_mutex_unlock(&t->recv_mu);
+    return rc;
+}
+
+int ds4_transport_mapped_leases_supported(const ds4_transport *t) {
+    return t && t->ops && t->ops->mapped_leases_supported
+        ? t->ops->mapped_leases_supported(t) : 0;
+}
+
+static int transport_lease_acquire(
+        ds4_transport *t,
+        const ds4_transport_bulk_desc *desc,
+        ds4_transport_lease **out,
+        uint32_t direction,
+        char *err,
+        size_t errlen) {
+    if (!out) {
+        transport_set_err(err, errlen, "missing mapped lease output");
+        errno = EINVAL;
+        return -1;
+    }
+    *out = NULL;
+    if (!t || !desc ||
+        (direction != DS4_TRANSPORT_LEASE_TX &&
+         direction != DS4_TRANSPORT_LEASE_RX)) {
+        transport_set_err(err, errlen, "invalid mapped lease request");
+        errno = EINVAL;
+        return -1;
+    }
+    if (desc->mode != DS4_TRANSPORT_BULK_NHI_OOB ||
+        !ds4_transport_mapped_leases_supported(t)) {
+        transport_set_err(err, errlen,
+                          "mapped leases are unavailable for this descriptor");
+        errno = ENOTSUP;
+        return -1;
+    }
+
+    ds4_transport_lease *lease = calloc(1, sizeof(*lease));
+    if (!lease) {
+        transport_set_err(err, errlen, "out of memory creating mapped lease");
+        return -1;
+    }
+    lease->transport = ds4_transport_retain(t);
+    lease->desc = *desc;
+    lease->bytes = desc->payload_bytes;
+    lease->direction = direction;
+    lease->state = DS4_TRANSPORT_LEASE_ACTIVE;
+
+    pthread_mutex_t *direction_mu = direction == DS4_TRANSPORT_LEASE_TX
+        ? &t->send_mu : &t->recv_mu;
+    pthread_mutex_lock(direction_mu);
+    int rc = validate_directional_desc(t, desc, desc->payload_bytes,
+                                       direction == DS4_TRANSPORT_LEASE_TX);
+    if (rc == 0) {
+        if (direction == DS4_TRANSPORT_LEASE_TX) {
+            if (!t->ops->tx_lease_acquire) {
+                errno = ENOTSUP;
+                rc = -1;
+            } else {
+                rc = t->ops->tx_lease_acquire(t, desc, lease, err, errlen);
+            }
+        } else {
+            if (!t->ops->rx_lease_acquire) {
+                errno = ENOTSUP;
+                rc = -1;
+            } else {
+                rc = t->ops->rx_lease_acquire(t, desc, lease, err, errlen);
+            }
+        }
+    }
+    pthread_mutex_unlock(direction_mu);
+
+    if (rc != 0) {
+        const int saved = errno ? errno : EIO;
+        /* A received descriptor is already committed by the peer. Invalid
+         * metadata/event failures are fatal, but ENOTSUP deliberately leaves
+         * the event untouched so the copy receive path can consume it. */
+        if (direction == DS4_TRANSPORT_LEASE_RX && saved != ENOTSUP &&
+            saved != EBUSY)
+            ds4_transport_internal_fail(t, saved);
+        ds4_transport_release(lease->transport);
+        free(lease);
+        errno = saved;
+        return -1;
+    }
+    *out = lease;
+    return 0;
+}
+
+int ds4_transport_tx_lease_acquire(
+        ds4_transport *t,
+        const ds4_transport_bulk_desc *desc,
+        ds4_transport_lease **out,
+        char *err,
+        size_t errlen) {
+    return transport_lease_acquire(t, desc, out, DS4_TRANSPORT_LEASE_TX,
+                                   err, errlen);
+}
+
+int ds4_transport_rx_lease_acquire(
+        ds4_transport *t,
+        const ds4_transport_bulk_desc *desc,
+        ds4_transport_lease **out,
+        char *err,
+        size_t errlen) {
+    return transport_lease_acquire(t, desc, out, DS4_TRANSPORT_LEASE_RX,
+                                   err, errlen);
+}
+
+void *ds4_transport_lease_host_ptr(const ds4_transport_lease *lease) {
+    return lease && lease->state == DS4_TRANSPORT_LEASE_ACTIVE
+        ? lease->host_ptr : NULL;
+}
+
+void *ds4_transport_lease_device_ptr(const ds4_transport_lease *lease) {
+    return lease && lease->state == DS4_TRANSPORT_LEASE_ACTIVE
+        ? lease->device_ptr : NULL;
+}
+
+size_t ds4_transport_lease_bytes(const ds4_transport_lease *lease) {
+    return lease && lease->state == DS4_TRANSPORT_LEASE_ACTIVE
+        ? lease->bytes : 0;
+}
+
+int ds4_transport_tx_lease_mark_control_sent(ds4_transport_lease *lease) {
+    if (!lease || lease->state != DS4_TRANSPORT_LEASE_ACTIVE ||
+        lease->direction != DS4_TRANSPORT_LEASE_TX || !lease->transport ||
+        !lease->transport->ops ||
+        !lease->transport->ops->tx_lease_mark_control_sent) {
+        errno = EINVAL;
+        return -1;
+    }
+    ds4_transport *t = lease->transport;
+    /* This call is the caller's assertion that the complete control record
+     * has already been sent. Preserve that irreversible fact even if the
+     * backend reports a simultaneous failure while recording it. */
+    lease->control_sent = 1;
+    pthread_mutex_lock(&t->send_mu);
+    int rc = t->ops->tx_lease_mark_control_sent(lease);
+    pthread_mutex_unlock(&t->send_mu);
+    if (rc != 0) {
+        int saved = errno ? errno : EIO;
+        /* The caller invokes this only after the TCP control record is fully
+         * visible to the peer, so inability to mark it is already fatal. */
+        ds4_transport_internal_fail(t, saved);
+        errno = saved;
+    }
+    return rc;
+}
+
+static int transport_advance_lease_sequence(ds4_transport_lease *lease) {
+    ds4_transport *t = lease->transport;
+    pthread_mutex_lock(&t->link_mu);
+    uint64_t *sequence = lease->direction == DS4_TRANSPORT_LEASE_TX
+        ? &t->tx_send_sequence : &t->rx_sequence;
+    const int valid = t->configured && t->fatal_error == 0 &&
+        t->generation == lease->desc.generation &&
+        *sequence == lease->desc.sequence;
+    if (valid) (*sequence)++;
+    int saved = t->fatal_error ? t->fatal_error : EPROTO;
+    pthread_mutex_unlock(&t->link_mu);
+    if (!valid) {
+        errno = saved;
+        return -1;
+    }
+    return 0;
+}
+
+static int transport_lease_commit_impl(ds4_transport_lease *lease,
+                                       int gpu_quiesced) {
+    if (!lease || lease->state != DS4_TRANSPORT_LEASE_ACTIVE ||
+        !lease->transport || !lease->transport->ops ||
+        !lease->transport->ops->lease_commit) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (lease->direction == DS4_TRANSPORT_LEASE_TX &&
+        !lease->control_sent) {
+        errno = EPERM;
+        return -1;
+    }
+
+    ds4_transport *t = lease->transport;
+    pthread_mutex_t *direction_mu =
+        lease->direction == DS4_TRANSPORT_LEASE_TX
+        ? &t->send_mu : &t->recv_mu;
+    pthread_mutex_lock(direction_mu);
+    int rc = validate_directional_desc(
+        t, &lease->desc, lease->desc.payload_bytes,
+        lease->direction == DS4_TRANSPORT_LEASE_TX);
+    if (rc == 0) {
+        rc = t->ops->lease_commit(lease, gpu_quiesced);
+    } else {
+        const int validation_error = errno ? errno : EPROTO;
+        /* Drop the backend's active pointer even when a concurrent fatal
+         * condition made the core descriptor check fail before commit. */
+        (void)t->ops->lease_abort(lease);
+        errno = validation_error;
+    }
+    if (rc == 0) rc = transport_advance_lease_sequence(lease);
+    if (rc == 0) {
+        lease->state = DS4_TRANSPORT_LEASE_COMMITTED;
+    } else {
+        int saved = errno ? errno : EIO;
+        /* RX descriptors and marked TX descriptors are already committed on
+         * TCP. Any ownership, submit, repost, or sequence failure abandons
+         * the generation; there is no safe inline retry. */
+        ds4_transport_internal_fail(t, saved);
+        lease->state = DS4_TRANSPORT_LEASE_ABORTED;
+        errno = saved;
+    }
+    lease->host_ptr = NULL;
+    lease->device_ptr = NULL;
+    lease->bytes = 0;
+    pthread_mutex_unlock(direction_mu);
+    return rc;
+}
+
+int ds4_transport_lease_commit(ds4_transport_lease *lease) {
+    return transport_lease_commit_impl(lease, 0);
+}
+
+int ds4_transport_lease_commit_gpu_quiesced(ds4_transport_lease *lease) {
+    return transport_lease_commit_impl(lease, 1);
+}
+
+int ds4_transport_lease_abort(ds4_transport_lease *lease) {
+    if (!lease || lease->state != DS4_TRANSPORT_LEASE_ACTIVE ||
+        !lease->transport || !lease->transport->ops ||
+        !lease->transport->ops->lease_abort ||
+        (lease->direction == DS4_TRANSPORT_LEASE_TX &&
+         !lease->control_sent &&
+         !lease->transport->ops->lease_abort_finish)) {
+        errno = EINVAL;
+        return -1;
+    }
+    ds4_transport *t = lease->transport;
+    pthread_mutex_t *direction_mu =
+        lease->direction == DS4_TRANSPORT_LEASE_TX
+        ? &t->send_mu : &t->recv_mu;
+    const int recoverable = lease->direction == DS4_TRANSPORT_LEASE_TX &&
+        !lease->control_sent;
+
+    pthread_mutex_lock(direction_mu);
+    int rc = t->ops->lease_abort(lease);
+    if (rc == 0 && recoverable) {
+        pthread_mutex_lock(&t->link_mu);
+        const int can_rollback = t->configured && t->fatal_error == 0 &&
+            t->generation == lease->desc.generation &&
+            t->tx_send_sequence == lease->desc.sequence &&
+            lease->desc.sequence != UINT64_MAX &&
+            t->tx_prepare_sequence == lease->desc.sequence + 1u;
+        /* The backend keeps its active marker until this point. Holding the
+         * link lock while clearing it closes the check_prepare(ctx) race: a
+         * new prepare observes either the old active lease or the rolled-back
+         * sequence, never the transient state between them. */
+        const int finish_rc = t->ops->lease_abort_finish(lease);
+        if (can_rollback && finish_rc == 0)
+            t->tx_prepare_sequence = lease->desc.sequence;
+        pthread_mutex_unlock(&t->link_mu);
+        if (!can_rollback || finish_rc != 0) {
+            if (finish_rc == 0 || errno == 0) errno = EPROTO;
+            rc = -1;
+        }
+    }
+    if (rc != 0 || !recoverable) {
+        int saved = errno ? errno : ECANCELED;
+        ds4_transport_internal_fail(t, saved);
+        errno = saved;
+        rc = -1;
+    }
+    lease->state = DS4_TRANSPORT_LEASE_ABORTED;
+    lease->host_ptr = NULL;
+    lease->device_ptr = NULL;
+    lease->bytes = 0;
+    pthread_mutex_unlock(direction_mu);
+    return rc;
+}
+
+void ds4_transport_lease_release(ds4_transport_lease *lease) {
+    if (!lease) return;
+    if (lease->state == DS4_TRANSPORT_LEASE_ACTIVE)
+        (void)ds4_transport_lease_abort(lease);
+    ds4_transport_release(lease->transport);
+    free(lease);
+}
+
+const char *ds4_transport_name(const ds4_transport *t) {
+    return t && t->ops ? t->ops->name : "none";
+}
+
+uint32_t ds4_transport_caps(const ds4_transport *t) {
+    uint32_t caps = t && t->ops ? t->ops->caps : 0;
+    if (ds4_transport_mapped_leases_supported(t))
+        caps |= DS4_TRANSPORT_CAP_GPU_MAPPED;
+    return caps;
+}

--- a/ds4_transport.h
+++ b/ds4_transport.h
@@ -1,0 +1,209 @@
+#ifndef DS4_TRANSPORT_H
+#define DS4_TRANSPORT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Bulk boundary-tensor transport. Control and negotiation traffic stay on the
+ * distributed TCP socket; only hidden-state and batched-logit payloads move
+ * through this vtable. A zero-copy NHI/USB4STREAM backend can replace that
+ * path once peers negotiate an out-of-band bulk descriptor.
+ */
+
+typedef struct ds4_transport ds4_transport;
+typedef struct ds4_transport_lease ds4_transport_lease;
+
+#define DS4_TRANSPORT_CAP_STREAM   0x1u /* reliable byte stream (TCP) */
+#define DS4_TRANSPORT_CAP_ZEROCOPY 0x2u /* out-of-band zero-copy payloads */
+#define DS4_TRANSPORT_CAP_GPU_MAPPED 0x4u /* direct mapped-slot GPU leases */
+
+#define DS4_TRANSPORT_BULK_DESC_BYTES 64u
+
+typedef enum {
+    DS4_TRANSPORT_BULK_NONE = 0,
+    DS4_TRANSPORT_BULK_TCP_INLINE = 1,
+    DS4_TRANSPORT_BULK_NHI_OOB = 2,
+} ds4_transport_bulk_mode;
+
+typedef enum {
+    DS4_TRANSPORT_BULK_INPUT_HIDDEN = 1,
+    DS4_TRANSPORT_BULK_RESULT_HIDDEN = 2,
+    DS4_TRANSPORT_BULK_RESULT_LOGITS = 3,
+} ds4_transport_bulk_kind;
+
+/* Host-order v3 descriptor. The corresponding wire record is always exactly
+ * 64 bytes; encode/decode helpers avoid exposing host padding or byte order.
+ * Local NHI slot indices are deliberately absent because the peer RX cursor
+ * is independent of the sender's TX cursor. */
+typedef struct {
+    uint32_t mode;
+    uint32_t kind;
+    uint64_t generation;
+    uint64_t sequence;
+    uint64_t session_id;
+    uint64_t request_id;
+    uint32_t payload_bytes;
+    uint32_t element_bits;
+    uint32_t frame_count;
+    uint32_t flags;
+    uint32_t reserved[2];
+} ds4_transport_bulk_desc;
+
+typedef struct {
+    uint8_t bytes[DS4_TRANSPORT_BULK_DESC_BYTES];
+} ds4_transport_bulk_desc_wire;
+
+/* Byte-stream primitives shared by the control path and the TCP bulk backend.
+ * write returns 0/-1; read returns 1 on success, 0 on peer close, -1 on error.
+ */
+int ds4_transport_tcp_write(int fd, const void *buf, size_t len);
+int ds4_transport_tcp_read(int fd, void *buf, size_t len);
+
+/* Create a persistent TCP bulk transport over an established control/data fd.
+ * tcp_create() borrows fd; tcp_dup() owns a duplicate that is closed with the
+ * final transport reference. Transports support concurrent full-duplex sender
+ * and receiver paths.
+ */
+ds4_transport *ds4_transport_tcp_create(int fd, char *err, size_t errlen);
+ds4_transport *ds4_transport_tcp_dup(int fd, char *err, size_t errlen);
+ds4_transport *ds4_transport_retain(ds4_transport *t);
+void ds4_transport_release(ds4_transport *t);
+int ds4_transport_control_fd(const ds4_transport *t);
+
+/* Open and map one exclusive /dev/tbstreamX zero-copy endpoint. create()
+ * borrows control_fd; dup() owns a duplicate. Both are Linux-only and return
+ * NULL with ENOTSUP on other platforms. The link must be configured with the
+ * generation and peer geometry selected by HELLO before preparing OOB bulk. */
+ds4_transport *ds4_transport_nhi_create(
+        int control_fd,
+        const char *device_path,
+        char *err,
+        size_t errlen);
+ds4_transport *ds4_transport_nhi_dup(
+        int control_fd,
+        const char *device_path,
+        char *err,
+        size_t errlen);
+
+/* Configure the negotiated connection identity and peer receive geometry.
+ * TCP accepts zero peer geometry. NHI requires its peer frame size to match
+ * and limits each message and aggregate in-flight frames to the smaller ring.
+ */
+int ds4_transport_configure_link(
+        ds4_transport *t,
+        uint64_t generation,
+        uint32_t peer_frame_size,
+        uint32_t peer_ring_size,
+        char *err,
+        size_t errlen);
+uint64_t ds4_transport_generation(const ds4_transport *t);
+uint32_t ds4_transport_frame_size(const ds4_transport *t);
+uint32_t ds4_transport_ring_size(const ds4_transport *t);
+size_t ds4_transport_max_oob_bytes(const ds4_transport *t);
+int ds4_transport_can_oob(const ds4_transport *t, size_t payload_bytes);
+
+/* Allocate the next directional sequence and select NHI only when this link
+ * is configured and the complete tagged message fits. Oversized payloads are
+ * described as inline TCP before any OOB submission can become ambiguous.
+ * The caller must serialize prepare -> complete TCP control frame -> tagged
+ * send for each direction; this is the same per-link write lock required to
+ * keep control frames ordered on the TCP socket. */
+int ds4_transport_prepare_bulk(
+        ds4_transport *t,
+        uint32_t kind,
+        uint64_t session_id,
+        uint64_t request_id,
+        uint32_t payload_bytes,
+        uint32_t element_bits,
+        ds4_transport_bulk_desc *desc,
+        char *err,
+        size_t errlen);
+int ds4_transport_validate_inline_desc(
+        const ds4_transport_bulk_desc *desc,
+        uint32_t kind,
+        uint64_t session_id,
+        uint64_t request_id,
+        uint32_t payload_bytes,
+        uint32_t element_bits,
+        char *err,
+        size_t errlen);
+int ds4_transport_validate_oob_desc(
+        const ds4_transport *t,
+        const ds4_transport_bulk_desc *desc,
+        uint32_t kind,
+        uint64_t session_id,
+        uint64_t request_id,
+        uint32_t payload_bytes,
+        uint32_t element_bits,
+        char *err,
+        size_t errlen);
+int ds4_transport_bulk_desc_encode(
+        const ds4_transport_bulk_desc *desc,
+        ds4_transport_bulk_desc_wire *wire);
+int ds4_transport_bulk_desc_decode(
+        const ds4_transport_bulk_desc_wire *wire,
+        ds4_transport_bulk_desc *desc);
+
+int ds4_transport_send_bulk(ds4_transport *t, const void *buf, size_t len);
+int ds4_transport_recv_bulk(ds4_transport *t, void *buf, size_t len);
+int ds4_transport_send_bulk_desc(
+        ds4_transport *t,
+        const ds4_transport_bulk_desc *desc,
+        const void *buf,
+        size_t len);
+int ds4_transport_recv_bulk_desc(
+        ds4_transport *t,
+        const ds4_transport_bulk_desc *desc,
+        void *buf,
+        size_t len);
+
+/* Optional direct access to one mapped NHI payload. A lease retains its
+ * transport and only exposes a single contiguous payload span. Acquire
+ * returns ENOTSUP without consuming a cursor/event when mapping is absent or
+ * the payload wraps, allowing the same prepared descriptor to use the copy
+ * send/receive API instead. Only one lease per direction may be active.
+ *
+ * TX order is: acquire, fill through device_ptr, write the complete TCP
+ * control frame, mark_control_sent, commit, release. Commit synchronizes GPU
+ * ownership before NHI submission. Aborting before any TCP control write has
+ * been attempted is safe and rolls back only that immediately outstanding
+ * prepare sequence. A partial/failed control write must abandon the generation
+ * (mark then abort, or shut down the socket); absence of mark_control_sent does
+ * not make bytes already written recoverable. Aborting after the mark is fatal
+ * because the peer already expects OOB data.
+ *
+ * RX acquire validates the queued event and tagged envelope before exposing
+ * memory. Commit synchronizes GPU ownership, reposts the exact frames, and
+ * advances receive sequence. An RX abort is necessarily fatal. Pointers and
+ * byte count are valid only while the lease remains active.
+ *
+ * commit_gpu_quiesced() is the scoped fast path for a caller that has already
+ * completed every GPU read or write touching the lease (or never exposed the
+ * lease to GPU work). It preserves all transport and DMA ownership operations
+ * while avoiding a redundant backend GPU synchronization. */
+int ds4_transport_mapped_leases_supported(const ds4_transport *t);
+int ds4_transport_tx_lease_acquire(
+        ds4_transport *t,
+        const ds4_transport_bulk_desc *desc,
+        ds4_transport_lease **out,
+        char *err,
+        size_t errlen);
+int ds4_transport_rx_lease_acquire(
+        ds4_transport *t,
+        const ds4_transport_bulk_desc *desc,
+        ds4_transport_lease **out,
+        char *err,
+        size_t errlen);
+void *ds4_transport_lease_host_ptr(const ds4_transport_lease *lease);
+void *ds4_transport_lease_device_ptr(const ds4_transport_lease *lease);
+size_t ds4_transport_lease_bytes(const ds4_transport_lease *lease);
+int ds4_transport_tx_lease_mark_control_sent(ds4_transport_lease *lease);
+int ds4_transport_lease_commit(ds4_transport_lease *lease);
+int ds4_transport_lease_commit_gpu_quiesced(ds4_transport_lease *lease);
+int ds4_transport_lease_abort(ds4_transport_lease *lease);
+void ds4_transport_lease_release(ds4_transport_lease *lease);
+
+const char *ds4_transport_name(const ds4_transport *t);
+uint32_t ds4_transport_caps(const ds4_transport *t);
+
+#endif

--- a/ds4_transport_internal.h
+++ b/ds4_transport_internal.h
@@ -1,0 +1,109 @@
+#ifndef DS4_TRANSPORT_INTERNAL_H
+#define DS4_TRANSPORT_INTERNAL_H
+
+#include "ds4_transport.h"
+
+#include <pthread.h>
+
+typedef struct ds4_transport_ops {
+    const char *name;
+    uint32_t caps;
+    int (*send_bulk)(ds4_transport *t, const void *buf, size_t len);
+    int (*recv_bulk)(ds4_transport *t, void *buf, size_t len);
+    int (*send_bulk_desc)(ds4_transport *t,
+                          const ds4_transport_bulk_desc *desc,
+                          const void *buf,
+                          size_t len);
+    int (*recv_bulk_desc)(ds4_transport *t,
+                          const ds4_transport_bulk_desc *desc,
+                          void *buf,
+                          size_t len);
+    int (*mapped_leases_supported)(const ds4_transport *t);
+    int (*tx_lease_acquire)(ds4_transport *t,
+                            const ds4_transport_bulk_desc *desc,
+                            ds4_transport_lease *lease,
+                            char *err,
+                            size_t errlen);
+    int (*rx_lease_acquire)(ds4_transport *t,
+                            const ds4_transport_bulk_desc *desc,
+                            ds4_transport_lease *lease,
+                            char *err,
+                            size_t errlen);
+    int (*tx_lease_mark_control_sent)(ds4_transport_lease *lease);
+    int (*lease_commit)(ds4_transport_lease *lease, int gpu_quiesced);
+    int (*lease_abort)(ds4_transport_lease *lease);
+    int (*lease_abort_finish)(ds4_transport_lease *lease);
+    int (*check_prepare)(ds4_transport *t);
+    int (*configure)(ds4_transport *t,
+                     uint32_t peer_frame_size,
+                     uint32_t peer_ring_size,
+                     char *err,
+                     size_t errlen);
+    size_t (*max_oob_bytes)(const ds4_transport *t);
+    void (*close)(ds4_transport *t);
+} ds4_transport_ops;
+
+enum {
+    DS4_TRANSPORT_LEASE_TX = 1,
+    DS4_TRANSPORT_LEASE_RX = 2,
+};
+
+enum {
+    DS4_TRANSPORT_LEASE_ACTIVE = 1,
+    DS4_TRANSPORT_LEASE_COMMITTED = 2,
+    DS4_TRANSPORT_LEASE_ABORTED = 3,
+};
+
+struct ds4_transport_lease {
+    ds4_transport *transport;
+    ds4_transport_bulk_desc desc;
+    void *host_ptr;
+    void *device_ptr;
+    size_t bytes;
+    uint32_t direction;
+    uint32_t state;
+    int control_sent;
+
+    uint32_t first;
+    uint32_t nframes;
+    uint32_t event_bytes;
+};
+
+struct ds4_transport {
+    const ds4_transport_ops *ops;
+    int control_fd;
+    int owns_control_fd;
+    void *ctx;
+
+    pthread_mutex_t ref_mu;
+    unsigned int refs;
+
+    pthread_mutex_t link_mu;
+    pthread_mutex_t send_mu;
+    pthread_mutex_t recv_mu;
+    uint64_t generation;
+    uint64_t tx_prepare_sequence;
+    uint64_t tx_send_sequence;
+    uint64_t rx_sequence;
+    uint32_t local_frame_size;
+    uint32_t local_ring_size;
+    uint32_t peer_frame_size;
+    uint32_t peer_ring_size;
+    int configured;
+    int fatal_error;
+};
+
+ds4_transport *ds4_transport_internal_create(
+        const ds4_transport_ops *ops,
+        int control_fd,
+        int owns_control_fd,
+        void *ctx,
+        uint32_t local_frame_size,
+        uint32_t local_ring_size,
+        char *err,
+        size_t errlen);
+
+void ds4_transport_internal_fail(ds4_transport *t, int error_code);
+int ds4_transport_internal_error(const ds4_transport *t);
+
+#endif

--- a/ds4_transport_nhi.c
+++ b/ds4_transport_nhi.c
@@ -1,0 +1,1474 @@
+/* =========================================================================
+ * ds4_transport_nhi.c - CPU-copy USB4STREAM zero-copy-slot transport.
+ * ========================================================================= */
+
+#include "ds4_transport_internal.h"
+#include "ds4_gpu.h"
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+#ifdef __linux__
+
+#include "ds4_tbstream_uapi.h"
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#define DS4_NHI_ENVELOPE_MAGIC 0x44344e48u /* D4NH */
+#define DS4_NHI_ENVELOPE_VERSION 1u
+#define DS4_NHI_ENVELOPE_BYTES 64u
+#define DS4_NHI_REAP_BATCH 64u
+#define DS4_NHI_DEFAULT_TIMEOUT_SEC 30u
+
+typedef char ds4_nhi_envelope_is_64_bytes[
+    DS4_NHI_ENVELOPE_BYTES == DS4_TRANSPORT_BULK_DESC_BYTES ? 1 : -1];
+
+typedef struct {
+    uint32_t first;
+    uint32_t nframes;
+    uint64_t sequence;
+} ds4_nhi_pending_tx;
+
+typedef struct {
+    int device_fd;
+    int wake_fd;
+    void *mapping;
+    size_t mapping_bytes;
+    unsigned char *tx_pool;
+    unsigned char *rx_pool;
+    void *gpu_mapping;
+    size_t pool_bytes;
+    uint32_t frame_size;
+    uint32_t ring_size;
+    uint32_t tx_frame_limit;
+    uint32_t timeout_sec;
+
+    pthread_mutex_t mu;
+    pthread_cond_t tx_cv;
+    pthread_cond_t rx_cv;
+    pthread_t dispatcher;
+    int dispatcher_started;
+    int stopping;
+    int failed;
+    int peer_closed;
+    int activated;
+    int gpu_mapping_registered;
+
+    ds4_transport_lease *active_tx_lease;
+    ds4_transport_lease *active_rx_lease;
+
+    uint32_t tx_next;
+    uint32_t tx_inflight;
+    ds4_nhi_pending_tx *tx_pending;
+    uint32_t tx_head;
+    uint32_t tx_tail;
+    uint32_t tx_count;
+
+    struct tbstream_zc_event *rx_events;
+    uint32_t rx_head;
+    uint32_t rx_tail;
+    uint32_t rx_count;
+    uint32_t rx_next;
+    uint32_t rx_event_next;
+
+    ds4_transport *owner;
+} ds4_nhi_ctx;
+
+static int nhi_trace_enabled(void) {
+    const char *value = getenv("DS4_DIST_NHI_TRACE");
+    return value && value[0] && strcmp(value, "0") != 0;
+}
+
+/* Direct GPU access to NHI-owned pages is deliberately opt-in. The ordinary
+ * NHI backend still uses the mmap pools and avoids the socket stack, but
+ * stages model tensors through CPU copies. Model-independent mapping gates are
+ * useful qualification coverage; they are not sufficient evidence that a
+ * platform's GPU/NHI peer-DMA interaction is reliable under model load. */
+static int nhi_mapped_model_io_enabled(void) {
+    const char *value = getenv("DS4_DIST_NHI_MAPPED");
+    return value &&
+        (!strcmp(value, "1") || !strcmp(value, "true") ||
+         !strcmp(value, "yes") || !strcmp(value, "on"));
+}
+
+static void nhi_trace(ds4_nhi_ctx *ctx, const char *format, ...) {
+    if (!nhi_trace_enabled()) return;
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    fprintf(stderr, "ds4: NHI trace: %lld.%06ld ctx=%p ",
+            (long long)now.tv_sec, now.tv_nsec / 1000, (void *)ctx);
+    va_list args;
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
+    fputc('\n', stderr);
+}
+
+static void nhi_set_err(char *err, size_t errlen, const char *message) {
+    if (err && errlen) snprintf(err, errlen, "%s", message);
+}
+
+static uint32_t nhi_timeout_sec(void) {
+    const char *text = getenv("DS4_DIST_NHI_TIMEOUT_SEC");
+    if (!text || !text[0]) return DS4_NHI_DEFAULT_TIMEOUT_SEC;
+    errno = 0;
+    char *end = NULL;
+    unsigned long value = strtoul(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0' ||
+        value == 0 || value > 3600) return DS4_NHI_DEFAULT_TIMEOUT_SEC;
+    return (uint32_t)value;
+}
+
+static void nhi_wire_put_u32(unsigned char *p, uint32_t value) {
+    value = htonl(value);
+    memcpy(p, &value, sizeof(value));
+}
+
+static uint32_t nhi_wire_get_u32(const unsigned char *p) {
+    uint32_t value;
+    memcpy(&value, p, sizeof(value));
+    return ntohl(value);
+}
+
+static void nhi_wire_put_u64(unsigned char *p, uint64_t value) {
+    nhi_wire_put_u32(p, (uint32_t)(value >> 32));
+    nhi_wire_put_u32(p + 4, (uint32_t)value);
+}
+
+static uint64_t nhi_wire_get_u64(const unsigned char *p) {
+    return ((uint64_t)nhi_wire_get_u32(p) << 32) |
+           nhi_wire_get_u32(p + 4);
+}
+
+/* The NHI message repeats every identity field from the TCP descriptor. The
+ * UAPI event has no application tag, so accepting an event based on FIFO
+ * position alone would make stale or malformed traffic indistinguishable. */
+static void nhi_envelope_encode(
+        const ds4_transport_bulk_desc *desc,
+        unsigned char envelope[DS4_NHI_ENVELOPE_BYTES]) {
+    memset(envelope, 0, DS4_NHI_ENVELOPE_BYTES);
+    nhi_wire_put_u32(envelope + 0, DS4_NHI_ENVELOPE_MAGIC);
+    nhi_wire_put_u32(envelope + 4, DS4_NHI_ENVELOPE_VERSION);
+    nhi_wire_put_u32(envelope + 8, desc->kind);
+    nhi_wire_put_u32(envelope + 12, desc->element_bits);
+    nhi_wire_put_u64(envelope + 16, desc->generation);
+    nhi_wire_put_u64(envelope + 24, desc->sequence);
+    nhi_wire_put_u64(envelope + 32, desc->session_id);
+    nhi_wire_put_u64(envelope + 40, desc->request_id);
+    nhi_wire_put_u32(envelope + 48, desc->payload_bytes);
+    nhi_wire_put_u32(envelope + 52, desc->frame_count);
+    nhi_wire_put_u32(envelope + 56, desc->flags);
+    nhi_wire_put_u32(envelope + 60, 0);
+}
+
+static int nhi_envelope_matches(
+        const unsigned char envelope[DS4_NHI_ENVELOPE_BYTES],
+        const ds4_transport_bulk_desc *desc) {
+    return nhi_wire_get_u32(envelope + 0) == DS4_NHI_ENVELOPE_MAGIC &&
+        nhi_wire_get_u32(envelope + 4) == DS4_NHI_ENVELOPE_VERSION &&
+        nhi_wire_get_u32(envelope + 8) == desc->kind &&
+        nhi_wire_get_u32(envelope + 12) == desc->element_bits &&
+        nhi_wire_get_u64(envelope + 16) == desc->generation &&
+        nhi_wire_get_u64(envelope + 24) == desc->sequence &&
+        nhi_wire_get_u64(envelope + 32) == desc->session_id &&
+        nhi_wire_get_u64(envelope + 40) == desc->request_id &&
+        nhi_wire_get_u32(envelope + 48) == desc->payload_bytes &&
+        nhi_wire_get_u32(envelope + 52) == desc->frame_count &&
+        nhi_wire_get_u32(envelope + 56) == desc->flags &&
+        nhi_wire_get_u32(envelope + 60) == 0;
+}
+
+static void nhi_ring_copy_in(ds4_nhi_ctx *ctx,
+                             uint32_t first,
+                             size_t message_offset,
+                             const void *source,
+                             size_t bytes) {
+    const unsigned char *src = source;
+    size_t offset = (size_t)first * ctx->frame_size + message_offset;
+    offset %= ctx->pool_bytes;
+    while (bytes != 0) {
+        size_t chunk = ctx->pool_bytes - offset;
+        if (chunk > bytes) chunk = bytes;
+        memcpy(ctx->tx_pool + offset, src, chunk);
+        src += chunk;
+        bytes -= chunk;
+        offset = 0;
+    }
+}
+
+static void nhi_ring_copy_out(ds4_nhi_ctx *ctx,
+                              uint32_t first,
+                              size_t message_offset,
+                              void *destination,
+                              size_t bytes) {
+    unsigned char *dst = destination;
+    size_t offset = (size_t)first * ctx->frame_size + message_offset;
+    offset %= ctx->pool_bytes;
+    while (bytes != 0) {
+        size_t chunk = ctx->pool_bytes - offset;
+        if (chunk > bytes) chunk = bytes;
+        memcpy(dst, ctx->rx_pool + offset, chunk);
+        dst += chunk;
+        bytes -= chunk;
+        offset = 0;
+    }
+}
+
+static void nhi_broadcast_locked(ds4_nhi_ctx *ctx) {
+    pthread_cond_broadcast(&ctx->tx_cv);
+    pthread_cond_broadcast(&ctx->rx_cv);
+}
+
+static int nhi_fail_locked(ds4_nhi_ctx *ctx, int error_code) {
+    if (error_code <= 0) error_code = EIO;
+    if (ctx->failed == 0) ctx->failed = error_code;
+    nhi_broadcast_locked(ctx);
+    return ctx->failed;
+}
+
+static void nhi_fail(ds4_nhi_ctx *ctx, int error_code) {
+    pthread_mutex_lock(&ctx->mu);
+    int saved = nhi_fail_locked(ctx, error_code);
+    const int activated = ctx->activated;
+    pthread_mutex_unlock(&ctx->mu);
+    /* An opened endpoint is only a negotiation candidate until configure.
+     * Candidate failure must not tear down the shared TCP HELLO socket: AUTO
+     * may still select descriptor-framed TCP before the ACK commits NHI. */
+    if (activated) ds4_transport_internal_fail(ctx->owner, saved);
+}
+
+static int nhi_event_rx_valid(ds4_nhi_ctx *ctx,
+                              const struct tbstream_zc_event *ev) {
+    if (ev->nframes == 0 || ev->nframes > ctx->tx_frame_limit ||
+        ev->first >= ctx->ring_size || ev->first != ctx->rx_event_next)
+        return 0;
+    const uint64_t minimum = (uint64_t)(ev->nframes - 1u) * ctx->frame_size + 1u;
+    const uint64_t maximum = (uint64_t)ev->nframes * ctx->frame_size;
+    return ev->bytes >= minimum && ev->bytes <= maximum;
+}
+
+static int nhi_dispatch_event(ds4_nhi_ctx *ctx,
+                              const struct tbstream_zc_event *ev) {
+    int failure = 0;
+    int activated = 0;
+    pthread_mutex_lock(&ctx->mu);
+    nhi_trace(ctx,
+              "event type=%u first=%u nframes=%u bytes=%u tx_next=%u "
+              "tx_inflight=%u tx_count=%u rx_next=%u rx_event_next=%u "
+              "rx_count=%u",
+              ev->type, ev->first, ev->nframes, ev->bytes,
+              ctx->tx_next, ctx->tx_inflight, ctx->tx_count,
+              ctx->rx_next, ctx->rx_event_next, ctx->rx_count);
+    if (ctx->stopping || ctx->failed) {
+        const int already_failed = ctx->failed;
+        pthread_mutex_unlock(&ctx->mu);
+        if (already_failed) errno = already_failed;
+        return already_failed ? -1 : 0;
+    }
+    switch (ev->type) {
+    case TBSTREAM_ZC_EV_TX_DONE:
+        if (ev->bytes != 0 || ctx->tx_count == 0) {
+            failure = nhi_fail_locked(ctx, EPROTO);
+            break;
+        }
+        {
+            ds4_nhi_pending_tx *pending = &ctx->tx_pending[ctx->tx_head];
+            if (ev->first != pending->first ||
+                ev->nframes != pending->nframes ||
+                ev->nframes > ctx->tx_inflight) {
+                failure = nhi_fail_locked(ctx, EPROTO);
+                break;
+            }
+            ctx->tx_inflight -= ev->nframes;
+            ctx->tx_head = (ctx->tx_head + 1u) % ctx->ring_size;
+            ctx->tx_count--;
+            pthread_cond_broadcast(&ctx->tx_cv);
+        }
+        break;
+    case TBSTREAM_ZC_EV_RX:
+        if (!nhi_event_rx_valid(ctx, ev) || ctx->rx_count >= ctx->ring_size) {
+            failure = nhi_fail_locked(ctx, EPROTO);
+            break;
+        }
+        ctx->rx_events[ctx->rx_tail] = *ev;
+        ctx->rx_tail = (ctx->rx_tail + 1u) % ctx->ring_size;
+        ctx->rx_count++;
+        ctx->rx_event_next = (ctx->rx_event_next + ev->nframes) % ctx->ring_size;
+        pthread_cond_broadcast(&ctx->rx_cv);
+        break;
+    case TBSTREAM_ZC_EV_CLOSE:
+        ctx->peer_closed = 1;
+        nhi_broadcast_locked(ctx);
+        break;
+    default:
+        failure = nhi_fail_locked(ctx, EPROTO);
+        break;
+    }
+    activated = ctx->activated;
+    pthread_mutex_unlock(&ctx->mu);
+
+    if (failure && activated)
+        ds4_transport_internal_fail(ctx->owner, failure);
+    return failure ? -1 : 0;
+}
+
+static int nhi_reap_available(ds4_nhi_ctx *ctx) {
+    struct tbstream_zc_event events[DS4_NHI_REAP_BATCH];
+    for (;;) {
+        struct tbstream_zc_reap reap;
+        memset(&reap, 0, sizeof(reap));
+        reap.max = DS4_NHI_REAP_BATCH;
+        reap.flags = TBSTREAM_ZC_REAP_NONBLOCK;
+        reap.events = (uint64_t)(uintptr_t)events;
+        int count = ioctl(ctx->device_fd, TBSTREAM_ZC_REAP, &reap);
+        if (count < 0) {
+            if (errno == EINTR) continue;
+            if (errno == EAGAIN) return 0;
+            return -1;
+        }
+        if (count <= 0 || count > (int)DS4_NHI_REAP_BATCH) {
+            errno = EPROTO;
+            return -1;
+        }
+        for (int i = 0; i < count; i++) {
+            if (nhi_dispatch_event(ctx, &events[i]) != 0) return -1;
+        }
+    }
+}
+
+static void *nhi_dispatch_main(void *arg) {
+    ds4_nhi_ctx *ctx = arg;
+    for (;;) {
+        struct pollfd fds[3];
+        memset(fds, 0, sizeof(fds));
+        fds[0].fd = ctx->device_fd;
+        fds[0].events = POLLIN;
+        fds[1].fd = ctx->wake_fd;
+        fds[1].events = POLLIN;
+        fds[2].fd = ctx->owner->control_fd;
+#ifdef POLLRDHUP
+        fds[2].events = POLLRDHUP;
+#endif
+        int rc = poll(fds, 3, -1);
+        if (rc < 0) {
+            if (errno == EINTR) continue;
+            nhi_fail(ctx, errno);
+            break;
+        }
+        if (fds[1].revents & (POLLIN | POLLERR | POLLHUP | POLLNVAL)) break;
+        pthread_mutex_lock(&ctx->mu);
+        int stopping = ctx->stopping;
+        pthread_mutex_unlock(&ctx->mu);
+        if (stopping) break;
+
+        if (fds[2].revents & (POLLERR | POLLHUP | POLLNVAL
+#ifdef POLLRDHUP
+                              | POLLRDHUP
+#endif
+                              )) {
+            nhi_fail(ctx, ECONNRESET);
+            break;
+        }
+        if (fds[0].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            nhi_fail(ctx, ENXIO);
+            break;
+        }
+        if ((fds[0].revents & POLLIN) && nhi_reap_available(ctx) != 0) {
+            int saved = errno ? errno : EIO;
+            nhi_fail(ctx, saved);
+            break;
+        }
+    }
+    return NULL;
+}
+
+static int nhi_raw_send(ds4_transport *t, const void *buf, size_t len) {
+    return ds4_transport_tcp_write(t->control_fd, buf, len);
+}
+
+static int nhi_raw_recv(ds4_transport *t, void *buf, size_t len) {
+    return ds4_transport_tcp_read(t->control_fd, buf, len);
+}
+
+/* Backend liveness is intentionally separate from max_oob_bytes(). Geometry
+ * remains stable so a failed NHI link can never masquerade as an oversized
+ * payload and silently downgrade to TCP. Queued inbound completions may still
+ * drain after peer CLOSE, but no new outbound descriptor is prepared. */
+static int nhi_check_prepare(ds4_transport *t) {
+    ds4_nhi_ctx *ctx = t ? t->ctx : NULL;
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+    pthread_mutex_lock(&ctx->mu);
+    int saved = ctx->failed;
+    if (saved == 0 && (ctx->peer_closed || ctx->stopping)) saved = EPIPE;
+    if (saved == 0 && ctx->active_tx_lease) saved = EBUSY;
+    pthread_mutex_unlock(&ctx->mu);
+    if (saved != 0) {
+        errno = saved;
+        return -1;
+    }
+    return 0;
+}
+
+static int nhi_configure(ds4_transport *t,
+                         uint32_t peer_frame_size,
+                         uint32_t peer_ring_size,
+                         char *err,
+                         size_t errlen) {
+    ds4_nhi_ctx *ctx = t->ctx;
+    if (!ctx || peer_frame_size != ctx->frame_size || peer_ring_size < 2u) {
+        nhi_set_err(err, errlen, "NHI peer pool geometry is incompatible");
+        errno = EPROTO;
+        return -1;
+    }
+    uint32_t shared_ring = peer_ring_size < ctx->ring_size
+        ? peer_ring_size : ctx->ring_size;
+    pthread_mutex_lock(&ctx->mu);
+    if (ctx->failed || ctx->peer_closed || ctx->stopping) {
+        int saved = ctx->failed ? ctx->failed : EPIPE;
+        pthread_mutex_unlock(&ctx->mu);
+        nhi_set_err(err, errlen, "NHI candidate failed before activation");
+        errno = saved;
+        return -1;
+    }
+    if (ctx->tx_inflight != 0 || ctx->tx_count != 0 || ctx->rx_count != 0) {
+        pthread_mutex_unlock(&ctx->mu);
+        nhi_set_err(err, errlen, "NHI link has traffic before negotiation");
+        errno = EBUSY;
+        return -1;
+    }
+    ctx->tx_frame_limit = shared_ring - 1u;
+    ctx->activated = 1;
+    pthread_mutex_unlock(&ctx->mu);
+    return 0;
+}
+
+static size_t nhi_max_oob_bytes(const ds4_transport *t) {
+    const ds4_nhi_ctx *ctx_const = t ? t->ctx : NULL;
+    if (!ctx_const) return 0;
+    ds4_nhi_ctx *ctx = (ds4_nhi_ctx *)ctx_const;
+    pthread_mutex_lock(&ctx->mu);
+    /* This is negotiated geometry, not a liveness probe. Once NHI has been
+     * selected for a link, backend failure must make the next OOB operation
+     * fail; it must never silently turn a prepared message into TCP fallback
+     * after the connection generation may already have NHI traffic. */
+    const uint64_t capacity =
+        (uint64_t)ctx->tx_frame_limit * ctx->frame_size;
+    pthread_mutex_unlock(&ctx->mu);
+    if (capacity <= DS4_NHI_ENVELOPE_BYTES) return 0;
+    uint64_t payload = capacity - DS4_NHI_ENVELOPE_BYTES;
+    if (payload > (uint64_t)UINT32_MAX - DS4_NHI_ENVELOPE_BYTES)
+        payload = (uint64_t)UINT32_MAX - DS4_NHI_ENVELOPE_BYTES;
+    return payload > SIZE_MAX ? SIZE_MAX : (size_t)payload;
+}
+
+static void nhi_deadline(struct timespec *deadline, uint32_t timeout_sec) {
+    clock_gettime(CLOCK_REALTIME, deadline);
+    deadline->tv_sec += (time_t)timeout_sec;
+}
+
+static int nhi_wait_for_tx_locked(ds4_nhi_ctx *ctx, uint32_t nframes) {
+    struct timespec deadline;
+    nhi_deadline(&deadline, ctx->timeout_sec);
+    while (!ctx->stopping && !ctx->failed && !ctx->peer_closed &&
+           nframes > ctx->tx_frame_limit - ctx->tx_inflight) {
+        int rc = pthread_cond_timedwait(&ctx->tx_cv, &ctx->mu, &deadline);
+        if (rc == ETIMEDOUT) {
+            nhi_trace(ctx,
+                      "TX wait timeout need=%u inflight=%u limit=%u count=%u",
+                      nframes, ctx->tx_inflight, ctx->tx_frame_limit,
+                      ctx->tx_count);
+            errno = ETIMEDOUT;
+            return -1;
+        }
+        if (rc != 0) {
+            errno = rc;
+            return -1;
+        }
+    }
+    if (ctx->failed) {
+        errno = ctx->failed;
+        return -1;
+    }
+    if (ctx->stopping || ctx->peer_closed) {
+        errno = EPIPE;
+        return -1;
+    }
+    return 0;
+}
+
+static int nhi_send_desc(ds4_transport *t,
+                         const ds4_transport_bulk_desc *desc,
+                         const void *buf,
+                         size_t len) {
+    ds4_nhi_ctx *ctx = t->ctx;
+    const uint64_t total = (uint64_t)DS4_NHI_ENVELOPE_BYTES + len;
+    const uint32_t nframes = (uint32_t)((total + ctx->frame_size - 1u) /
+                                        ctx->frame_size);
+    const uint32_t last_len = (uint32_t)(total -
+        (uint64_t)(nframes - 1u) * ctx->frame_size);
+    if (total > UINT32_MAX || nframes == 0 ||
+        nframes != desc->frame_count ||
+        nframes > ctx->tx_frame_limit) {
+        errno = EMSGSIZE;
+        return -1;
+    }
+
+    unsigned char envelope[DS4_NHI_ENVELOPE_BYTES];
+    nhi_envelope_encode(desc, envelope);
+
+    pthread_mutex_lock(&ctx->mu);
+    if (ctx->active_tx_lease) {
+        pthread_mutex_unlock(&ctx->mu);
+        errno = EBUSY;
+        return -1;
+    }
+    if (nhi_wait_for_tx_locked(ctx, nframes) != 0) {
+        const int saved_errno = errno ? errno : EIO;
+        int saved = nhi_fail_locked(ctx, saved_errno);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = saved_errno;
+        return -1;
+    }
+    if (ctx->tx_count >= ctx->ring_size) {
+        int saved = nhi_fail_locked(ctx, EOVERFLOW);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = saved;
+        return -1;
+    }
+
+    const uint32_t first = ctx->tx_next;
+    nhi_ring_copy_in(ctx, first, 0, envelope, sizeof(envelope));
+    nhi_ring_copy_in(ctx, first, sizeof(envelope), buf, len);
+
+    struct tbstream_zc_tx tx;
+    memset(&tx, 0, sizeof(tx));
+    tx.nframes = nframes;
+    tx.last_len = last_len;
+    if (ioctl(ctx->device_fd, TBSTREAM_ZC_SUBMIT_TX, &tx) != 0) {
+        int saved_errno = errno ? errno : EIO;
+        int saved = nhi_fail_locked(ctx, saved_errno);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = saved_errno;
+        return -1;
+    }
+    if (tx.first != first) {
+        int saved = nhi_fail_locked(ctx, EPROTO);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = EPROTO;
+        return -1;
+    }
+
+    ds4_nhi_pending_tx *pending = &ctx->tx_pending[ctx->tx_tail];
+    pending->first = first;
+    pending->nframes = nframes;
+    pending->sequence = desc->sequence;
+    ctx->tx_tail = (ctx->tx_tail + 1u) % ctx->ring_size;
+    ctx->tx_count++;
+    ctx->tx_inflight += nframes;
+    ctx->tx_next = (ctx->tx_next + nframes) % ctx->ring_size;
+    pthread_mutex_unlock(&ctx->mu);
+    return 0;
+}
+
+static int nhi_wait_for_rx_locked(ds4_nhi_ctx *ctx) {
+    struct timespec deadline;
+    nhi_deadline(&deadline, ctx->timeout_sec);
+    while (ctx->rx_count == 0 && !ctx->failed && !ctx->peer_closed &&
+           !ctx->stopping) {
+        int rc = pthread_cond_timedwait(&ctx->rx_cv, &ctx->mu, &deadline);
+        if (rc == ETIMEDOUT) {
+            nhi_trace(ctx,
+                      "RX wait timeout next=%u event_next=%u count=%u",
+                      ctx->rx_next, ctx->rx_event_next, ctx->rx_count);
+            errno = ETIMEDOUT;
+            return -1;
+        }
+        if (rc != 0) {
+            errno = rc;
+            return -1;
+        }
+    }
+    if (ctx->rx_count != 0) return 1;
+    if (ctx->failed) {
+        errno = ctx->failed;
+        return -1;
+    }
+    if (ctx->peer_closed) return 0;
+    errno = ECANCELED;
+    return -1;
+}
+
+static int nhi_recv_desc(ds4_transport *t,
+                         const ds4_transport_bulk_desc *desc,
+                         void *buf,
+                         size_t len) {
+    ds4_nhi_ctx *ctx = t->ctx;
+    const uint64_t total = (uint64_t)DS4_NHI_ENVELOPE_BYTES + len;
+    const uint32_t expected_frames = (uint32_t)(
+        (total + ctx->frame_size - 1u) / ctx->frame_size);
+    if (expected_frames == 0 || expected_frames != desc->frame_count ||
+        expected_frames > ctx->tx_frame_limit || total > UINT32_MAX) {
+        errno = EMSGSIZE;
+        return -1;
+    }
+
+    pthread_mutex_lock(&ctx->mu);
+    if (ctx->active_rx_lease) {
+        pthread_mutex_unlock(&ctx->mu);
+        errno = EBUSY;
+        return -1;
+    }
+    int wait_rc = nhi_wait_for_rx_locked(ctx);
+    if (wait_rc <= 0) {
+        if (wait_rc < 0) {
+            const int saved_errno = errno ? errno : EIO;
+            int saved = nhi_fail_locked(ctx, saved_errno);
+            pthread_mutex_unlock(&ctx->mu);
+            ds4_transport_internal_fail(t, saved);
+            errno = saved_errno;
+            return -1;
+        }
+        pthread_mutex_unlock(&ctx->mu);
+        return wait_rc;
+    }
+
+    const struct tbstream_zc_event ev = ctx->rx_events[ctx->rx_head];
+    if (ev.first != ctx->rx_next || ev.nframes != expected_frames ||
+        ev.bytes != (uint32_t)total) {
+        int saved = nhi_fail_locked(ctx, EPROTO);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = EPROTO;
+        return -1;
+    }
+
+    unsigned char envelope[DS4_NHI_ENVELOPE_BYTES];
+    nhi_ring_copy_out(ctx, ev.first, 0, envelope, sizeof(envelope));
+    if (!nhi_envelope_matches(envelope, desc)) {
+        int saved = nhi_fail_locked(ctx, EPROTO);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = EPROTO;
+        return -1;
+    }
+    nhi_ring_copy_out(ctx, ev.first, sizeof(envelope), buf, len);
+
+    uint32_t repost = ev.nframes;
+    if (ioctl(ctx->device_fd, TBSTREAM_ZC_POST_RX, &repost) != 0) {
+        int saved_errno = errno ? errno : EIO;
+        int saved = nhi_fail_locked(ctx, saved_errno);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = saved_errno;
+        return -1;
+    }
+    ctx->rx_head = (ctx->rx_head + 1u) % ctx->ring_size;
+    ctx->rx_count--;
+    ctx->rx_next = (ctx->rx_next + ev.nframes) % ctx->ring_size;
+    pthread_mutex_unlock(&ctx->mu);
+    return 1;
+}
+
+static int nhi_mapped_leases_supported(const ds4_transport *t) {
+    const ds4_nhi_ctx *ctx_const = t ? t->ctx : NULL;
+    if (!ctx_const) return 0;
+    ds4_nhi_ctx *ctx = (ds4_nhi_ctx *)ctx_const;
+    pthread_mutex_lock(&ctx->mu);
+    const int supported = nhi_mapped_model_io_enabled() &&
+        ctx->gpu_mapping_registered &&
+        ctx->gpu_mapping != NULL;
+    pthread_mutex_unlock(&ctx->mu);
+    return supported;
+}
+
+static int nhi_tx_lease_acquire(ds4_transport *t,
+                                const ds4_transport_bulk_desc *desc,
+                                ds4_transport_lease *lease,
+                                char *err,
+                                size_t errlen) {
+    ds4_nhi_ctx *ctx = t ? t->ctx : NULL;
+    if (!ctx || !desc || !lease) {
+        nhi_set_err(err, errlen, "invalid NHI TX lease request");
+        errno = EINVAL;
+        return -1;
+    }
+    const uint64_t total =
+        (uint64_t)DS4_NHI_ENVELOPE_BYTES + desc->payload_bytes;
+    const uint32_t nframes = (uint32_t)(
+        (total + ctx->frame_size - 1u) / ctx->frame_size);
+    if (total > UINT32_MAX || nframes == 0 ||
+        nframes != desc->frame_count || nframes > ctx->tx_frame_limit) {
+        nhi_set_err(err, errlen, "invalid NHI TX lease geometry");
+        errno = EMSGSIZE;
+        return -1;
+    }
+
+    pthread_mutex_lock(&ctx->mu);
+    if (!ctx->gpu_mapping_registered || !ctx->gpu_mapping) {
+        pthread_mutex_unlock(&ctx->mu);
+        nhi_set_err(err, errlen, "NHI GPU mapping is unavailable");
+        errno = ENOTSUP;
+        return -1;
+    }
+    if (ctx->active_tx_lease) {
+        pthread_mutex_unlock(&ctx->mu);
+        nhi_set_err(err, errlen, "an NHI TX lease is already active");
+        errno = EBUSY;
+        return -1;
+    }
+    if (ctx->failed || ctx->peer_closed || ctx->stopping) {
+        int saved = ctx->failed ? ctx->failed : EPIPE;
+        pthread_mutex_unlock(&ctx->mu);
+        nhi_set_err(err, errlen, "NHI TX endpoint is unavailable");
+        errno = saved;
+        return -1;
+    }
+
+    const uint32_t first = ctx->tx_next;
+    const size_t payload_offset =
+        (size_t)first * ctx->frame_size + DS4_NHI_ENVELOPE_BYTES;
+    if (payload_offset > ctx->pool_bytes ||
+        desc->payload_bytes > ctx->pool_bytes - payload_offset) {
+        pthread_mutex_unlock(&ctx->mu);
+        nhi_set_err(err, errlen,
+                    "NHI TX payload wraps and requires the copy path");
+        errno = ENOTSUP;
+        return -1;
+    }
+    if (nhi_wait_for_tx_locked(ctx, nframes) != 0) {
+        const int saved_errno = errno ? errno : EIO;
+        int saved = nhi_fail_locked(ctx, saved_errno);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = saved_errno;
+        return -1;
+    }
+
+    unsigned char envelope[DS4_NHI_ENVELOPE_BYTES];
+    nhi_envelope_encode(desc, envelope);
+    nhi_ring_copy_in(ctx, first, 0, envelope, sizeof(envelope));
+
+    const size_t mapping_offset =
+        (size_t)(ctx->tx_pool - (unsigned char *)ctx->mapping) +
+        payload_offset;
+    lease->host_ptr = ctx->tx_pool + payload_offset;
+    lease->device_ptr = (unsigned char *)ctx->gpu_mapping + mapping_offset;
+    lease->bytes = desc->payload_bytes;
+    lease->first = first;
+    lease->nframes = nframes;
+    lease->event_bytes = (uint32_t)total;
+    ctx->active_tx_lease = lease;
+    nhi_trace(ctx,
+              "TX acquire seq=%llu request=%llu first=%u nframes=%u bytes=%u "
+              "inflight=%u count=%u",
+              (unsigned long long)desc->sequence,
+              (unsigned long long)desc->request_id,
+              first, nframes, (uint32_t)total,
+              ctx->tx_inflight, ctx->tx_count);
+    pthread_mutex_unlock(&ctx->mu);
+    return 0;
+}
+
+static int nhi_rx_lease_acquire(ds4_transport *t,
+                                const ds4_transport_bulk_desc *desc,
+                                ds4_transport_lease *lease,
+                                char *err,
+                                size_t errlen) {
+    ds4_nhi_ctx *ctx = t ? t->ctx : NULL;
+    if (!ctx || !desc || !lease) {
+        nhi_set_err(err, errlen, "invalid NHI RX lease request");
+        errno = EINVAL;
+        return -1;
+    }
+    const uint64_t total =
+        (uint64_t)DS4_NHI_ENVELOPE_BYTES + desc->payload_bytes;
+    const uint32_t nframes = (uint32_t)(
+        (total + ctx->frame_size - 1u) / ctx->frame_size);
+    if (total > UINT32_MAX || nframes == 0 ||
+        nframes != desc->frame_count || nframes > ctx->tx_frame_limit) {
+        nhi_set_err(err, errlen, "invalid NHI RX lease geometry");
+        errno = EMSGSIZE;
+        return -1;
+    }
+
+    pthread_mutex_lock(&ctx->mu);
+    if (!ctx->gpu_mapping_registered || !ctx->gpu_mapping) {
+        pthread_mutex_unlock(&ctx->mu);
+        nhi_set_err(err, errlen, "NHI GPU mapping is unavailable");
+        errno = ENOTSUP;
+        return -1;
+    }
+    if (ctx->active_rx_lease) {
+        pthread_mutex_unlock(&ctx->mu);
+        nhi_set_err(err, errlen, "an NHI RX lease is already active");
+        errno = EBUSY;
+        return -1;
+    }
+
+    nhi_trace(ctx,
+              "RX acquire wait seq=%llu request=%llu nframes=%u bytes=%u "
+              "next=%u event_next=%u count=%u",
+              (unsigned long long)desc->sequence,
+              (unsigned long long)desc->request_id,
+              nframes, (uint32_t)total, ctx->rx_next,
+              ctx->rx_event_next, ctx->rx_count);
+    int wait_rc = nhi_wait_for_rx_locked(ctx);
+    if (wait_rc <= 0) {
+        const int saved_errno = wait_rc == 0
+            ? ECONNRESET : (errno ? errno : EIO);
+        if (wait_rc < 0) {
+            int saved = nhi_fail_locked(ctx, saved_errno);
+            pthread_mutex_unlock(&ctx->mu);
+            ds4_transport_internal_fail(t, saved);
+        } else {
+            pthread_mutex_unlock(&ctx->mu);
+        }
+        errno = saved_errno;
+        return -1;
+    }
+
+    const struct tbstream_zc_event ev = ctx->rx_events[ctx->rx_head];
+    if (ev.first != ctx->rx_next || ev.nframes != nframes ||
+        ev.bytes != (uint32_t)total) {
+        int saved = nhi_fail_locked(ctx, EPROTO);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        nhi_set_err(err, errlen, "NHI RX lease event mismatch");
+        errno = EPROTO;
+        return -1;
+    }
+
+    unsigned char envelope[DS4_NHI_ENVELOPE_BYTES];
+    nhi_ring_copy_out(ctx, ev.first, 0, envelope, sizeof(envelope));
+    if (!nhi_envelope_matches(envelope, desc)) {
+        int saved = nhi_fail_locked(ctx, EPROTO);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        nhi_set_err(err, errlen, "NHI RX lease envelope mismatch");
+        errno = EPROTO;
+        return -1;
+    }
+
+    const size_t payload_offset =
+        (size_t)ev.first * ctx->frame_size + DS4_NHI_ENVELOPE_BYTES;
+    if (payload_offset > ctx->pool_bytes ||
+        desc->payload_bytes > ctx->pool_bytes - payload_offset) {
+        pthread_mutex_unlock(&ctx->mu);
+        nhi_set_err(err, errlen,
+                    "NHI RX payload wraps and requires the copy path");
+        errno = ENOTSUP;
+        return -1;
+    }
+
+    const size_t mapping_offset =
+        (size_t)(ctx->rx_pool - (unsigned char *)ctx->mapping) +
+        payload_offset;
+    lease->host_ptr = ctx->rx_pool + payload_offset;
+    lease->device_ptr = (unsigned char *)ctx->gpu_mapping + mapping_offset;
+    lease->bytes = desc->payload_bytes;
+    lease->first = ev.first;
+    lease->nframes = ev.nframes;
+    lease->event_bytes = ev.bytes;
+    ctx->active_rx_lease = lease;
+    nhi_trace(ctx,
+              "RX acquire ready seq=%llu request=%llu first=%u nframes=%u "
+              "bytes=%u count=%u",
+              (unsigned long long)desc->sequence,
+              (unsigned long long)desc->request_id,
+              ev.first, ev.nframes, ev.bytes, ctx->rx_count);
+    pthread_mutex_unlock(&ctx->mu);
+    return 0;
+}
+
+static int nhi_tx_lease_mark_control_sent(ds4_transport_lease *lease) {
+    if (!lease || !lease->transport ||
+        lease->direction != DS4_TRANSPORT_LEASE_TX) {
+        errno = EINVAL;
+        return -1;
+    }
+    ds4_nhi_ctx *ctx = lease->transport->ctx;
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+    pthread_mutex_lock(&ctx->mu);
+    /* The caller has already written TCP before entering this notification.
+     * Record that fact even when a concurrent backend failure is discovered. */
+    lease->control_sent = 1;
+    if (ctx->active_tx_lease != lease) {
+        pthread_mutex_unlock(&ctx->mu);
+        errno = EINVAL;
+        return -1;
+    }
+    if (ctx->failed || ctx->peer_closed || ctx->stopping) {
+        int saved = ctx->failed ? ctx->failed : EPIPE;
+        pthread_mutex_unlock(&ctx->mu);
+        errno = saved;
+        return -1;
+    }
+    pthread_mutex_unlock(&ctx->mu);
+    return 0;
+}
+
+static int nhi_mapped_sync(const char *label) {
+    if (ds4_gpu_host_mapped_synchronize(label)) return 0;
+    errno = EIO;
+    return -1;
+}
+
+static int nhi_finish_lease_failure(ds4_nhi_ctx *ctx,
+                                    ds4_transport_lease *lease,
+                                    int error_code) {
+    pthread_mutex_lock(&ctx->mu);
+    if (ctx->active_tx_lease == lease) ctx->active_tx_lease = NULL;
+    if (ctx->active_rx_lease == lease) ctx->active_rx_lease = NULL;
+    int saved = nhi_fail_locked(ctx, error_code);
+    pthread_mutex_unlock(&ctx->mu);
+    ds4_transport_internal_fail(lease->transport, saved);
+    errno = error_code > 0 ? error_code : saved;
+    return -1;
+}
+
+static int nhi_tx_lease_commit(ds4_transport_lease *lease,
+                               int gpu_quiesced) {
+    ds4_transport *t = lease ? lease->transport : NULL;
+    ds4_nhi_ctx *ctx = t ? t->ctx : NULL;
+    if (!ctx || !lease->control_sent) {
+        errno = EPERM;
+        return -1;
+    }
+    if (gpu_quiesced) {
+        nhi_trace(ctx,
+                  "TX commit sync skipped (caller GPU-quiesced) "
+                  "seq=%llu request=%llu first=%u nframes=%u",
+                  (unsigned long long)lease->desc.sequence,
+                  (unsigned long long)lease->desc.request_id,
+                  lease->first, lease->nframes);
+    } else {
+        nhi_trace(ctx,
+                  "TX commit sync begin seq=%llu request=%llu first=%u nframes=%u",
+                  (unsigned long long)lease->desc.sequence,
+                  (unsigned long long)lease->desc.request_id,
+                  lease->first, lease->nframes);
+        if (nhi_mapped_sync("NHI TX mapped ownership") != 0)
+            return nhi_finish_lease_failure(ctx, lease, EIO);
+        nhi_trace(ctx,
+                  "TX commit sync done seq=%llu request=%llu first=%u nframes=%u",
+                  (unsigned long long)lease->desc.sequence,
+                  (unsigned long long)lease->desc.request_id,
+                  lease->first, lease->nframes);
+    }
+
+    pthread_mutex_lock(&ctx->mu);
+    if (ctx->active_tx_lease != lease || !ctx->gpu_mapping_registered ||
+        ctx->failed || ctx->peer_closed || ctx->stopping ||
+        lease->first != ctx->tx_next || lease->nframes == 0 ||
+        ctx->tx_inflight > ctx->tx_frame_limit ||
+        lease->nframes > ctx->tx_frame_limit - ctx->tx_inflight ||
+        ctx->tx_count >= ctx->ring_size) {
+        int error_code = ctx->failed ? ctx->failed
+            : (ctx->peer_closed ? EPIPE
+               : (ctx->stopping ? ECANCELED : EPROTO));
+        ctx->active_tx_lease = NULL;
+        int saved = nhi_fail_locked(ctx, error_code);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = error_code;
+        return -1;
+    }
+
+    struct tbstream_zc_tx tx;
+    memset(&tx, 0, sizeof(tx));
+    tx.nframes = lease->nframes;
+    tx.last_len = lease->event_bytes -
+        (lease->nframes - 1u) * ctx->frame_size;
+    nhi_trace(ctx,
+              "TX submit begin seq=%llu request=%llu first=%u nframes=%u",
+              (unsigned long long)lease->desc.sequence,
+              (unsigned long long)lease->desc.request_id,
+              lease->first, lease->nframes);
+    if (ioctl(ctx->device_fd, TBSTREAM_ZC_SUBMIT_TX, &tx) != 0) {
+        int error_code = errno ? errno : EIO;
+        ctx->active_tx_lease = NULL;
+        int saved = nhi_fail_locked(ctx, error_code);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = error_code;
+        return -1;
+    }
+    nhi_trace(ctx,
+              "TX submit done seq=%llu request=%llu expected_first=%u got_first=%u "
+              "nframes=%u last_len=%u",
+              (unsigned long long)lease->desc.sequence,
+              (unsigned long long)lease->desc.request_id,
+              lease->first, tx.first, tx.nframes, tx.last_len);
+    if (tx.first != lease->first) {
+        ctx->active_tx_lease = NULL;
+        int saved = nhi_fail_locked(ctx, EPROTO);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = EPROTO;
+        return -1;
+    }
+
+    ds4_nhi_pending_tx *pending = &ctx->tx_pending[ctx->tx_tail];
+    pending->first = lease->first;
+    pending->nframes = lease->nframes;
+    pending->sequence = lease->desc.sequence;
+    ctx->tx_tail = (ctx->tx_tail + 1u) % ctx->ring_size;
+    ctx->tx_count++;
+    ctx->tx_inflight += lease->nframes;
+    ctx->tx_next = (ctx->tx_next + lease->nframes) % ctx->ring_size;
+    ctx->active_tx_lease = NULL;
+    pthread_mutex_unlock(&ctx->mu);
+    return 0;
+}
+
+static int nhi_rx_lease_commit(ds4_transport_lease *lease,
+                               int gpu_quiesced) {
+    ds4_transport *t = lease ? lease->transport : NULL;
+    ds4_nhi_ctx *ctx = t ? t->ctx : NULL;
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (gpu_quiesced) {
+        nhi_trace(ctx,
+                  "RX commit sync skipped (caller GPU-quiesced) "
+                  "seq=%llu request=%llu first=%u nframes=%u",
+                  (unsigned long long)lease->desc.sequence,
+                  (unsigned long long)lease->desc.request_id,
+                  lease->first, lease->nframes);
+    } else {
+        nhi_trace(ctx,
+                  "RX commit sync begin seq=%llu request=%llu first=%u nframes=%u",
+                  (unsigned long long)lease->desc.sequence,
+                  (unsigned long long)lease->desc.request_id,
+                  lease->first, lease->nframes);
+        if (nhi_mapped_sync("NHI RX mapped ownership") != 0)
+            return nhi_finish_lease_failure(ctx, lease, EIO);
+        nhi_trace(ctx,
+                  "RX commit sync done seq=%llu request=%llu first=%u nframes=%u",
+                  (unsigned long long)lease->desc.sequence,
+                  (unsigned long long)lease->desc.request_id,
+                  lease->first, lease->nframes);
+    }
+
+    pthread_mutex_lock(&ctx->mu);
+    if (ctx->active_rx_lease != lease || !ctx->gpu_mapping_registered ||
+        ctx->failed || ctx->stopping || ctx->rx_count == 0) {
+        int error_code = ctx->failed ? ctx->failed : EPROTO;
+        ctx->active_rx_lease = NULL;
+        int saved = nhi_fail_locked(ctx, error_code);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = error_code;
+        return -1;
+    }
+    const struct tbstream_zc_event *ev = &ctx->rx_events[ctx->rx_head];
+    if (ev->first != lease->first || ev->first != ctx->rx_next ||
+        ev->nframes != lease->nframes || ev->bytes != lease->event_bytes) {
+        ctx->active_rx_lease = NULL;
+        int saved = nhi_fail_locked(ctx, EPROTO);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = EPROTO;
+        return -1;
+    }
+
+    uint32_t repost = ev->nframes;
+    nhi_trace(ctx,
+              "RX repost begin seq=%llu request=%llu first=%u nframes=%u",
+              (unsigned long long)lease->desc.sequence,
+              (unsigned long long)lease->desc.request_id,
+              ev->first, ev->nframes);
+    if (ioctl(ctx->device_fd, TBSTREAM_ZC_POST_RX, &repost) != 0) {
+        int error_code = errno ? errno : EIO;
+        ctx->active_rx_lease = NULL;
+        int saved = nhi_fail_locked(ctx, error_code);
+        pthread_mutex_unlock(&ctx->mu);
+        ds4_transport_internal_fail(t, saved);
+        errno = error_code;
+        return -1;
+    }
+    nhi_trace(ctx,
+              "RX repost done seq=%llu request=%llu first=%u nframes=%u count=%u",
+              (unsigned long long)lease->desc.sequence,
+              (unsigned long long)lease->desc.request_id,
+              ev->first, ev->nframes, ctx->rx_count);
+    ctx->rx_head = (ctx->rx_head + 1u) % ctx->ring_size;
+    ctx->rx_count--;
+    ctx->rx_next = (ctx->rx_next + ev->nframes) % ctx->ring_size;
+    ctx->active_rx_lease = NULL;
+    pthread_mutex_unlock(&ctx->mu);
+    return 0;
+}
+
+static int nhi_lease_commit(ds4_transport_lease *lease, int gpu_quiesced) {
+    if (!lease) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (lease->direction == DS4_TRANSPORT_LEASE_TX)
+        return nhi_tx_lease_commit(lease, gpu_quiesced);
+    if (lease->direction == DS4_TRANSPORT_LEASE_RX)
+        return nhi_rx_lease_commit(lease, gpu_quiesced);
+    errno = EINVAL;
+    return -1;
+}
+
+static int nhi_lease_abort(ds4_transport_lease *lease) {
+    ds4_transport *t = lease ? lease->transport : NULL;
+    ds4_nhi_ctx *ctx = t ? t->ctx : NULL;
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    const int recoverable = lease->direction == DS4_TRANSPORT_LEASE_TX &&
+        !lease->control_sent;
+    /* Even a locally recoverable abort may follow queued GPU writes. Fence
+     * them before making tx_next reusable by the copy path or a new lease. */
+    if (recoverable &&
+        nhi_mapped_sync("NHI TX mapped abort ownership") != 0)
+        return nhi_finish_lease_failure(ctx, lease, EIO);
+
+    pthread_mutex_lock(&ctx->mu);
+    ds4_transport_lease **active =
+        lease->direction == DS4_TRANSPORT_LEASE_TX
+        ? &ctx->active_tx_lease : &ctx->active_rx_lease;
+    if (*active != lease) {
+        pthread_mutex_unlock(&ctx->mu);
+        errno = EINVAL;
+        return -1;
+    }
+    if (recoverable) {
+        pthread_mutex_unlock(&ctx->mu);
+        return 0;
+    }
+
+    *active = NULL;
+    int saved = nhi_fail_locked(ctx, ECANCELED);
+    pthread_mutex_unlock(&ctx->mu);
+    ds4_transport_internal_fail(t, saved);
+    errno = ECANCELED;
+    return -1;
+}
+
+static int nhi_lease_abort_finish(ds4_transport_lease *lease) {
+    ds4_transport *t = lease ? lease->transport : NULL;
+    ds4_nhi_ctx *ctx = t ? t->ctx : NULL;
+    if (!ctx || lease->direction != DS4_TRANSPORT_LEASE_TX ||
+        lease->control_sent) {
+        errno = EINVAL;
+        return -1;
+    }
+    pthread_mutex_lock(&ctx->mu);
+    if (ctx->active_tx_lease != lease) {
+        pthread_mutex_unlock(&ctx->mu);
+        errno = EINVAL;
+        return -1;
+    }
+    ctx->active_tx_lease = NULL;
+    pthread_mutex_unlock(&ctx->mu);
+    return 0;
+}
+
+static int nhi_unregister_gpu_mapping(ds4_nhi_ctx *ctx) {
+    if (!ctx || !ctx->gpu_mapping_registered) return 1;
+    if (!ds4_gpu_host_unregister_mapped(ctx->mapping)) {
+        fprintf(stderr,
+                "ds4: NHI mapped-host unregister failed; preserving mmap\n");
+        return 0;
+    }
+    ctx->gpu_mapping_registered = 0;
+    ctx->gpu_mapping = NULL;
+    return 1;
+}
+
+static void nhi_close(ds4_transport *t) {
+    ds4_nhi_ctx *ctx = t ? t->ctx : NULL;
+    if (!ctx) return;
+
+    pthread_mutex_lock(&ctx->mu);
+    ctx->stopping = 1;
+    nhi_broadcast_locked(ctx);
+    pthread_mutex_unlock(&ctx->mu);
+    if (ctx->wake_fd >= 0) {
+        uint64_t one = 1;
+        (void)write(ctx->wake_fd, &one, sizeof(one));
+    }
+    if (ctx->dispatcher_started)
+        (void)pthread_join(ctx->dispatcher, NULL);
+    const int mapping_unregistered = nhi_unregister_gpu_mapping(ctx);
+    if (ctx->mapping != MAP_FAILED && mapping_unregistered)
+        (void)munmap(ctx->mapping, ctx->mapping_bytes);
+    if (ctx->device_fd >= 0) close(ctx->device_fd);
+    if (ctx->wake_fd >= 0) close(ctx->wake_fd);
+    pthread_cond_destroy(&ctx->rx_cv);
+    pthread_cond_destroy(&ctx->tx_cv);
+    pthread_mutex_destroy(&ctx->mu);
+    free(ctx->rx_events);
+    free(ctx->tx_pending);
+    free(ctx);
+    t->ctx = NULL;
+}
+
+static const ds4_transport_ops nhi_ops = {
+    .name = "nhi-cpu-copy",
+    .caps = DS4_TRANSPORT_CAP_STREAM | DS4_TRANSPORT_CAP_ZEROCOPY,
+    .send_bulk = nhi_raw_send,
+    .recv_bulk = nhi_raw_recv,
+    .send_bulk_desc = nhi_send_desc,
+    .recv_bulk_desc = nhi_recv_desc,
+    .mapped_leases_supported = nhi_mapped_leases_supported,
+    .tx_lease_acquire = nhi_tx_lease_acquire,
+    .rx_lease_acquire = nhi_rx_lease_acquire,
+    .tx_lease_mark_control_sent = nhi_tx_lease_mark_control_sent,
+    .lease_commit = nhi_lease_commit,
+    .lease_abort = nhi_lease_abort,
+    .lease_abort_finish = nhi_lease_abort_finish,
+    .check_prepare = nhi_check_prepare,
+    .configure = nhi_configure,
+    .max_oob_bytes = nhi_max_oob_bytes,
+    .close = nhi_close,
+};
+
+static void nhi_unstarted_cleanup(ds4_nhi_ctx *ctx,
+                                  int mutex_ready,
+                                  int tx_cv_ready,
+                                  int rx_cv_ready) {
+    if (!ctx) return;
+    const int mapping_unregistered = nhi_unregister_gpu_mapping(ctx);
+    if (ctx->mapping != MAP_FAILED && mapping_unregistered)
+        (void)munmap(ctx->mapping, ctx->mapping_bytes);
+    if (ctx->device_fd >= 0) close(ctx->device_fd);
+    if (ctx->wake_fd >= 0) close(ctx->wake_fd);
+    if (rx_cv_ready) pthread_cond_destroy(&ctx->rx_cv);
+    if (tx_cv_ready) pthread_cond_destroy(&ctx->tx_cv);
+    if (mutex_ready) pthread_mutex_destroy(&ctx->mu);
+    free(ctx->rx_events);
+    free(ctx->tx_pending);
+    free(ctx);
+}
+
+static ds4_transport *nhi_create_common(
+        int control_fd,
+        int owns_control_fd,
+        const char *device_path,
+        char *err,
+        size_t errlen) {
+    if (control_fd < 0 || !device_path || !device_path[0]) {
+        nhi_set_err(err, errlen, "invalid NHI transport arguments");
+        errno = EINVAL;
+        if (owns_control_fd && control_fd >= 0) close(control_fd);
+        return NULL;
+    }
+
+    ds4_nhi_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (!ctx) {
+        nhi_set_err(err, errlen, "out of memory creating NHI transport");
+        if (owns_control_fd) close(control_fd);
+        return NULL;
+    }
+    ctx->device_fd = -1;
+    ctx->wake_fd = -1;
+    ctx->mapping = MAP_FAILED;
+    ctx->timeout_sec = nhi_timeout_sec();
+    int mutex_ready = 0, tx_cv_ready = 0, rx_cv_ready = 0;
+
+    ctx->device_fd = open(device_path, O_RDWR | O_NONBLOCK | O_CLOEXEC);
+    if (ctx->device_fd < 0) {
+        if (err && errlen)
+            snprintf(err, errlen, "open %s: %s", device_path, strerror(errno));
+        goto fail;
+    }
+    if (ioctl(ctx->device_fd, TBSTREAM_ZC_ENABLE) != 0) {
+        if (err && errlen)
+            snprintf(err, errlen, "%s: TBSTREAM_ZC_ENABLE: %s",
+                     device_path, strerror(errno));
+        goto fail;
+    }
+    struct tbstream_zc_info info;
+    memset(&info, 0, sizeof(info));
+    if (ioctl(ctx->device_fd, TBSTREAM_ZC_GET_INFO, &info) != 0) {
+        if (err && errlen)
+            snprintf(err, errlen, "%s: TBSTREAM_ZC_GET_INFO: %s",
+                     device_path, strerror(errno));
+        goto fail;
+    }
+    if (info.frame_size != TBSTREAM_ZC_FRAME_SIZE || info.ring_size < 2u ||
+        (size_t)info.ring_size > SIZE_MAX / info.frame_size) {
+        nhi_set_err(err, errlen, "invalid NHI zero-copy pool geometry");
+        errno = EPROTO;
+        goto fail;
+    }
+    ctx->frame_size = info.frame_size;
+    ctx->ring_size = info.ring_size;
+    ctx->pool_bytes = (size_t)info.ring_size * info.frame_size;
+    if (ctx->pool_bytes > SIZE_MAX / 2u || info.tx_pool_offset != 0 ||
+        info.rx_pool_offset != ctx->pool_bytes) {
+        nhi_set_err(err, errlen, "invalid NHI zero-copy pool offsets");
+        errno = EPROTO;
+        goto fail;
+    }
+    ctx->mapping_bytes = ctx->pool_bytes * 2u;
+    ctx->mapping = mmap(NULL, ctx->mapping_bytes,
+                        PROT_READ | PROT_WRITE, MAP_SHARED,
+                        ctx->device_fd, 0);
+    if (ctx->mapping == MAP_FAILED) {
+        if (err && errlen)
+            snprintf(err, errlen, "%s: mmap zero-copy pools: %s",
+                     device_path, strerror(errno));
+        goto fail;
+    }
+#ifdef MADV_DONTFORK
+    (void)madvise(ctx->mapping, ctx->mapping_bytes, MADV_DONTFORK);
+#endif
+    ctx->tx_pool = (unsigned char *)ctx->mapping + info.tx_pool_offset;
+    ctx->rx_pool = (unsigned char *)ctx->mapping + info.rx_pool_offset;
+    const int mapped_requested = nhi_mapped_model_io_enabled();
+#ifdef DS4_ROCM_BUILD
+    if (mapped_requested && ds4_gpu_host_mapping_supported()) {
+        void *gpu_mapping = NULL;
+        if (ds4_gpu_host_register_mapped(
+                ctx->mapping, (uint64_t)ctx->mapping_bytes, &gpu_mapping)) {
+            ctx->gpu_mapping = gpu_mapping;
+            ctx->gpu_mapping_registered = 1;
+        }
+    }
+#endif
+    ctx->tx_frame_limit = info.ring_size - 1u;
+    ctx->tx_pending = calloc(info.ring_size, sizeof(*ctx->tx_pending));
+    ctx->rx_events = calloc(info.ring_size, sizeof(*ctx->rx_events));
+    if (!ctx->tx_pending || !ctx->rx_events) {
+        nhi_set_err(err, errlen, "out of memory creating NHI event queues");
+        goto fail;
+    }
+    int rc = pthread_mutex_init(&ctx->mu, NULL);
+    if (rc != 0) {
+        errno = rc;
+        nhi_set_err(err, errlen, "failed to initialize NHI state mutex");
+        goto fail;
+    }
+    mutex_ready = 1;
+    rc = pthread_cond_init(&ctx->tx_cv, NULL);
+    if (rc != 0) {
+        errno = rc;
+        nhi_set_err(err, errlen, "failed to initialize NHI TX condition");
+        goto fail;
+    }
+    tx_cv_ready = 1;
+    rc = pthread_cond_init(&ctx->rx_cv, NULL);
+    if (rc != 0) {
+        errno = rc;
+        nhi_set_err(err, errlen, "failed to initialize NHI RX condition");
+        goto fail;
+    }
+    rx_cv_ready = 1;
+    ctx->wake_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    if (ctx->wake_fd < 0) {
+        nhi_set_err(err, errlen, "failed to create NHI dispatcher eventfd");
+        goto fail;
+    }
+
+    ds4_transport *t = ds4_transport_internal_create(
+        &nhi_ops, control_fd, owns_control_fd, ctx,
+        info.frame_size, info.ring_size, err, errlen);
+    if (!t) goto fail;
+    ctx->owner = t;
+    nhi_trace(ctx,
+              "created device=%s frame_size=%u ring_size=%u "
+              "mapped_requested=%d mapped=%d",
+              device_path, ctx->frame_size, ctx->ring_size,
+              mapped_requested, ctx->gpu_mapping_registered);
+    rc = pthread_create(&ctx->dispatcher, NULL, nhi_dispatch_main, ctx);
+    if (rc != 0) {
+        errno = rc;
+        nhi_set_err(err, errlen, "failed to start NHI completion dispatcher");
+        ds4_transport_release(t);
+        return NULL;
+    }
+    ctx->dispatcher_started = 1;
+    return t;
+
+fail:
+    {
+        int saved = errno ? errno : EIO;
+        nhi_unstarted_cleanup(ctx, mutex_ready, tx_cv_ready, rx_cv_ready);
+        if (owns_control_fd) close(control_fd);
+        errno = saved;
+        return NULL;
+    }
+}
+
+ds4_transport *ds4_transport_nhi_create(
+        int control_fd,
+        const char *device_path,
+        char *err,
+        size_t errlen) {
+    return nhi_create_common(control_fd, 0, device_path, err, errlen);
+}
+
+ds4_transport *ds4_transport_nhi_dup(
+        int control_fd,
+        const char *device_path,
+        char *err,
+        size_t errlen) {
+    if (control_fd < 0) {
+        nhi_set_err(err, errlen, "invalid NHI control fd");
+        errno = EINVAL;
+        return NULL;
+    }
+    int copy = fcntl(control_fd, F_DUPFD_CLOEXEC, 0);
+    if (copy < 0) {
+        nhi_set_err(err, errlen, "failed to duplicate NHI control fd");
+        return NULL;
+    }
+    return nhi_create_common(copy, 1, device_path, err, errlen);
+}
+
+#else
+
+ds4_transport *ds4_transport_nhi_create(
+        int control_fd,
+        const char *device_path,
+        char *err,
+        size_t errlen) {
+    (void)control_fd;
+    (void)device_path;
+    if (err && errlen)
+        snprintf(err, errlen, "nhi transport unavailable on this platform");
+    errno = ENOTSUP;
+    return NULL;
+}
+
+ds4_transport *ds4_transport_nhi_dup(
+        int control_fd,
+        const char *device_path,
+        char *err,
+        size_t errlen) {
+    return ds4_transport_nhi_create(control_fd, device_path, err, errlen);
+}
+
+#endif

--- a/rocm/ds4_rocm_hipblaslt.cuh
+++ b/rocm/ds4_rocm_hipblaslt.cuh
@@ -35,6 +35,13 @@ static int hipblaslt_ok(hipblasStatus_t st, const char *what) {
     return 0;
 }
 
+static int hipblaslt_ensure_ready(void) {
+    if (g_hipblaslt_ready) return 1;
+    if (!hipblaslt_ok(hipblasLtCreate(&g_hipblaslt), "create handle")) return 0;
+    g_hipblaslt_ready = 1;
+    return 1;
+}
+
 static cuda_hipblaslt_gemm_plan *hipblaslt_gemm_plan_get(
         uint32_t out_dim,
         uint32_t n_tok,
@@ -119,8 +126,9 @@ static int hipblaslt_gemm_tn_f16_out_f16(
         uint32_t n_tok,
         uint32_t in_dim,
         const char *label) {
-    if (!g_hipblaslt_ready || !out || !w_rowmajor_out_in || !x_rowmajor_tok_in ||
+    if (!out || !w_rowmajor_out_in || !x_rowmajor_tok_in ||
         out_dim == 0 || n_tok == 0 || in_dim == 0) return 0;
+    if (!hipblaslt_ensure_ready()) return 0;
     cuda_hipblaslt_gemm_plan *p = hipblaslt_gemm_plan_get(out_dim, n_tok, in_dim, label);
     if (!p) return 0;
     const float alpha = 1.0f;

--- a/rocm/ds4_rocm_runtime.cuh
+++ b/rocm/ds4_rocm_runtime.cuh
@@ -19,6 +19,7 @@ static cublasHandle_t g_cublas;
 static int g_cublas_ready;
 #ifdef __HIP_PLATFORM_AMD__
 #include "ds4_rocm_hipblaslt.cuh"
+#include "ds4_rocm_timing.cuh"
 #endif
 static int g_quality_mode;
 static int g_glm_model;
@@ -4851,7 +4852,8 @@ static const ds4_rocm_runtime_config *cuda_runtime_config(void) {
 }
 
 static bool cuda_q8_prequant_decode_enabled(void) {
-    return !g_glm_model && cuda_runtime_config()->q8_prequant_decode;
+    const ds4_rocm_runtime_config *cfg = cuda_runtime_config();
+    return !g_glm_model && !cfg->graph_dump && cfg->q8_prequant_decode;
 }
 
 static uint64_t cuda_q8_f16_cache_limit_bytes(void) {
@@ -5824,8 +5826,35 @@ static int cublas_ok(cublasStatus_t st, const char *what) {
     return 0;
 }
 
+#ifdef __HIP_PLATFORM_AMD__
+static pthread_once_t g_mapped_host_flags_once = PTHREAD_ONCE_INIT;
+
+static void cuda_mapped_host_enable_once(void) {
+    /* hipDeviceMapHost is currently always enabled/ignored by the AMD
+     * runtime.  Keep the explicit request for CUDA-compatibility semantics,
+     * but never make ordinary ROCm initialization depend on it: device
+     * discovery may already have activated the primary context. */
+    hipError_t err = hipSetDeviceFlags(hipDeviceMapHost);
+    if (err != hipSuccess) {
+        fprintf(stderr,
+                DS4_GPU_LOG_PREFIX
+                "mapped-host device flag was not applied (continuing): %s\n",
+                hipGetErrorString(err));
+        (void)hipGetLastError();
+    }
+}
+
+static void cuda_mapped_host_enable_best_effort(void) {
+    (void)pthread_once(&g_mapped_host_flags_once,
+                       cuda_mapped_host_enable_once);
+}
+#endif
+
 
 extern "C" int ds4_gpu_init(void) {
+#ifdef __HIP_PLATFORM_AMD__
+    cuda_mapped_host_enable_best_effort();
+#endif
     int dev = 0;
     if (!cuda_ok(cudaSetDevice(dev), "set device")) return 0;
     cudaDeviceProp prop;
@@ -5839,18 +5868,14 @@ extern "C" int ds4_gpu_init(void) {
         (void)cublasSetMathMode(g_cublas, math_mode);
         g_cublas_ready = 1;
     }
-#ifdef __HIP_PLATFORM_AMD__
-    if (!g_hipblaslt_ready) {
-        if (hipblaslt_ok(hipblasLtCreate(&g_hipblaslt), "create handle")) {
-            g_hipblaslt_ready = 1;
-        }
-    }
-#endif
     return 1;
 }
 
 extern "C" void ds4_gpu_cleanup(void) {
     (void)cudaDeviceSynchronize();
+#ifdef __HIP_PLATFORM_AMD__
+    ds4_rocm_timing_cleanup();
+#endif
     cuda_stream_cache_stats_print("cleanup");
     cuda_shared_gate_up_async_cleanup();
 #ifdef __HIP_PLATFORM_AMD__
@@ -5998,6 +6023,16 @@ extern "C" ds4_gpu_tensor *ds4_gpu_tensor_view(const ds4_gpu_tensor *base, uint6
     return t;
 }
 
+extern "C" ds4_gpu_tensor *ds4_gpu_tensor_wrap_external(void *device_ptr, uint64_t bytes) {
+    if (!device_ptr || bytes == 0) return NULL;
+    ds4_gpu_tensor *t = (ds4_gpu_tensor *)calloc(1, sizeof(*t));
+    if (!t) return NULL;
+    t->ptr = device_ptr;
+    t->bytes = bytes;
+    t->owner = 0;
+    return t;
+}
+
 extern "C" void ds4_gpu_tensor_free(ds4_gpu_tensor *tensor) {
     if (!tensor) return;
     if (tensor->owner && tensor->ptr) (void)cudaFree(tensor->ptr);
@@ -6013,6 +6048,72 @@ extern "C" void *ds4_gpu_tensor_contents(ds4_gpu_tensor *tensor) {
     (void)cudaDeviceSynchronize();
     return tensor->ptr;
 }
+
+#ifdef __HIP_PLATFORM_AMD__
+extern "C" int ds4_gpu_host_mapping_supported(void) {
+    int device = 0;
+    hipDeviceProp_t prop;
+    if (hipGetDevice(&device) != hipSuccess ||
+        hipGetDeviceProperties(&prop, device) != hipSuccess) {
+        (void)hipGetLastError();
+        return 0;
+    }
+    return prop.canMapHostMemory != 0;
+}
+
+extern "C" int ds4_gpu_host_register_mapped(void *host_ptr,
+                                              uint64_t bytes,
+                                              void **device_ptr) {
+    if (device_ptr) *device_ptr = NULL;
+    if (!host_ptr || !device_ptr || bytes == 0 ||
+        (uint64_t)(size_t)bytes != bytes) {
+        return 0;
+    }
+
+    cuda_mapped_host_enable_best_effort();
+    if (!ds4_gpu_host_mapping_supported()) return 0;
+
+    hipError_t err = hipHostRegister(host_ptr,
+                                     (size_t)bytes,
+                                     hipHostRegisterMapped);
+    if (err != hipSuccess) {
+        return cuda_ok(err, "mapped host registration");
+    }
+
+    void *mapped = NULL;
+    err = hipHostGetDevicePointer(&mapped, host_ptr, 0);
+    if (err != hipSuccess || !mapped) {
+        if (err != hipSuccess) {
+            (void)cuda_ok(err, "mapped host device-pointer lookup");
+        } else {
+            fprintf(stderr,
+                    DS4_GPU_LOG_PREFIX
+                    "mapped host device-pointer lookup returned NULL\n");
+        }
+        (void)hipHostUnregister(host_ptr);
+        return 0;
+    }
+
+    *device_ptr = mapped;
+    return 1;
+}
+
+extern "C" int ds4_gpu_host_mapped_synchronize(const char *label) {
+    return cuda_ok(hipDeviceSynchronize(),
+                   label && label[0]
+                       ? label
+                       : "mapped host ownership synchronization");
+}
+
+extern "C" int ds4_gpu_host_unregister_mapped(void *host_ptr) {
+    if (!host_ptr) return 0;
+    const int sync_ok = ds4_gpu_host_mapped_synchronize(
+        "mapped host unregister synchronization");
+    if (!sync_ok) return 0;
+    return cuda_ok(hipHostUnregister(host_ptr),
+                   "mapped host unregister");
+}
+#endif
 
 extern "C" int ds4_gpu_tensor_fill_f32(ds4_gpu_tensor *tensor, float value, uint64_t count) {
     if (!tensor || count > tensor->bytes / sizeof(float)) return 0;

--- a/rocm/ds4_rocm_timing.cuh
+++ b/rocm/ds4_rocm_timing.cuh
@@ -1,0 +1,221 @@
+#ifndef DS4_ROCM_TIMING_CUH
+#define DS4_ROCM_TIMING_CUH
+
+/*
+ * A small, process-wide pool keeps diagnostic timing out of the allocation
+ * hot path.  Events use the default timing-enabled mode and are recorded only
+ * on stream 0.  The public API intentionally exposes no wait operation.
+ */
+enum { DS4_ROCM_TIMING_POOL_SAMPLES = 4u };
+
+struct ds4_rocm_timing_slot {
+    hipEvent_t events[DS4_GPU_TIMING_MAX_MARKS];
+    uint32_t generation;
+    uint32_t mark_count;
+    int in_use;
+};
+
+static pthread_mutex_t g_ds4_rocm_timing_mutex = PTHREAD_MUTEX_INITIALIZER;
+static ds4_rocm_timing_slot
+    g_ds4_rocm_timing_slots[DS4_ROCM_TIMING_POOL_SAMPLES];
+/* 0 = lazy/uninitialized, 1 = ready, -1 = unavailable after allocation error. */
+static int g_ds4_rocm_timing_pool_state;
+static uint32_t g_ds4_rocm_timing_next_generation;
+
+static void ds4_rocm_timing_sample_reset(ds4_gpu_timing_sample *sample) {
+    if (!sample) return;
+    sample->slot = 0;
+    sample->generation = 0;
+    sample->mark_count = 0;
+    sample->reserved = 0;
+}
+
+static void ds4_rocm_timing_destroy_events_locked(void) {
+    for (uint32_t i = 0; i < DS4_ROCM_TIMING_POOL_SAMPLES; ++i) {
+        ds4_rocm_timing_slot *slot = &g_ds4_rocm_timing_slots[i];
+        for (uint32_t j = 0; j < DS4_GPU_TIMING_MAX_MARKS; ++j) {
+            if (slot->events[j]) {
+                (void)hipEventDestroy(slot->events[j]);
+                slot->events[j] = NULL;
+            }
+        }
+        slot->generation = 0;
+        slot->mark_count = 0;
+        slot->in_use = 0;
+    }
+}
+
+static int ds4_rocm_timing_pool_init_locked(void) {
+    if (g_ds4_rocm_timing_pool_state != 0) {
+        return g_ds4_rocm_timing_pool_state > 0;
+    }
+
+    for (uint32_t i = 0; i < DS4_ROCM_TIMING_POOL_SAMPLES; ++i) {
+        for (uint32_t j = 0; j < DS4_GPU_TIMING_MAX_MARKS; ++j) {
+            hipError_t err = hipEventCreateWithFlags(
+                &g_ds4_rocm_timing_slots[i].events[j], hipEventDefault);
+            if (err != hipSuccess) {
+                ds4_rocm_timing_destroy_events_locked();
+                g_ds4_rocm_timing_pool_state = -1;
+                return 0;
+            }
+        }
+    }
+    g_ds4_rocm_timing_pool_state = 1;
+    return 1;
+}
+
+static ds4_rocm_timing_slot *ds4_rocm_timing_slot_locked(
+        const ds4_gpu_timing_sample *sample) {
+    if (!sample || sample->slot == 0 ||
+        sample->slot > DS4_ROCM_TIMING_POOL_SAMPLES) {
+        return NULL;
+    }
+    ds4_rocm_timing_slot *slot =
+        &g_ds4_rocm_timing_slots[sample->slot - 1u];
+    if (!slot->in_use || slot->generation != sample->generation ||
+        slot->mark_count != sample->mark_count) {
+        return NULL;
+    }
+    return slot;
+}
+
+static void ds4_rocm_timing_release_locked(ds4_rocm_timing_slot *slot) {
+    if (!slot) return;
+    slot->mark_count = 0;
+    slot->in_use = 0;
+}
+
+extern "C" int ds4_gpu_timing_begin(ds4_gpu_timing_sample *sample) {
+    if (!sample) return 0;
+    ds4_rocm_timing_sample_reset(sample);
+
+    (void)pthread_mutex_lock(&g_ds4_rocm_timing_mutex);
+    if (!ds4_rocm_timing_pool_init_locked()) {
+        (void)pthread_mutex_unlock(&g_ds4_rocm_timing_mutex);
+        return 0;
+    }
+
+    ds4_rocm_timing_slot *slot = NULL;
+    uint32_t slot_index = 0;
+    for (uint32_t i = 0; i < DS4_ROCM_TIMING_POOL_SAMPLES; ++i) {
+        if (!g_ds4_rocm_timing_slots[i].in_use) {
+            slot = &g_ds4_rocm_timing_slots[i];
+            slot_index = i;
+            break;
+        }
+    }
+    if (!slot) {
+        (void)pthread_mutex_unlock(&g_ds4_rocm_timing_mutex);
+        return 0;
+    }
+
+    ++g_ds4_rocm_timing_next_generation;
+    if (g_ds4_rocm_timing_next_generation == 0) {
+        ++g_ds4_rocm_timing_next_generation;
+    }
+    slot->generation = g_ds4_rocm_timing_next_generation;
+    slot->mark_count = 1;
+    slot->in_use = 1;
+
+    hipError_t err = hipEventRecord(slot->events[0], (hipStream_t)0);
+    if (err != hipSuccess) {
+        ds4_rocm_timing_release_locked(slot);
+        (void)pthread_mutex_unlock(&g_ds4_rocm_timing_mutex);
+        return 0;
+    }
+
+    sample->slot = slot_index + 1u;
+    sample->generation = slot->generation;
+    sample->mark_count = 1;
+    sample->reserved = 0;
+    (void)pthread_mutex_unlock(&g_ds4_rocm_timing_mutex);
+    return 1;
+}
+
+extern "C" int ds4_gpu_timing_mark(ds4_gpu_timing_sample *sample) {
+    if (!sample) return 0;
+
+    (void)pthread_mutex_lock(&g_ds4_rocm_timing_mutex);
+    ds4_rocm_timing_slot *slot = ds4_rocm_timing_slot_locked(sample);
+    if (!slot || slot->mark_count >= DS4_GPU_TIMING_MAX_MARKS) {
+        ds4_rocm_timing_release_locked(slot);
+        (void)pthread_mutex_unlock(&g_ds4_rocm_timing_mutex);
+        ds4_rocm_timing_sample_reset(sample);
+        return 0;
+    }
+
+    const uint32_t mark = slot->mark_count;
+    hipError_t err = hipEventRecord(slot->events[mark], (hipStream_t)0);
+    if (err != hipSuccess) {
+        ds4_rocm_timing_release_locked(slot);
+        (void)pthread_mutex_unlock(&g_ds4_rocm_timing_mutex);
+        ds4_rocm_timing_sample_reset(sample);
+        return 0;
+    }
+
+    slot->mark_count = mark + 1u;
+    sample->mark_count = slot->mark_count;
+    (void)pthread_mutex_unlock(&g_ds4_rocm_timing_mutex);
+    return 1;
+}
+
+extern "C" int ds4_gpu_timing_collect(ds4_gpu_timing_sample *sample,
+                                        float *segment_ms,
+                                        uint32_t segment_capacity,
+                                        uint32_t *segment_count) {
+    if (segment_count) *segment_count = 0;
+    if (!sample || !segment_count) {
+        ds4_gpu_timing_discard(sample);
+        return 0;
+    }
+
+    (void)pthread_mutex_lock(&g_ds4_rocm_timing_mutex);
+    ds4_rocm_timing_slot *slot = ds4_rocm_timing_slot_locked(sample);
+    const uint32_t count = slot && slot->mark_count > 0
+        ? slot->mark_count - 1u : 0u;
+    if (!slot || count == 0 || !segment_ms || segment_capacity < count) {
+        ds4_rocm_timing_release_locked(slot);
+        (void)pthread_mutex_unlock(&g_ds4_rocm_timing_mutex);
+        ds4_rocm_timing_sample_reset(sample);
+        return 0;
+    }
+
+    /* Query is nonblocking.  Same-stream ordering means a ready final marker
+     * also guarantees that every preceding marker is complete. */
+    hipError_t err = hipEventQuery(slot->events[slot->mark_count - 1u]);
+    if (err == hipSuccess) {
+        for (uint32_t i = 0; i < count; ++i) {
+            err = hipEventElapsedTime(&segment_ms[i],
+                                      slot->events[i],
+                                      slot->events[i + 1u]);
+            if (err != hipSuccess) break;
+        }
+    }
+
+    ds4_rocm_timing_release_locked(slot);
+    (void)pthread_mutex_unlock(&g_ds4_rocm_timing_mutex);
+    ds4_rocm_timing_sample_reset(sample);
+    if (err != hipSuccess) return 0;
+    *segment_count = count;
+    return 1;
+}
+
+extern "C" void ds4_gpu_timing_discard(ds4_gpu_timing_sample *sample) {
+    if (!sample) return;
+    (void)pthread_mutex_lock(&g_ds4_rocm_timing_mutex);
+    ds4_rocm_timing_slot *slot = ds4_rocm_timing_slot_locked(sample);
+    ds4_rocm_timing_release_locked(slot);
+    (void)pthread_mutex_unlock(&g_ds4_rocm_timing_mutex);
+    ds4_rocm_timing_sample_reset(sample);
+}
+
+/* ds4_gpu_cleanup already synchronizes the device before calling this. */
+static void ds4_rocm_timing_cleanup(void) {
+    (void)pthread_mutex_lock(&g_ds4_rocm_timing_mutex);
+    ds4_rocm_timing_destroy_events_locked();
+    g_ds4_rocm_timing_pool_state = 0;
+    (void)pthread_mutex_unlock(&g_ds4_rocm_timing_mutex);
+}
+
+#endif /* DS4_ROCM_TIMING_CUH */

--- a/tests/test_dist_v3.c
+++ b/tests/test_dist_v3.c
@@ -1,0 +1,469 @@
+#include "ds4_dist_v3.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int checks;
+static int failures;
+
+#define CHECK(expr) do { \
+    checks++; \
+    if (!(expr)) { \
+        failures++; \
+        fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+    } \
+} while (0)
+
+#define NHI_FRAME_SIZE 4096u
+#define NHI_RING_LARGE 4096u
+#define NHI_RING_SMALL 2048u
+#define NHI_MAX_LARGE \
+    ((NHI_RING_LARGE - 1u) * NHI_FRAME_SIZE - DS4_TRANSPORT_BULK_DESC_BYTES)
+#define NHI_MAX_SMALL \
+    ((NHI_RING_SMALL - 1u) * NHI_FRAME_SIZE - DS4_TRANSPORT_BULK_DESC_BYTES)
+
+static ds4_dist_v3_hello_ext tcp_offer(uint32_t policy) {
+    ds4_dist_v3_hello_ext offer = {
+        DS4_DIST_V3_PROTOCOL_VERSION,
+        DS4_DIST_V3_PROTOCOL_VERSION,
+        DS4_DIST_V3_CAP_BULK_DESC_V1,
+        policy,
+        0,
+        0,
+        0,
+        0,
+    };
+    return offer;
+}
+
+static ds4_dist_v3_hello_ext nhi_offer(
+        uint32_t policy,
+        uint32_t ring_size,
+        uint32_t max_payload) {
+    ds4_dist_v3_hello_ext offer = {
+        DS4_DIST_V3_PROTOCOL_VERSION,
+        DS4_DIST_V3_PROTOCOL_VERSION,
+        DS4_DIST_V3_CAP_NHI_V1,
+        policy,
+        NHI_FRAME_SIZE,
+        ring_size,
+        max_payload,
+        0,
+    };
+    return offer;
+}
+
+static int hello_equal(
+        const ds4_dist_v3_hello_ext *a,
+        const ds4_dist_v3_hello_ext *b) {
+    return a->protocol_min == b->protocol_min &&
+        a->protocol_max == b->protocol_max &&
+        a->capabilities == b->capabilities &&
+        a->transport_policy == b->transport_policy &&
+        a->nhi_frame_size == b->nhi_frame_size &&
+        a->nhi_ring_size == b->nhi_ring_size &&
+        a->nhi_max_payload == b->nhi_max_payload &&
+        a->reserved == b->reserved;
+}
+
+static int ack_equal(
+        const ds4_dist_v3_hello_ack *a,
+        const ds4_dist_v3_hello_ack *b) {
+    uint32_t i;
+    if (a->protocol_version != b->protocol_version ||
+        a->coordinator_caps != b->coordinator_caps ||
+        a->selected_caps != b->selected_caps ||
+        a->selected_transport != b->selected_transport ||
+        a->generation_hi != b->generation_hi ||
+        a->generation_lo != b->generation_lo ||
+        a->nhi_frame_size != b->nhi_frame_size ||
+        a->nhi_ring_size != b->nhi_ring_size ||
+        a->nhi_max_payload != b->nhi_max_payload)
+        return 0;
+    for (i = 0; i < 3u; i++) {
+        if (a->reserved[i] != b->reserved[i]) return 0;
+    }
+    return 1;
+}
+
+static int ready_equal(
+        const ds4_dist_v3_hello_ready *a,
+        const ds4_dist_v3_hello_ready *b) {
+    return a->protocol_version == b->protocol_version &&
+        a->selected_transport == b->selected_transport &&
+        a->generation_hi == b->generation_hi &&
+        a->generation_lo == b->generation_lo &&
+        a->reserved[0] == b->reserved[0] &&
+        a->reserved[1] == b->reserved[1];
+}
+
+static int desc_equal(
+        const ds4_transport_bulk_desc *a,
+        const ds4_transport_bulk_desc *b) {
+    return a->mode == b->mode && a->kind == b->kind &&
+        a->generation == b->generation && a->sequence == b->sequence &&
+        a->session_id == b->session_id && a->request_id == b->request_id &&
+        a->payload_bytes == b->payload_bytes &&
+        a->element_bits == b->element_bits &&
+        a->frame_count == b->frame_count && a->flags == b->flags &&
+        a->reserved[0] == b->reserved[0] &&
+        a->reserved[1] == b->reserved[1];
+}
+
+static void test_endian_round_trips(void) {
+    ds4_dist_v3_hello_ext hello = {
+        0x01020304u, 0x11121314u, 0x21222324u, 0x31323334u,
+        0x41424344u, 0x51525354u, 0x61626364u, 0x71727374u,
+    };
+    ds4_dist_v3_hello_ext hello_wire;
+    ds4_dist_v3_hello_ext hello_got;
+    ds4_dist_v3_hello_ext_to_wire(&hello_wire, &hello);
+    ds4_dist_v3_hello_ext_from_wire(&hello_got, &hello_wire);
+    CHECK(hello_equal(&hello, &hello_got));
+
+    ds4_dist_v3_hello_ack ack = {
+        0x01020304u, 0x11121314u, 0x21222324u, 0x31323334u,
+        0x41424344u, 0x51525354u, 0x61626364u, 0x71727374u,
+        0x81828384u, {0x91929394u, 0xa1a2a3a4u, 0xb1b2b3b4u},
+    };
+    ds4_dist_v3_hello_ack ack_wire;
+    ds4_dist_v3_hello_ack ack_got;
+    ds4_dist_v3_hello_ack_to_wire(&ack_wire, &ack);
+    ds4_dist_v3_hello_ack_from_wire(&ack_got, &ack_wire);
+    CHECK(ack_equal(&ack, &ack_got));
+
+    ds4_dist_v3_hello_ready ready = {
+        0x01020304u,
+        0x11121314u,
+        0x21222324u,
+        0x31323334u,
+        {0x41424344u, 0x51525354u},
+    };
+    ds4_dist_v3_hello_ready ready_wire;
+    ds4_dist_v3_hello_ready ready_got;
+    ds4_dist_v3_hello_ready_to_wire(&ready_wire, &ready);
+    ds4_dist_v3_hello_ready_from_wire(&ready_got, &ready_wire);
+    CHECK(ready_equal(&ready, &ready_got));
+
+    ds4_transport_bulk_desc desc = {
+        DS4_TRANSPORT_BULK_NHI_OOB,
+        DS4_TRANSPORT_BULK_RESULT_LOGITS,
+        UINT64_C(0x0102030405060708),
+        UINT64_C(0x1112131415161718),
+        UINT64_C(0x2122232425262728),
+        UINT64_C(0x3132333435363738),
+        0x41424344u,
+        32u,
+        0x51525354u,
+        0,
+        {0, 0},
+    };
+    ds4_transport_bulk_desc_wire desc_wire;
+    ds4_transport_bulk_desc desc_got;
+    CHECK(ds4_transport_bulk_desc_encode(&desc, &desc_wire) == 0);
+    CHECK(desc_wire.bytes[0] == 0 && desc_wire.bytes[1] == 0 &&
+          desc_wire.bytes[2] == 0 &&
+          desc_wire.bytes[3] == DS4_TRANSPORT_BULK_NHI_OOB);
+    CHECK(desc_wire.bytes[8] == 0x01u && desc_wire.bytes[15] == 0x08u);
+    CHECK(ds4_transport_bulk_desc_decode(&desc_wire, &desc_got) == 0);
+    CHECK(desc_equal(&desc, &desc_got));
+    CHECK(ds4_transport_bulk_desc_encode(NULL, &desc_wire) == -1);
+    CHECK(ds4_transport_bulk_desc_decode(NULL, &desc_got) == -1);
+}
+
+static void test_offer_validation(void) {
+    char err[160];
+    ds4_dist_v3_hello_ext offer = tcp_offer(DS4_DIST_V3_POLICY_AUTO);
+    CHECK(ds4_dist_v3_hello_ext_validate(&offer, err, sizeof(err)) == 0);
+
+    offer = nhi_offer(DS4_DIST_V3_POLICY_AUTO, NHI_RING_LARGE,
+                      NHI_MAX_LARGE);
+    CHECK(ds4_dist_v3_hello_ext_validate(&offer, err, sizeof(err)) == 0);
+
+    offer.reserved = 1;
+    CHECK(ds4_dist_v3_hello_ext_validate(&offer, err, sizeof(err)) == -1);
+    offer = tcp_offer(DS4_DIST_V3_POLICY_AUTO);
+    offer.capabilities = 0;
+    CHECK(ds4_dist_v3_hello_ext_validate(&offer, err, sizeof(err)) == -1);
+    offer.capabilities = DS4_DIST_V3_CAP_BULK_DESC_V1 |
+                         DS4_DIST_V3_CAP_NHI_CPU_COPY_V1;
+    CHECK(ds4_dist_v3_hello_ext_validate(&offer, err, sizeof(err)) == -1);
+    offer = tcp_offer(DS4_DIST_V3_POLICY_REQUIRE_NHI);
+    CHECK(ds4_dist_v3_hello_ext_validate(&offer, err, sizeof(err)) == -1);
+    offer = nhi_offer(DS4_DIST_V3_POLICY_AUTO, NHI_RING_LARGE,
+                      NHI_MAX_LARGE + 1u);
+    CHECK(ds4_dist_v3_hello_ext_validate(&offer, err, sizeof(err)) == -1);
+    offer = tcp_offer(DS4_DIST_V3_POLICY_AUTO);
+    offer.protocol_min = DS4_DIST_V3_PROTOCOL_VERSION + 1u;
+    offer.protocol_max = offer.protocol_min;
+    CHECK(ds4_dist_v3_hello_ext_validate(&offer, err, sizeof(err)) == -1);
+    offer = tcp_offer(99u);
+    CHECK(ds4_dist_v3_hello_ext_validate(&offer, err, sizeof(err)) == -1);
+}
+
+static void test_negotiation(void) {
+    const uint64_t generation = UINT64_C(0x1020304050607080);
+    char err[160];
+    ds4_dist_v3_hello_ack ack;
+    ds4_dist_v3_hello_ext worker = tcp_offer(DS4_DIST_V3_POLICY_AUTO);
+    ds4_dist_v3_hello_ext coordinator = tcp_offer(DS4_DIST_V3_POLICY_AUTO);
+
+    CHECK(ds4_dist_v3_negotiate(&worker, &coordinator, generation,
+                                &ack, err, sizeof(err)) == 0);
+    CHECK(ack.selected_transport == DS4_DIST_V3_TRANSPORT_TCP);
+    CHECK(ack.selected_caps == DS4_DIST_V3_CAP_BULK_DESC_V1);
+    CHECK(ds4_dist_v3_u64_from_halves(ack.generation_hi,
+                                     ack.generation_lo) == generation);
+    CHECK(ack.nhi_frame_size == 0 && ack.nhi_ring_size == 0 &&
+          ack.nhi_max_payload == 0);
+    CHECK(ds4_dist_v3_hello_ack_validate(&ack, &worker,
+                                         err, sizeof(err)) == 0);
+
+    worker = nhi_offer(DS4_DIST_V3_POLICY_AUTO, NHI_RING_LARGE,
+                       NHI_MAX_LARGE);
+    coordinator = nhi_offer(DS4_DIST_V3_POLICY_AUTO, NHI_RING_SMALL,
+                            NHI_MAX_SMALL);
+    CHECK(ds4_dist_v3_negotiate(&worker, &coordinator, generation + 1u,
+                                &ack, err, sizeof(err)) == 0);
+    CHECK(ack.selected_transport == DS4_DIST_V3_TRANSPORT_NHI);
+    CHECK((ack.selected_caps & DS4_DIST_V3_CAP_NHI_V1) ==
+          DS4_DIST_V3_CAP_NHI_V1);
+    CHECK(ack.nhi_frame_size == NHI_FRAME_SIZE);
+    CHECK(ack.nhi_ring_size == NHI_RING_SMALL);
+    CHECK(ack.nhi_max_payload == NHI_MAX_SMALL);
+    CHECK(ds4_dist_v3_hello_ack_validate(&ack, &worker,
+                                         err, sizeof(err)) == 0);
+
+    coordinator = tcp_offer(DS4_DIST_V3_POLICY_AUTO);
+    CHECK(ds4_dist_v3_negotiate(&worker, &coordinator, generation + 2u,
+                                &ack, err, sizeof(err)) == 0);
+    CHECK(ack.selected_transport == DS4_DIST_V3_TRANSPORT_TCP);
+
+    worker.transport_policy = DS4_DIST_V3_POLICY_REQUIRE_NHI;
+    CHECK(ds4_dist_v3_negotiate(&worker, &coordinator, generation + 3u,
+                                &ack, err, sizeof(err)) == -1);
+    CHECK(errno == EPROTONOSUPPORT);
+
+    worker = tcp_offer(DS4_DIST_V3_POLICY_AUTO);
+    coordinator = nhi_offer(DS4_DIST_V3_POLICY_REQUIRE_NHI,
+                            NHI_RING_LARGE, NHI_MAX_LARGE);
+    CHECK(ds4_dist_v3_negotiate(&worker, &coordinator, generation + 4u,
+                                &ack, err, sizeof(err)) == -1);
+    CHECK(ds4_dist_v3_negotiate(&worker, &worker, 0,
+                                &ack, err, sizeof(err)) == -1);
+
+    worker = nhi_offer(DS4_DIST_V3_POLICY_REQUIRE_NHI,
+                       NHI_RING_LARGE, NHI_MAX_LARGE);
+    coordinator = nhi_offer(DS4_DIST_V3_POLICY_AUTO,
+                            NHI_RING_SMALL, NHI_MAX_SMALL);
+    coordinator.nhi_frame_size = 8192u;
+    coordinator.nhi_max_payload =
+        (NHI_RING_SMALL - 1u) * coordinator.nhi_frame_size -
+        DS4_TRANSPORT_BULK_DESC_BYTES;
+    CHECK(ds4_dist_v3_negotiate(&worker, &coordinator, generation + 5u,
+                                &ack, err, sizeof(err)) == -1);
+
+    worker = tcp_offer(DS4_DIST_V3_POLICY_AUTO);
+    coordinator = tcp_offer(DS4_DIST_V3_POLICY_AUTO);
+    CHECK(ds4_dist_v3_negotiate(&worker, &coordinator, generation + 6u,
+                                &ack, err, sizeof(err)) == 0);
+    ack.generation_hi = 0;
+    ack.generation_lo = 0;
+    CHECK(ds4_dist_v3_hello_ack_validate(&ack, &worker,
+                                         err, sizeof(err)) == -1);
+    CHECK(ds4_dist_v3_negotiate(&worker, &coordinator, generation + 7u,
+                                &ack, err, sizeof(err)) == 0);
+    ack.reserved[1] = 1;
+    CHECK(ds4_dist_v3_hello_ack_validate(&ack, &worker,
+                                         err, sizeof(err)) == -1);
+    ack.reserved[1] = 0;
+    ack.selected_caps |= DS4_DIST_V3_CAP_NHI_CPU_COPY_V1;
+    CHECK(ds4_dist_v3_hello_ack_validate(&ack, &worker,
+                                         err, sizeof(err)) == -1);
+
+    worker = nhi_offer(DS4_DIST_V3_POLICY_REQUIRE_NHI,
+                       NHI_RING_LARGE, NHI_MAX_LARGE);
+    coordinator = nhi_offer(DS4_DIST_V3_POLICY_AUTO,
+                            NHI_RING_LARGE, NHI_MAX_LARGE);
+    CHECK(ds4_dist_v3_negotiate(&worker, &coordinator, generation + 8u,
+                                &ack, err, sizeof(err)) == 0);
+    ack.selected_transport = DS4_DIST_V3_TRANSPORT_TCP;
+    ack.selected_caps = DS4_DIST_V3_CAP_BULK_DESC_V1;
+    ack.nhi_frame_size = 0;
+    ack.nhi_ring_size = 0;
+    ack.nhi_max_payload = 0;
+    CHECK(ds4_dist_v3_hello_ack_validate(&ack, &worker,
+                                         err, sizeof(err)) == -1);
+}
+
+static void test_frame_sizes(void) {
+    uint32_t control = 0;
+    uint32_t frame = 0;
+    const uint32_t work_control = DS4_DIST_V3_WORK_FIXED_BYTES +
+        DS4_TRANSPORT_BULK_DESC_BYTES + 8u + 12u;
+    const uint32_t result_control = DS4_DIST_V3_RESULT_FIXED_BYTES +
+        DS4_TRANSPORT_BULK_DESC_BYTES + 40u;
+
+    CHECK(ds4_dist_v3_work_frame_sizes(8, 12, 16,
+                                      DS4_TRANSPORT_BULK_TCP_INLINE,
+                                      &control, &frame) == 0);
+    CHECK(control == work_control && frame == work_control + 16u);
+    CHECK(ds4_dist_v3_work_frame_sizes(8, 12, 16,
+                                      DS4_TRANSPORT_BULK_NHI_OOB,
+                                      &control, &frame) == 0);
+    CHECK(control == work_control && frame == work_control);
+    CHECK(ds4_dist_v3_work_frame_sizes(8, 12, 0,
+                                      DS4_TRANSPORT_BULK_NONE,
+                                      &control, &frame) == 0);
+    CHECK(control == work_control && frame == work_control);
+    CHECK(ds4_dist_v3_work_frame_sizes(8, 12, 1,
+                                      DS4_TRANSPORT_BULK_NONE,
+                                      &control, &frame) == -1);
+    CHECK(ds4_dist_v3_work_frame_sizes(8, 12, 0,
+                                      DS4_TRANSPORT_BULK_TCP_INLINE,
+                                      &control, &frame) == -1);
+    CHECK(ds4_dist_v3_work_frame_sizes(UINT32_MAX, 0, 0,
+                                      DS4_TRANSPORT_BULK_NONE,
+                                      &control, &frame) == -1);
+    CHECK(errno == EOVERFLOW);
+
+    CHECK(ds4_dist_v3_result_frame_sizes(40, 0, 100,
+                                        DS4_TRANSPORT_BULK_TCP_INLINE,
+                                        &control, &frame) == 0);
+    CHECK(control == result_control && frame == result_control + 100u);
+    CHECK(ds4_dist_v3_result_frame_sizes(40, 0, 100,
+                                        DS4_TRANSPORT_BULK_NHI_OOB,
+                                        &control, &frame) == 0);
+    CHECK(control == result_control && frame == result_control);
+    CHECK(ds4_dist_v3_result_frame_sizes(40, 17, 0,
+                                        DS4_TRANSPORT_BULK_NONE,
+                                        &control, &frame) == 0);
+    CHECK(control == result_control + 17u && frame == result_control + 17u);
+    CHECK(ds4_dist_v3_result_frame_sizes(40, 1, 100,
+                                        DS4_TRANSPORT_BULK_TCP_INLINE,
+                                        &control, &frame) == -1);
+    CHECK(ds4_dist_v3_result_frame_sizes(UINT32_MAX, 0, 0,
+                                        DS4_TRANSPORT_BULK_NONE,
+                                        &control, &frame) == -1);
+    CHECK(errno == EOVERFLOW);
+}
+
+static void test_ready_barrier(void) {
+    const uint64_t generation = UINT64_C(0x123456789abcdef0);
+    char err[160];
+    ds4_dist_v3_hello_ext worker = nhi_offer(
+        DS4_DIST_V3_POLICY_AUTO, NHI_RING_LARGE, NHI_MAX_LARGE);
+    ds4_dist_v3_hello_ext coordinator = nhi_offer(
+        DS4_DIST_V3_POLICY_AUTO, NHI_RING_SMALL, NHI_MAX_SMALL);
+    ds4_dist_v3_hello_ack ack;
+    ds4_dist_v3_hello_ready ready = {0};
+
+    CHECK(ds4_dist_v3_negotiate(&worker, &coordinator, generation,
+                                &ack, err, sizeof(err)) == 0);
+    ready.protocol_version = DS4_DIST_V3_PROTOCOL_VERSION;
+    ready.selected_transport = ack.selected_transport;
+    ready.generation_hi = ack.generation_hi;
+    ready.generation_lo = ack.generation_lo;
+    CHECK(ds4_dist_v3_hello_ready_validate(&ready, &ack,
+                                           err, sizeof(err)) == 0);
+
+    ready.protocol_version++;
+    CHECK(ds4_dist_v3_hello_ready_validate(&ready, &ack,
+                                           err, sizeof(err)) == -1);
+    ready.protocol_version = DS4_DIST_V3_PROTOCOL_VERSION;
+    ready.selected_transport = DS4_DIST_V3_TRANSPORT_TCP;
+    CHECK(ds4_dist_v3_hello_ready_validate(&ready, &ack,
+                                           err, sizeof(err)) == -1);
+    ready.selected_transport = ack.selected_transport;
+    ready.generation_lo++;
+    CHECK(ds4_dist_v3_hello_ready_validate(&ready, &ack,
+                                           err, sizeof(err)) == -1);
+    ready.generation_hi = 0;
+    ready.generation_lo = 0;
+    CHECK(ds4_dist_v3_hello_ready_validate(&ready, &ack,
+                                           err, sizeof(err)) == -1);
+    ready.generation_hi = ack.generation_hi;
+    ready.generation_lo = ack.generation_lo;
+    ready.reserved[1] = 1;
+    CHECK(ds4_dist_v3_hello_ready_validate(&ready, &ack,
+                                           err, sizeof(err)) == -1);
+    CHECK(ds4_dist_v3_hello_ready_validate(NULL, &ack,
+                                           err, sizeof(err)) == -1);
+}
+
+static void test_descriptor_validation(void) {
+    char err[160];
+    ds4_transport_bulk_desc desc = {
+        DS4_TRANSPORT_BULK_TCP_INLINE,
+        DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+        9,
+        1,
+        11,
+        12,
+        4096,
+        16,
+        0,
+        0,
+        {0, 0},
+    };
+    CHECK(ds4_transport_validate_inline_desc(
+              &desc, DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+              11, 12, 4096, 16, err, sizeof(err)) == 0);
+    desc.frame_count = 1;
+    CHECK(ds4_transport_validate_inline_desc(
+              &desc, DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+              11, 12, 4096, 16, err, sizeof(err)) == -1);
+    desc.frame_count = 0;
+    desc.flags = 1;
+    CHECK(ds4_transport_validate_inline_desc(
+              &desc, DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+              11, 12, 4096, 16, err, sizeof(err)) == -1);
+    desc.flags = 0;
+    desc.generation = 0;
+    CHECK(ds4_transport_validate_inline_desc(
+              &desc, DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+              11, 12, 4096, 16, err, sizeof(err)) == -1);
+    desc.generation = 9;
+    desc.sequence = 0;
+    CHECK(ds4_transport_validate_inline_desc(
+              &desc, DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+              11, 12, 4096, 16, err, sizeof(err)) == -1);
+    desc.sequence = 1;
+    desc.reserved[1] = 1;
+    CHECK(ds4_transport_validate_inline_desc(
+              &desc, DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+              11, 12, 4096, 16, err, sizeof(err)) == -1);
+    desc.reserved[1] = 0;
+    CHECK(ds4_transport_validate_inline_desc(
+              &desc, DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+              11, 13, 4096, 16, err, sizeof(err)) == -1);
+
+    desc.mode = DS4_TRANSPORT_BULK_NHI_OOB;
+    desc.frame_count = 2;
+    ds4_transport_bulk_desc_wire wire;
+    ds4_transport_bulk_desc got;
+    CHECK(ds4_transport_bulk_desc_encode(&desc, &wire) == 0);
+    CHECK(ds4_transport_bulk_desc_decode(&wire, &got) == 0);
+    CHECK(desc_equal(&desc, &got));
+}
+
+int main(void) {
+    CHECK(sizeof(ds4_dist_v3_hello_ext) == DS4_DIST_V3_HELLO_EXT_BYTES);
+    CHECK(sizeof(ds4_dist_v3_hello_ack) == DS4_DIST_V3_HELLO_ACK_BYTES);
+    CHECK(sizeof(ds4_dist_v3_hello_ready) == DS4_DIST_V3_HELLO_READY_BYTES);
+    CHECK(sizeof(ds4_transport_bulk_desc_wire) ==
+          DS4_TRANSPORT_BULK_DESC_BYTES);
+
+    test_endian_round_trips();
+    test_offer_validation();
+    test_negotiation();
+    test_frame_sizes();
+    test_ready_barrier();
+    test_descriptor_validation();
+
+    fprintf(stderr, "test_dist_v3: %d/%d checks passed (%d failed)\n",
+            checks - failures, checks, failures);
+    return failures ? 1 : 0;
+}

--- a/tests/test_distributed_transport.c
+++ b/tests/test_distributed_transport.c
@@ -1,0 +1,16 @@
+#include "ds4_distributed.h"
+
+#include <stdio.h>
+
+int main(void) {
+    char err[256] = "";
+    int rc = ds4_dist_test_tcp_bulk_split(err, sizeof(err));
+    if (rc != 0) {
+        fprintf(stderr, "test_distributed_transport: FAIL: %s\n",
+                err[0] ? err : "unknown error");
+        return 1;
+    }
+    fprintf(stderr,
+            "test_distributed_transport: WORK/RESULT framing, mapped rejection, and v3 terminal checks passed\n");
+    return 0;
+}

--- a/tests/test_gpu_args_cli.sh
+++ b/tests/test_gpu_args_cli.sh
@@ -34,7 +34,7 @@ assert_not_grep() {
 BINS=(./ds4 ./ds4-server ./ds4-bench ./ds4-agent)
 NAMES=(ds4 ds4-server ds4-bench ds4-agent)
 
-# 1: each binary's --help mentions both flags.
+# 1: each binary advertises the options supported by its GPU backend.
 for i in "${!BINS[@]}"; do
     name=${NAMES[$i]}; bin=${BINS[$i]}
     if [ ! -x "$bin" ]; then
@@ -42,16 +42,52 @@ for i in "${!BINS[@]}"; do
         continue
     fi
     "$bin" --help > "$LOG" 2>&1 || true
-    assert_grep "$name --help mentions --gpu-vram" "gpu-vram" "$LOG"
-    assert_grep "$name --help mentions --gpu-devices" "gpu-devices" "$LOG"
-    assert_grep "$name --help mentions --cuda-tensor-parallel" "cuda-tensor-parallel" "$LOG"
+    if grep -q -- "--rocm" "$LOG" 2>/dev/null; then
+        assert_grep "$name --help mentions --rocm" "--rocm" "$LOG"
+        assert_not_grep "$name --help omits CUDA tensor parallelism" \
+            "--cuda-tensor-parallel" "$LOG"
+    else
+        assert_grep "$name --help mentions --gpu-vram" "--gpu-vram" "$LOG"
+        assert_grep "$name --help mentions --gpu-devices" "--gpu-devices" "$LOG"
+        assert_grep "$name --help mentions --cuda-tensor-parallel" \
+            "--cuda-tensor-parallel" "$LOG"
+    fi
     if [ "$name" = "ds4" ]; then
         "$bin" --help distributed > "$LOG" 2>&1 || true
         assert_grep "$name --help distributed mentions --tensor-parallel-token-prefill" \
             "tensor-parallel-token-prefill" "$LOG"
+        assert_grep "$name --help distributed mentions --dist-transport" \
+            "--dist-transport" "$LOG"
+        assert_grep "$name --help distributed mentions --dist-nhi-device" \
+            "--dist-nhi-device" "$LOG"
         assert_not_grep "$name --help distributed omits old --tp spellings" "--tp-" "$LOG"
     fi
 done
+
+# ds4-bench owns legacy-MTP benchmark options in addition to the shared
+# runtime help/parser surface.
+if [ -x ./ds4-bench ]; then
+    ./ds4-bench --help > "$LOG" 2>&1 || true
+    assert_grep "ds4-bench --help mentions --mtp" "--mtp FILE" "$LOG"
+    assert_grep "ds4-bench --help mentions --mtp-draft" "--mtp-draft" "$LOG"
+    assert_grep "ds4-bench --help mentions --mtp-margin" "--mtp-margin" "$LOG"
+
+    for bad in \
+        "--mtp-draft 0" \
+        "--mtp-margin -1" \
+        "--mtp-margin 1001" \
+        "--mtp-margin nan"
+    do
+        # Word splitting is intentional: each item is one option/value pair.
+        ./ds4-bench $bad --prompt-file /dev/null -m /dev/null > "$LOG" 2>&1
+        rc=$?
+        if [ $rc -eq 2 ] && ! grep -q "unknown option" "$LOG"; then
+            ok "ds4-bench rejects $bad"
+        else
+            fail "ds4-bench did not reject $bad in its MTP parser"
+        fi
+    done
+fi
 
 # 2: parser error on syntactically invalid value. For ds4-bench, we
 # also pass --prompt-file /dev/null so it doesn't exit on the

--- a/tests/test_gpu_timing_stubs.c
+++ b/tests/test_gpu_timing_stubs.c
@@ -1,0 +1,65 @@
+#include "ds4_gpu.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+static int checks;
+static int failures;
+
+#define CHECK(expr) do { \
+    ++checks; \
+    if (!(expr)) { \
+        ++failures; \
+        fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+    } \
+} while (0)
+
+static int sample_is_reset(const ds4_gpu_timing_sample *sample) {
+    return sample && sample->slot == 0 && sample->generation == 0 &&
+           sample->mark_count == 0 && sample->reserved == 0;
+}
+
+static ds4_gpu_timing_sample poisoned_sample(void) {
+    ds4_gpu_timing_sample sample = {1, 2, 3, 4};
+    return sample;
+}
+
+int main(void) {
+    ds4_gpu_timing_sample sample = poisoned_sample();
+    CHECK(ds4_gpu_timing_begin(&sample) == 0);
+    CHECK(sample_is_reset(&sample));
+
+    CHECK(ds4_gpu_timing_mark(&sample) == 0);
+    CHECK(sample_is_reset(&sample));
+
+    sample = poisoned_sample();
+    float segments[2] = {17.0f, 23.0f};
+    uint32_t segment_count = 99;
+    CHECK(ds4_gpu_timing_collect(&sample, segments, 2, &segment_count) == 0);
+    CHECK(sample_is_reset(&sample));
+    CHECK(segment_count == 0);
+    CHECK(segments[0] == 17.0f && segments[1] == 23.0f);
+
+    sample = poisoned_sample();
+    CHECK(ds4_gpu_timing_collect(&sample, NULL, 0, NULL) == 0);
+    CHECK(sample_is_reset(&sample));
+
+    sample = poisoned_sample();
+    ds4_gpu_timing_discard(&sample);
+    CHECK(sample_is_reset(&sample));
+
+    segment_count = 99;
+    CHECK(ds4_gpu_timing_begin(NULL) == 0);
+    CHECK(ds4_gpu_timing_mark(NULL) == 0);
+    CHECK(ds4_gpu_timing_collect(NULL, segments, 2, &segment_count) == 0);
+    CHECK(segment_count == 0);
+    ds4_gpu_timing_discard(NULL);
+
+    if (failures) {
+        fprintf(stderr, "GPU timing stubs: %d/%d checks failed\n", failures,
+                checks);
+        return 1;
+    }
+    printf("GPU timing stubs: %d checks passed\n", checks);
+    return 0;
+}

--- a/tests/test_mxfp4_rocm.c
+++ b/tests/test_mxfp4_rocm.c
@@ -1,0 +1,590 @@
+/* Synthetic end-to-end test for the ROCm MXFP4 routed-MoE paths.
+ *
+ * The ROCm kernels quantize both the input and the fused FP32 SwiGLU mid
+ * activation to Q8_K.  The CPU oracle below independently mirrors that
+ * quantization before applying the MXFP4 weights.  Four repeated routing
+ * patterns keep the 512-token reference inexpensive while still exercising
+ * token indexing, expert bucketing, rectangular expert matrices, multiple
+ * Q8_K chunks per row, and expert IDs at both ends of a 256-expert table.
+ */
+
+#include "ds4_gpu.h"
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#define MXFP4_TYPE 39u
+#define QK_MXFP4 32u
+#define QK_K 256u
+#define N_TOTAL_EXPERT 256u
+#define N_EXPERT 6u
+#define MODEL_DIM 512u
+#define FFN_DIM 256u
+#define N_PATTERN 4u
+#define CLAMP 7.0f
+
+typedef struct {
+    uint8_t e;
+    uint8_t qs[QK_MXFP4 / 2u];
+} block_mxfp4;
+
+typedef struct {
+    float d;
+    int8_t qs[QK_K];
+} ref_block_q8_K;
+
+typedef struct {
+    float x[MODEL_DIM];
+    int32_t selected[N_EXPERT];
+    float weights[N_EXPERT];
+    float mid[N_EXPERT * FFN_DIM];
+    float out[MODEL_DIM];
+} reference_pattern;
+
+static const float mxfp4_values[16] = {
+     0.0f,  0.5f,  1.0f,  1.5f,  2.0f,  3.0f,  4.0f,  6.0f,
+    -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+};
+
+static uint64_t align_up(uint64_t value, uint64_t alignment) {
+    return (value + alignment - 1u) / alignment * alignment;
+}
+
+static uint32_t mix32(uint32_t x) {
+    x ^= x >> 16u;
+    x *= 0x7feb352du;
+    x ^= x >> 15u;
+    x *= 0x846ca68bu;
+    x ^= x >> 16u;
+    return x;
+}
+
+static float e8m0_to_f32(uint8_t e) {
+    uint32_t bits = e == 0u ? 0x00400000u : (uint32_t)e << 23u;
+    float value;
+    memcpy(&value, &bits, sizeof(value));
+    return value;
+}
+
+static void quantize_q8_K_block(ref_block_q8_K *out, const float *x) {
+    float amax = 0.0f;
+    float maxv = 0.0f;
+    for (uint32_t i = 0; i < QK_K; i++) {
+        const float ax = fabsf(x[i]);
+        /* The device reduction also keeps the lower index on an exact tie. */
+        if (ax > amax) {
+            amax = ax;
+            maxv = x[i];
+        }
+    }
+    if (amax == 0.0f) {
+        out->d = 0.0f;
+        memset(out->qs, 0, sizeof(out->qs));
+        return;
+    }
+
+    const float iscale = -127.0f / maxv;
+    out->d = 1.0f / iscale;
+    for (uint32_t i = 0; i < QK_K; i++) {
+        long q = lrintf(iscale * x[i]);
+        if (q > 127) q = 127;
+        if (q < -128) q = -128;
+        out->qs[i] = (int8_t)q;
+    }
+}
+
+static void quantize_q8_K(ref_block_q8_K *out,
+                          const float *x,
+                          uint32_t n) {
+    for (uint32_t block = 0; block < n / QK_K; block++) {
+        quantize_q8_K_block(out + block, x + (uint64_t)block * QK_K);
+    }
+}
+
+static float dot_mxfp4_q8_K(const block_mxfp4 *row,
+                            const ref_block_q8_K *x,
+                            uint32_t input_dim) {
+    float sum = 0.0f;
+    const uint32_t mxfp4_per_q8 = QK_K / QK_MXFP4;
+    for (uint32_t block = 0; block < input_dim / QK_MXFP4; block++) {
+        const block_mxfp4 *b = row + block;
+        const ref_block_q8_K *xb = x + block / mxfp4_per_q8;
+        const uint32_t q8_offset = (block % mxfp4_per_q8) * QK_MXFP4;
+        const float scale = e8m0_to_f32(b->e) * xb->d;
+        for (uint32_t i = 0; i < QK_MXFP4 / 2u; i++) {
+            const uint8_t q = b->qs[i];
+            sum += scale * mxfp4_values[q & 15u] *
+                   (float)xb->qs[q8_offset + i];
+            sum += scale * mxfp4_values[q >> 4u] *
+                   (float)xb->qs[q8_offset + i + QK_MXFP4 / 2u];
+        }
+    }
+    return sum;
+}
+
+static void fill_matrix(block_mxfp4 *matrix,
+                        uint32_t rows,
+                        uint32_t input_dim,
+                        uint32_t salt) {
+    const uint32_t blocks_per_row = input_dim / QK_MXFP4;
+    for (uint32_t expert = 0; expert < N_TOTAL_EXPERT; expert++) {
+        for (uint32_t row = 0; row < rows; row++) {
+            block_mxfp4 *blocks = matrix +
+                ((uint64_t)expert * rows + row) * blocks_per_row;
+            for (uint32_t block = 0; block < blocks_per_row; block++) {
+                block_mxfp4 *b = blocks + block;
+                const uint32_t key = salt ^ (expert * 0x9e3779b9u) ^
+                                     (row * 0x85ebca6bu) ^
+                                     (block * 0xc2b2ae35u);
+                b->e = (uint8_t)(120u + mix32(key) % 5u);
+                for (uint32_t i = 0; i < QK_MXFP4 / 2u; i++) {
+                    const uint32_t h = mix32(key + i * 0x27d4eb2du);
+                    b->qs[i] = (uint8_t)((h & 15u) | (((h >> 9u) & 15u) << 4u));
+                }
+            }
+        }
+    }
+}
+
+static const block_mxfp4 *matrix_row(const block_mxfp4 *matrix,
+                                      uint32_t expert,
+                                      uint32_t row,
+                                      uint32_t rows,
+                                      uint32_t input_dim) {
+    return matrix + ((uint64_t)expert * rows + row) *
+                    (input_dim / QK_MXFP4);
+}
+
+static void init_patterns(reference_pattern patterns[N_PATTERN]) {
+    static const int32_t selected[N_PATTERN][N_EXPERT] = {
+        {   0,   1,   2,   3,   4, 255 },
+        {  17,  63, 127, 128, 200, 254 },
+        { 255,   0, 129,  42,  11, 201 },
+        {   5,  85, 170, 250,  13, 199 },
+    };
+    static const float base_weights[N_EXPERT] = {
+        0.25f, 0.20f, 0.18f, 0.15f, 0.12f, 0.10f,
+    };
+
+    memset(patterns, 0, sizeof(reference_pattern) * N_PATTERN);
+    for (uint32_t p = 0; p < N_PATTERN; p++) {
+        memcpy(patterns[p].selected, selected[p], sizeof(selected[p]));
+        for (uint32_t slot = 0; slot < N_EXPERT; slot++) {
+            patterns[p].weights[slot] =
+                base_weights[(slot + p) % N_EXPERT];
+        }
+        for (uint32_t i = 0; i < MODEL_DIM; i++) {
+            const uint32_t h = mix32(i + 1u + p * 0x9e3779b9u);
+            patterns[p].x[i] =
+                (float)((int32_t)(h % 255u) - 127) / 256.0f;
+        }
+        /* Give each vector a unique signed maximum so Q8_K scale selection
+         * is deterministic on both the CPU and GPU. */
+        patterns[p].x[19u + p * 47u] = (p & 1u) ? 0.875f : -0.875f;
+    }
+}
+
+static void build_reference(reference_pattern *pattern,
+                            const block_mxfp4 *gate_matrix,
+                            const block_mxfp4 *up_matrix,
+                            const block_mxfp4 *down_matrix) {
+    ref_block_q8_K xq[MODEL_DIM / QK_K];
+    ref_block_q8_K midq[N_EXPERT][FFN_DIM / QK_K];
+    quantize_q8_K(xq, pattern->x, MODEL_DIM);
+
+    for (uint32_t slot = 0; slot < N_EXPERT; slot++) {
+        const uint32_t expert = (uint32_t)pattern->selected[slot];
+        float *mid = pattern->mid + (uint64_t)slot * FFN_DIM;
+        for (uint32_t row = 0; row < FFN_DIM; row++) {
+            float gate = dot_mxfp4_q8_K(
+                matrix_row(gate_matrix, expert, row, FFN_DIM, MODEL_DIM),
+                xq, MODEL_DIM);
+            float up = dot_mxfp4_q8_K(
+                matrix_row(up_matrix, expert, row, FFN_DIM, MODEL_DIM),
+                xq, MODEL_DIM);
+            if (gate > CLAMP) gate = CLAMP;
+            if (up > CLAMP) up = CLAMP;
+            if (up < -CLAMP) up = -CLAMP;
+            mid[row] = (gate / (1.0f + expf(-gate))) * up *
+                       pattern->weights[slot];
+        }
+        quantize_q8_K(midq[slot], mid, FFN_DIM);
+    }
+
+    for (uint32_t row = 0; row < MODEL_DIM; row++) {
+        float sum = 0.0f;
+        for (uint32_t slot = 0; slot < N_EXPERT; slot++) {
+            const uint32_t expert = (uint32_t)pattern->selected[slot];
+            sum += dot_mxfp4_q8_K(
+                matrix_row(down_matrix, expert, row, MODEL_DIM, FFN_DIM),
+                midq[slot], FFN_DIM);
+        }
+        pattern->out[row] = sum;
+    }
+}
+
+static int compare_repeated(const char *name,
+                            const float *actual,
+                            uint32_t n_tokens,
+                            uint32_t token_elems,
+                            const reference_pattern patterns[N_PATTERN],
+                            bool compare_mid,
+                            float abs_tolerance,
+                            float rel_tolerance) {
+    float max_abs = 0.0f;
+    float max_ratio = 0.0f;
+    uint64_t max_abs_index = 0u;
+    uint64_t max_ratio_index = 0u;
+    uint64_t failures = 0u;
+    const uint64_t count = (uint64_t)n_tokens * token_elems;
+
+    for (uint32_t token = 0; token < n_tokens; token++) {
+        const float *expected = compare_mid ?
+            patterns[token % N_PATTERN].mid :
+            patterns[token % N_PATTERN].out;
+        for (uint32_t i = 0; i < token_elems; i++) {
+            const uint64_t index = (uint64_t)token * token_elems + i;
+            const float got = actual[index];
+            const float want = expected[i];
+            if (!isfinite(got) || !isfinite(want)) {
+                fprintf(stderr,
+                        "MXFP4 ROCm tokens=%u %s non-finite at token=%u element=%u "
+                        "got=%g expected=%g\n",
+                        n_tokens, name, token, i, got, want);
+                return 0;
+            }
+            const float error = fabsf(got - want);
+            const float allowed = abs_tolerance + rel_tolerance * fabsf(want);
+            const float ratio = allowed > 0.0f ? error / allowed : error;
+            if (error > max_abs) {
+                max_abs = error;
+                max_abs_index = index;
+            }
+            if (ratio > max_ratio) {
+                max_ratio = ratio;
+                max_ratio_index = index;
+            }
+            if (error > allowed) failures++;
+        }
+    }
+
+    fprintf(stderr,
+            "MXFP4 ROCm tokens=%-3u %-3s max_abs=%-10g at=%llu "
+            "max_tol_ratio=%g at=%llu failures=%llu/%llu\n",
+            n_tokens, name, max_abs, (unsigned long long)max_abs_index,
+            max_ratio, (unsigned long long)max_ratio_index,
+            (unsigned long long)failures, (unsigned long long)count);
+    return failures == 0u;
+}
+
+static int run_case(uint32_t n_tokens,
+                    const void *model,
+                    uint64_t model_size,
+                    uint64_t gate_offset,
+                    uint64_t up_offset,
+                    uint64_t down_offset,
+                    uint64_t gate_expert_bytes,
+                    uint64_t gate_row_bytes,
+                    uint64_t down_expert_bytes,
+                    uint64_t down_row_bytes,
+                    const reference_pattern patterns[N_PATTERN]) {
+    const uint64_t token_x_count = (uint64_t)n_tokens * MODEL_DIM;
+    const uint64_t route_count = (uint64_t)n_tokens * N_EXPERT;
+    const uint64_t mid_count = route_count * FFN_DIM;
+    const uint64_t down_count = route_count * MODEL_DIM;
+    const uint64_t out_count = token_x_count;
+    float *x = (float *)calloc((size_t)token_x_count, sizeof(float));
+    int32_t *selected = (int32_t *)calloc((size_t)route_count, sizeof(int32_t));
+    float *weights = (float *)calloc((size_t)route_count, sizeof(float));
+    float *mid_actual = (float *)calloc((size_t)mid_count, sizeof(float));
+    float *out_actual = (float *)calloc((size_t)out_count, sizeof(float));
+    ds4_gpu_tensor *x_tensor = NULL;
+    ds4_gpu_tensor *selected_tensor = NULL;
+    ds4_gpu_tensor *weights_tensor = NULL;
+    ds4_gpu_tensor *gate_tensor = NULL;
+    ds4_gpu_tensor *up_tensor = NULL;
+    ds4_gpu_tensor *mid_tensor = NULL;
+    ds4_gpu_tensor *experts_tensor = NULL;
+    ds4_gpu_tensor *out_tensor = NULL;
+    int ok = x && selected && weights && mid_actual && out_actual;
+
+    for (uint32_t token = 0; ok && token < n_tokens; token++) {
+        const reference_pattern *pattern = &patterns[token % N_PATTERN];
+        memcpy(x + (uint64_t)token * MODEL_DIM,
+               pattern->x, sizeof(pattern->x));
+        memcpy(selected + (uint64_t)token * N_EXPERT,
+               pattern->selected, sizeof(pattern->selected));
+        memcpy(weights + (uint64_t)token * N_EXPERT,
+               pattern->weights, sizeof(pattern->weights));
+    }
+
+    if (ok) x_tensor = ds4_gpu_tensor_alloc(token_x_count * sizeof(float));
+    if (ok) selected_tensor = ds4_gpu_tensor_alloc(route_count * sizeof(int32_t));
+    if (ok) weights_tensor = ds4_gpu_tensor_alloc(route_count * sizeof(float));
+    if (ok) gate_tensor = ds4_gpu_tensor_alloc(mid_count * sizeof(float));
+    if (ok) up_tensor = ds4_gpu_tensor_alloc(mid_count * sizeof(float));
+    if (ok) mid_tensor = ds4_gpu_tensor_alloc(mid_count * sizeof(float));
+    if (ok) experts_tensor = ds4_gpu_tensor_alloc(down_count * sizeof(float));
+    if (ok) out_tensor = ds4_gpu_tensor_alloc(out_count * sizeof(float));
+    ok = ok && x_tensor && selected_tensor && weights_tensor && gate_tensor &&
+         up_tensor && mid_tensor && experts_tensor && out_tensor;
+
+    ok = ok && ds4_gpu_tensor_write(
+        x_tensor, 0u, x, token_x_count * sizeof(float));
+    ok = ok && ds4_gpu_tensor_write(
+        selected_tensor, 0u, selected, route_count * sizeof(int32_t));
+    ok = ok && ds4_gpu_tensor_write(
+        weights_tensor, 0u, weights, route_count * sizeof(float));
+
+    if (ok && n_tokens == 1u) {
+        ok = ds4_gpu_routed_moe_one_tensor(
+            out_tensor, gate_tensor, up_tensor, mid_tensor, experts_tensor,
+            model, model_size, gate_offset, up_offset, down_offset,
+            MXFP4_TYPE, MXFP4_TYPE, gate_expert_bytes, gate_row_bytes,
+            down_expert_bytes, down_row_bytes,
+            MODEL_DIM, FFN_DIM, MODEL_DIM,
+            selected_tensor, weights_tensor, N_TOTAL_EXPERT, N_EXPERT,
+            CLAMP, x_tensor, NULL, 0u, true);
+    } else if (ok) {
+        bool mid_is_f16 = true;
+        ok = ds4_gpu_routed_moe_batch_tensor(
+            out_tensor, gate_tensor, up_tensor, mid_tensor, experts_tensor,
+            model, model_size, gate_offset, up_offset, down_offset,
+            MXFP4_TYPE, MXFP4_TYPE, gate_expert_bytes, gate_row_bytes,
+            down_expert_bytes, down_row_bytes,
+            MODEL_DIM, FFN_DIM, MODEL_DIM,
+            selected_tensor, weights_tensor, N_TOTAL_EXPERT, N_EXPERT,
+            CLAMP, x_tensor, 0u, n_tokens, &mid_is_f16, true);
+        if (ok && mid_is_f16) {
+            fprintf(stderr,
+                    "MXFP4 ROCm tokens=%u unexpectedly reported FP16 mid storage\n",
+                    n_tokens);
+            ok = 0;
+        }
+    }
+
+    if (!ok) {
+        fprintf(stderr, "MXFP4 ROCm tokens=%u launch failed\n", n_tokens);
+    }
+    ok = ok && ds4_gpu_tensor_read(
+        mid_tensor, 0u, mid_actual, mid_count * sizeof(float));
+    ok = ok && ds4_gpu_tensor_read(
+        out_tensor, 0u, out_actual, out_count * sizeof(float));
+
+    if (ok) {
+        /* Gate/up are optional scratch outputs in the optimized ROCm paths;
+         * mid is the public, stable result of that fused stage. */
+        const int mid_ok = compare_repeated(
+            "mid", mid_actual, n_tokens, N_EXPERT * FFN_DIM, patterns, true,
+            1.0e-4f, 1.0e-4f);
+        const int out_ok = compare_repeated(
+            "out", out_actual, n_tokens, MODEL_DIM, patterns, false,
+            2.0e-4f, 1.0e-4f);
+        ok = mid_ok && out_ok;
+    }
+
+    ds4_gpu_tensor_free(out_tensor);
+    ds4_gpu_tensor_free(experts_tensor);
+    ds4_gpu_tensor_free(mid_tensor);
+    ds4_gpu_tensor_free(up_tensor);
+    ds4_gpu_tensor_free(gate_tensor);
+    ds4_gpu_tensor_free(weights_tensor);
+    ds4_gpu_tensor_free(selected_tensor);
+    ds4_gpu_tensor_free(x_tensor);
+    free(out_actual);
+    free(mid_actual);
+    free(weights);
+    free(selected);
+    free(x);
+    return ok;
+}
+
+static int run_streaming_decode_cases(
+        const void *model,
+        uint64_t model_size,
+        uint64_t gate_offset,
+        uint64_t up_offset,
+        uint64_t down_offset,
+        uint64_t gate_expert_bytes,
+        uint64_t gate_row_bytes,
+        uint64_t down_expert_bytes,
+        uint64_t down_row_bytes,
+        const reference_pattern patterns[N_PATTERN]) {
+    const ds4_gpu_stream_expert_table table = {
+        .model_map = model,
+        .model_size = model_size,
+        .layer = 0u,
+        .n_total_expert = N_TOTAL_EXPERT,
+        .gate_offset = gate_offset,
+        .up_offset = up_offset,
+        .down_offset = down_offset,
+        .gate_expert_bytes = gate_expert_bytes,
+        .down_expert_bytes = down_expert_bytes,
+    };
+    int ok = 1;
+
+    ds4_gpu_set_ssd_streaming(true);
+    ds4_gpu_set_streaming_expert_cache_budget(N_EXPERT);
+
+    fprintf(stderr, "MXFP4 ROCm SSD streaming cold selected decode\n");
+    ok = ds4_gpu_stream_expert_cache_begin_selected_load(
+             &table, patterns[0].selected, N_EXPERT) &&
+         ds4_gpu_routed_moe_set_selected_override(
+             patterns[0].selected, N_EXPERT) &&
+         run_case(1u, model, model_size,
+                  gate_offset, up_offset, down_offset,
+                  gate_expert_bytes, gate_row_bytes,
+                  down_expert_bytes, down_row_bytes, patterns);
+
+    /* Force the non-split apply path on a warm resident-cache hit too.  Both
+     * routes must remap the original expert IDs to tightly packed slots; the
+     * MXFP4 payload itself remains the exact 17-byte GGUF block stream. */
+    if (ok && setenv("DS4_ROCM_DISABLE_STREAMING_SPLIT_SELECTED", "1", 1) != 0) {
+        ok = 0;
+    }
+    if (ok) {
+        fprintf(stderr, "MXFP4 ROCm SSD streaming warm compact decode\n");
+        ok = ds4_gpu_stream_expert_cache_begin_selected_load(
+                 &table, patterns[0].selected, N_EXPERT) &&
+             ds4_gpu_routed_moe_set_selected_override(
+                 patterns[0].selected, N_EXPERT) &&
+             run_case(1u, model, model_size,
+                      gate_offset, up_offset, down_offset,
+                      gate_expert_bytes, gate_row_bytes,
+                      down_expert_bytes, down_row_bytes, patterns);
+    }
+    (void)unsetenv("DS4_ROCM_DISABLE_STREAMING_SPLIT_SELECTED");
+    ds4_gpu_stream_expert_cache_release_resident();
+    ds4_gpu_set_ssd_streaming(false);
+    return ok;
+}
+
+int main(void) {
+    static const uint32_t token_cases[] = {
+        1u, 2u, 3u, 4u, 5u, 32u, 128u, 512u,
+    };
+    const uint64_t gate_row_bytes =
+        (MODEL_DIM / QK_MXFP4) * sizeof(block_mxfp4);
+    const uint64_t gate_expert_bytes = FFN_DIM * gate_row_bytes;
+    const uint64_t gate_tensor_bytes =
+        N_TOTAL_EXPERT * gate_expert_bytes;
+    const uint64_t down_row_bytes =
+        (FFN_DIM / QK_MXFP4) * sizeof(block_mxfp4);
+    const uint64_t down_expert_bytes = MODEL_DIM * down_row_bytes;
+    const uint64_t down_tensor_bytes =
+        N_TOTAL_EXPERT * down_expert_bytes;
+    const uint64_t gate_offset = 0u;
+    const uint64_t up_offset = align_up(gate_tensor_bytes, 4096u);
+    const uint64_t down_offset =
+        align_up(up_offset + gate_tensor_bytes, 4096u);
+    const uint64_t model_size =
+        align_up(down_offset + down_tensor_bytes, 4096u);
+    FILE *model_file = NULL;
+    void *model = MAP_FAILED;
+    reference_pattern *patterns = NULL;
+    int initialized = 0;
+    int ok = sizeof(block_mxfp4) == 17u;
+
+    if (!ok) {
+        fprintf(stderr, "MXFP4 ROCm unexpected block size %zu (expected 17)\n",
+                sizeof(block_mxfp4));
+        return 1;
+    }
+
+    model_file = tmpfile();
+    if (model_file &&
+        ftruncate(fileno(model_file), (off_t)model_size) == 0) {
+        model = mmap(NULL, (size_t)model_size, PROT_READ | PROT_WRITE,
+                     MAP_SHARED, fileno(model_file), 0);
+    }
+    patterns = (reference_pattern *)calloc(N_PATTERN, sizeof(*patterns));
+    if (!model_file || model == MAP_FAILED || !patterns) {
+        fprintf(stderr, "MXFP4 ROCm host allocation failed\n");
+        ok = 0;
+        goto cleanup;
+    }
+    memset(model, 0, (size_t)model_size);
+    fill_matrix((block_mxfp4 *)((uint8_t *)model + gate_offset),
+                FFN_DIM, MODEL_DIM, 0x12345678u);
+    fill_matrix((block_mxfp4 *)((uint8_t *)model + up_offset),
+                FFN_DIM, MODEL_DIM, 0x9abcdef0u);
+    fill_matrix((block_mxfp4 *)((uint8_t *)model + down_offset),
+                MODEL_DIM, FFN_DIM, 0x0f1e2d3cu);
+    init_patterns(patterns);
+
+    const block_mxfp4 *gate_matrix =
+        (const block_mxfp4 *)((const uint8_t *)model + gate_offset);
+    const block_mxfp4 *up_matrix =
+        (const block_mxfp4 *)((const uint8_t *)model + up_offset);
+    const block_mxfp4 *down_matrix =
+        (const block_mxfp4 *)((const uint8_t *)model + down_offset);
+    for (uint32_t p = 0; p < N_PATTERN; p++) {
+        build_reference(&patterns[p], gate_matrix, up_matrix, down_matrix);
+    }
+
+    fprintf(stderr,
+            "MXFP4 ROCm synthetic model: %.2f MiB, experts=%u, "
+            "model_dim=%u, ffn_dim=%u, selected=%u\n",
+            (double)model_size / 1048576.0, N_TOTAL_EXPERT,
+            MODEL_DIM, FFN_DIM, N_EXPERT);
+    ok = ds4_gpu_init();
+    initialized = ok;
+    if (!ok) {
+        fprintf(stderr, "MXFP4 ROCm ds4_gpu_init failed\n");
+        goto cleanup;
+    }
+    ds4_gpu_set_quality(false);
+    ds4_gpu_set_ssd_streaming(false);
+    const uint64_t model_offsets[] = {
+        gate_offset, up_offset, down_offset,
+    };
+    const uint64_t model_sizes[] = {
+        gate_tensor_bytes, gate_tensor_bytes, down_tensor_bytes,
+    };
+    const uint64_t max_tensor_bytes =
+        gate_tensor_bytes > down_tensor_bytes ?
+        gate_tensor_bytes : down_tensor_bytes;
+    ok = ds4_gpu_set_model_map(model, model_size) &&
+         ds4_gpu_set_model_fd(fileno(model_file)) &&
+         ds4_gpu_set_model_map_spans(
+             model, model_size, model_offsets, model_sizes,
+             sizeof(model_offsets) / sizeof(model_offsets[0]),
+             max_tensor_bytes);
+    if (!ok) {
+        fprintf(stderr, "MXFP4 ROCm model cache setup failed\n");
+        goto cleanup;
+    }
+
+    for (uint32_t i = 0; i < sizeof(token_cases) / sizeof(token_cases[0]); i++) {
+        if (!run_case(token_cases[i], model, model_size,
+                      gate_offset, up_offset, down_offset,
+                      gate_expert_bytes, gate_row_bytes,
+                      down_expert_bytes, down_row_bytes, patterns)) {
+            ok = 0;
+        }
+    }
+    if (ok && !run_streaming_decode_cases(
+                  model, model_size,
+                  gate_offset, up_offset, down_offset,
+                  gate_expert_bytes, gate_row_bytes,
+                  down_expert_bytes, down_row_bytes, patterns)) {
+        ok = 0;
+    }
+
+cleanup:
+    if (initialized) {
+        ds4_gpu_set_model_fd(-1);
+        ds4_gpu_cleanup();
+    }
+    free(patterns);
+    if (model != MAP_FAILED) munmap(model, (size_t)model_size);
+    if (model_file) fclose(model_file);
+    fprintf(stderr, "MXFP4 ROCm routed MoE: %s\n", ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}

--- a/tests/test_nhi_live.c
+++ b/tests/test_nhi_live.c
@@ -1,0 +1,1239 @@
+/*
+ * Opt-in, model-independent two-host test for the DS4 NHI CPU-copy backend.
+ *
+ * This binary deliberately stays out of `make test`: it requires a connected
+ * /dev/tbstreamX endpoint on each host.  TCP carries only this test's HELLO,
+ * READY, descriptor, and completion records; payloads must use NHI OOB mode.
+ */
+
+#include "ds4_transport.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <netdb.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#define LIVE_MAGIC 0x44344c56u /* D4LV */
+#define LIVE_VERSION 1u
+#define LIVE_HELLO_BYTES 32u
+#define LIVE_CONTROL_BYTES (16u + DS4_TRANSPORT_BULK_DESC_BYTES)
+#define LIVE_DEFAULT_PORT "48444"
+#define LIVE_DEFAULT_DEVICE "/dev/tbstream0"
+#define LIVE_DEFAULT_TIMEOUT_SEC 30u
+#define LIVE_MIN_MESSAGES 32u
+#define LIVE_REQUIRED_WRAPS 2u
+#define LIVE_MAX_PAYLOAD_BYTES (16u * 1024u * 1024u)
+#define LIVE_MAX_SIZES 8u
+#define LIVE_ENVELOPE_BYTES 64u
+
+#define LIVE_ROLE_SERVER 1u
+#define LIVE_ROLE_CLIENT 2u
+#define LIVE_HELLO_F_GPU_ALIAS 0x00000001u
+
+#define LIVE_CONTROL_READY 1u
+#define LIVE_CONTROL_DESC 2u
+#define LIVE_CONTROL_DONE 3u
+#define LIVE_CONTROL_ERROR 4u
+
+#define LIVE_SESSION_C2S UINT64_C(0x4e48494c49564501)
+#define LIVE_SESSION_S2C UINT64_C(0x4e48494c49564502)
+
+typedef struct {
+    int server;
+    int require_mapped;
+    int require_copy;
+    int require_gpu_alias;
+    const char *host;
+    const char *port;
+    const char *device;
+    uint32_t timeout_sec;
+} live_options;
+
+typedef struct {
+    uint32_t role;
+    uint32_t frame_size;
+    uint32_t ring_size;
+    uint32_t flags;
+    uint64_t generation;
+} live_hello;
+
+typedef struct {
+    uint32_t type;
+    uint32_t status;
+    ds4_transport_bulk_desc desc;
+} live_control;
+
+typedef struct {
+    size_t sizes[LIVE_MAX_SIZES];
+    size_t size_count;
+    size_t max_payload;
+    uint64_t messages;
+    uint64_t frames_per_direction;
+    uint64_t bytes_per_direction;
+} live_plan;
+
+typedef struct {
+    uint64_t tx_mapped;
+    uint64_t tx_copy;
+    uint64_t rx_mapped;
+    uint64_t rx_copy;
+    uint64_t tx_gpu_alias;
+    uint64_t rx_gpu_alias;
+} live_path_counts;
+
+#ifdef DS4_ROCM_BUILD
+int ds4_test_nhi_gpu_alias_fill(void *device_ptr,
+                                uint64_t bytes,
+                                uint32_t direction,
+                                uint64_t generation,
+                                uint64_t message);
+int ds4_test_nhi_gpu_alias_verify(const void *device_ptr,
+                                  uint64_t bytes,
+                                  uint32_t direction,
+                                  uint64_t generation,
+                                  uint64_t message,
+                                  uint64_t *first_bad);
+#endif
+
+static int live_validate_paths(const live_options *options,
+                               const live_plan *plan,
+                               const live_path_counts *paths);
+
+static void live_usage(FILE *out, const char *program) {
+    fprintf(out,
+            "Usage:\n"
+            "  server: %s --listen [--port PORT] [--device PATH] [--timeout SEC]\n"
+            "            [--require-mapped] [--require-copy] [--require-gpu-alias]\n"
+            "  client: %s --connect HOST [--port PORT] [--device PATH] [--timeout SEC]\n"
+            "            [--require-mapped] [--require-copy] [--require-gpu-alias]\n"
+            "\n"
+            "Run one command on each directly connected host. Defaults: port %s,\n"
+            "device %s, timeout %u seconds. The test is destructive only to the\n"
+            "exclusive endpoint session and fails if the device is already open.\n"
+            "Traffic covers frame boundaries and at least two full ring wraps.\n",
+            program, program, LIVE_DEFAULT_PORT, LIVE_DEFAULT_DEVICE,
+            LIVE_DEFAULT_TIMEOUT_SEC);
+}
+
+static int live_error(const char *format, ...) {
+    va_list ap;
+    va_start(ap, format);
+    fputs("test_nhi_live: ", stderr);
+    vfprintf(stderr, format, ap);
+    fputc('\n', stderr);
+    va_end(ap);
+    return -1;
+}
+
+static int live_parse_u32(const char *text, uint32_t low, uint32_t high,
+                          uint32_t *out) {
+    if (!text || !text[0] || !out) return -1;
+    errno = 0;
+    char *end = NULL;
+    unsigned long value = strtoul(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0' ||
+        value < low || value > high) return -1;
+    *out = (uint32_t)value;
+    return 0;
+}
+
+static int live_parse_options(int argc, char **argv, live_options *options) {
+    memset(options, 0, sizeof(*options));
+    options->port = LIVE_DEFAULT_PORT;
+    options->device = LIVE_DEFAULT_DEVICE;
+    options->timeout_sec = LIVE_DEFAULT_TIMEOUT_SEC;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+            live_usage(stdout, argv[0]);
+            return 1;
+        }
+        if (strcmp(argv[i], "--listen") == 0) {
+            if (options->server || options->host)
+                return live_error("choose exactly one of --listen or --connect");
+            options->server = 1;
+            continue;
+        }
+        if (strcmp(argv[i], "--require-mapped") == 0) {
+            options->require_mapped = 1;
+            continue;
+        }
+        if (strcmp(argv[i], "--require-copy") == 0) {
+            options->require_copy = 1;
+            continue;
+        }
+        if (strcmp(argv[i], "--require-gpu-alias") == 0) {
+            options->require_gpu_alias = 1;
+            options->require_mapped = 1;
+            continue;
+        }
+        if (strcmp(argv[i], "--connect") == 0) {
+            if (options->server || options->host || i + 1 >= argc)
+                return live_error("--connect requires one host and one role");
+            options->host = argv[++i];
+            if (!options->host[0]) return live_error("empty --connect host");
+            continue;
+        }
+        if (strcmp(argv[i], "--port") == 0) {
+            uint32_t port;
+            if (i + 1 >= argc ||
+                live_parse_u32(argv[i + 1], 1u, 65535u, &port) != 0)
+                return live_error("--port must be an integer from 1 to 65535");
+            options->port = argv[++i];
+            continue;
+        }
+        if (strcmp(argv[i], "--device") == 0) {
+            if (i + 1 >= argc || !argv[i + 1][0])
+                return live_error("--device requires a path");
+            options->device = argv[++i];
+            continue;
+        }
+        if (strcmp(argv[i], "--timeout") == 0) {
+            if (i + 1 >= argc ||
+                live_parse_u32(argv[i + 1], 1u, 3600u,
+                               &options->timeout_sec) != 0)
+                return live_error("--timeout must be an integer from 1 to 3600");
+            i++;
+            continue;
+        }
+        return live_error("unknown argument: %s", argv[i]);
+    }
+    if (!options->server && !options->host) {
+        live_usage(stderr, argv[0]);
+        return live_error("choose --listen or --connect HOST");
+    }
+    return 0;
+}
+
+static void live_put_u32(unsigned char *p, uint32_t value) {
+    value = htonl(value);
+    memcpy(p, &value, sizeof(value));
+}
+
+static uint32_t live_get_u32(const unsigned char *p) {
+    uint32_t value;
+    memcpy(&value, p, sizeof(value));
+    return ntohl(value);
+}
+
+static void live_put_u64(unsigned char *p, uint64_t value) {
+    live_put_u32(p, (uint32_t)(value >> 32));
+    live_put_u32(p + 4, (uint32_t)value);
+}
+
+static uint64_t live_get_u64(const unsigned char *p) {
+    return ((uint64_t)live_get_u32(p) << 32) | live_get_u32(p + 4);
+}
+
+static int live_write(int fd, const void *buf, size_t bytes) {
+    if (ds4_transport_tcp_write(fd, buf, bytes) == 0) return 0;
+    return live_error("TCP write: %s", strerror(errno));
+}
+
+static int live_read(int fd, void *buf, size_t bytes) {
+    int rc = ds4_transport_tcp_read(fd, buf, bytes);
+    if (rc == 1) return 0;
+    if (rc == 0) errno = ECONNRESET;
+    return live_error("TCP read: %s", strerror(errno));
+}
+
+static int live_send_hello(int fd, const live_hello *hello) {
+    unsigned char wire[LIVE_HELLO_BYTES];
+    memset(wire, 0, sizeof(wire));
+    live_put_u32(wire + 0, LIVE_MAGIC);
+    live_put_u32(wire + 4, LIVE_VERSION);
+    live_put_u32(wire + 8, hello->role);
+    live_put_u32(wire + 12, hello->frame_size);
+    live_put_u32(wire + 16, hello->ring_size);
+    live_put_u32(wire + 20, hello->flags);
+    live_put_u64(wire + 24, hello->generation);
+    return live_write(fd, wire, sizeof(wire));
+}
+
+static int live_recv_hello(int fd, live_hello *hello) {
+    unsigned char wire[LIVE_HELLO_BYTES];
+    if (live_read(fd, wire, sizeof(wire)) != 0) return -1;
+    if (live_get_u32(wire + 0) != LIVE_MAGIC ||
+        live_get_u32(wire + 4) != LIVE_VERSION) {
+        errno = EPROTO;
+        return live_error("invalid peer HELLO record");
+    }
+    hello->role = live_get_u32(wire + 8);
+    hello->frame_size = live_get_u32(wire + 12);
+    hello->ring_size = live_get_u32(wire + 16);
+    hello->flags = live_get_u32(wire + 20);
+    if ((hello->flags & ~LIVE_HELLO_F_GPU_ALIAS) != 0) {
+        errno = EPROTO;
+        return live_error("peer HELLO has unsupported feature flags");
+    }
+    hello->generation = live_get_u64(wire + 24);
+    return 0;
+}
+
+static int live_send_control(int fd, uint32_t type, uint32_t status,
+                             const ds4_transport_bulk_desc *desc) {
+    unsigned char wire[LIVE_CONTROL_BYTES];
+    memset(wire, 0, sizeof(wire));
+    live_put_u32(wire + 0, LIVE_MAGIC);
+    live_put_u32(wire + 4, LIVE_VERSION);
+    live_put_u32(wire + 8, type);
+    live_put_u32(wire + 12, status);
+    if (desc) {
+        ds4_transport_bulk_desc_wire desc_wire;
+        if (ds4_transport_bulk_desc_encode(desc, &desc_wire) != 0)
+            return live_error("encode descriptor: %s", strerror(errno));
+        memcpy(wire + 16, desc_wire.bytes, sizeof(desc_wire.bytes));
+    }
+    return live_write(fd, wire, sizeof(wire));
+}
+
+static int live_recv_control(int fd, live_control *control) {
+    unsigned char wire[LIVE_CONTROL_BYTES];
+    if (live_read(fd, wire, sizeof(wire)) != 0) return -1;
+    if (live_get_u32(wire + 0) != LIVE_MAGIC ||
+        live_get_u32(wire + 4) != LIVE_VERSION) {
+        errno = EPROTO;
+        return live_error("invalid peer control record");
+    }
+    memset(control, 0, sizeof(*control));
+    control->type = live_get_u32(wire + 8);
+    control->status = live_get_u32(wire + 12);
+    if (control->type < LIVE_CONTROL_READY ||
+        control->type > LIVE_CONTROL_ERROR) {
+        errno = EPROTO;
+        return live_error("unknown peer control type %u", control->type);
+    }
+    if ((control->type != LIVE_CONTROL_ERROR && control->status != 0) ||
+        (control->type == LIVE_CONTROL_ERROR &&
+         (control->status == 0 || control->status > INT32_MAX))) {
+        errno = EPROTO;
+        return live_error("invalid status %u for control type %u",
+                          control->status, control->type);
+    }
+    if (control->type == LIVE_CONTROL_DESC) {
+        ds4_transport_bulk_desc_wire desc_wire;
+        memcpy(desc_wire.bytes, wire + 16, sizeof(desc_wire.bytes));
+        if (ds4_transport_bulk_desc_decode(&desc_wire, &control->desc) != 0)
+            return live_error("decode descriptor: %s", strerror(errno));
+    } else {
+        for (size_t i = 16; i < sizeof(wire); i++) {
+            if (wire[i] != 0) {
+                errno = EPROTO;
+                return live_error("nonzero reserved control bytes");
+            }
+        }
+    }
+    return 0;
+}
+
+static void live_send_error_best_effort(int fd, int error_code) {
+    if (fd < 0) return;
+    if (error_code <= 0) error_code = EIO;
+    (void)live_send_control(fd, LIVE_CONTROL_ERROR,
+                            (uint32_t)error_code, NULL);
+}
+
+static int live_peer_error(const live_control *control) {
+    if (control->type != LIVE_CONTROL_ERROR) return 0;
+    int error_code = control->status > 0 && control->status <= INT32_MAX
+        ? (int)control->status : EPROTO;
+    errno = error_code;
+    return live_error("peer reported failure: %s", strerror(error_code));
+}
+
+static int live_set_cloexec(int fd) {
+    int flags = fcntl(fd, F_GETFD, 0);
+    if (flags < 0 || fcntl(fd, F_SETFD, flags | FD_CLOEXEC) != 0) return -1;
+    return 0;
+}
+
+static int live_set_socket_options(int fd, uint32_t timeout_sec) {
+    struct timeval timeout;
+    timeout.tv_sec = (time_t)timeout_sec;
+    timeout.tv_usec = 0;
+    int one = 1;
+    if (live_set_cloexec(fd) != 0 ||
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO,
+                   &timeout, sizeof(timeout)) != 0 ||
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO,
+                   &timeout, sizeof(timeout)) != 0 ||
+        setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one)) != 0)
+        return -1;
+    return 0;
+}
+
+static int live_poll(int fd, short events, uint32_t timeout_sec) {
+    struct pollfd pfd;
+    memset(&pfd, 0, sizeof(pfd));
+    pfd.fd = fd;
+    pfd.events = events;
+    const int timeout_ms = timeout_sec > (uint32_t)(INT32_MAX / 1000)
+        ? INT32_MAX : (int)(timeout_sec * 1000u);
+    for (;;) {
+        int rc = poll(&pfd, 1, timeout_ms);
+        if (rc > 0) return 0;
+        if (rc == 0) {
+            errno = ETIMEDOUT;
+            return -1;
+        }
+        if (errno != EINTR) return -1;
+    }
+}
+
+static int live_listen(const char *port, uint32_t timeout_sec) {
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+    struct addrinfo *addresses = NULL;
+    int gai_rc = getaddrinfo(NULL, port, &hints, &addresses);
+    if (gai_rc != 0) {
+        live_error("getaddrinfo for port %s: %s", port,
+                   gai_strerror(gai_rc));
+        errno = EINVAL;
+        return -1;
+    }
+
+    int listener = -1;
+    int saved = EADDRNOTAVAIL;
+    for (const struct addrinfo *address = addresses;
+         address; address = address->ai_next) {
+        listener = socket(address->ai_family, address->ai_socktype,
+                          address->ai_protocol);
+        if (listener < 0) {
+            saved = errno;
+            continue;
+        }
+        int one = 1;
+        (void)setsockopt(listener, SOL_SOCKET, SO_REUSEADDR,
+                         &one, sizeof(one));
+        if (live_set_cloexec(listener) == 0 &&
+            bind(listener, address->ai_addr, address->ai_addrlen) == 0 &&
+            listen(listener, 1) == 0)
+            break;
+        saved = errno;
+        close(listener);
+        listener = -1;
+    }
+    freeaddrinfo(addresses);
+    if (listener < 0) {
+        errno = saved;
+        live_error("listen on port %s: %s", port, strerror(errno));
+        return -1;
+    }
+
+    fprintf(stderr, "test_nhi_live: waiting on TCP port %s (%us timeout)\n",
+            port, timeout_sec);
+    if (live_poll(listener, POLLIN, timeout_sec) != 0) {
+        saved = errno;
+        live_error("accept wait: %s", strerror(saved));
+        close(listener);
+        errno = saved;
+        return -1;
+    }
+    int fd;
+    do {
+        fd = accept(listener, NULL, NULL);
+    } while (fd < 0 && errno == EINTR);
+    saved = errno;
+    close(listener);
+    if (fd < 0) {
+        errno = saved;
+        live_error("accept: %s", strerror(errno));
+        return -1;
+    }
+    if (live_set_socket_options(fd, timeout_sec) != 0) {
+        saved = errno;
+        live_error("accepted socket options: %s", strerror(saved));
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+}
+
+static int live_connect(const char *host, const char *port,
+                        uint32_t timeout_sec) {
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    struct addrinfo *addresses = NULL;
+    int gai_rc = getaddrinfo(host, port, &hints, &addresses);
+    if (gai_rc != 0) {
+        live_error("getaddrinfo for %s:%s: %s", host, port,
+                   gai_strerror(gai_rc));
+        errno = EINVAL;
+        return -1;
+    }
+
+    int fd = -1;
+    int saved = ECONNREFUSED;
+    for (const struct addrinfo *address = addresses;
+         address; address = address->ai_next) {
+        fd = socket(address->ai_family, address->ai_socktype,
+                    address->ai_protocol);
+        if (fd < 0) {
+            saved = errno;
+            continue;
+        }
+        int flags = fcntl(fd, F_GETFL, 0);
+        if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) != 0) {
+            saved = errno;
+            close(fd);
+            fd = -1;
+            continue;
+        }
+        int rc = connect(fd, address->ai_addr, address->ai_addrlen);
+        if (rc != 0 && errno == EINPROGRESS) {
+            rc = live_poll(fd, POLLOUT, timeout_sec);
+            if (rc == 0) {
+                socklen_t len = sizeof(saved);
+                if (getsockopt(fd, SOL_SOCKET, SO_ERROR,
+                               &saved, &len) != 0)
+                    saved = errno;
+                rc = saved == 0 ? 0 : -1;
+            } else {
+                saved = errno;
+            }
+        } else if (rc != 0) {
+            saved = errno;
+        }
+        if (rc == 0 && fcntl(fd, F_SETFL, flags) == 0) break;
+        if (rc == 0) saved = errno;
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(addresses);
+    if (fd < 0) {
+        errno = saved;
+        live_error("connect to %s:%s: %s", host, port, strerror(errno));
+        return -1;
+    }
+    if (live_set_socket_options(fd, timeout_sec) != 0) {
+        saved = errno;
+        live_error("connected socket options: %s", strerror(saved));
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+}
+
+static uint64_t live_generation(void) {
+    struct timespec realtime;
+    struct timespec monotonic;
+    memset(&realtime, 0, sizeof(realtime));
+    memset(&monotonic, 0, sizeof(monotonic));
+    (void)clock_gettime(CLOCK_REALTIME, &realtime);
+    (void)clock_gettime(CLOCK_MONOTONIC, &monotonic);
+    uint64_t value = (uint64_t)realtime.tv_sec;
+    value ^= (uint64_t)realtime.tv_nsec << 32;
+    value ^= (uint64_t)monotonic.tv_nsec << 1;
+    value ^= (uint64_t)(unsigned)getpid() << 17;
+    value ^= value >> 30;
+    value *= UINT64_C(0xbf58476d1ce4e5b9);
+    value ^= value >> 27;
+    value *= UINT64_C(0x94d049bb133111eb);
+    value ^= value >> 31;
+    return value ? value : UINT64_C(1);
+}
+
+static uint64_t live_now_ns(void) {
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) return 0;
+    return (uint64_t)now.tv_sec * UINT64_C(1000000000) +
+        (uint64_t)now.tv_nsec;
+}
+
+static void live_add_size(live_plan *plan, uint64_t candidate,
+                          size_t payload_cap) {
+    if (candidate == 0 || candidate > payload_cap ||
+        candidate > UINT32_MAX || plan->size_count >= LIVE_MAX_SIZES)
+        return;
+    const size_t value = (size_t)candidate;
+    for (size_t i = 0; i < plan->size_count; i++) {
+        if (plan->sizes[i] == value) return;
+    }
+    plan->sizes[plan->size_count++] = value;
+    if (value > plan->max_payload) plan->max_payload = value;
+}
+
+static uint32_t live_frames(size_t bytes, uint32_t frame_size) {
+    const uint64_t total = LIVE_ENVELOPE_BYTES + (uint64_t)bytes;
+    return (uint32_t)((total + frame_size - 1u) / frame_size);
+}
+
+static int live_build_plan(uint32_t frame_size, uint32_t wrap_ring,
+                           size_t max_oob, live_plan *plan) {
+    memset(plan, 0, sizeof(*plan));
+    if (frame_size <= LIVE_ENVELOPE_BYTES || wrap_ring < 2u ||
+        max_oob == 0)
+        return live_error("unusable negotiated NHI geometry");
+    size_t payload_cap = max_oob;
+    if (payload_cap > LIVE_MAX_PAYLOAD_BYTES)
+        payload_cap = LIVE_MAX_PAYLOAD_BYTES;
+
+    live_add_size(plan, 1u, payload_cap);
+    live_add_size(plan, 64u, payload_cap);
+    live_add_size(plan, frame_size / 2u, payload_cap);
+    live_add_size(plan, (uint64_t)frame_size - LIVE_ENVELOPE_BYTES,
+                  payload_cap);
+    live_add_size(plan, (uint64_t)frame_size - LIVE_ENVELOPE_BYTES + 1u,
+                  payload_cap);
+    live_add_size(plan, (uint64_t)frame_size * 2u - LIVE_ENVELOPE_BYTES,
+                  payload_cap);
+    live_add_size(plan, (uint64_t)frame_size * 2u -
+                  LIVE_ENVELOPE_BYTES + 17u, payload_cap);
+    live_add_size(plan, payload_cap, payload_cap);
+    if (plan->size_count == 0 || plan->max_payload == 0)
+        return live_error("no payload sizes fit negotiated NHI geometry");
+
+    const uint64_t required_frames =
+        (uint64_t)LIVE_REQUIRED_WRAPS * wrap_ring;
+    while (plan->messages < LIVE_MIN_MESSAGES ||
+           plan->frames_per_direction < required_frames) {
+        size_t bytes = plan->sizes[plan->messages % plan->size_count];
+        plan->messages++;
+        plan->bytes_per_direction += bytes;
+        plan->frames_per_direction += live_frames(bytes, frame_size);
+    }
+    return 0;
+}
+
+static unsigned char live_pattern_byte(uint32_t direction,
+                                       uint64_t generation,
+                                       uint64_t message, size_t offset) {
+    uint64_t value = (uint64_t)offset * UINT64_C(0x9e3779b185ebca87);
+    value ^= (uint64_t)direction * UINT64_C(0xd6e8feb86659fd93);
+    value ^= generation * UINT64_C(0xe7037ed1a0b428db);
+    value ^= (message + 1u) * UINT64_C(0xa0761d6478bd642f);
+    value ^= value >> 29;
+    value *= UINT64_C(0xbf58476d1ce4e5b9);
+    value ^= value >> 32;
+    return (unsigned char)value;
+}
+
+static void live_fill_pattern(unsigned char *buf, size_t bytes,
+                              uint32_t direction, uint64_t generation,
+                              uint64_t message) {
+    for (size_t i = 0; i < bytes; i++)
+        buf[i] = live_pattern_byte(direction, generation, message, i);
+}
+
+static int live_verify_pattern(const unsigned char *buf, size_t bytes,
+                               uint32_t direction, uint64_t generation,
+                               uint64_t message) {
+    for (size_t i = 0; i < bytes; i++) {
+        unsigned char expected = live_pattern_byte(direction, generation,
+                                                   message, i);
+        if (buf[i] != expected) {
+            errno = EILSEQ;
+            return live_error("payload mismatch at message %" PRIu64
+                              ", byte %zu: got 0x%02x, expected 0x%02x",
+                              message + 1u, i, (unsigned)buf[i],
+                              (unsigned)expected);
+        }
+    }
+    return 0;
+}
+
+static uint32_t live_element_bits(size_t bytes, uint64_t message) {
+    if (bytes % 4u == 0 && message % 3u == 2u) return 32u;
+    if (bytes % 2u == 0 && message % 3u != 0u) return 16u;
+    return 8u;
+}
+
+static void live_expected_tag(int server_to_client, uint64_t message,
+                              size_t bytes, uint32_t *kind,
+                              uint32_t *element_bits, uint64_t *session_id) {
+    uint32_t bits = live_element_bits(bytes, message);
+    if (server_to_client && bits == 32u && message % 2u == 0u)
+        *kind = DS4_TRANSPORT_BULK_RESULT_LOGITS;
+    else
+        *kind = server_to_client
+            ? DS4_TRANSPORT_BULK_RESULT_HIDDEN
+            : DS4_TRANSPORT_BULK_INPUT_HIDDEN;
+    *element_bits = bits;
+    *session_id = server_to_client ? LIVE_SESSION_S2C : LIVE_SESSION_C2S;
+}
+
+static int live_prepare(ds4_transport *transport, int server_to_client,
+                        uint64_t message, size_t bytes,
+                        ds4_transport_bulk_desc *desc) {
+    uint32_t kind;
+    uint32_t element_bits;
+    uint64_t session_id;
+    live_expected_tag(server_to_client, message, bytes, &kind,
+                      &element_bits, &session_id);
+    char error[160];
+    if (ds4_transport_prepare_bulk(transport, kind, session_id,
+                                   message + 1u, (uint32_t)bytes,
+                                   element_bits, desc,
+                                   error, sizeof(error)) != 0)
+        return live_error("prepare message %" PRIu64 ": %s (%s)",
+                          message + 1u, error, strerror(errno));
+    if (desc->mode != DS4_TRANSPORT_BULK_NHI_OOB)
+        return live_error("message %" PRIu64
+                          " unexpectedly selected inline TCP", message + 1u);
+    return 0;
+}
+
+static int live_validate(ds4_transport *transport, int server_to_client,
+                         uint64_t message, size_t bytes,
+                         const ds4_transport_bulk_desc *desc) {
+    uint32_t kind;
+    uint32_t element_bits;
+    uint64_t session_id;
+    live_expected_tag(server_to_client, message, bytes, &kind,
+                      &element_bits, &session_id);
+    char error[160];
+    if (ds4_transport_validate_oob_desc(
+            transport, desc, kind, session_id, message + 1u,
+            (uint32_t)bytes, element_bits, error, sizeof(error)) != 0)
+        return live_error("validate message %" PRIu64 ": %s (%s)",
+                          message + 1u, error, strerror(errno));
+    return 0;
+}
+
+static int live_send_desc_and_payload(ds4_transport *transport, int fd,
+                                      const ds4_transport_bulk_desc *desc,
+                                      void *copy_payload, size_t bytes,
+                                      uint32_t pattern_direction,
+                                      int gpu_alias,
+                                      live_path_counts *paths) {
+    if (ds4_transport_mapped_leases_supported(transport)) {
+        ds4_transport_lease *lease = NULL;
+        char error[160];
+        if (ds4_transport_tx_lease_acquire(transport, desc, &lease,
+                                           error, sizeof(error)) == 0) {
+            unsigned char *mapped = ds4_transport_lease_host_ptr(lease);
+            void *device = ds4_transport_lease_device_ptr(lease);
+            if (!mapped || ds4_transport_lease_bytes(lease) != bytes ||
+                (gpu_alias && !device)) {
+                int saved = EPROTO;
+                (void)ds4_transport_lease_abort(lease);
+                ds4_transport_lease_release(lease);
+                errno = saved;
+                return live_error("invalid mapped TX lease for message %"
+                                  PRIu64, desc->request_id);
+            }
+            if (gpu_alias) {
+#ifdef DS4_ROCM_BUILD
+                if (!ds4_test_nhi_gpu_alias_fill(
+                        device, bytes, pattern_direction, desc->generation,
+                        desc->request_id - 1u)) {
+                    int saved = EIO;
+                    (void)ds4_transport_lease_abort(lease);
+                    ds4_transport_lease_release(lease);
+                    errno = saved;
+                    return live_error("GPU fill of mapped TX message %"
+                                      PRIu64 " failed", desc->request_id);
+                }
+                if (live_verify_pattern(mapped, bytes, pattern_direction,
+                                        desc->generation,
+                                        desc->request_id - 1u) != 0) {
+                    int saved = errno ? errno : EILSEQ;
+                    (void)ds4_transport_lease_abort(lease);
+                    ds4_transport_lease_release(lease);
+                    errno = saved;
+                    return -1;
+                }
+#else
+                (void)device;
+                (void)ds4_transport_lease_abort(lease);
+                ds4_transport_lease_release(lease);
+                errno = ENOTSUP;
+                return live_error("GPU alias mode requires the ROCm test binary");
+#endif
+            } else {
+                live_fill_pattern(mapped, bytes, pattern_direction,
+                                  desc->generation,
+                                  desc->request_id - 1u);
+            }
+            if (live_send_control(fd, LIVE_CONTROL_DESC, 0, desc) != 0) {
+                int saved = errno ? errno : EIO;
+                /* A failed write may be partial, so it is never safe to roll
+                 * the prepared descriptor back and retry it inline. */
+                (void)ds4_transport_tx_lease_mark_control_sent(lease);
+                (void)ds4_transport_lease_abort(lease);
+                ds4_transport_lease_release(lease);
+                errno = saved;
+                return -1;
+            }
+            if (ds4_transport_tx_lease_mark_control_sent(lease) != 0) {
+                int saved = errno ? errno : EIO;
+                (void)ds4_transport_lease_abort(lease);
+                ds4_transport_lease_release(lease);
+                errno = saved;
+                return live_error("mark mapped TX control for message %"
+                                  PRIu64 ": %s", desc->request_id,
+                                  strerror(saved));
+            }
+            if (ds4_transport_lease_commit(lease) != 0) {
+                int saved = errno ? errno : EIO;
+                ds4_transport_lease_release(lease);
+                errno = saved;
+                return live_error("commit mapped TX message %" PRIu64
+                                  ": %s", desc->request_id,
+                                  strerror(saved));
+            }
+            ds4_transport_lease_release(lease);
+            paths->tx_mapped++;
+            if (gpu_alias) paths->tx_gpu_alias++;
+            return 0;
+        }
+        if (errno != ENOTSUP)
+            return live_error("acquire mapped TX message %" PRIu64
+                              ": %s (%s)", desc->request_id,
+                              error, strerror(errno));
+    }
+
+    live_fill_pattern(copy_payload, bytes, pattern_direction,
+                      desc->generation,
+                      desc->request_id - 1u);
+    if (live_send_control(fd, LIVE_CONTROL_DESC, 0, desc) != 0) return -1;
+    if (ds4_transport_send_bulk_desc(transport, desc,
+                                     copy_payload, bytes) != 0)
+        return live_error("NHI send message %" PRIu64 ": %s",
+                          desc->request_id, strerror(errno));
+    paths->tx_copy++;
+    return 0;
+}
+
+static int live_recv_desc_and_payload(ds4_transport *transport, int fd,
+                                      int server_to_client, uint64_t message,
+                                      size_t bytes, void *copy_payload,
+                                      int gpu_alias,
+                                      live_path_counts *paths) {
+    live_control control = {0};
+    if (live_recv_control(fd, &control) != 0) return -1;
+    if (live_peer_error(&control) != 0) return -1;
+    if (control.type != LIVE_CONTROL_DESC) {
+        errno = EPROTO;
+        return live_error("expected descriptor for message %" PRIu64
+                          ", got control type %u", message + 1u,
+                          control.type);
+    }
+    if (live_validate(transport, server_to_client, message, bytes,
+                      &control.desc) != 0)
+        return -1;
+
+    const uint32_t pattern_direction = server_to_client
+        ? LIVE_ROLE_SERVER : LIVE_ROLE_CLIENT;
+    if (ds4_transport_mapped_leases_supported(transport)) {
+        ds4_transport_lease *lease = NULL;
+        char error[160];
+        if (ds4_transport_rx_lease_acquire(transport, &control.desc, &lease,
+                                           error, sizeof(error)) == 0) {
+            const unsigned char *mapped =
+                ds4_transport_lease_host_ptr(lease);
+            const void *device = ds4_transport_lease_device_ptr(lease);
+            int verify_rc;
+            int verify_error = EPROTO;
+            if (!mapped || ds4_transport_lease_bytes(lease) != bytes ||
+                (gpu_alias && !device)) {
+                verify_rc = live_error("invalid mapped RX lease for message %"
+                                       PRIu64, message + 1u);
+            } else if (gpu_alias) {
+#ifdef DS4_ROCM_BUILD
+                uint64_t first_bad = UINT64_MAX;
+                const int alias_ok = ds4_test_nhi_gpu_alias_verify(
+                    device, bytes, pattern_direction,
+                    control.desc.generation, message, &first_bad);
+                verify_rc = alias_ok
+                    ? 0
+                    : (first_bad == UINT64_MAX
+                        ? live_error("GPU verify of mapped RX message %"
+                                     PRIu64 " failed", message + 1u)
+                        : live_error("GPU verify of mapped RX message %"
+                                     PRIu64 " failed at byte %" PRIu64,
+                                     message + 1u, first_bad));
+                if (verify_rc == 0) {
+                    verify_rc = live_verify_pattern(
+                        mapped, bytes, pattern_direction,
+                        control.desc.generation, message);
+                }
+                if (verify_rc != 0) verify_error = EILSEQ;
+#else
+                verify_rc = live_error(
+                    "GPU alias mode requires the ROCm test binary");
+                verify_error = ENOTSUP;
+#endif
+            } else {
+                verify_rc = live_verify_pattern(
+                    mapped, bytes, pattern_direction,
+                    control.desc.generation, message);
+                if (verify_rc != 0) verify_error = errno ? errno : EILSEQ;
+            }
+            /* Verification finishes before commit returns the exact frames
+             * to the driver. Even corrupt data is reposted before failure is
+             * reported so the local endpoint is not left with a live lease. */
+            if (ds4_transport_lease_commit(lease) != 0) {
+                int saved = errno ? errno : EIO;
+                ds4_transport_lease_release(lease);
+                errno = saved;
+                return live_error("commit mapped RX message %" PRIu64
+                                  ": %s", message + 1u,
+                                  strerror(saved));
+            }
+            ds4_transport_lease_release(lease);
+            if (verify_rc != 0) {
+                errno = verify_error;
+                return -1;
+            }
+            paths->rx_mapped++;
+            if (gpu_alias) paths->rx_gpu_alias++;
+            return 0;
+        }
+        if (errno != ENOTSUP)
+            return live_error("acquire mapped RX message %" PRIu64
+                              ": %s (%s)", message + 1u,
+                              error, strerror(errno));
+    }
+
+    int rc = ds4_transport_recv_bulk_desc(transport, &control.desc,
+                                          copy_payload, bytes);
+    if (rc != 1)
+        return live_error("NHI receive message %" PRIu64 ": %s",
+                          message + 1u, strerror(errno));
+    if (live_verify_pattern(copy_payload, bytes, pattern_direction,
+                            control.desc.generation, message) != 0)
+        return -1;
+    paths->rx_copy++;
+    return 0;
+}
+
+static int live_ready_barrier(int fd) {
+    if (live_send_control(fd, LIVE_CONTROL_READY, 0, NULL) != 0) return -1;
+    live_control control = {0};
+    if (live_recv_control(fd, &control) != 0) return -1;
+    if (live_peer_error(&control) != 0) return -1;
+    if (control.type != LIVE_CONTROL_READY || control.status != 0) {
+        errno = EPROTO;
+        return live_error("invalid peer READY record");
+    }
+    return 0;
+}
+
+static void live_print_plan(const char *role, ds4_transport *transport,
+                            uint32_t peer_ring, uint32_t wrap_ring,
+                            const live_plan *plan) {
+    double mib = (double)plan->bytes_per_direction / (1024.0 * 1024.0);
+    double wraps = (double)plan->frames_per_direction / wrap_ring;
+    fprintf(stderr,
+            "test_nhi_live: %s ready: transport=%s generation=%" PRIu64
+            " frame=%u local-ring=%u peer-ring=%u messages=%" PRIu64
+            " payload/dir=%.2f MiB frames/dir=%" PRIu64
+            " (%.2f ring wraps)\n",
+            role, ds4_transport_name(transport),
+            ds4_transport_generation(transport),
+            ds4_transport_frame_size(transport),
+            ds4_transport_ring_size(transport), peer_ring,
+            plan->messages, mib, plan->frames_per_direction, wraps);
+    fprintf(stderr, "test_nhi_live: %s mapped leases: %s\n", role,
+            ds4_transport_mapped_leases_supported(transport)
+                ? "available (used when payload span is contiguous)"
+                : "unavailable (CPU-copy path only)");
+}
+
+static int live_run_server(ds4_transport *transport, int fd,
+                           const live_options *options,
+                           const live_plan *plan, unsigned char *tx,
+                           unsigned char *rx, uint64_t *elapsed_ns,
+                           live_path_counts *paths) {
+    uint64_t start = live_now_ns();
+    for (uint64_t message = 0; message < plan->messages; message++) {
+        size_t bytes = plan->sizes[message % plan->size_count];
+        if (live_recv_desc_and_payload(transport, fd, 0, message,
+                                       bytes, rx,
+                                       options->require_gpu_alias,
+                                       paths) != 0) {
+            int saved = errno ? errno : EILSEQ;
+            live_send_error_best_effort(fd, saved);
+            errno = saved;
+            return -1;
+        }
+        ds4_transport_bulk_desc reply;
+        if (live_prepare(transport, 1, message, bytes, &reply) != 0 ||
+            live_send_desc_and_payload(transport, fd, &reply,
+                                       tx, bytes, LIVE_ROLE_SERVER,
+                                       options->require_gpu_alias,
+                                       paths) != 0) {
+            int saved = errno ? errno : EIO;
+            live_send_error_best_effort(fd, saved);
+            errno = saved;
+            return -1;
+        }
+    }
+
+    if (live_validate_paths(options, plan, paths) != 0) {
+        int saved = errno ? errno : EPROTO;
+        live_send_error_best_effort(fd, saved);
+        errno = saved;
+        return -1;
+    }
+    live_control control = {0};
+    if (live_recv_control(fd, &control) != 0) return -1;
+    if (live_peer_error(&control) != 0) return -1;
+    if (control.type != LIVE_CONTROL_DONE || control.status != 0) {
+        errno = EPROTO;
+        return live_error("expected peer DONE record");
+    }
+    if (live_send_control(fd, LIVE_CONTROL_DONE, 0, NULL) != 0) return -1;
+    uint64_t end = live_now_ns();
+    *elapsed_ns = end >= start ? end - start : 0;
+    return 0;
+}
+
+static int live_run_client(ds4_transport *transport, int fd,
+                           const live_options *options,
+                           const live_plan *plan, unsigned char *tx,
+                           unsigned char *rx, uint64_t *elapsed_ns,
+                           uint64_t *rtt_min_ns, uint64_t *rtt_max_ns,
+                           uint64_t *rtt_sum_ns,
+                           live_path_counts *paths) {
+    *rtt_min_ns = UINT64_MAX;
+    *rtt_max_ns = 0;
+    *rtt_sum_ns = 0;
+    uint64_t start = live_now_ns();
+    for (uint64_t message = 0; message < plan->messages; message++) {
+        size_t bytes = plan->sizes[message % plan->size_count];
+        uint64_t rtt_start = live_now_ns();
+        ds4_transport_bulk_desc request;
+        if (live_prepare(transport, 0, message, bytes, &request) != 0 ||
+            live_send_desc_and_payload(transport, fd, &request,
+                                       tx, bytes, LIVE_ROLE_CLIENT,
+                                       options->require_gpu_alias,
+                                       paths) != 0 ||
+            live_recv_desc_and_payload(transport, fd, 1, message,
+                                       bytes, rx,
+                                       options->require_gpu_alias,
+                                       paths) != 0)
+            return -1;
+        uint64_t rtt_end = live_now_ns();
+        uint64_t rtt = rtt_end >= rtt_start ? rtt_end - rtt_start : 0;
+        if (rtt < *rtt_min_ns) *rtt_min_ns = rtt;
+        if (rtt > *rtt_max_ns) *rtt_max_ns = rtt;
+        if (UINT64_MAX - *rtt_sum_ns < rtt)
+            return live_error("RTT accumulator overflow");
+        *rtt_sum_ns += rtt;
+    }
+    if (live_validate_paths(options, plan, paths) != 0) {
+        int saved = errno ? errno : EPROTO;
+        live_send_error_best_effort(fd, saved);
+        errno = saved;
+        return -1;
+    }
+    if (live_send_control(fd, LIVE_CONTROL_DONE, 0, NULL) != 0) return -1;
+    live_control control = {0};
+    if (live_recv_control(fd, &control) != 0) return -1;
+    if (live_peer_error(&control) != 0) return -1;
+    if (control.type != LIVE_CONTROL_DONE || control.status != 0) {
+        errno = EPROTO;
+        return live_error("invalid peer DONE record");
+    }
+    uint64_t end = live_now_ns();
+    *elapsed_ns = end >= start ? end - start : 0;
+    return 0;
+}
+
+static void live_print_result(const char *role, const live_plan *plan,
+                              uint32_t wrap_ring, uint64_t elapsed_ns,
+                              uint64_t rtt_min_ns, uint64_t rtt_max_ns,
+                              uint64_t rtt_sum_ns,
+                              const live_path_counts *paths) {
+    const double seconds = (double)elapsed_ns / 1000000000.0;
+    const double total_mib = (double)plan->bytes_per_direction * 2.0 /
+        (1024.0 * 1024.0);
+    const double mib_per_sec = seconds > 0.0 ? total_mib / seconds : 0.0;
+    const double wraps = (double)plan->frames_per_direction / wrap_ring;
+    printf("test_nhi_live: PASS %s messages=%" PRIu64
+           " wraps/dir=%.2f verified=%.2f MiB elapsed=%.3fs"
+           " throughput=%.2f MiB/s",
+           role, plan->messages, wraps, total_mib, seconds, mib_per_sec);
+    if (rtt_min_ns != UINT64_MAX) {
+        const double average_us = (double)rtt_sum_ns /
+            (double)plan->messages / 1000.0;
+        printf(" verified-rtt-us avg=%.2f min=%.2f max=%.2f",
+               average_us, (double)rtt_min_ns / 1000.0,
+               (double)rtt_max_ns / 1000.0);
+    }
+    printf(" paths=tx(mapped=%" PRIu64 ",copy=%" PRIu64
+           ",gpu-alias=%" PRIu64 ")/rx(mapped=%" PRIu64
+           ",copy=%" PRIu64 ",gpu-alias=%" PRIu64 ")\n",
+           paths->tx_mapped, paths->tx_copy,
+           paths->tx_gpu_alias, paths->rx_mapped, paths->rx_copy,
+           paths->rx_gpu_alias);
+}
+
+static int live_validate_paths(const live_options *options,
+                               const live_plan *plan,
+                               const live_path_counts *paths) {
+    if (paths->tx_mapped + paths->tx_copy != plan->messages ||
+        paths->rx_mapped + paths->rx_copy != plan->messages)
+        return live_error("internal path accounting mismatch");
+    if (options->require_mapped &&
+        (paths->tx_mapped == 0 || paths->rx_mapped == 0)) {
+        errno = ENOTSUP;
+        return live_error("required mapped TX/RX paths were not exercised");
+    }
+    if (options->require_copy &&
+        (paths->tx_copy == 0 || paths->rx_copy == 0)) {
+        errno = ENOTSUP;
+        return live_error("required CPU-copy TX/RX paths were not exercised");
+    }
+    if (options->require_gpu_alias &&
+        (paths->tx_gpu_alias == 0 || paths->rx_gpu_alias == 0 ||
+         paths->tx_gpu_alias != paths->tx_mapped ||
+         paths->rx_gpu_alias != paths->rx_mapped)) {
+        errno = ENOTSUP;
+        return live_error("required GPU-alias TX/RX paths were not exercised");
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    live_options options;
+    int parse_rc = live_parse_options(argc, argv, &options);
+    if (parse_rc > 0) return 0;
+    if (parse_rc < 0) return 2;
+
+#ifndef __linux__
+    live_error("the NHI live test requires Linux");
+    return 77;
+#endif
+#ifndef DS4_ROCM_BUILD
+    if (options.require_gpu_alias) {
+        live_error("--require-gpu-alias requires the ROCm test binary");
+        return 77;
+    }
+#endif
+    char timeout_text[16];
+    snprintf(timeout_text, sizeof(timeout_text), "%u", options.timeout_sec);
+    if (setenv("DS4_DIST_NHI_TIMEOUT_SEC", timeout_text, 1) != 0) {
+        live_error("set NHI timeout: %s", strerror(errno));
+        return 1;
+    }
+
+    int fd = options.server
+        ? live_listen(options.port, options.timeout_sec)
+        : live_connect(options.host, options.port, options.timeout_sec);
+    if (fd < 0) return 1;
+
+    int result = 1;
+    ds4_transport *transport = NULL;
+    unsigned char *tx = NULL;
+    unsigned char *rx = NULL;
+    char error[256];
+    transport = ds4_transport_nhi_create(fd, options.device,
+                                         error, sizeof(error));
+    if (!transport) {
+        live_error("create NHI transport on %s: %s (%s)",
+                   options.device, error, strerror(errno));
+        goto cleanup;
+    }
+    if (strcmp(ds4_transport_name(transport), "nhi-cpu-copy") != 0 ||
+        (ds4_transport_caps(transport) & DS4_TRANSPORT_CAP_ZEROCOPY) == 0) {
+        live_error("unexpected transport backend: %s",
+                   ds4_transport_name(transport));
+        goto cleanup;
+    }
+
+    live_hello local;
+    local.role = options.server ? LIVE_ROLE_SERVER : LIVE_ROLE_CLIENT;
+    local.frame_size = ds4_transport_frame_size(transport);
+    local.ring_size = ds4_transport_ring_size(transport);
+    local.flags = options.require_gpu_alias ? LIVE_HELLO_F_GPU_ALIAS : 0u;
+    local.generation = options.server ? live_generation() : 0;
+    live_hello peer = {0};
+    if (live_send_hello(fd, &local) != 0 ||
+        live_recv_hello(fd, &peer) != 0)
+        goto cleanup;
+    if (peer.role == local.role ||
+        (peer.role != LIVE_ROLE_SERVER && peer.role != LIVE_ROLE_CLIENT) ||
+        peer.frame_size != local.frame_size ||
+        peer.ring_size != local.ring_size || peer.ring_size < 2u ||
+        peer.flags != local.flags ||
+        (options.server ? peer.generation != 0 : peer.generation == 0)) {
+        live_error("incompatible peer HELLO geometry or role");
+        live_send_error_best_effort(fd, EPROTO);
+        goto cleanup;
+    }
+    uint64_t generation = options.server
+        ? local.generation : peer.generation;
+    if (ds4_transport_configure_link(transport, generation,
+                                     peer.frame_size, peer.ring_size,
+                                     error, sizeof(error)) != 0) {
+        live_error("configure NHI link: %s (%s)", error, strerror(errno));
+        live_send_error_best_effort(fd, errno);
+        goto cleanup;
+    }
+    if (options.require_mapped &&
+        !ds4_transport_mapped_leases_supported(transport)) {
+        live_error("mapped leases are required but unavailable");
+        live_send_error_best_effort(fd, ENOTSUP);
+        goto cleanup;
+    }
+    if (live_ready_barrier(fd) != 0) goto cleanup;
+
+    /* This hardware gate requires equal physical geometry, so two traversals
+     * here are literal wraps of both endpoints rather than only of a smaller
+     * negotiated credit window. */
+    uint32_t wrap_ring = local.ring_size;
+    live_plan plan;
+    if (live_build_plan(local.frame_size, wrap_ring,
+                        ds4_transport_max_oob_bytes(transport), &plan) != 0) {
+        live_send_error_best_effort(fd, errno);
+        goto cleanup;
+    }
+    live_print_plan(options.server ? "server" : "client", transport,
+                    peer.ring_size, wrap_ring, &plan);
+
+    tx = malloc(plan.max_payload);
+    rx = malloc(plan.max_payload);
+    if (!tx || !rx) {
+        live_error("allocate %zu-byte verification buffers: %s",
+                   plan.max_payload, strerror(errno));
+        live_send_error_best_effort(fd, ENOMEM);
+        goto cleanup;
+    }
+    uint64_t elapsed_ns = 0;
+    uint64_t rtt_min_ns = UINT64_MAX;
+    uint64_t rtt_max_ns = 0;
+    uint64_t rtt_sum_ns = 0;
+    live_path_counts paths;
+    memset(&paths, 0, sizeof(paths));
+    int run_rc = options.server
+        ? live_run_server(transport, fd, &options, &plan, tx, rx, &elapsed_ns,
+                          &paths)
+        : live_run_client(transport, fd, &options, &plan, tx, rx, &elapsed_ns,
+                          &rtt_min_ns, &rtt_max_ns, &rtt_sum_ns,
+                          &paths);
+    if (run_rc != 0) goto cleanup;
+    live_print_result(options.server ? "server" : "client", &plan,
+                      wrap_ring, elapsed_ns, rtt_min_ns,
+                      rtt_max_ns, rtt_sum_ns, &paths);
+    result = 0;
+
+cleanup:
+    free(rx);
+    free(tx);
+    ds4_transport_release(transport);
+    (void)shutdown(fd, SHUT_RDWR);
+    close(fd);
+    return result;
+}

--- a/tests/test_nhi_live_rocm_alias.cu
+++ b/tests/test_nhi_live_rocm_alias.cu
@@ -1,0 +1,99 @@
+#include <hip/hip_runtime.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+
+static __device__ __forceinline__ unsigned char alias_pattern_byte(
+        uint32_t direction,
+        uint64_t generation,
+        uint64_t message,
+        uint64_t offset) {
+    uint64_t value = offset * UINT64_C(0x9e3779b185ebca87);
+    value ^= (uint64_t)direction * UINT64_C(0xd6e8feb86659fd93);
+    value ^= generation * UINT64_C(0xe7037ed1a0b428db);
+    value ^= (message + 1u) * UINT64_C(0xa0761d6478bd642f);
+    value ^= value >> 29;
+    value *= UINT64_C(0xbf58476d1ce4e5b9);
+    value ^= value >> 32;
+    return (unsigned char)value;
+}
+
+static __global__ void alias_fill_kernel(unsigned char *payload,
+                                         uint64_t bytes,
+                                         uint32_t direction,
+                                         uint64_t generation,
+                                         uint64_t message) {
+    uint64_t offset = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (offset < bytes)
+        payload[offset] = alias_pattern_byte(direction, generation, message,
+                                             offset);
+}
+
+static __global__ void alias_verify_kernel(const unsigned char *payload,
+                                           uint64_t bytes,
+                                           uint32_t direction,
+                                           uint64_t generation,
+                                           uint64_t message,
+                                           unsigned long long *first_bad) {
+    uint64_t offset = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (offset < bytes &&
+        payload[offset] != alias_pattern_byte(direction, generation, message,
+                                              offset)) {
+        atomicMin(first_bad, (unsigned long long)offset);
+    }
+}
+
+extern "C" int ds4_test_nhi_gpu_alias_fill(void *device_ptr,
+                                             uint64_t bytes,
+                                             uint32_t direction,
+                                             uint64_t generation,
+                                             uint64_t message) {
+    if (!device_ptr || bytes == 0) return 0;
+    const unsigned int threads = 256u;
+    const unsigned int blocks = (unsigned int)((bytes + threads - 1u) / threads);
+    alias_fill_kernel<<<blocks, threads>>>((unsigned char *)device_ptr,
+                                           bytes,
+                                           direction,
+                                           generation,
+                                           message);
+    return hipGetLastError() == hipSuccess &&
+           hipDeviceSynchronize() == hipSuccess;
+}
+
+extern "C" int ds4_test_nhi_gpu_alias_verify(const void *device_ptr,
+                                               uint64_t bytes,
+                                               uint32_t direction,
+                                               uint64_t generation,
+                                               uint64_t message,
+                                               uint64_t *first_bad) {
+    if (first_bad) *first_bad = UINT64_MAX;
+    if (!device_ptr || bytes == 0) return 0;
+
+    unsigned long long *device_bad = NULL;
+    if (hipMalloc((void **)&device_bad, sizeof(*device_bad)) != hipSuccess)
+        return 0;
+    int ok = hipMemset(device_bad, 0xff, sizeof(*device_bad)) == hipSuccess;
+    if (ok) {
+        const unsigned int threads = 256u;
+        const unsigned int blocks =
+            (unsigned int)((bytes + threads - 1u) / threads);
+        alias_verify_kernel<<<blocks, threads>>>(
+            (const unsigned char *)device_ptr,
+            bytes,
+            direction,
+            generation,
+            message,
+            device_bad);
+        ok = hipGetLastError() == hipSuccess &&
+             hipDeviceSynchronize() == hipSuccess;
+    }
+
+    unsigned long long host_bad = UINT64_MAX;
+    if (ok) {
+        ok = hipMemcpy(&host_bad, device_bad, sizeof(host_bad),
+                       hipMemcpyDeviceToHost) == hipSuccess;
+    }
+    if (hipFree(device_bad) != hipSuccess) ok = 0;
+    if (first_bad) *first_bad = (uint64_t)host_bad;
+    return ok && host_bad == UINT64_MAX;
+}

--- a/tests/test_rocm_timing_fake.cc
+++ b/tests/test_rocm_timing_fake.cc
@@ -1,0 +1,428 @@
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Host-only fake for the ROCm event timing backend.  Deliberately do not
+ * provide hipEventSynchronize, hipStreamSynchronize, or hipDeviceSynchronize:
+ * this test must fail to link if collection ever becomes blocking.
+ */
+struct fake_hip_event {
+    unsigned int id;
+    int recorded;
+    int ready;
+    float timestamp_ms;
+};
+
+typedef int hipError_t;
+typedef fake_hip_event *hipEvent_t;
+typedef void *hipStream_t;
+
+static const hipError_t hipSuccess = 0;
+static const hipError_t hipErrorNotReady = 600;
+static const hipError_t hipErrorUnknown = 999;
+static const unsigned int hipEventDefault = 0;
+
+static unsigned int fake_create_calls;
+static unsigned int fake_destroy_calls;
+static unsigned int fake_record_calls;
+static unsigned int fake_query_calls;
+static unsigned int fake_elapsed_calls;
+static unsigned int fake_next_event_id;
+static unsigned int fake_fail_create_call;
+static unsigned int fake_fail_record_call;
+static unsigned int fake_fail_elapsed_call;
+static hipError_t fake_query_result;
+static int fake_recorded_events_ready;
+
+static hipError_t hipEventCreateWithFlags(hipEvent_t *event,
+                                           unsigned int flags) {
+    ++fake_create_calls;
+    if (!event || flags != hipEventDefault ||
+        fake_create_calls == fake_fail_create_call) {
+        if (event) *event = NULL;
+        return hipErrorUnknown;
+    }
+    fake_hip_event *created =
+        static_cast<fake_hip_event *>(calloc(1, sizeof(*created)));
+    if (!created) return hipErrorUnknown;
+    created->id = ++fake_next_event_id;
+    *event = created;
+    return hipSuccess;
+}
+
+static hipError_t hipEventDestroy(hipEvent_t event) {
+    if (!event) return hipErrorUnknown;
+    ++fake_destroy_calls;
+    free(event);
+    return hipSuccess;
+}
+
+static hipError_t hipEventRecord(hipEvent_t event, hipStream_t stream) {
+    ++fake_record_calls;
+    if (!event || stream != NULL ||
+        fake_record_calls == fake_fail_record_call) {
+        return hipErrorUnknown;
+    }
+    event->recorded = 1;
+    event->ready = fake_recorded_events_ready;
+    event->timestamp_ms = static_cast<float>(fake_record_calls) * 1.25f;
+    return hipSuccess;
+}
+
+static hipError_t hipEventQuery(hipEvent_t event) {
+    ++fake_query_calls;
+    if (!event || !event->recorded) return hipErrorUnknown;
+    if (fake_query_result != hipSuccess) return fake_query_result;
+    return event->ready ? hipSuccess : hipErrorNotReady;
+}
+
+static hipError_t hipEventElapsedTime(float *elapsed,
+                                      hipEvent_t start,
+                                      hipEvent_t end) {
+    ++fake_elapsed_calls;
+    if (!elapsed || !start || !end || !start->recorded || !end->recorded ||
+        fake_elapsed_calls == fake_fail_elapsed_call) {
+        return hipErrorUnknown;
+    }
+    *elapsed = end->timestamp_ms - start->timestamp_ms;
+    return hipSuccess;
+}
+
+#define DS4_ROCM_BUILD 1
+#include "ds4_gpu.h"
+#include "rocm/ds4_rocm_timing.cuh"
+
+static int checks;
+static int failures;
+
+#define CHECK(expr) do { \
+    ++checks; \
+    if (!(expr)) { \
+        ++failures; \
+        fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+    } \
+} while (0)
+
+static int sample_is_reset(const ds4_gpu_timing_sample *sample) {
+    return sample && sample->slot == 0 && sample->generation == 0 &&
+           sample->mark_count == 0 && sample->reserved == 0;
+}
+
+static ds4_gpu_timing_sample poisoned_sample(void) {
+    ds4_gpu_timing_sample sample;
+    sample.slot = 91;
+    sample.generation = 92;
+    sample.mark_count = 93;
+    sample.reserved = 94;
+    return sample;
+}
+
+static void reset_fixture(void) {
+    ds4_rocm_timing_cleanup();
+    g_ds4_rocm_timing_next_generation = 0;
+    fake_create_calls = 0;
+    fake_destroy_calls = 0;
+    fake_record_calls = 0;
+    fake_query_calls = 0;
+    fake_elapsed_calls = 0;
+    fake_next_event_id = 0;
+    fake_fail_create_call = 0;
+    fake_fail_record_call = 0;
+    fake_fail_elapsed_call = 0;
+    fake_query_result = hipSuccess;
+    fake_recorded_events_ready = 1;
+}
+
+static void test_happy_path(void) {
+    reset_fixture();
+    ds4_gpu_timing_sample sample = poisoned_sample();
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(sample.slot == 1);
+    CHECK(sample.generation != 0);
+    CHECK(sample.mark_count == 1);
+    CHECK(sample.reserved == 0);
+    CHECK(fake_create_calls == 4u * DS4_GPU_TIMING_MAX_MARKS);
+    CHECK(fake_record_calls == 1);
+
+    CHECK(ds4_gpu_timing_mark(&sample) == 1);
+    CHECK(ds4_gpu_timing_mark(&sample) == 1);
+    CHECK(sample.mark_count == 3);
+
+    float segments[2] = {-1.0f, -1.0f};
+    uint32_t segment_count = 99;
+    CHECK(ds4_gpu_timing_collect(&sample, segments, 2, &segment_count) == 1);
+    CHECK(segment_count == 2);
+    CHECK(segments[0] == 1.25f);
+    CHECK(segments[1] == 1.25f);
+    CHECK(fake_query_calls == 1);
+    CHECK(fake_elapsed_calls == 2);
+    CHECK(sample_is_reset(&sample));
+
+    ds4_rocm_timing_cleanup();
+    CHECK(fake_destroy_calls == 4u * DS4_GPU_TIMING_MAX_MARKS);
+}
+
+static void test_pool_exhaustion_and_reuse(void) {
+    reset_fixture();
+    ds4_gpu_timing_sample samples[5];
+    uint32_t generations[4];
+    for (unsigned int i = 0; i < 5; ++i) samples[i] = poisoned_sample();
+
+    for (unsigned int i = 0; i < 4; ++i) {
+        CHECK(ds4_gpu_timing_begin(&samples[i]) == 1);
+        CHECK(samples[i].slot == i + 1);
+        generations[i] = samples[i].generation;
+    }
+    CHECK(ds4_gpu_timing_begin(&samples[4]) == 0);
+    CHECK(sample_is_reset(&samples[4]));
+    CHECK(fake_create_calls == 4u * DS4_GPU_TIMING_MAX_MARKS);
+
+    ds4_gpu_timing_discard(&samples[1]);
+    CHECK(sample_is_reset(&samples[1]));
+    CHECK(ds4_gpu_timing_begin(&samples[4]) == 1);
+    CHECK(samples[4].slot == 2);
+    CHECK(samples[4].generation != generations[1]);
+
+    for (unsigned int i = 0; i < 4; ++i) ds4_gpu_timing_discard(&samples[i]);
+    ds4_gpu_timing_discard(&samples[4]);
+}
+
+static void test_mark_limit_releases_slot(void) {
+    reset_fixture();
+    ds4_gpu_timing_sample sample = poisoned_sample();
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    const uint32_t first_generation = sample.generation;
+    for (uint32_t i = 1; i < DS4_GPU_TIMING_MAX_MARKS; ++i) {
+        CHECK(ds4_gpu_timing_mark(&sample) == 1);
+        CHECK(sample.mark_count == i + 1);
+    }
+    CHECK(fake_record_calls == DS4_GPU_TIMING_MAX_MARKS);
+    CHECK(ds4_gpu_timing_mark(&sample) == 0);
+    CHECK(sample_is_reset(&sample));
+    CHECK(fake_record_calls == DS4_GPU_TIMING_MAX_MARKS);
+
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(sample.slot == 1);
+    CHECK(sample.generation != first_generation);
+    ds4_gpu_timing_discard(&sample);
+}
+
+static void test_allocation_and_record_failures(void) {
+    reset_fixture();
+    fake_fail_create_call = 10;
+    ds4_gpu_timing_sample sample = poisoned_sample();
+    CHECK(ds4_gpu_timing_begin(&sample) == 0);
+    CHECK(sample_is_reset(&sample));
+    CHECK(fake_create_calls == 10);
+    CHECK(fake_destroy_calls == 9);
+
+    /* Allocation failure latches unavailable until backend cleanup. */
+    fake_fail_create_call = 0;
+    CHECK(ds4_gpu_timing_begin(&sample) == 0);
+    CHECK(fake_create_calls == 10);
+    ds4_rocm_timing_cleanup();
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    ds4_gpu_timing_discard(&sample);
+
+    reset_fixture();
+    fake_fail_record_call = 1;
+    sample = poisoned_sample();
+    CHECK(ds4_gpu_timing_begin(&sample) == 0);
+    CHECK(sample_is_reset(&sample));
+    fake_fail_record_call = 0;
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(sample.slot == 1);
+    ds4_gpu_timing_discard(&sample);
+
+    reset_fixture();
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    fake_fail_record_call = 2;
+    CHECK(ds4_gpu_timing_mark(&sample) == 0);
+    CHECK(sample_is_reset(&sample));
+    fake_fail_record_call = 0;
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(sample.slot == 1);
+    ds4_gpu_timing_discard(&sample);
+}
+
+static void test_collect_validation_and_failures(void) {
+    reset_fixture();
+    ds4_gpu_timing_sample sample = poisoned_sample();
+    float segments[2] = {-1.0f, -1.0f};
+    uint32_t segment_count = 99;
+
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(ds4_gpu_timing_collect(&sample, segments, 2, &segment_count) == 0);
+    CHECK(segment_count == 0);
+    CHECK(sample_is_reset(&sample));
+    CHECK(fake_query_calls == 0);
+
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(ds4_gpu_timing_mark(&sample) == 1);
+    segment_count = 99;
+    CHECK(ds4_gpu_timing_collect(&sample, segments, 0, &segment_count) == 0);
+    CHECK(segment_count == 0);
+    CHECK(sample_is_reset(&sample));
+    CHECK(fake_query_calls == 0);
+
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(ds4_gpu_timing_mark(&sample) == 1);
+    CHECK(ds4_gpu_timing_collect(&sample, NULL, 2, &segment_count) == 0);
+    CHECK(sample_is_reset(&sample));
+
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(ds4_gpu_timing_mark(&sample) == 1);
+    CHECK(ds4_gpu_timing_collect(&sample, segments, 2, NULL) == 0);
+    CHECK(sample_is_reset(&sample));
+
+    segment_count = 99;
+    CHECK(ds4_gpu_timing_collect(NULL, segments, 2, &segment_count) == 0);
+    CHECK(segment_count == 0);
+
+    /* A not-ready final marker is queried once and consumed without waiting. */
+    fake_recorded_events_ready = 0;
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(ds4_gpu_timing_mark(&sample) == 1);
+    const unsigned int queries_before = fake_query_calls;
+    const unsigned int elapsed_before = fake_elapsed_calls;
+    segment_count = 99;
+    CHECK(ds4_gpu_timing_collect(&sample, segments, 2, &segment_count) == 0);
+    CHECK(segment_count == 0);
+    CHECK(sample_is_reset(&sample));
+    CHECK(fake_query_calls == queries_before + 1);
+    CHECK(fake_elapsed_calls == elapsed_before);
+
+    fake_recorded_events_ready = 1;
+    fake_query_result = hipErrorUnknown;
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(ds4_gpu_timing_mark(&sample) == 1);
+    segment_count = 99;
+    CHECK(ds4_gpu_timing_collect(&sample, segments, 2, &segment_count) == 0);
+    CHECK(segment_count == 0);
+    CHECK(sample_is_reset(&sample));
+
+    fake_query_result = hipSuccess;
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(ds4_gpu_timing_mark(&sample) == 1);
+    CHECK(ds4_gpu_timing_mark(&sample) == 1);
+    fake_fail_elapsed_call = fake_elapsed_calls + 2;
+    segment_count = 99;
+    CHECK(ds4_gpu_timing_collect(&sample, segments, 2, &segment_count) == 0);
+    CHECK(segment_count == 0);
+    CHECK(sample_is_reset(&sample));
+}
+
+static void test_stale_generation_and_cleanup(void) {
+    reset_fixture();
+    ds4_gpu_timing_sample first = poisoned_sample();
+    CHECK(ds4_gpu_timing_begin(&first) == 1);
+    ds4_gpu_timing_sample stale = first;
+    ds4_gpu_timing_discard(&first);
+
+    ds4_gpu_timing_sample live = poisoned_sample();
+    CHECK(ds4_gpu_timing_begin(&live) == 1);
+    CHECK(live.slot == stale.slot);
+    CHECK(live.generation != stale.generation);
+    ds4_gpu_timing_discard(&stale);
+    CHECK(sample_is_reset(&stale));
+    CHECK(ds4_gpu_timing_mark(&live) == 1);
+
+    ds4_gpu_timing_sample bad_count = live;
+    ++bad_count.mark_count;
+    ds4_gpu_timing_discard(&bad_count);
+    CHECK(sample_is_reset(&bad_count));
+    CHECK(ds4_gpu_timing_mark(&live) == 1);
+    ds4_gpu_timing_discard(&live);
+
+    ds4_gpu_timing_sample before_cleanup = poisoned_sample();
+    CHECK(ds4_gpu_timing_begin(&before_cleanup) == 1);
+    const uint32_t old_generation = before_cleanup.generation;
+    ds4_rocm_timing_cleanup();
+
+    ds4_gpu_timing_sample after_cleanup = poisoned_sample();
+    CHECK(ds4_gpu_timing_begin(&after_cleanup) == 1);
+    CHECK(after_cleanup.slot == before_cleanup.slot);
+    CHECK(after_cleanup.generation != old_generation);
+    CHECK(ds4_gpu_timing_mark(&before_cleanup) == 0);
+    CHECK(sample_is_reset(&before_cleanup));
+    CHECK(ds4_gpu_timing_mark(&after_cleanup) == 1);
+    ds4_gpu_timing_discard(&after_cleanup);
+}
+
+static void test_nulls_and_generation_wrap(void) {
+    reset_fixture();
+    CHECK(ds4_gpu_timing_begin(NULL) == 0);
+    CHECK(ds4_gpu_timing_mark(NULL) == 0);
+    ds4_gpu_timing_discard(NULL);
+
+    g_ds4_rocm_timing_next_generation = UINT32_MAX;
+    ds4_gpu_timing_sample sample = poisoned_sample();
+    CHECK(ds4_gpu_timing_begin(&sample) == 1);
+    CHECK(sample.generation == 1);
+    ds4_gpu_timing_discard(&sample);
+}
+
+struct begin_thread_result {
+    ds4_gpu_timing_sample sample;
+    int began;
+};
+
+static void *begin_thread(void *opaque) {
+    begin_thread_result *result = static_cast<begin_thread_result *>(opaque);
+    result->sample = poisoned_sample();
+    result->began = ds4_gpu_timing_begin(&result->sample);
+    return NULL;
+}
+
+static void test_concurrent_pool_limit(void) {
+    reset_fixture();
+    enum { THREADS = 12 };
+    pthread_t threads[THREADS];
+    begin_thread_result results[THREADS];
+    memset(results, 0, sizeof(results));
+
+    for (unsigned int i = 0; i < THREADS; ++i) {
+        CHECK(pthread_create(&threads[i], NULL, begin_thread, &results[i]) == 0);
+    }
+    for (unsigned int i = 0; i < THREADS; ++i) {
+        CHECK(pthread_join(threads[i], NULL) == 0);
+    }
+
+    unsigned int began = 0;
+    unsigned int slot_mask = 0;
+    for (unsigned int i = 0; i < THREADS; ++i) {
+        if (results[i].began) {
+            ++began;
+            CHECK(results[i].sample.slot >= 1 && results[i].sample.slot <= 4);
+            slot_mask |= 1u << (results[i].sample.slot - 1u);
+            ds4_gpu_timing_discard(&results[i].sample);
+        } else {
+            CHECK(sample_is_reset(&results[i].sample));
+        }
+    }
+    CHECK(began == 4);
+    CHECK(slot_mask == 0x0fu);
+}
+
+int main(void) {
+    test_happy_path();
+    test_pool_exhaustion_and_reuse();
+    test_mark_limit_releases_slot();
+    test_allocation_and_record_failures();
+    test_collect_validation_and_failures();
+    test_stale_generation_and_cleanup();
+    test_nulls_and_generation_wrap();
+    test_concurrent_pool_limit();
+    ds4_rocm_timing_cleanup();
+
+    if (failures) {
+        fprintf(stderr, "ROCm timing fake: %d/%d checks failed\n", failures,
+                checks);
+        return 1;
+    }
+    printf("ROCm timing fake: %d checks passed\n", checks);
+    return 0;
+}

--- a/tests/test_transport.c
+++ b/tests/test_transport.c
@@ -1,0 +1,462 @@
+#include "ds4_transport_internal.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int checks;
+static int failures;
+
+#define CHECK(expr) do { \
+    checks++; \
+    if (!(expr)) { \
+        failures++; \
+        fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+    } \
+} while (0)
+
+typedef struct {
+    unsigned char host[256];
+    unsigned char device[256];
+    ds4_transport_lease *tx;
+    ds4_transport_lease *rx;
+    unsigned int conservative_commits;
+    unsigned int gpu_quiesced_commits;
+} fake_lease_ctx;
+
+static int fake_mapped_supported(const ds4_transport *t) {
+    return t && t->ctx != NULL;
+}
+
+static int fake_tx_acquire(ds4_transport *t,
+                           const ds4_transport_bulk_desc *desc,
+                           ds4_transport_lease *lease,
+                           char *err,
+                           size_t errlen) {
+    (void)err;
+    (void)errlen;
+    fake_lease_ctx *ctx = t->ctx;
+    if (ctx->tx) {
+        errno = EBUSY;
+        return -1;
+    }
+    ctx->tx = lease;
+    lease->host_ptr = ctx->host;
+    lease->device_ptr = ctx->device;
+    lease->bytes = desc->payload_bytes;
+    return 0;
+}
+
+static int fake_rx_acquire(ds4_transport *t,
+                           const ds4_transport_bulk_desc *desc,
+                           ds4_transport_lease *lease,
+                           char *err,
+                           size_t errlen) {
+    (void)err;
+    (void)errlen;
+    fake_lease_ctx *ctx = t->ctx;
+    if (ctx->rx) {
+        errno = EBUSY;
+        return -1;
+    }
+    ctx->rx = lease;
+    lease->host_ptr = ctx->host;
+    lease->device_ptr = ctx->device;
+    lease->bytes = desc->payload_bytes;
+    return 0;
+}
+
+static int fake_mark_control(ds4_transport_lease *lease) {
+    fake_lease_ctx *ctx = lease->transport->ctx;
+    if (ctx->tx != lease) {
+        errno = EINVAL;
+        return -1;
+    }
+    lease->control_sent = 1;
+    return 0;
+}
+
+static int fake_lease_commit(ds4_transport_lease *lease,
+                             int gpu_quiesced) {
+    fake_lease_ctx *ctx = lease->transport->ctx;
+    ds4_transport_lease **active =
+        lease->direction == DS4_TRANSPORT_LEASE_TX ? &ctx->tx : &ctx->rx;
+    if (*active != lease) {
+        errno = EINVAL;
+        return -1;
+    }
+    *active = NULL;
+    if (gpu_quiesced)
+        ctx->gpu_quiesced_commits++;
+    else
+        ctx->conservative_commits++;
+    return 0;
+}
+
+static int fake_lease_abort(ds4_transport_lease *lease) {
+    fake_lease_ctx *ctx = lease->transport->ctx;
+    ds4_transport_lease **active =
+        lease->direction == DS4_TRANSPORT_LEASE_TX ? &ctx->tx : &ctx->rx;
+    if (*active != lease) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (lease->direction == DS4_TRANSPORT_LEASE_TX &&
+        !lease->control_sent)
+        return 0;
+    *active = NULL;
+    errno = ECANCELED;
+    return -1;
+}
+
+static int fake_lease_abort_finish(ds4_transport_lease *lease) {
+    fake_lease_ctx *ctx = lease->transport->ctx;
+    if (ctx->tx != lease || lease->control_sent) {
+        errno = EINVAL;
+        return -1;
+    }
+    ctx->tx = NULL;
+    return 0;
+}
+
+static int fake_check_prepare(ds4_transport *t) {
+    fake_lease_ctx *ctx = t->ctx;
+    if (!ctx->tx) return 0;
+    errno = EBUSY;
+    return -1;
+}
+
+static int fake_configure(ds4_transport *t,
+                          uint32_t peer_frame_size,
+                          uint32_t peer_ring_size,
+                          char *err,
+                          size_t errlen) {
+    (void)t;
+    (void)err;
+    (void)errlen;
+    if (peer_frame_size == 4096u && peer_ring_size == 8u) return 0;
+    errno = EPROTO;
+    return -1;
+}
+
+static size_t fake_max_oob(const ds4_transport *t) {
+    (void)t;
+    return 4096u * 7u - DS4_TRANSPORT_BULK_DESC_BYTES;
+}
+
+static void fake_close(ds4_transport *t) {
+    free(t->ctx);
+    t->ctx = NULL;
+}
+
+static const ds4_transport_ops fake_lease_ops = {
+    .name = "fake-mapped",
+    .caps = DS4_TRANSPORT_CAP_STREAM | DS4_TRANSPORT_CAP_ZEROCOPY,
+    .mapped_leases_supported = fake_mapped_supported,
+    .tx_lease_acquire = fake_tx_acquire,
+    .rx_lease_acquire = fake_rx_acquire,
+    .tx_lease_mark_control_sent = fake_mark_control,
+    .lease_commit = fake_lease_commit,
+    .lease_abort = fake_lease_abort,
+    .lease_abort_finish = fake_lease_abort_finish,
+    .check_prepare = fake_check_prepare,
+    .configure = fake_configure,
+    .max_oob_bytes = fake_max_oob,
+    .close = fake_close,
+};
+
+static void test_descriptor_sequences(void) {
+    int sv[2] = {-1, -1};
+    char err[128] = "";
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+    if (sv[0] < 0 || sv[1] < 0) return;
+    ds4_transport *left = ds4_transport_tcp_create(sv[0], err, sizeof(err));
+    ds4_transport *right = ds4_transport_tcp_create(sv[1], err, sizeof(err));
+    CHECK(left != NULL);
+    CHECK(right != NULL);
+    if (!left || !right) goto done;
+
+    const uint64_t generation = 0x1122334455667788ull;
+    CHECK(ds4_transport_configure_link(left, generation, 0, 0,
+                                       err, sizeof(err)) == 0);
+    CHECK(ds4_transport_configure_link(right, generation, 0, 0,
+                                       err, sizeof(err)) == 0);
+    CHECK(ds4_transport_generation(left) == generation);
+    CHECK(ds4_transport_generation(right) == generation);
+
+    static const char payload[] = "descriptor-framed payload";
+    ds4_transport_bulk_desc desc;
+    CHECK(ds4_transport_prepare_bulk(left,
+                                     DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+                                     17, 23, (uint32_t)sizeof(payload), 32,
+                                     &desc, err, sizeof(err)) == 0);
+    CHECK(desc.mode == DS4_TRANSPORT_BULK_TCP_INLINE);
+    CHECK(desc.generation == generation);
+    CHECK(desc.sequence == 1);
+    CHECK(desc.frame_count == 0);
+
+    ds4_transport_bulk_desc_wire wire;
+    ds4_transport_bulk_desc decoded;
+    CHECK(ds4_transport_bulk_desc_encode(&desc, &wire) == 0);
+    CHECK(ds4_transport_bulk_desc_decode(&wire, &decoded) == 0);
+    CHECK(memcmp(&decoded, &desc, sizeof(desc)) == 0);
+    CHECK(ds4_transport_validate_inline_desc(
+              &decoded, DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+              17, 23, (uint32_t)sizeof(payload), 32,
+              err, sizeof(err)) == 0);
+
+    /* TCP exposes the lease API as a clean, non-consuming fallback decision.
+     * The prepared descriptor remains valid for the ordinary tagged path. */
+    CHECK(ds4_transport_mapped_leases_supported(left) == 0);
+    CHECK((ds4_transport_caps(left) & DS4_TRANSPORT_CAP_GPU_MAPPED) == 0);
+    ds4_transport_lease *lease = (ds4_transport_lease *)(uintptr_t)1u;
+    errno = 0;
+    CHECK(ds4_transport_tx_lease_acquire(left, &desc, &lease,
+                                         err, sizeof(err)) == -1);
+    CHECK(errno == ENOTSUP);
+    CHECK(lease == NULL);
+    CHECK(ds4_transport_lease_host_ptr(NULL) == NULL);
+    CHECK(ds4_transport_lease_device_ptr(NULL) == NULL);
+    CHECK(ds4_transport_lease_bytes(NULL) == 0);
+    ds4_transport_lease_release(NULL);
+
+    char received[sizeof(payload)] = {0};
+    CHECK(ds4_transport_send_bulk_desc(left, &desc,
+                                       payload, sizeof(payload)) == 0);
+    CHECK(ds4_transport_recv_bulk_desc(right, &decoded,
+                                       received, sizeof(received)) == 1);
+    CHECK(memcmp(received, payload, sizeof(payload)) == 0);
+
+    /* Directional sequences are independent on the full-duplex link. */
+    ds4_transport_bulk_desc reverse_desc;
+    CHECK(ds4_transport_prepare_bulk(right,
+                                     DS4_TRANSPORT_BULK_RESULT_HIDDEN,
+                                     17, 23, (uint32_t)sizeof(payload), 32,
+                                     &reverse_desc, err, sizeof(err)) == 0);
+    CHECK(reverse_desc.sequence == 1);
+    memset(received, 0, sizeof(received));
+    CHECK(ds4_transport_send_bulk_desc(right, &reverse_desc,
+                                       payload, sizeof(payload)) == 0);
+    CHECK(ds4_transport_recv_bulk_desc(left, &reverse_desc,
+                                       received, sizeof(received)) == 1);
+    CHECK(memcmp(received, payload, sizeof(payload)) == 0);
+
+    /* A descriptor from another connection generation is rejected before
+     * reading any payload, and poisons this generation against retry. */
+    ds4_transport_bulk_desc next_desc;
+    CHECK(ds4_transport_prepare_bulk(left,
+                                     DS4_TRANSPORT_BULK_INPUT_HIDDEN,
+                                     17, 29, (uint32_t)sizeof(payload), 32,
+                                     &next_desc, err, sizeof(err)) == 0);
+    CHECK(ds4_transport_send_bulk_desc(left, &next_desc,
+                                       payload, sizeof(payload)) == 0);
+    ds4_transport_bulk_desc stale = next_desc;
+    stale.generation--;
+    errno = 0;
+    CHECK(ds4_transport_recv_bulk_desc(right, &stale,
+                                       received, sizeof(received)) == -1);
+    CHECK(errno == EPROTO);
+    errno = 0;
+    CHECK(ds4_transport_recv_bulk_desc(right, &next_desc,
+                                       received, sizeof(received)) == -1);
+    CHECK(errno == EPROTO);
+
+done:
+    ds4_transport_release(right);
+    ds4_transport_release(left);
+    if (sv[1] >= 0) close(sv[1]);
+    if (sv[0] >= 0) close(sv[0]);
+}
+
+static void test_mapped_lease_core(void) {
+    int sv[2] = {-1, -1};
+    char err[128] = "";
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+    if (sv[0] < 0 || sv[1] < 0) return;
+
+    fake_lease_ctx *ctx = calloc(1, sizeof(*ctx));
+    CHECK(ctx != NULL);
+    if (!ctx) goto done;
+    ds4_transport *t = ds4_transport_internal_create(
+        &fake_lease_ops, sv[0], 0, ctx, 4096u, 8u, err, sizeof(err));
+    CHECK(t != NULL);
+    if (!t) {
+        free(ctx);
+        goto done;
+    }
+    CHECK(ds4_transport_configure_link(t, 77u, 4096u, 8u,
+                                       err, sizeof(err)) == 0);
+    CHECK(ds4_transport_mapped_leases_supported(t) == 1);
+    CHECK((ds4_transport_caps(t) & DS4_TRANSPORT_CAP_GPU_MAPPED) != 0);
+
+    ds4_transport_bulk_desc desc;
+    CHECK(ds4_transport_prepare_bulk(
+              t, DS4_TRANSPORT_BULK_INPUT_HIDDEN, 3u, 5u, 128u, 16u,
+              &desc, err, sizeof(err)) == 0);
+    CHECK(desc.mode == DS4_TRANSPORT_BULK_NHI_OOB);
+    CHECK(desc.sequence == 1u);
+
+    ds4_transport_lease *lease = NULL;
+    CHECK(ds4_transport_tx_lease_acquire(t, &desc, &lease,
+                                         err, sizeof(err)) == 0);
+    CHECK(lease != NULL);
+    CHECK(ds4_transport_lease_host_ptr(lease) == ctx->host);
+    CHECK(ds4_transport_lease_device_ptr(lease) == ctx->device);
+    CHECK(ds4_transport_lease_bytes(lease) == 128u);
+
+    /* A lease blocks a second prepare, and commit cannot precede the control
+     * record. Neither condition consumes the directional sequence. */
+    ds4_transport_bulk_desc blocked;
+    errno = 0;
+    CHECK(ds4_transport_prepare_bulk(
+              t, DS4_TRANSPORT_BULK_INPUT_HIDDEN, 3u, 6u, 128u, 16u,
+              &blocked, err, sizeof(err)) == -1);
+    CHECK(errno == EBUSY);
+    errno = 0;
+    CHECK(ds4_transport_lease_commit(lease) == -1);
+    CHECK(errno == EPERM);
+    errno = 0;
+    CHECK(ds4_transport_lease_commit_gpu_quiesced(lease) == -1);
+    CHECK(errno == EPERM);
+
+    CHECK(ds4_transport_lease_abort(lease) == 0);
+    CHECK(ds4_transport_lease_host_ptr(lease) == NULL);
+    ds4_transport_lease_release(lease);
+    lease = NULL;
+
+    /* Recoverable abort rolls back exactly the immediately outstanding
+     * prepare, so the next descriptor reuses sequence one. */
+    CHECK(ds4_transport_prepare_bulk(
+              t, DS4_TRANSPORT_BULK_INPUT_HIDDEN, 3u, 7u, 128u, 16u,
+              &desc, err, sizeof(err)) == 0);
+    CHECK(desc.sequence == 1u);
+    CHECK(ds4_transport_tx_lease_acquire(t, &desc, &lease,
+                                         err, sizeof(err)) == 0);
+    CHECK(ds4_transport_tx_lease_mark_control_sent(lease) == 0);
+    CHECK(ds4_transport_lease_commit(lease) == 0);
+    CHECK(ctx->conservative_commits == 1u);
+    CHECK(ctx->gpu_quiesced_commits == 0u);
+    CHECK(ds4_transport_lease_bytes(lease) == 0);
+    ds4_transport_lease_release(lease);
+    lease = NULL;
+
+    /* RX commit independently advances the receive sequence. */
+    CHECK(ds4_transport_rx_lease_acquire(t, &desc, &lease,
+                                         err, sizeof(err)) == 0);
+    CHECK(ds4_transport_lease_commit_gpu_quiesced(lease) == 0);
+    CHECK(ctx->conservative_commits == 1u);
+    CHECK(ctx->gpu_quiesced_commits == 1u);
+    ds4_transport_lease_release(lease);
+    lease = NULL;
+
+    /* The scoped fast path has the same TX control and sequence rules while
+     * forwarding the caller's quiescence assertion to the backend. */
+    CHECK(ds4_transport_prepare_bulk(
+              t, DS4_TRANSPORT_BULK_INPUT_HIDDEN, 3u, 8u, 128u, 16u,
+              &desc, err, sizeof(err)) == 0);
+    CHECK(desc.sequence == 2u);
+    CHECK(ds4_transport_tx_lease_acquire(t, &desc, &lease,
+                                         err, sizeof(err)) == 0);
+    CHECK(ds4_transport_tx_lease_mark_control_sent(lease) == 0);
+    CHECK(ds4_transport_lease_commit_gpu_quiesced(lease) == 0);
+    CHECK(ctx->conservative_commits == 1u);
+    CHECK(ctx->gpu_quiesced_commits == 2u);
+    ds4_transport_lease_release(lease);
+    lease = NULL;
+
+    CHECK(ds4_transport_prepare_bulk(
+              t, DS4_TRANSPORT_BULK_INPUT_HIDDEN, 3u, 9u, 128u, 16u,
+              &desc, err, sizeof(err)) == 0);
+    CHECK(desc.sequence == 3u);
+    CHECK(ds4_transport_tx_lease_acquire(t, &desc, &lease,
+                                         err, sizeof(err)) == 0);
+    CHECK(ds4_transport_tx_lease_mark_control_sent(lease) == 0);
+    errno = 0;
+    CHECK(ds4_transport_lease_abort(lease) == -1);
+    CHECK(errno == ECANCELED);
+    ds4_transport_lease_release(lease);
+    errno = 0;
+    CHECK(ds4_transport_prepare_bulk(
+              t, DS4_TRANSPORT_BULK_INPUT_HIDDEN, 3u, 10u, 128u, 16u,
+              &desc, err, sizeof(err)) == -1);
+    CHECK(errno == ECANCELED);
+
+    ds4_transport_release(t);
+
+done:
+    if (sv[1] >= 0) close(sv[1]);
+    if (sv[0] >= 0) close(sv[0]);
+}
+
+int main(void) {
+    int sv[2] = {-1, -1};
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+    if (sv[0] < 0 || sv[1] < 0) return 1;
+
+    char err[128] = "";
+    ds4_transport *left = ds4_transport_tcp_dup(sv[0], err, sizeof(err));
+    ds4_transport *right = ds4_transport_tcp_create(sv[1], err, sizeof(err));
+    CHECK(left != NULL);
+    CHECK(right != NULL);
+    if (!left || !right) return 1;
+
+    CHECK(ds4_transport_retain(left) == left);
+    CHECK(ds4_transport_control_fd(left) >= 0);
+    CHECK(ds4_transport_control_fd(left) != sv[0]);
+    CHECK(strcmp(ds4_transport_name(left), "tcp") == 0);
+    CHECK(ds4_transport_caps(left) == DS4_TRANSPORT_CAP_STREAM);
+
+    /* The owned transport keeps its duplicate alive after the monitored
+     * original descriptor is closed. */
+    close(sv[0]);
+    sv[0] = -1;
+
+    static const char forward[] = "persistent transport";
+    char buf[sizeof(forward)] = {0};
+    CHECK(ds4_transport_send_bulk(left, forward, sizeof(forward)) == 0);
+    CHECK(ds4_transport_recv_bulk(right, buf, sizeof(buf)) == 1);
+    CHECK(memcmp(buf, forward, sizeof(forward)) == 0);
+
+    static const char reverse[] = "full duplex";
+    memset(buf, 0, sizeof(buf));
+    CHECK(ds4_transport_send_bulk(right, reverse, sizeof(reverse)) == 0);
+    CHECK(ds4_transport_recv_bulk(left, buf, sizeof(reverse)) == 1);
+    CHECK(memcmp(buf, reverse, sizeof(reverse)) == 0);
+
+    CHECK(ds4_transport_send_bulk(left, NULL, 0) == 0);
+    CHECK(ds4_transport_recv_bulk(right, NULL, 0) == 1);
+
+    ds4_transport_release(left);
+    CHECK(ds4_transport_send_bulk(left, forward, sizeof(forward)) == 0);
+    memset(buf, 0, sizeof(buf));
+    CHECK(ds4_transport_recv_bulk(right, buf, sizeof(forward)) == 1);
+    CHECK(memcmp(buf, forward, sizeof(forward)) == 0);
+
+    CHECK(shutdown(ds4_transport_control_fd(left), SHUT_WR) == 0);
+    CHECK(ds4_transport_recv_bulk(right, buf, 1) == 0);
+
+    ds4_transport_release(right);
+    right = NULL;
+    close(sv[1]);
+    sv[1] = -1;
+
+    /* A closed peer is an ordinary write failure, never process-wide
+     * SIGPIPE. This covers Linux MSG_NOSIGNAL and BSD/macOS SO_NOSIGPIPE. */
+    CHECK(ds4_transport_send_bulk(left, forward, sizeof(forward)) == -1);
+    ds4_transport_release(left);
+    left = NULL;
+
+    errno = 0;
+    CHECK(ds4_transport_tcp_create(-1, err, sizeof(err)) == NULL);
+    CHECK(errno == EINVAL);
+
+    test_descriptor_sequences();
+    test_mapped_lease_core();
+
+    fprintf(stderr, "test_transport: %d/%d checks passed (%d failed)\n",
+            checks - failures, checks, failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What this does

Extends the distributed layer with a second bulk transport, GPU event timing, and the tests that qualify both.

- **Protocol v3 links.** Link negotiation is versioned and fails closed: peers agree on either descriptor-framed TCP or NHI (the USB4/Thunderbolt native host interface), with generation-scoped bulk descriptors, an ACK/READY activation barrier, and single-link lifecycle checks. `--dist-transport auto` selects descriptor-framed TCP. `--dist-transport nhi --dist-nhi-device PATH` selects the NHI backend. `--dist-transport tcp` keeps the legacy protocol.
- **NHI transport.** Bulk payloads move over the Thunderbolt link through a zero-copy stream device with staged CPU copies. A separate mapped-lease mode (`DS4_DIST_NHI_MAPPED=1` on both peers) hands contiguous payloads directly to the registered driver slot, with a HIP fence on every ownership transfer.
- **Multi-token-prediction support** in the distributed transport and session layer.
- **ROCm event timing** (`ds4_rocm_timing`): low-overhead GPU event timing with a host-testable fake backend, plus prequantized decode controls.
- **Tests:** `tests/test_dist_v3` (87 checks), `tests/test_rocm_timing_fake` (183 checks), `tests/test_gpu_timing_stubs` (15 checks), `tests/test_transport`, and two opt-in live tests that need two hosts (`make test-nhi-live`, `make test-nhi-live-rocm`).
- **Documentation:** `RDMA.md` describes the transport design and the hardware limits behind it; README and STRIXHALO are updated.

## Performance

Measured on two Radeon 8060S machines over Thunderbolt, with a pipelined prefill of about 7,500 tokens and 32-bit activations. Full tables and method are in the benchmark comment below.

| configuration | bulk send throughput |
|---|---:|
| legacy TCP | 1062 MiB/s |
| descriptor-framed TCP (default with `auto`) | 1191 MiB/s |
| NHI, CPU-copy mode | 1192 MiB/s |
| NHI, mapped-lease mode | 131 MiB/s |

Descriptor framing is 12% faster than the legacy protocol. The NHI CPU-copy path matches descriptor-framed TCP exactly, which is why it remains a lab option behind an explicit device flag, as `RDMA.md` states. The mapped-lease mode is nine times slower because of the per-transfer fences; it exists for hardware qualification and defaults off. At these payload sizes, transport is about half a percent of total prefill time — the value of the faster framing is in per-token transfers and larger activation shapes, not in the prefill total.

## Correctness

Rebased on current main (`84cc882`):

- Warning-free `make strix-halo`. Built with `-fPIC` in `CFLAGS`; main does not yet carry the `ROCM_HOST_CFLAGS` fix, which ships separately in #656. The build rule already references `ROCM_HOST_CFLAGS`, which stays empty until that lands.
- `make test-dist-v3 test-gpu-timing test-rocm-timing`: 87 of 87, 183 of 183, and 15 of 15 checks pass.
- End to end on two machines with greedy decoding and the released Q4_K-experts model file, coordinator running layers 0–21 and worker running 22–output: output byte-identical to unmodified main's distributed run at the same settings, throughput at parity (24.7 tokens/s prefill, 13.4 tokens/s decode).

## Scope

Left out to keep this reviewable: the multi-row decode kernels (#821), batched speculative verification, decode staggering, HIP graph capture (#819), and the MXFP4 kernels (#656). One note for whoever merges both this and #656: a follow-up adds `n_expert` and `atomic_out` parameters to the MXFP4 down-projection kernel for batched verification; that change is deliberately absent here because main has no MXFP4 code.

## How to test

`make strix-halo && make test-dist-v3 test-gpu-timing test-rocm-timing`. The live NHI tests need two hosts; see `RDMA.md`.
