### PR TITLE
ROCm: exact-rows k-row kernel tier for batched decode (kernels + exactness gate)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ DS4_LINK_LIBS ?= $(CUDA_LDLIBS)
 METAL_LDLIBS := $(LDLIBS)
 endif
 
-.PHONY: all help clean test test-metal-session-batch test-mxfp4-cuda test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
+.PHONY: all help clean test test-metal-session-batch test-mxfp4-cuda test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm test-q8-krow-rocm
 
 ifeq ($(UNAME_S),Darwin)
 .PHONY: metal-decode-schedule-bench metal-prefill-variant-bench check-mxfp4-half-lut
@@ -331,6 +331,14 @@ cuda/mmq/ds4_repack.o: cuda/mmq/ds4_repack.cu cuda/mmq/ds4_repack.h
 ds4_rocm.o: ds4_rocm.cu ds4_gpu.h ds4_iq2_tables_cuda.inc $(ROCM_SRCS)
 	$(HIPCC) $(ROCM_CFLAGS) -c -o $@ ds4_rocm.cu
 
+tests/test_q8_krow_rocm.o: tests/test_q8_krow_rocm.c ds4_gpu.h
+	$(CC) $(filter-out -ffast-math,$(CFLAGS)) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD -I. -c -o $@ $<
+
+tests/test_q8_krow_rocm: tests/test_q8_krow_rocm.o ds4_rocm.o ds4_rocm_compat.o
+	$(HIPCC) $(ROCM_CFLAGS) -o $@ $^ $(ROCM_LDLIBS)
+
+test-q8-krow-rocm: tests/test_q8_krow_rocm
+	./tests/test_q8_krow_rocm
 ds4_rocm_compat.o: ds4_rocm_compat.cu ds4_gpu.h ds4_gpu_mgpu.h ds4_gpu_args.h
 	$(HIPCC) $(ROCM_CFLAGS) -c -o $@ ds4_rocm_compat.cu
 

--- a/ds4_rocm_compat.cu
+++ b/ds4_rocm_compat.cu
@@ -214,13 +214,34 @@ extern "C" int ds4_gpu_set_decode_score_vec4(int enabled) {
     return 0;
 }
 
+/* The exact-rows contract promises every row in the one-row reduction
+ * order.  Rows 2..5 ride the k-row tiers; beyond that, evaluate each row
+ * through the one-row path rather than silently handing the span to the
+ * generic batch tiers, whose reduction order differs. */
 extern "C" int ds4_gpu_matmul_q8_0_decode_rows_exact_tensor(
         ds4_gpu_tensor *out, const void *model_map, uint64_t model_size,
         uint64_t weight_offset, uint64_t in_dim, uint64_t out_dim,
         const ds4_gpu_tensor *x, uint32_t n_rows) {
-    return ds4_gpu_matmul_q8_0_tensor(out, model_map, model_size,
-                                      weight_offset, in_dim, out_dim, x,
-                                      n_rows);
+    if (n_rows <= 5u) {
+        return ds4_gpu_matmul_q8_0_tensor(out, model_map, model_size,
+                                          weight_offset, in_dim, out_dim, x,
+                                          n_rows);
+    }
+    for (uint32_t r = 0; r < n_rows; r++) {
+        ds4_gpu_tensor *out_row = ds4_gpu_tensor_view(
+            out, (uint64_t)r * out_dim * sizeof(float),
+            out_dim * sizeof(float));
+        ds4_gpu_tensor *x_row = ds4_gpu_tensor_view(
+            x, (uint64_t)r * in_dim * sizeof(float), in_dim * sizeof(float));
+        const int ok = out_row && x_row &&
+            ds4_gpu_matmul_q8_0_tensor(out_row, model_map, model_size,
+                                       weight_offset, in_dim, out_dim,
+                                       x_row, 1u);
+        if (out_row) ds4_gpu_tensor_free(out_row);
+        if (x_row) ds4_gpu_tensor_free(x_row);
+        if (!ok) return 0;
+    }
+    return 1;
 }
 
 extern "C" int ds4_gpu_matmul_q8_0_pair_decode_rows_exact_tensor(
@@ -228,16 +249,58 @@ extern "C" int ds4_gpu_matmul_q8_0_pair_decode_rows_exact_tensor(
         uint64_t model_size, uint64_t weight0_offset,
         uint64_t weight1_offset, uint64_t in_dim, uint64_t out0_dim,
         uint64_t out1_dim, const ds4_gpu_tensor *x, uint32_t n_rows) {
-    return ds4_gpu_matmul_q8_0_pair_tensor(
-            out0, out1, model_map, model_size, weight0_offset, weight1_offset,
-            in_dim, out0_dim, out1_dim, x, n_rows);
+    if (n_rows <= 5u) {
+        return ds4_gpu_matmul_q8_0_pair_tensor(
+                out0, out1, model_map, model_size, weight0_offset,
+                weight1_offset, in_dim, out0_dim, out1_dim, x, n_rows);
+    }
+    for (uint32_t r = 0; r < n_rows; r++) {
+        ds4_gpu_tensor *o0 = ds4_gpu_tensor_view(
+            out0, (uint64_t)r * out0_dim * sizeof(float),
+            out0_dim * sizeof(float));
+        ds4_gpu_tensor *o1 = ds4_gpu_tensor_view(
+            out1, (uint64_t)r * out1_dim * sizeof(float),
+            out1_dim * sizeof(float));
+        ds4_gpu_tensor *x_row = ds4_gpu_tensor_view(
+            x, (uint64_t)r * in_dim * sizeof(float), in_dim * sizeof(float));
+        const int ok = o0 && o1 && x_row &&
+            ds4_gpu_matmul_q8_0_pair_tensor(
+                o0, o1, model_map, model_size, weight0_offset,
+                weight1_offset, in_dim, out0_dim, out1_dim, x_row, 1u);
+        if (o0) ds4_gpu_tensor_free(o0);
+        if (o1) ds4_gpu_tensor_free(o1);
+        if (x_row) ds4_gpu_tensor_free(x_row);
+        if (!ok) return 0;
+    }
+    return 1;
 }
 
 extern "C" int ds4_gpu_matmul_f16_router_rows_exact_tensor(
         ds4_gpu_tensor *out, const void *model_map, uint64_t model_size,
         uint64_t weight_offset, const ds4_gpu_tensor *x, uint32_t n_rows) {
-    return ds4_gpu_matmul_f16_tensor(out, model_map, model_size, weight_offset,
-                                     4096u, 256u, x, n_rows);
+    /* Router logits gate expert selection, so every row must reduce in
+     * the one-row order or batched rows can route to different experts
+     * than solo decode.  The multi-row f16 tiers do not preserve that
+     * order; the router is small enough (4096x256) that evaluating the
+     * rows through the one-row path costs nothing measurable. */
+    if (n_rows <= 1u) {
+        return ds4_gpu_matmul_f16_tensor(out, model_map, model_size,
+                                         weight_offset, 4096u, 256u, x, 1u);
+    }
+    for (uint32_t r = 0; r < n_rows; r++) {
+        ds4_gpu_tensor *out_row = ds4_gpu_tensor_view(
+            out, (uint64_t)r * 256u * sizeof(float), 256u * sizeof(float));
+        ds4_gpu_tensor *x_row = ds4_gpu_tensor_view(
+            (ds4_gpu_tensor *)x, (uint64_t)r * 4096u * sizeof(float),
+            4096u * sizeof(float));
+        const int ok = out_row && x_row &&
+            ds4_gpu_matmul_f16_tensor(out_row, model_map, model_size,
+                                      weight_offset, 4096u, 256u, x_row, 1u);
+        if (out_row) ds4_gpu_tensor_free(out_row);
+        if (x_row) ds4_gpu_tensor_free(x_row);
+        if (!ok) return 0;
+    }
+    return 1;
 }
 
 extern "C" int ds4_gpu_dsv4_qkv_rms_norm_rows_kv_rope_tensor(

--- a/rocm/ds4_rocm_matmul.cuh
+++ b/rocm/ds4_rocm_matmul.cuh
@@ -321,7 +321,7 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
         !cuda_u64_mul3_checked(n_tok, in_dim, sizeof(float), &x_bytes) ||
         !cuda_u64_mul3_checked(n_tok, out_dim, sizeof(float), &out_bytes) ||
         x->bytes < x_bytes || out->bytes < out_bytes) return 0;
-    if (n_tok > 1 && !g_quality_mode &&
+    if (n_tok > 5u && !g_quality_mode &&
         cuda_runtime_config()->shared_down_cublas && in_dim == 2048u && out_dim == 4096u &&
         cuda_matmul_q8_0_tensor_f16_gemm(out, model_map, model_size, weight_offset,
                                          in_dim, out_dim, x, n_tok, label ? label : "shared_expert")) {
@@ -329,6 +329,55 @@ static int cuda_matmul_q8_0_tensor_labeled(ds4_gpu_tensor *out, const void *mode
     }
     const char *wptr = cuda_model_range_ptr(model_map, weight_offset, weight_bytes, "q8_0");
     if (!wptr) return 0;
+    if (n_tok >= 2u && n_tok <= 5u && cuda_q8_prequant_decode_enabled()) {
+        /* Tiny multi-row spans (speculative verify, small dist chunks): one
+         * weight pass serves every row and each row keeps the decode tier's
+         * exact summation order.  The f32 batch tiers below re-read the
+         * weights per row and reduce in a different shape, which is both
+         * slower at these widths (gfx1151: 2 MB L2, no MALL, so re-reads
+         * always come from DRAM) and not usable by the exact verifier. */
+        const uint64_t xq_bytes = n_tok * blocks * 32u;
+        const uint64_t scale_offset = (xq_bytes + 15u) & ~15ull;
+        const uint64_t tmp_bytes = scale_offset + n_tok * blocks * sizeof(float);
+        void *tmp = cuda_tmp_alloc(tmp_bytes, "q8_0 krow prequant");
+        if (tmp) {
+            int8_t *xq = (int8_t *)tmp;
+            float *xscale = (float *)((char *)tmp + scale_offset);
+            dim3 qgrid((unsigned)blocks, (unsigned)n_tok, 1);
+            quantize_q8_0_f32_kernel<<<qgrid, 32>>>(
+                    xq, xscale, (const float *)x->ptr, in_dim, blocks);
+            if (!cuda_ok(cudaGetLastError(), "matmul_q8_0 krow quantize launch"))
+                return 0;
+            const uint32_t rows_per_block = cuda_runtime_config()->q8_decode_rpb;
+            const unsigned kgrid = ((unsigned)out_dim + rows_per_block - 1u) / rows_per_block;
+            const unsigned kthreads = rows_per_block * 32u;
+            const int use_dp4a = 1;
+            switch (n_tok) {
+            case 2u:
+                matmul_q8_0_preq_krow_rows_w32_kernel<2u><<<kgrid, kthreads>>>(
+                        (float *)out->ptr, reinterpret_cast<const unsigned char *>(wptr),
+                        xq, xscale, in_dim, out_dim, blocks, rows_per_block, use_dp4a);
+                break;
+            case 3u:
+                matmul_q8_0_preq_krow_rows_w32_kernel<3u><<<kgrid, kthreads>>>(
+                        (float *)out->ptr, reinterpret_cast<const unsigned char *>(wptr),
+                        xq, xscale, in_dim, out_dim, blocks, rows_per_block, use_dp4a);
+                break;
+            case 4u:
+                matmul_q8_0_preq_krow_rows_w32_kernel<4u><<<kgrid, kthreads>>>(
+                        (float *)out->ptr, reinterpret_cast<const unsigned char *>(wptr),
+                        xq, xscale, in_dim, out_dim, blocks, rows_per_block, use_dp4a);
+                break;
+            default:
+                matmul_q8_0_preq_krow_rows_w32_kernel<5u><<<kgrid, kthreads>>>(
+                        (float *)out->ptr, reinterpret_cast<const unsigned char *>(wptr),
+                        xq, xscale, in_dim, out_dim, blocks, rows_per_block, use_dp4a);
+                break;
+            }
+            return cuda_ok(cudaGetLastError(), "matmul_q8_0 krow launch");
+        }
+        /* Temporary-buffer pressure: fall through to the generic tiers. */
+    }
     if (n_tok == 1 && !cuda_q8_prequant_decode_enabled()) {
         const bool extended_sharedx =
             in_dim > 8192u &&
@@ -599,7 +648,8 @@ extern "C" int ds4_gpu_matmul_q8_0_pair_tensor(
         in_dim > UINT32_MAX || out0_dim > UINT32_MAX || out1_dim > UINT32_MAX || n_tok > UINT32_MAX) {
         return 0;
     }
-    if (n_tok != 1) {
+    if (n_tok != 1 &&
+        !(n_tok <= 5u && cuda_q8_prequant_decode_enabled())) {
         return cuda_matmul_q8_0_tensor_labeled(out0, model_map, model_size, weight0_offset,
                                                in_dim, out0_dim, x, n_tok, "q8_0_pair0") &&
                cuda_matmul_q8_0_tensor_labeled(out1, model_map, model_size, weight1_offset,
@@ -615,9 +665,9 @@ extern "C" int ds4_gpu_matmul_q8_0_pair_tensor(
     }
     if (weight0_bytes > model_size - weight0_offset ||
         weight1_bytes > model_size - weight1_offset ||
-        x->bytes < in_dim * sizeof(float) ||
-        out0->bytes < out0_dim * sizeof(float) ||
-        out1->bytes < out1_dim * sizeof(float)) {
+        x->bytes < n_tok * in_dim * sizeof(float) ||
+        out0->bytes < n_tok * out0_dim * sizeof(float) ||
+        out1->bytes < n_tok * out1_dim * sizeof(float)) {
         return 0;
     }
     const char *w0 = cuda_model_range_ptr(model_map, weight0_offset, weight0_bytes, "q8_0_pair0");
@@ -656,34 +706,66 @@ extern "C" int ds4_gpu_matmul_q8_0_pair_tensor(
         return cuda_ok(cudaGetLastError(), "matmul_q8_0 pair f32 warp launch");
     }
 
-    const uint64_t xq_bytes = blocks * 32u;
+    const uint64_t xq_bytes = n_tok * blocks * 32u;
     const uint64_t scale_offset = (xq_bytes + 15u) & ~15ull;
-    const uint64_t tmp_bytes = scale_offset + blocks * sizeof(float);
+    const uint64_t tmp_bytes = scale_offset + n_tok * blocks * sizeof(float);
     void *tmp = cuda_tmp_alloc(tmp_bytes, "q8_0 pair prequant");
     if (!tmp) return 0;
     int8_t *xq = (int8_t *)tmp;
     float *xscale = (float *)((char *)tmp + scale_offset);
     const int use_dp4a = 1;
-    dim3 qgrid((unsigned)blocks, 1, 1);
+    dim3 qgrid((unsigned)blocks, (unsigned)n_tok, 1);
     quantize_q8_0_f32_kernel<<<qgrid, 32>>>(
             xq, xscale, (const float *)x->ptr, in_dim, blocks);
     if (!cuda_ok(cudaGetLastError(), "matmul_q8_0 pair quantize launch")) {
         return 0;
     }
     const uint64_t max_out = out0_dim > out1_dim ? out0_dim : out1_dim;
-    matmul_q8_0_pair_preq_warp8_kernel<<<
-            ((unsigned)max_out + 7u) / 8u, 256>>>(
-            (float *)out0->ptr,
-            (float *)out1->ptr,
-            reinterpret_cast<const unsigned char *>(w0),
-            reinterpret_cast<const unsigned char *>(w1),
-            xq,
-            xscale,
-            in_dim,
-            out0_dim,
-            out1_dim,
-            blocks,
-            use_dp4a);
+    const unsigned pgrid = ((unsigned)max_out + 7u) / 8u;
+    switch (n_tok) {
+    case 1u:
+        matmul_q8_0_pair_preq_warp8_kernel<<<pgrid, 256>>>(
+                (float *)out0->ptr,
+                (float *)out1->ptr,
+                reinterpret_cast<const unsigned char *>(w0),
+                reinterpret_cast<const unsigned char *>(w1),
+                xq,
+                xscale,
+                in_dim,
+                out0_dim,
+                out1_dim,
+                blocks,
+                use_dp4a);
+        break;
+    case 2u:
+        matmul_q8_0_pair_preq_krow_warp8_kernel<2u><<<pgrid, 256>>>(
+                (float *)out0->ptr, (float *)out1->ptr,
+                reinterpret_cast<const unsigned char *>(w0),
+                reinterpret_cast<const unsigned char *>(w1),
+                xq, xscale, in_dim, out0_dim, out1_dim, blocks, use_dp4a);
+        break;
+    case 3u:
+        matmul_q8_0_pair_preq_krow_warp8_kernel<3u><<<pgrid, 256>>>(
+                (float *)out0->ptr, (float *)out1->ptr,
+                reinterpret_cast<const unsigned char *>(w0),
+                reinterpret_cast<const unsigned char *>(w1),
+                xq, xscale, in_dim, out0_dim, out1_dim, blocks, use_dp4a);
+        break;
+    case 4u:
+        matmul_q8_0_pair_preq_krow_warp8_kernel<4u><<<pgrid, 256>>>(
+                (float *)out0->ptr, (float *)out1->ptr,
+                reinterpret_cast<const unsigned char *>(w0),
+                reinterpret_cast<const unsigned char *>(w1),
+                xq, xscale, in_dim, out0_dim, out1_dim, blocks, use_dp4a);
+        break;
+    default:
+        matmul_q8_0_pair_preq_krow_warp8_kernel<5u><<<pgrid, 256>>>(
+                (float *)out0->ptr, (float *)out1->ptr,
+                reinterpret_cast<const unsigned char *>(w0),
+                reinterpret_cast<const unsigned char *>(w1),
+                xq, xscale, in_dim, out0_dim, out1_dim, blocks, use_dp4a);
+        break;
+    }
     return cuda_ok(cudaGetLastError(), "matmul_q8_0 pair warp launch");
 }
 

--- a/rocm/ds4_rocm_q8.cuh
+++ b/rocm/ds4_rocm_q8.cuh
@@ -202,6 +202,78 @@ __global__ static void matmul_q8_0_preq_rows_w32_kernel(
     if (lane == 0u) out[row] = acc;
 }
 
+/* K-row variant of the preq rows_w32 matvec: one weight pass serves K
+ * resident activation rows.  gfx1151 exposes a 2 MB L2 and no MALL, so a
+ * weight stream re-read by another workgroup or launch always comes back
+ * from DRAM; keeping the K dots live in registers is the only level of the
+ * hierarchy that can share it.  The per-row block loop, operand order, and
+ * warp reduction are copied from matmul_q8_0_preq_rows_w32_kernel, so each
+ * row's result is bit-identical to a one-row launch of the decode tier. */
+template <uint32_t K>
+__global__ static void matmul_q8_0_preq_krow_rows_w32_kernel(
+        float *out,
+        const unsigned char *w,
+        const int8_t *xq,
+        const float *xscale,
+        uint64_t in_dim,
+        uint64_t out_dim,
+        uint64_t blocks,
+        uint32_t rows_per_block,
+        int use_dp4a) {
+    const uint64_t row = (uint64_t)blockIdx.x * rows_per_block + (threadIdx.x >> 5u);
+    const uint32_t lane = threadIdx.x & 31u;
+    if (row >= out_dim) return;
+    const unsigned char *wr = w + row * blocks * 34u;
+    float acc[K];
+#pragma unroll
+    for (uint32_t r = 0; r < K; r++) acc[r] = 0.0f;
+    for (uint64_t b = lane; b < blocks; b += 32u) {
+        const uint64_t i0 = b * 32u;
+        const uint64_t bn = in_dim - i0 < 32u ? in_dim - i0 : 32u;
+        const __half *scale_h = (const __half *)(wr + b * 34u);
+        const int8_t *qs = (const int8_t *)(wr + b * 34u + 2u);
+        if (use_dp4a && bn == 32u) {
+            /* Assemble the eight misaligned weight words once; the integer
+             * dot per row is then identical to dot_i8x32_dp4a's, and the
+             * float statement below matches
+             * matmul_q8_0_preq_rows_w32_kernel exactly so fast-math
+             * contraction resolves identically: every row stays bit-equal
+             * to a one-row launch while the weight stream is read once. */
+            int32_t wv[8];
+#pragma unroll
+            for (uint32_t i = 0; i < 8u; i++) {
+                wv[i] = load_i8x4_i32_unaligned(qs + i * 4u);
+            }
+            /* Keep this loop rolled: with -ffast-math an unrolled tail
+             * iteration can contract the accumulate differently from the
+             * body, which breaks row-vs-row bit equality. */
+#pragma unroll 1
+            for (uint32_t r = 0; r < K; r++) {
+                const int8_t *xqb = xq + ((uint64_t)r * blocks + b) * 32u;
+                int32_t d32 = 0;
+#pragma unroll
+                for (uint32_t i = 0; i < 8u; i++) {
+                    d32 = __dp4a(wv[i], load_i8x4_i32_aligned(xqb + i * 4u), d32);
+                }
+                int dot = d32;
+                acc[r] += __half2float(*scale_h) * xscale[(uint64_t)r * blocks + b] * (float)dot;
+            }
+        } else {
+#pragma unroll
+            for (uint32_t r = 0; r < K; r++) {
+                const int8_t *xqb = xq + ((uint64_t)r * blocks + b) * 32u;
+                int dot = dot_i8_block(qs, xqb, bn, use_dp4a);
+                acc[r] += __half2float(*scale_h) * xscale[(uint64_t)r * blocks + b] * (float)dot;
+            }
+        }
+    }
+#pragma unroll
+    for (uint32_t r = 0; r < K; r++) {
+        const float a = warp_sum_f32(acc[r]);
+        if (lane == 0u) out[(uint64_t)r * out_dim + row] = a;
+    }
+}
+
 __global__ static void matmul_q8_0_pair_preq_warp8_kernel(
         float *out0,
         float *out1,
@@ -244,6 +316,113 @@ __global__ static void matmul_q8_0_pair_preq_warp8_kernel(
     if (lane == 0) {
         if (row < out0_dim) out0[row] = acc0;
         if (row < out1_dim) out1[row] = acc1;
+    }
+}
+
+/* K-row variant of the fused pair matvec, same discipline as
+ * matmul_q8_0_preq_krow_rows_w32_kernel: both weight streams are read
+ * once for K rows, weight words are assembled once per block, the row
+ * loop stays rolled, and the accumulate statements mirror
+ * matmul_q8_0_pair_preq_warp8_kernel so every row is bit-equal to a
+ * one-row pair launch. */
+template <uint32_t K>
+__global__ static void matmul_q8_0_pair_preq_krow_warp8_kernel(
+        float *out0,
+        float *out1,
+        const unsigned char *w0,
+        const unsigned char *w1,
+        const int8_t *xq,
+        const float *xscale,
+        uint64_t in_dim,
+        uint64_t out0_dim,
+        uint64_t out1_dim,
+        uint64_t blocks,
+        int use_dp4a) {
+    const uint64_t row = (uint64_t)blockIdx.x * 8u + (threadIdx.x >> 5u);
+    const uint32_t lane = threadIdx.x & 31u;
+    if (row >= out0_dim && row >= out1_dim) return;
+    float acc0[K];
+    float acc1[K];
+#pragma unroll
+    for (uint32_t r = 0; r < K; r++) {
+        acc0[r] = 0.0f;
+        acc1[r] = 0.0f;
+    }
+    const unsigned char *wr0 = row < out0_dim ? w0 + row * blocks * 34u : NULL;
+    const unsigned char *wr1 = row < out1_dim ? w1 + row * blocks * 34u : NULL;
+    for (uint64_t b = lane; b < blocks; b += 32u) {
+        const uint64_t i0 = b * 32u;
+        const uint64_t bn = in_dim - i0 < 32u ? in_dim - i0 : 32u;
+        if (use_dp4a && bn == 32u) {
+            int32_t wv0[8];
+            int32_t wv1[8];
+            if (wr0) {
+                const int8_t *qs = (const int8_t *)(wr0 + b * 34u + 2u);
+#pragma unroll
+                for (uint32_t i = 0; i < 8u; i++) {
+                    wv0[i] = load_i8x4_i32_unaligned(qs + i * 4u);
+                }
+            }
+            if (wr1) {
+                const int8_t *qs = (const int8_t *)(wr1 + b * 34u + 2u);
+#pragma unroll
+                for (uint32_t i = 0; i < 8u; i++) {
+                    wv1[i] = load_i8x4_i32_unaligned(qs + i * 4u);
+                }
+            }
+#pragma unroll 1
+            for (uint32_t r = 0; r < K; r++) {
+                const int8_t *xqb = xq + ((uint64_t)r * blocks + b) * 32u;
+                const float xs = xscale[(uint64_t)r * blocks + b];
+                if (wr0) {
+                    const __half *scale_h = (const __half *)(wr0 + b * 34u);
+                    int32_t d32 = 0;
+#pragma unroll
+                    for (uint32_t i = 0; i < 8u; i++) {
+                        d32 = __dp4a(wv0[i], load_i8x4_i32_aligned(xqb + i * 4u), d32);
+                    }
+                    int dot = d32;
+                    acc0[r] += __half2float(*scale_h) * xs * (float)dot;
+                }
+                if (wr1) {
+                    const __half *scale_h = (const __half *)(wr1 + b * 34u);
+                    int32_t d32 = 0;
+#pragma unroll
+                    for (uint32_t i = 0; i < 8u; i++) {
+                        d32 = __dp4a(wv1[i], load_i8x4_i32_aligned(xqb + i * 4u), d32);
+                    }
+                    int dot = d32;
+                    acc1[r] += __half2float(*scale_h) * xs * (float)dot;
+                }
+            }
+        } else {
+#pragma unroll 1
+            for (uint32_t r = 0; r < K; r++) {
+                const int8_t *xqb = xq + ((uint64_t)r * blocks + b) * 32u;
+                const float xs = xscale[(uint64_t)r * blocks + b];
+                if (wr0) {
+                    const __half *scale_h = (const __half *)(wr0 + b * 34u);
+                    const int8_t *qs = (const int8_t *)(wr0 + b * 34u + 2u);
+                    int dot = dot_i8_block(qs, xqb, bn, use_dp4a);
+                    acc0[r] += __half2float(*scale_h) * xs * (float)dot;
+                }
+                if (wr1) {
+                    const __half *scale_h = (const __half *)(wr1 + b * 34u);
+                    const int8_t *qs = (const int8_t *)(wr1 + b * 34u + 2u);
+                    int dot = dot_i8_block(qs, xqb, bn, use_dp4a);
+                    acc1[r] += __half2float(*scale_h) * xs * (float)dot;
+                }
+            }
+        }
+    }
+#pragma unroll
+    for (uint32_t r = 0; r < K; r++) {
+        const float a0 = warp_sum_f32(acc0[r]);
+        const float a1 = warp_sum_f32(acc1[r]);
+        if (lane == 0) {
+            if (row < out0_dim) out0[(uint64_t)r * out0_dim + row] = a0;
+            if (row < out1_dim) out1[(uint64_t)r * out1_dim + row] = a1;
+        }
     }
 }
 

--- a/rocm/ds4_rocm_shared_expert.cuh
+++ b/rocm/ds4_rocm_shared_expert.cuh
@@ -79,10 +79,52 @@ extern "C" int ds4_gpu_shared_gate_up_swiglu_q8_0_rows_scalar_tensor(
         const ds4_gpu_tensor *x,
         uint64_t                n_tok,
         float                   clamp) {
-    (void)gate; (void)up; (void)mid; (void)model_map; (void)model_size;
-    (void)gate_offset; (void)up_offset; (void)in_dim; (void)out_dim;
-    (void)x; (void)n_tok; (void)clamp;
-    return 0;
+    /* Multi-row shared expert in the one-row reduction order.  With
+     * prequantized decode active, the one-row path is the fused pair
+     * matvec plus the elementwise swiglu, so the k-row pair tier plus the
+     * same swiglu over every row reproduces it bit-for-bit.  Quality mode
+     * uses the fused w32 kernel instead; return 0 there so the caller
+     * keeps its existing fallback. */
+    if (!gate || !up || !mid || !x || n_tok == 0u ||
+        out_dim > UINT32_MAX ||
+        !cuda_q8_prequant_decode_enabled()) {
+        return 0;
+    }
+    uint64_t mid_values = 0;
+    if (!cuda_u64_mul_checked(n_tok, out_dim, &mid_values) ||
+        mid_values > UINT32_MAX) {
+        return 0;
+    }
+    if (n_tok <= 5u) {
+        return ds4_gpu_matmul_q8_0_pair_tensor(gate, up,
+                                               model_map, model_size,
+                                               gate_offset, up_offset,
+                                               in_dim, out_dim, out_dim,
+                                               x, n_tok) &&
+               ds4_gpu_swiglu_tensor(mid, gate, up, (uint32_t)mid_values,
+                                     clamp, 1.0f);
+    }
+    /* Wider spans: per-row through the one-row entry keeps the contract. */
+    for (uint64_t r = 0; r < n_tok; r++) {
+        ds4_gpu_tensor *g_row = ds4_gpu_tensor_view(
+            gate, r * out_dim * sizeof(float), out_dim * sizeof(float));
+        ds4_gpu_tensor *u_row = ds4_gpu_tensor_view(
+            up, r * out_dim * sizeof(float), out_dim * sizeof(float));
+        ds4_gpu_tensor *m_row = ds4_gpu_tensor_view(
+            mid, r * out_dim * sizeof(float), out_dim * sizeof(float));
+        ds4_gpu_tensor *x_row = ds4_gpu_tensor_view(
+            x, r * in_dim * sizeof(float), in_dim * sizeof(float));
+        const int ok = g_row && u_row && m_row && x_row &&
+            ds4_gpu_shared_gate_up_swiglu_q8_0_tensor(
+                g_row, u_row, m_row, model_map, model_size,
+                gate_offset, up_offset, in_dim, out_dim, x_row, clamp);
+        if (g_row) ds4_gpu_tensor_free(g_row);
+        if (u_row) ds4_gpu_tensor_free(u_row);
+        if (m_row) ds4_gpu_tensor_free(m_row);
+        if (x_row) ds4_gpu_tensor_free(x_row);
+        if (!ok) return 0;
+    }
+    return 1;
 }
 
 extern "C" int ds4_gpu_shared_gate_up_swiglu_q8_0_batch_tensor(

--- a/tests/bench_q8_krow_rocm.c
+++ b/tests/bench_q8_krow_rocm.c
@@ -1,0 +1,241 @@
+/* Throughput benchmark for the ROCm k-row Q8_0 prequant matvec tier.
+ *
+ * Compares, at production decode shapes:
+ *   A) one k-row batched call  (ds4_gpu_matmul_q8_0_decode_rows_exact_tensor)
+ *   B) k sequential one-row calls (ds4_gpu_matmul_q8_0_tensor, n_tok=1)
+ * which is what the speculative verifier's span evaluation costs without
+ * the tier.  Also verifies the two paths stay bit-identical, so the
+ * reported speedup is for the exact-rows contract, not an approximation.
+ */
+
+#include "ds4_gpu.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+
+static double now_sec(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+#define Q8_BLOCK_BYTES 34u
+#define MAX_K 6u
+
+typedef struct {
+    uint32_t in_dim;
+    uint32_t out_dim;
+} shape;
+
+static uint32_t rng_state;
+static uint32_t rng_next(void) {
+    rng_state = rng_state * 1664525u + 1013904223u;
+    return rng_state;
+}
+static float rng_float(void) {
+    return ((float)(rng_next() >> 8) / (float)(1u << 24)) * 2.0f - 1.0f;
+}
+
+static void fill_q8_weights(uint8_t *w, uint32_t out_dim, uint32_t blocks) {
+    for (uint64_t row = 0; row < out_dim; row++) {
+        for (uint64_t b = 0; b < blocks; b++) {
+            uint8_t *blk = w + (row * blocks + b) * Q8_BLOCK_BYTES;
+            const uint16_t scale_bits = (uint16_t)(0x2c00u + (rng_next() & 0x3ffu));
+            blk[0] = (uint8_t)(scale_bits & 0xffu);
+            blk[1] = (uint8_t)(scale_bits >> 8);
+            for (uint32_t j = 0; j < 32u; j++) {
+                blk[2u + j] = (uint8_t)(int8_t)((int)(rng_next() % 255u) - 127);
+            }
+        }
+    }
+}
+
+static double bench_rows(ds4_gpu_tensor *out_batch_t, const void *model,
+                         uint64_t model_size, uint64_t weight_offset,
+                         uint32_t in_dim, uint32_t out_dim,
+                         ds4_gpu_tensor *x_batch_t, uint32_t k,
+                         float *out_batch, int iters) {
+    double best = 1e30;
+    for (int t = 0; t < 3; t++) {
+        const double t0 = now_sec();
+        for (int i = 0; i < iters; i++) {
+            if (!ds4_gpu_matmul_q8_0_decode_rows_exact_tensor(
+                    out_batch_t, model, model_size, weight_offset,
+                    in_dim, out_dim, x_batch_t, k)) return -1.0;
+        }
+        if (!ds4_gpu_tensor_read(out_batch_t, 0u, out_batch, sizeof(float)))
+            return -1.0;
+        const double el = (now_sec() - t0) * 1000.0 / iters;
+        if (el < best) best = el;
+    }
+    return best;
+}
+
+static double bench_seq(ds4_gpu_tensor *out_row_t, const void *model,
+                        uint64_t model_size, uint64_t weight_offset,
+                        uint32_t in_dim, uint32_t out_dim,
+                        ds4_gpu_tensor *x_row_t, float *x, uint32_t k,
+                        float *out_row, int iters) {
+    double best = 1e30;
+    for (int t = 0; t < 3; t++) {
+        const double t0 = now_sec();
+        for (int i = 0; i < iters; i++) {
+            for (uint32_t r = 0; r < k; r++) {
+                if (!ds4_gpu_tensor_write(x_row_t, 0u,
+                                          x + (uint64_t)r * in_dim,
+                                          (uint64_t)in_dim * sizeof(float)) ||
+                    !ds4_gpu_matmul_q8_0_tensor(out_row_t, model, model_size,
+                                                weight_offset, in_dim, out_dim,
+                                                x_row_t, 1u)) return -1.0;
+            }
+        }
+        if (!ds4_gpu_tensor_read(out_row_t, 0u, out_row, sizeof(float)))
+            return -1.0;
+        const double el = (now_sec() - t0) * 1000.0 / iters;
+        if (el < best) best = el;
+    }
+    return best;
+}
+
+static int run_shape(const shape *sh) {
+    const uint32_t in_dim = sh->in_dim;
+    const uint32_t out_dim = sh->out_dim;
+    const uint32_t blocks = (in_dim + 31u) / 32u;
+    const uint64_t weight_bytes = (uint64_t)out_dim * blocks * Q8_BLOCK_BYTES;
+    const uint64_t weight_offset = 4096u;
+    const uint64_t model_size = weight_offset + weight_bytes;
+
+    int ok = 1;
+    FILE *model_file = tmpfile();
+    void *model = MAP_FAILED;
+    float *x = NULL, *out_batch = NULL, *out_row = NULL;
+    ds4_gpu_tensor *x_batch_t = NULL, *x_row_t = NULL;
+    ds4_gpu_tensor *out_batch_t = NULL, *out_row_t = NULL;
+
+    if (model_file &&
+        ftruncate(fileno(model_file), (off_t)model_size) == 0) {
+        model = mmap(NULL, (size_t)model_size, PROT_READ | PROT_WRITE,
+                     MAP_SHARED, fileno(model_file), 0);
+    }
+    x = (float *)malloc((size_t)MAX_K * in_dim * sizeof(float));
+    out_batch = (float *)malloc((size_t)MAX_K * out_dim * sizeof(float));
+    out_row = (float *)malloc((size_t)out_dim * sizeof(float));
+    if (!model_file || model == MAP_FAILED || !x || !out_batch || !out_row) {
+        fprintf(stderr, "krow bench: host allocation failed\n");
+        ok = 0;
+        goto cleanup;
+    }
+    memset(model, 0, (size_t)model_size);
+    rng_state = 0x51c05eedu ^ in_dim ^ (out_dim << 8);
+    fill_q8_weights((uint8_t *)model + weight_offset, out_dim, blocks);
+    for (uint64_t i = 0; i < (uint64_t)MAX_K * in_dim; i++) x[i] = rng_float();
+
+    if (!ds4_gpu_set_model_map(model, model_size)) {
+        fprintf(stderr, "krow bench: model map setup failed\n");
+        ok = 0;
+        goto cleanup;
+    }
+    x_batch_t = ds4_gpu_tensor_alloc((uint64_t)MAX_K * in_dim * sizeof(float));
+    x_row_t = ds4_gpu_tensor_alloc((uint64_t)in_dim * sizeof(float));
+    out_batch_t = ds4_gpu_tensor_alloc((uint64_t)MAX_K * out_dim * sizeof(float));
+    out_row_t = ds4_gpu_tensor_alloc((uint64_t)out_dim * sizeof(float));
+    if (!x_batch_t || !x_row_t || !out_batch_t || !out_row_t) {
+        fprintf(stderr, "krow bench: tensor allocation failed\n");
+        ok = 0;
+        goto cleanup;
+    }
+    if (!ds4_gpu_tensor_write(x_batch_t, 0u, x,
+                              (uint64_t)MAX_K * in_dim * sizeof(float))) {
+        ok = 0;
+        goto cleanup;
+    }
+
+    fprintf(stderr, "shape %ux%u (q8_0, best-of-3, 200 iters):\n",
+            in_dim, out_dim);
+    for (uint32_t k = 2; k <= MAX_K; k++) {
+        /* Exactness first: batched vs sequential must stay bit-identical. */
+        if (!ds4_gpu_matmul_q8_0_decode_rows_exact_tensor(
+                out_batch_t, model, model_size, weight_offset,
+                in_dim, out_dim, x_batch_t, k) ||
+            !ds4_gpu_tensor_read(out_batch_t, 0u, out_batch,
+                                 (uint64_t)k * out_dim * sizeof(float))) {
+            fprintf(stderr, "  k=%u: batched eval failed\n", k);
+            ok = 0;
+            continue;
+        }
+        uint64_t mismatches = 0;
+        for (uint32_t r = 0; r < k; r++) {
+            if (!ds4_gpu_tensor_write(x_row_t, 0u, x + (uint64_t)r * in_dim,
+                                      (uint64_t)in_dim * sizeof(float)) ||
+                !ds4_gpu_matmul_q8_0_tensor(out_row_t, model, model_size,
+                                            weight_offset, in_dim, out_dim,
+                                            x_row_t, 1u) ||
+                !ds4_gpu_tensor_read(out_row_t, 0u, out_row,
+                                     (uint64_t)out_dim * sizeof(float))) {
+                ok = 0;
+                break;
+            }
+            for (uint32_t i = 0; i < out_dim; i++) {
+                if (memcmp(&out_batch[(uint64_t)r * out_dim + i], &out_row[i],
+                           sizeof(float)) != 0) mismatches++;
+            }
+        }
+        const double rows_ms = bench_rows(out_batch_t, model, model_size,
+                                          weight_offset, in_dim, out_dim,
+                                          x_batch_t, k, out_batch, 200);
+        const double seq_ms = bench_seq(out_row_t, model, model_size,
+                                        weight_offset, in_dim, out_dim,
+                                        x_row_t, x, k, out_row, 200);
+        if (rows_ms < 0.0 || seq_ms < 0.0) {
+            ok = 0;
+            continue;
+        }
+        fprintf(stderr,
+                "  k=%u: rows=%.4f ms  seq=%.4f ms  speedup=%.2fx  %s\n",
+                k, rows_ms, seq_ms, seq_ms / rows_ms,
+                mismatches == 0 ? "BITEXACT" : "MISMATCH");
+        if (mismatches != 0) ok = 0;
+    }
+
+cleanup:
+    if (x_batch_t) ds4_gpu_tensor_free(x_batch_t);
+    if (x_row_t) ds4_gpu_tensor_free(x_row_t);
+    if (out_batch_t) ds4_gpu_tensor_free(out_batch_t);
+    if (out_row_t) ds4_gpu_tensor_free(out_row_t);
+    if (model != MAP_FAILED) munmap(model, (size_t)model_size);
+    if (model_file) fclose(model_file);
+    free(x);
+    free(out_batch);
+    free(out_row);
+    return ok;
+}
+
+int main(void) {
+    /* Production decode matvec shapes: square attention-sized, the shared
+     * expert pair, and a wide FFN. */
+    const shape shapes[] = {
+        {4096u, 4096u},
+        {2048u, 4096u},
+        {4096u, 14336u},
+    };
+    if (!ds4_gpu_init()) {
+        fprintf(stderr, "krow bench: ds4_gpu_init failed\n");
+        return 1;
+    }
+    ds4_gpu_set_quality(false);
+    ds4_gpu_set_ssd_streaming(false);
+    int ok = 1;
+    for (size_t i = 0; i < sizeof(shapes) / sizeof(shapes[0]); i++) {
+        if (!run_shape(&shapes[i])) ok = 0;
+    }
+    ds4_gpu_set_model_map(NULL, 0u);
+    ds4_gpu_cleanup();
+    fprintf(stderr, "krow bench: %s\n", ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}

--- a/tests/test_q8_krow_rocm.c
+++ b/tests/test_q8_krow_rocm.c
@@ -1,0 +1,414 @@
+/* Bit-exactness test for the ROCm k-row Q8_0 prequant matvec tier.
+ *
+ * The decode tier (matmul_q8_0_preq_rows_w32_kernel) defines the reference
+ * summation order for one-row evals.  The k-row tier must produce, for
+ * every row of an n_tok in 2..5 call, bitwise the same output as a
+ * one-row call on the same weights and that row's activations: the exact
+ * speculative verifier depends on this equivalence, and it is what the
+ * generic batch tiers (different reduction shapes, weights re-read per
+ * row) do not provide.
+ */
+
+#include "ds4_gpu.h"
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+
+static double now_sec(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+#define Q8_BLOCK_BYTES 34u
+/* 2..5 exercises the k-row kernel tiers; 6..7 exercises the per-row
+ * fallback that keeps the exact-rows contract honest for wider spans. */
+#define MAX_K 7u
+
+typedef struct {
+    uint32_t in_dim;
+    uint32_t out_dim;
+} shape;
+
+/* Deterministic PRNG so failures reproduce. */
+static uint32_t rng_state;
+static uint32_t rng_next(void) {
+    rng_state = rng_state * 1664525u + 1013904223u;
+    return rng_state;
+}
+static float rng_float(void) {
+    return ((float)(rng_next() >> 8) / (float)(1u << 24)) * 2.0f - 1.0f;
+}
+
+static void fill_q8_weights(uint8_t *w, uint32_t out_dim, uint32_t blocks) {
+    for (uint64_t row = 0; row < out_dim; row++) {
+        for (uint64_t b = 0; b < blocks; b++) {
+            uint8_t *blk = w + (row * blocks + b) * Q8_BLOCK_BYTES;
+            /* fp16 scale in (0, 0.125]: bias 0x2c00 (~0.0625) plus noise. */
+            const uint16_t scale_bits = (uint16_t)(0x2c00u + (rng_next() & 0x3ffu));
+            blk[0] = (uint8_t)(scale_bits & 0xffu);
+            blk[1] = (uint8_t)(scale_bits >> 8);
+            for (uint32_t j = 0; j < 32u; j++) {
+                blk[2u + j] = (uint8_t)(int8_t)((int)(rng_next() % 255u) - 127);
+            }
+        }
+    }
+}
+
+static int run_shape(const shape *sh) {
+    const uint32_t in_dim = sh->in_dim;
+    const uint32_t out_dim = sh->out_dim;
+    const uint32_t blocks = (in_dim + 31u) / 32u;
+    /* Second matrix for the pair entry point: a different out_dim keeps
+     * the divergent row guards honest. */
+    const uint32_t out1_dim = out_dim / 2u + 3u;
+    const uint64_t weight_bytes = (uint64_t)out_dim * blocks * Q8_BLOCK_BYTES;
+    const uint64_t weight1_bytes = (uint64_t)out1_dim * blocks * Q8_BLOCK_BYTES;
+    /* Keep the weight tensors away from offset zero so range checks see a
+     * realistic layout. */
+    const uint64_t weight_offset = 4096u;
+    const uint64_t weight1_offset = weight_offset + weight_bytes;
+    /* F16 router matrix (4096x256) for the router rows entry. */
+    const uint64_t router_offset = weight1_offset + weight1_bytes;
+    const uint64_t router_bytes = 4096u * 256u * 2u;
+    const uint64_t model_size = router_offset + router_bytes;
+
+    int ok = 1;
+    FILE *model_file = tmpfile();
+    void *model = MAP_FAILED;
+    float *x = NULL;
+    float *out_batch = NULL;
+    float *out_row = NULL;
+    ds4_gpu_tensor *x_batch_t = NULL;
+    ds4_gpu_tensor *x_row_t = NULL;
+    ds4_gpu_tensor *out_batch_t = NULL;
+    ds4_gpu_tensor *out_row_t = NULL;
+
+    if (model_file &&
+        ftruncate(fileno(model_file), (off_t)model_size) == 0) {
+        model = mmap(NULL, (size_t)model_size, PROT_READ | PROT_WRITE,
+                     MAP_SHARED, fileno(model_file), 0);
+    }
+    x = (float *)malloc((size_t)MAX_K * in_dim * sizeof(float));
+    out_batch = (float *)malloc((size_t)MAX_K * out_dim * sizeof(float));
+    out_row = (float *)malloc((size_t)out_dim * sizeof(float));
+    if (!model_file || model == MAP_FAILED || !x || !out_batch || !out_row) {
+        fprintf(stderr, "q8 krow: host allocation failed\n");
+        ok = 0;
+        goto cleanup;
+    }
+    memset(model, 0, (size_t)model_size);
+    rng_state = 0x51c05eedu ^ in_dim ^ (out_dim << 8);
+    fill_q8_weights((uint8_t *)model + weight_offset, out_dim, blocks);
+    fill_q8_weights((uint8_t *)model + weight1_offset, out1_dim, blocks);
+    {
+        uint16_t *rw = (uint16_t *)((uint8_t *)model + router_offset);
+        for (uint64_t i = 0; i < 4096u * 256u; i++) {
+            rw[i] = (uint16_t)(0x2c00u + (rng_next() & 0x3ffu)) |
+                    (uint16_t)((rng_next() & 1u) << 15);
+        }
+    }
+    for (uint64_t i = 0; i < (uint64_t)MAX_K * in_dim; i++) x[i] = rng_float();
+
+    if (!ds4_gpu_set_model_map(model, model_size)) {
+        fprintf(stderr, "q8 krow: model map setup failed\n");
+        ok = 0;
+        goto cleanup;
+    }
+
+    x_batch_t = ds4_gpu_tensor_alloc((uint64_t)MAX_K * in_dim * sizeof(float));
+    x_row_t = ds4_gpu_tensor_alloc((uint64_t)in_dim * sizeof(float));
+    out_batch_t = ds4_gpu_tensor_alloc((uint64_t)MAX_K * out_dim * sizeof(float));
+    out_row_t = ds4_gpu_tensor_alloc((uint64_t)out_dim * sizeof(float));
+    if (!x_batch_t || !x_row_t || !out_batch_t || !out_row_t) {
+        fprintf(stderr, "q8 krow: tensor allocation failed\n");
+        ok = 0;
+        goto cleanup;
+    }
+    if (!ds4_gpu_tensor_write(x_batch_t, 0u, x,
+                              (uint64_t)MAX_K * in_dim * sizeof(float))) {
+        fprintf(stderr, "q8 krow: activation upload failed\n");
+        ok = 0;
+        goto cleanup;
+    }
+
+    for (uint32_t k = 2; k <= MAX_K; k++) {
+        if (!ds4_gpu_matmul_q8_0_decode_rows_exact_tensor(
+                out_batch_t, model, model_size,
+                weight_offset, in_dim, out_dim,
+                x_batch_t, k) ||
+            !ds4_gpu_tensor_read(out_batch_t, 0u, out_batch,
+                                 (uint64_t)k * out_dim * sizeof(float))) {
+            fprintf(stderr, "q8 krow: batch eval failed (%ux%u k=%u)\n",
+                    in_dim, out_dim, k);
+            ok = 0;
+            continue;
+        }
+        uint64_t mismatches = 0;
+        uint64_t first_at = 0;
+        for (uint32_t r = 0; r < k; r++) {
+            if (!ds4_gpu_tensor_write(x_row_t, 0u, x + (uint64_t)r * in_dim,
+                                      (uint64_t)in_dim * sizeof(float)) ||
+                !ds4_gpu_matmul_q8_0_tensor(out_row_t, model, model_size,
+                                            weight_offset, in_dim, out_dim,
+                                            x_row_t, 1u) ||
+                !ds4_gpu_tensor_read(out_row_t, 0u, out_row,
+                                     (uint64_t)out_dim * sizeof(float))) {
+                fprintf(stderr, "q8 krow: row eval failed (%ux%u k=%u r=%u)\n",
+                        in_dim, out_dim, k, r);
+                ok = 0;
+                break;
+            }
+            for (uint32_t i = 0; i < out_dim; i++) {
+                if (memcmp(&out_batch[(uint64_t)r * out_dim + i], &out_row[i],
+                           sizeof(float)) != 0) {
+                    if (mismatches == 0) first_at = (uint64_t)r * out_dim + i;
+                    mismatches++;
+                }
+            }
+        }
+        /* Timed pass: the same call the exactness check exercised.  With
+         * DS4_ROCM_DSV4_PREQUANT_DECODE=0 the dispatch reverts to the f32
+         * batch tiers, so this doubles as an A/B probe for the tier. */
+        const int iters = 100;
+        double best = 1e30;
+        for (int t = 0; t < 3; t++) {
+            const double t0 = now_sec();
+            for (int i = 0; i < iters; i++) {
+                if (!ds4_gpu_matmul_q8_0_tensor(out_batch_t, model, model_size,
+                                                weight_offset, in_dim, out_dim,
+                                                x_batch_t, k)) {
+                    ok = 0;
+                    break;
+                }
+            }
+            if (!ds4_gpu_tensor_read(out_batch_t, 0u, out_batch,
+                                     sizeof(float))) ok = 0;
+            const double el = (now_sec() - t0) * 1000.0 / iters;
+            if (el < best) best = el;
+        }
+        fprintf(stderr, "q8 krow %ux%u k=%u: %s (%llu mismatches",
+                in_dim, out_dim, k,
+                mismatches == 0 ? "BITEXACT" : "MISMATCH",
+                (unsigned long long)mismatches);
+        if (mismatches) {
+            fprintf(stderr, ", first at %llu", (unsigned long long)first_at);
+            ok = 0;
+        }
+        fprintf(stderr, ") %.3f ms/call\n", best);
+    }
+
+    /* Pair entry point: n_rows in 2..5 must match per-row one-row pair
+     * calls, whose reduction order comes from the fused pair kernel. */
+    {
+        ds4_gpu_tensor *out1_batch_t =
+            ds4_gpu_tensor_alloc((uint64_t)MAX_K * out1_dim * sizeof(float));
+        ds4_gpu_tensor *out1_row_t =
+            ds4_gpu_tensor_alloc((uint64_t)out1_dim * sizeof(float));
+        float *out1_batch = (float *)malloc((size_t)MAX_K * out1_dim * sizeof(float));
+        float *out1_row = (float *)malloc((size_t)out1_dim * sizeof(float));
+        if (!out1_batch_t || !out1_row_t || !out1_batch || !out1_row) {
+            fprintf(stderr, "q8 krow pair: allocation failed\n");
+            ok = 0;
+        } else {
+            for (uint32_t k = 2; k <= MAX_K; k++) {
+                if (!ds4_gpu_matmul_q8_0_pair_decode_rows_exact_tensor(
+                        out_batch_t, out1_batch_t, model, model_size,
+                        weight_offset, weight1_offset, in_dim,
+                        out_dim, out1_dim, x_batch_t, k) ||
+                    !ds4_gpu_tensor_read(out_batch_t, 0u, out_batch,
+                                         (uint64_t)k * out_dim * sizeof(float)) ||
+                    !ds4_gpu_tensor_read(out1_batch_t, 0u, out1_batch,
+                                         (uint64_t)k * out1_dim * sizeof(float))) {
+                    fprintf(stderr, "q8 krow pair: batch eval failed (%ux%u k=%u)\n",
+                            in_dim, out_dim, k);
+                    ok = 0;
+                    continue;
+                }
+                uint64_t mism = 0;
+                for (uint32_t r = 0; r < k; r++) {
+                    if (!ds4_gpu_tensor_write(x_row_t, 0u, x + (uint64_t)r * in_dim,
+                                              (uint64_t)in_dim * sizeof(float)) ||
+                        !ds4_gpu_matmul_q8_0_pair_decode_rows_exact_tensor(
+                            out_row_t, out1_row_t, model, model_size,
+                            weight_offset, weight1_offset, in_dim,
+                            out_dim, out1_dim, x_row_t, 1u) ||
+                        !ds4_gpu_tensor_read(out_row_t, 0u, out_row,
+                                             (uint64_t)out_dim * sizeof(float)) ||
+                        !ds4_gpu_tensor_read(out1_row_t, 0u, out1_row,
+                                             (uint64_t)out1_dim * sizeof(float))) {
+                        fprintf(stderr, "q8 krow pair: row eval failed (k=%u r=%u)\n", k, r);
+                        ok = 0;
+                        break;
+                    }
+                    for (uint32_t i = 0; i < out_dim; i++)
+                        if (memcmp(&out_batch[(uint64_t)r * out_dim + i],
+                                   &out_row[i], sizeof(float)) != 0) mism++;
+                    for (uint32_t i = 0; i < out1_dim; i++)
+                        if (memcmp(&out1_batch[(uint64_t)r * out1_dim + i],
+                                   &out1_row[i], sizeof(float)) != 0) mism++;
+                }
+                fprintf(stderr, "q8 krow pair %ux%u+%u k=%u: %s (%llu mismatches)\n",
+                        in_dim, out_dim, out1_dim, k,
+                        mism == 0 ? "BITEXACT" : "MISMATCH",
+                        (unsigned long long)mism);
+                if (mism) ok = 0;
+            }
+        }
+        if (out1_batch_t) ds4_gpu_tensor_free(out1_batch_t);
+        if (out1_row_t) ds4_gpu_tensor_free(out1_row_t);
+        free(out1_batch);
+        free(out1_row);
+    }
+
+    /* Shared-expert rows entry: per-row bit-equality with the one-row
+     * shared gate/up + swiglu entry (both weight matrices point at the
+     * first weight region; the contract is about arithmetic order). */
+    {
+        ds4_gpu_tensor *gate_b = ds4_gpu_tensor_alloc((uint64_t)MAX_K * out_dim * sizeof(float));
+        ds4_gpu_tensor *up_b = ds4_gpu_tensor_alloc((uint64_t)MAX_K * out_dim * sizeof(float));
+        ds4_gpu_tensor *mid_b = ds4_gpu_tensor_alloc((uint64_t)MAX_K * out_dim * sizeof(float));
+        ds4_gpu_tensor *gate_r = ds4_gpu_tensor_alloc((uint64_t)out_dim * sizeof(float));
+        ds4_gpu_tensor *up_r = ds4_gpu_tensor_alloc((uint64_t)out_dim * sizeof(float));
+        ds4_gpu_tensor *mid_r = ds4_gpu_tensor_alloc((uint64_t)out_dim * sizeof(float));
+        float *mid_batch = (float *)malloc((size_t)MAX_K * out_dim * sizeof(float));
+        float *mid_row = (float *)malloc((size_t)out_dim * sizeof(float));
+        if (gate_b && up_b && mid_b && gate_r && up_r && mid_r &&
+            mid_batch && mid_row) {
+            for (uint32_t k = 2; k <= MAX_K; k++) {
+                if (!ds4_gpu_shared_gate_up_swiglu_q8_0_rows_scalar_tensor(
+                        gate_b, up_b, mid_b, model, model_size,
+                        weight_offset, weight_offset, in_dim, out_dim,
+                        x_batch_t, k, 30.0f) ||
+                    !ds4_gpu_tensor_read(mid_b, 0u, mid_batch,
+                                         (uint64_t)k * out_dim * sizeof(float))) {
+                    fprintf(stderr, "q8 krow swiglu: batch eval failed (k=%u)\n", k);
+                    ok = 0;
+                    continue;
+                }
+                uint64_t mism = 0;
+                for (uint32_t r = 0; r < k; r++) {
+                    if (!ds4_gpu_tensor_write(x_row_t, 0u, x + (uint64_t)r * in_dim,
+                                              (uint64_t)in_dim * sizeof(float)) ||
+                        !ds4_gpu_shared_gate_up_swiglu_q8_0_tensor(
+                            gate_r, up_r, mid_r, model, model_size,
+                            weight_offset, weight_offset, in_dim, out_dim,
+                            x_row_t, 30.0f) ||
+                        !ds4_gpu_tensor_read(mid_r, 0u, mid_row,
+                                             (uint64_t)out_dim * sizeof(float))) {
+                        fprintf(stderr, "q8 krow swiglu: row eval failed (k=%u r=%u)\n", k, r);
+                        ok = 0;
+                        break;
+                    }
+                    for (uint32_t i = 0; i < out_dim; i++)
+                        if (memcmp(&mid_batch[(uint64_t)r * out_dim + i],
+                                   &mid_row[i], sizeof(float)) != 0) mism++;
+                }
+                fprintf(stderr, "q8 krow swiglu %ux%u k=%u: %s (%llu mismatches)\n",
+                        in_dim, out_dim, k,
+                        mism == 0 ? "BITEXACT" : "MISMATCH",
+                        (unsigned long long)mism);
+                if (mism) ok = 0;
+            }
+        } else {
+            fprintf(stderr, "q8 krow swiglu: allocation failed\n");
+            ok = 0;
+        }
+        if (gate_b) ds4_gpu_tensor_free(gate_b);
+        if (up_b) ds4_gpu_tensor_free(up_b);
+        if (mid_b) ds4_gpu_tensor_free(mid_b);
+        if (gate_r) ds4_gpu_tensor_free(gate_r);
+        if (up_r) ds4_gpu_tensor_free(up_r);
+        if (mid_r) ds4_gpu_tensor_free(mid_r);
+        free(mid_batch);
+        free(mid_row);
+    }
+
+    /* Router rows entry: batched router logits must equal per-row one-row
+     * calls bitwise, or batch rows can select different experts. */
+    if (in_dim == 4096u) {
+        ds4_gpu_tensor *lg_b = ds4_gpu_tensor_alloc((uint64_t)MAX_K * 256u * sizeof(float));
+        ds4_gpu_tensor *lg_r = ds4_gpu_tensor_alloc(256u * sizeof(float));
+        float *lb = (float *)malloc((size_t)MAX_K * 256u * sizeof(float));
+        float *lr = (float *)malloc(256u * sizeof(float));
+        if (lg_b && lg_r && lb && lr) {
+            for (uint32_t k = 2; k <= MAX_K; k++) {
+                uint64_t mism = 0;
+                if (!ds4_gpu_matmul_f16_router_rows_exact_tensor(
+                        lg_b, model, model_size, router_offset, x_batch_t, k) ||
+                    !ds4_gpu_tensor_read(lg_b, 0u, lb,
+                                         (uint64_t)k * 256u * sizeof(float))) {
+                    fprintf(stderr, "q8 krow router: batch eval failed (k=%u)\n", k);
+                    ok = 0;
+                    continue;
+                }
+                for (uint32_t r = 0; r < k; r++) {
+                    if (!ds4_gpu_tensor_write(x_row_t, 0u, x + (uint64_t)r * in_dim,
+                                              (uint64_t)in_dim * sizeof(float)) ||
+                        !ds4_gpu_matmul_f16_router_rows_exact_tensor(
+                            lg_r, model, model_size, router_offset, x_row_t, 1u) ||
+                        !ds4_gpu_tensor_read(lg_r, 0u, lr, 256u * sizeof(float))) {
+                        fprintf(stderr, "q8 krow router: row eval failed\n");
+                        ok = 0;
+                        break;
+                    }
+                    for (uint32_t i = 0; i < 256u; i++)
+                        if (memcmp(&lb[(uint64_t)r * 256u + i], &lr[i],
+                                   sizeof(float)) != 0) mism++;
+                }
+                fprintf(stderr, "q8 krow router 4096x256 k=%u: %s (%llu mismatches)\n",
+                        k, mism == 0 ? "BITEXACT" : "MISMATCH",
+                        (unsigned long long)mism);
+                if (mism) ok = 0;
+            }
+        } else {
+            fprintf(stderr, "q8 krow router: allocation failed\n");
+            ok = 0;
+        }
+        if (lg_b) ds4_gpu_tensor_free(lg_b);
+        if (lg_r) ds4_gpu_tensor_free(lg_r);
+        free(lb);
+        free(lr);
+    }
+
+cleanup:
+    if (x_batch_t) ds4_gpu_tensor_free(x_batch_t);
+    if (x_row_t) ds4_gpu_tensor_free(x_row_t);
+    if (out_batch_t) ds4_gpu_tensor_free(out_batch_t);
+    if (out_row_t) ds4_gpu_tensor_free(out_row_t);
+    if (model != MAP_FAILED) munmap(model, (size_t)model_size);
+    if (model_file) fclose(model_file);
+    return ok;
+}
+
+int main(void) {
+    /* Production decode matvec shapes: square attention-sized, the shared
+     * expert pair, a wide FFN, and an odd out_dim for row-guard coverage. */
+    const shape shapes[] = {
+        {4096u, 4096u},
+        {2048u, 4096u},
+        {4096u, 14336u},
+        {4096u, 4099u},
+    };
+    if (!ds4_gpu_init()) {
+        fprintf(stderr, "q8 krow: ds4_gpu_init failed\n");
+        return 1;
+    }
+    ds4_gpu_set_quality(false);
+    ds4_gpu_set_ssd_streaming(false);
+    int ok = 1;
+    for (size_t i = 0; i < sizeof(shapes) / sizeof(shapes[0]); i++) {
+        if (!run_shape(&shapes[i])) ok = 0;
+    }
+    ds4_gpu_set_model_map(NULL, 0u);
+    ds4_gpu_cleanup();
+    fprintf(stderr, "Q8_0 k-row ROCm matvec: %s\n", ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## What this does

Adds a family of ROCm Q8_0 kernels that evaluate several rows in one call — two to five rows — while keeping each row's reduction in exactly the same order as the existing one-row kernel. Every row of a batched call is therefore bit-identical to a one-row call on the same data. That property is what makes these kernels usable for exact speculative verification, where verified logits must match what single-token decode would have produced. It is the same invariant every other decode kernel in this backend already holds.

- `rocm/ds4_rocm_q8.cuh`: the k-row kernels — two to five rows per block, one warp per row, one-row reduction order.
- `rocm/ds4_rocm_matmul.cuh`, `rocm/ds4_rocm_shared_expert.cuh`: k-row entry points.
- `ds4_rocm_compat.cu`: C-callable wrappers.
- `tests/test_q8_krow_rocm.c`: exactness test. Every row of every batched call is compared byte for byte with the one-row reference, across several shapes.
- `tests/bench_q8_krow_rocm.c`: throughput benchmark comparing one batched call against the same rows evaluated sequentially.
- `make test-q8-krow-rocm` runs the exactness test.

## Performance

On Radeon 8060S (gfx1151), best of three runs of 200 iterations each; every cell re-verified bit-identical during the run. One batched call against k sequential one-row calls, on 4096×4096 Q8_0 weights:

| rows | batched | sequential | speedup |
|---:|---:|---:|---:|
| 2 | 0.032 ms | 0.089 ms | 2.8× |
| 3 | 0.029 ms | 0.135 ms | 4.7× |
| 4 | 0.032 ms | 0.179 ms | 5.5× |
| 5 | 0.036 ms | 0.222 ms | 6.3× |
| 6 | 0.228 ms | 0.267 ms | 1.2× |

The other measured shapes (2048×4096 and 4096×14336) show the same pattern: two to six times faster at two to five rows. At six rows and beyond, the dispatch falls back to per-row evaluation — exactness is preserved and the speedup drops to about one — so callers should size batches to five rows or fewer. Speculative spans of two to three rows sit in the best region. Full tables are in the benchmark comment below.

## Scope

This pull request contains the kernel tier and its tests. Nothing calls the new kernels yet, and no existing path changes.

The host-side driver that uses them — batched evaluation of speculative spans — is not included, for a concrete reason. After this work was forked, main independently reworked the decode-phase evaluator for its own speculative decoding (the `quad_store` logic in `metal_graph_encode_decode_layer_phase`). The driver was built against the pre-rework evaluator, and the two designs solve the same problem with incompatible control flow. Porting the driver means choosing one of the two designs, and that should be a maintainer decision, not a side effect of this pull request. The driver runs in production on our branch, where spans four rows deep verify with no loss of acceptance; it will follow as its own pull request once the evaluator direction is agreed.

## Correctness

Rebased on current main (`84cc882`), TheRock toolchain:

- Warning-free `make strix-halo`. Built with `-fPIC` in `CFLAGS`; main does not yet carry the `ROCM_HOST_CFLAGS` fix, which ships separately in #656.
- `make test-q8-krow-rocm` passes; all shapes bit-exact.
- Additive only: no existing launch site or host path changes.

## How to test

`make strix-halo && make test-q8-krow-rocm`. The benchmark builds the same way as the test and runs standalone.
