### PR TITLE
Reject Q2K repack candidates whose dims truncate to uint32 kernel params

### DIFF
--- a/cuda/mmq/ds4_repack.cu
+++ b/cuda/mmq/ds4_repack.cu
@@ -466,6 +466,9 @@ bool ds4_repack_q2k_candidate(const ds4_repack_tensor &t) {
     if (t.type != 10u || t.ndim != 3u) return false; /* GGML_TYPE_Q2_K */
     if (t.dims[0] == 0 || t.dims[1] == 0 || t.dims[2] == 0 || t.dims[2] > UINT32_MAX) return false;
     if (t.dims[0] % 256u != 0 || t.dims[1] % 2u != 0) return false;
+    /* nb_row and nrows are passed to the kernel as uint32_t; reject tensors
+     * whose dims would truncate there. */
+    if (t.dims[0] / 256u > UINT32_MAX || t.dims[1] > UINT32_MAX) return false;
     if (t.bytes == 0 || t.bytes % 84u != 0) return false;
     static const char down_sfx[] = ".ffn_down_exps.weight";
     const size_t n = t.name.size();


### PR DESCRIPTION
### Summary

`ds4_repack_q2k_candidate()` bounded only `dims[2]`. `nb_row` (`dims[0]/256`)
and `nrows` (`dims[1]`) reach `repack_q2_k_aligned_kernel` as `uint32_t`
parameters, so a GGUF tensor with `dims[0] >= 256*2^32` or `dims[1] > 2^32`
truncates and the kernel's `pblk` index writes `qs2`/`sc4`/`dm2` past the
`cudaMalloc`ed artifact — OOB GPU write from a crafted model file.
Details and the concrete dims in #825.

### Fix

Reject the truncating dims at candidate time; no real tensor needs `nb_row`
or `nrows` above `UINT32_MAX`.

Fixes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)