### PR TITLE
metal: non-blocking GPU stage timestamps behind DS4_METAL_GPU_STAGE_TIMESTAMPS

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -27972,6 +27972,27 @@ static bool metal_graph_stage_profile_enabled_for_layer(
     return metal_graph_profile_layer_value_match(layer_env, il);
 }
 
+/* DS4_METAL_GPU_STAGE_TIMESTAMPS: the same stage boundaries as the layer/decode
+ * stage profilers, but each boundary only commits the batch and tags it (see
+ * ds4_gpu_stage_flush); nothing waits.  Reported per prefill chunk / decode
+ * token by ds4_gpu_stage_report. */
+static bool metal_graph_gpu_stage_timestamps(void) {
+    static int enabled = -1;
+    if (enabled < 0) {
+        const char *v = getenv("DS4_METAL_GPU_STAGE_TIMESTAMPS");
+        enabled = v != NULL && strcmp(v, "0") != 0;
+    }
+    return enabled != 0;
+}
+
+static bool metal_graph_gpu_stage_timestamps_layer(uint32_t il) {
+    return metal_graph_gpu_stage_timestamps() &&
+           metal_graph_stage_profile_enabled_for_layer(
+                "DS4_METAL_GPU_STAGE_TIMESTAMPS",
+                "DS4_METAL_GPU_STAGE_TIMESTAMPS_LAYER",
+                il);
+}
+
 static bool metal_graph_layer_stage_profile_enabled(uint32_t il) {
     return metal_graph_stage_profile_enabled_for_layer(
                 "DS4_ROCM_LAYER_STAGE_PROFILE",
@@ -27980,7 +28001,8 @@ static bool metal_graph_layer_stage_profile_enabled(uint32_t il) {
            metal_graph_stage_profile_enabled_for_layer(
                 "DS4_METAL_LAYER_STAGE_PROFILE",
                 "DS4_METAL_LAYER_STAGE_PROFILE_LAYER",
-                il);
+                il) ||
+           metal_graph_gpu_stage_timestamps_layer(il);
 }
 
 static bool metal_graph_decode_stage_profile_enabled(uint32_t il) {
@@ -27991,11 +28013,15 @@ static bool metal_graph_decode_stage_profile_enabled(uint32_t il) {
            metal_graph_stage_profile_enabled_for_layer(
                 "DS4_METAL_DECODE_STAGE_PROFILE",
                 "DS4_METAL_DECODE_STAGE_PROFILE_LAYER",
-                il);
+                il) ||
+           metal_graph_gpu_stage_timestamps_layer(il);
 }
 
 static bool metal_graph_layer_stage_profile_start(uint32_t il) {
     if (!metal_graph_layer_stage_profile_enabled(il)) return true;
+    if (metal_graph_gpu_stage_timestamps()) {
+        return ds4_gpu_stage_flush("layer", "before", il, 0, 0) != 0;
+    }
     if (ds4_gpu_end_commands() == 0) return false;
     return ds4_gpu_begin_commands() != 0;
 }
@@ -28011,6 +28037,9 @@ static bool metal_graph_layer_stage_profile_boundary(
         uint32_t    pos0,
         uint32_t    n_tokens,
         double     *stage_t0) {
+    if (metal_graph_gpu_stage_timestamps()) {
+        return ds4_gpu_stage_flush(part, stage, il, pos0, n_tokens) != 0;
+    }
     if (ds4_gpu_end_commands() == 0) return false;
     const double now = now_sec();
     if (stage != NULL) {
@@ -31280,6 +31309,7 @@ static bool metal_graph_eval_token_raw_swa_top(
                     (t_read - t_done) * 1000.0,
                     (t_read - t0) * 1000.0);
         }
+        if (metal_graph_gpu_stage_timestamps()) ds4_gpu_stage_report("decode", pos, 1);
         if (!ok) {
             if (ds4_gpu_synchronize() == 0) {
                 fprintf(stderr, "ds4: Metal synchronize after split-top graph eval failure also failed\n");
@@ -31338,6 +31368,7 @@ static bool metal_graph_eval_token_raw_swa_top(
                 (t_read - t0) * 1000.0,
                 logits != NULL);
     }
+    if (metal_graph_gpu_stage_timestamps()) ds4_gpu_stage_report("decode", pos, 1);
     if (!ok) {
         if (ds4_gpu_synchronize() == 0) {
             fprintf(stderr, "ds4: Metal synchronize after top-only graph eval failure also failed\n");
@@ -34569,6 +34600,7 @@ static bool metal_graph_prefill_layer_major(
         if (logits) {
             ok = ds4_gpu_tensor_read(metal_graph_logits(g), 0, logits, (uint64_t)DS4_N_VOCAB * sizeof(float)) != 0;
         }
+        if (metal_graph_gpu_stage_timestamps()) ds4_gpu_stage_report("prefill", start, n_tokens);
         if (profile) {
             const double t_read = now_sec();
             fprintf(stderr,
@@ -35113,6 +35145,7 @@ static bool metal_graph_prefill_layer_major(
                 (t_read - t_before_read) * 1000.0,
                 (t_read - t0) * 1000.0);
     }
+    if (metal_graph_gpu_stage_timestamps()) ds4_gpu_stage_report("prefill", start, n_tokens);
     return ok;
 }
 

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -3682,6 +3682,11 @@ extern "C" int ds4_gpu_pack_slot_rows_f32_tensor(
 
 extern "C" int ds4_gpu_begin_commands(void) { return 1; }
 extern "C" int ds4_gpu_flush_commands(void) { return cuda_ok(cudaDeviceSynchronize(), "flush"); }
+extern "C" int ds4_gpu_stage_flush(const char *part, const char *stage, uint32_t layer, uint32_t pos0, uint32_t n_tokens) {
+    (void)part; (void)stage; (void)layer; (void)pos0; (void)n_tokens;
+    return ds4_gpu_flush_commands();
+}
+extern "C" void ds4_gpu_stage_report(const char *what, uint32_t pos0, uint32_t n_tokens) { (void)what; (void)pos0; (void)n_tokens; }
 extern "C" int ds4_gpu_end_commands(void) {
     if (g_cuda_end_stream_sync) {
         return cuda_ok(cudaStreamSynchronize(0), "end commands stream");

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -109,6 +109,12 @@ int ds4_gpu_tensor_read_after_selected_event(const ds4_gpu_tensor *tensor,
 #endif
 int ds4_gpu_end_commands(void);
 int ds4_gpu_synchronize(void);
+/* DS4_METAL_GPU_STAGE_TIMESTAMPS: commit the command batch in flight without
+ * waiting and remember it under a stage tag; the report reads GPU start/end
+ * timestamps once the caller has waited for the whole layer or token.  Metal
+ * only: other backends flush and record nothing. */
+int ds4_gpu_stage_flush(const char *part, const char *stage, uint32_t layer, uint32_t pos0, uint32_t n_tokens);
+void ds4_gpu_stage_report(const char *what, uint32_t pos0, uint32_t n_tokens);
 
 int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size);
 int ds4_gpu_set_model_fd(int fd);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -10079,6 +10079,87 @@ int ds4_gpu_end_commands(void) {
     return ds4_gpu_finish_command_buffer(cb, 1, "command batch");
 }
 
+/* Non-blocking stage timing (DS4_METAL_GPU_STAGE_TIMESTAMPS).  Every stage
+ * boundary commits the batch in flight and starts a new one; the committed
+ * buffers stay retained here and their GPUStartTime/GPUEndTime are read by
+ * ds4_gpu_stage_report once the caller has waited for the whole layer or token
+ * (ds4_gpu_end_commands waits for every pending buffer first).  Unlike the
+ * DS4_METAL_*_STAGE_PROFILE printers this never blocks the CPU, so a stage's
+ * number is GPU busy time on the GPU clock, the stages of a chunk add up to
+ * its total, and first-start-to-last-end minus busy is scheduling gap. */
+typedef struct {
+    const char *part;
+    const char *stage;
+    uint32_t    layer;
+    uint32_t    pos0;
+    uint32_t    n_tokens;
+} ds4_gpu_stage_tag;
+static ds4_gpu_stage_tag *g_stage_tags;
+static size_t g_stage_tag_n;
+static size_t g_stage_tag_cap;
+static NSMutableArray<id<MTLCommandBuffer>> *g_stage_cbs;
+
+int ds4_gpu_stage_flush(const char *part, const char *stage, uint32_t layer, uint32_t pos0, uint32_t n_tokens) {
+    if (!g_batch_cb) return 0;
+    id<MTLCommandBuffer> cb = g_batch_cb;
+    if (ds4_gpu_flush_commands() == 0) return 0;
+    if (g_stage_tag_n == g_stage_tag_cap) {
+        const size_t cap = g_stage_tag_cap ? g_stage_tag_cap * 2 : 4096;
+        ds4_gpu_stage_tag *tags = realloc(g_stage_tags, cap * sizeof(*tags));
+        if (!tags) return 0;
+        g_stage_tags = tags;
+        g_stage_tag_cap = cap;
+    }
+    if (!g_stage_cbs) g_stage_cbs = [NSMutableArray array];
+    g_stage_tags[g_stage_tag_n++] = (ds4_gpu_stage_tag){part, stage, layer, pos0, n_tokens};
+    [g_stage_cbs addObject:cb];
+    return 1;
+}
+
+void ds4_gpu_stage_report(const char *what, uint32_t pos0, uint32_t n_tokens) {
+    if (g_stage_tag_n == 0) return;
+    const bool detail = getenv("DS4_METAL_GPU_STAGE_TIMESTAMPS_DETAIL") != NULL;
+    enum { MAX_KEYS = 128 };
+    struct { const char *part; const char *stage; size_t buffers; double busy; } keys[MAX_KEYS];
+    size_t n_keys = 0;
+    double first_start = 0.0, last_end = 0.0, busy_total = 0.0;
+    size_t incomplete = 0;
+    for (size_t i = 0; i < g_stage_tag_n; i++) {
+        id<MTLCommandBuffer> cb = g_stage_cbs[i];
+        const ds4_gpu_stage_tag *t = &g_stage_tags[i];
+        if (cb.status != MTLCommandBufferStatusCompleted) { incomplete++; continue; }
+        const double start = cb.GPUStartTime, end = cb.GPUEndTime;
+        const double busy = end > start ? end - start : 0.0;
+        if (i == 0 || start < first_start) first_start = start;
+        if (end > last_end) last_end = end;
+        busy_total += busy;
+        size_t k = 0;
+        for (; k < n_keys; k++) {
+            if (keys[k].part == t->part && keys[k].stage == t->stage) break;
+        }
+        if (k == n_keys && n_keys < MAX_KEYS) keys[n_keys++] = (typeof(keys[0])){t->part, t->stage, 0, 0.0};
+        if (k < n_keys) { keys[k].buffers++; keys[k].busy += busy; }
+        if (detail) {
+            fprintf(stderr,
+                    "ds4: gpu stage buffer what=%s part=%s stage=%s layer=%u pos=%u tokens=%u start_ms=%.3f gpu_ms=%.3f\n",
+                    what, t->part, t->stage ? t->stage : "-", t->layer, t->pos0, t->n_tokens,
+                    (start - first_start) * 1000.0, busy * 1000.0);
+        }
+    }
+    for (size_t k = 0; k < n_keys; k++) {
+        fprintf(stderr,
+                "ds4: gpu stage times what=%s pos=%u tokens=%u part=%s stage=%s buffers=%zu gpu_ms=%.3f\n",
+                what, pos0, n_tokens, keys[k].part, keys[k].stage ? keys[k].stage : "-",
+                keys[k].buffers, keys[k].busy * 1000.0);
+    }
+    fprintf(stderr,
+            "ds4: gpu stage times what=%s pos=%u tokens=%u total gpu_busy_ms=%.3f span_ms=%.3f gap_ms=%.3f buffers=%zu incomplete=%zu\n",
+            what, pos0, n_tokens, busy_total * 1000.0, (last_end - first_start) * 1000.0,
+            (last_end - first_start - busy_total) * 1000.0, g_stage_tag_n, incomplete);
+    g_stage_tag_n = 0;
+    [g_stage_cbs removeAllObjects];
+}
+
 static int ds4_gpu_flash_attn_stage_profile_boundary(
         id<MTLCommandBuffer> __strong *cbp,
         const char           *mode,


### PR DESCRIPTION
The stage profilers (`DS4_METAL_LAYER_STAGE_PROFILE`, `DS4_METAL_DECODE_STAGE_PROFILE` and the flash/MoE siblings) attribute time by ending the command buffer and waiting on the CPU at every stage boundary — fine for coarse questions, but each stage pays a CPU round trip, so the printed numbers don't add up to the unprofiled total and can't build a stage budget.

`DS4_METAL_GPU_STAGE_TIMESTAMPS=1` reuses the same stage boundaries but only *commits* the batch in flight and tags it (`ds4_gpu_stage_flush`); nothing waits. Once the layer/token completes (the existing `ds4_gpu_end_commands` already waits for every pending buffer), the report reads each tagged buffer's `GPUStartTime`/`GPUEndTime` and prints per (part, stage) GPU-busy ms, plus a total line with busy, span (first start → last end) and the gap between them — the scheduling overhead the run actually paid. `DS4_METAL_GPU_STAGE_TIMESTAMPS_DETAIL=1` adds one line per buffer. Diagnostic switch, off by default, validates the one release path; other backends flush and record nothing.

    ds4: gpu stage times what=prefill pos=0 tokens=2048 part=ffn stage=routed_moe buffers=43 gpu_ms=1375.896
    ds4: gpu stage times what=prefill pos=0 tokens=2048 total gpu_busy_ms=... span_ms=... gap_ms=... buffers=473 incomplete=0

Measured on Apple M3 Ultra (60-core GPU) 512 GB, DeepSeek V4 Flash 0731 native-MXFP4 GGUF, base 84cc882 — 16k cold prefill at `--prefill-chunk 2048`, first chunk, ms summed over the 43 layers, against the blocking profiler:

| stage | blocking profiler | GPU timestamps |
|---|---|---|
| ffn/routed_moe | 1393 | 1376 |
| attn/output_proj | 536 | 525 |
| attn/q_path | 352 | 335 |
| attn/attention | 299 | 281 |

i.e. the blocking numbers carry ~5-7% of sync overhead; the timestamp numbers are GPU busy time on the GPU clock and sum to the chunk total. This is what let me localize the long-context prefill decay to the attention stage alone (299 → 1098 ms/chunk from pos 0 to pos 14k while every other stage stays flat).

Exactness: full-vocab logits at frontiers 2048/4096/6144/8192 byte-identical to a build without the change (`ds4-bench --dump-frontier-logits-dir` byte-compare) — and the switch is off by default anyway. Built with zero warnings; model-free `make test` targets pass.
