### PR TITLE
Bound expert-output size products in ds4quant (heap overflow)

### DIFF
--- a/gguf-tools/deepseek4-quantize.c
+++ b/gguf-tools/deepseek4-quantize.c
@@ -1484,8 +1484,14 @@ static byte_buf generate_expert(st_db *db, const char *gguf_name, const tensor_m
     const char *wid = expert_part_name(e.part);
     const int64_t ncols = tmpl->ne[0];
     const int64_t nrows = tmpl->ne[1];
-    const size_t per_expert = (size_t)nrows * ds4q_row_size(target, ncols);
-    byte_buf out = { .size = per_expert * (size_t)n_experts, .data = xmalloc(per_expert * (size_t)n_experts) };
+    /* Template dims and expert_count are attacker-influenced; bound the
+     * products like the FP8/FP4 dequant paths (issue #823). */
+    const size_t per_expert = checked_size_product((size_t)nrows,
+                                                   ds4q_row_size(target, ncols),
+                                                   "expert per-expert size");
+    const size_t total_size = checked_size_product(per_expert, (size_t)n_experts,
+                                                   "expert total size");
+    byte_buf out = { .size = total_size, .data = xmalloc(total_size) };
     ds4q_quantize_init(target);
     int worker_count = n_threads > 0 ? n_threads : 8;
     if (worker_count < 1) worker_count = 1;


### PR DESCRIPTION
### Summary

`generate_expert()` sized the routed-expert output buffer with two unchecked
`size_t` multiplies (template dims × `expert_count`). A wrapped
`per_expert * n_experts` undersized the `xmalloc` while the per-expert
quantized output stayed at the real `per_expert`, so the worker `memcpy`
wrote past the buffer — heap-buffer-overflow write from a crafted GGUF
template + safetensors shard, the same trust boundary as #542 / #543.
Details and ASan PoC in #823.

### Fix

Route both multiplies through the existing `checked_size_product`, matching
the FP8/FP4 dequant paths hardened in a968c08.

### Verification

ASan-confirmed heap-buffer-overflow on `main` (see #823); with this change
the same PoC exits cleanly:

```
error: expert total size allocation is too large
```

`make -C gguf-tools -B` builds with no new warnings.

Fixes #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)