### PR TITLE
metal: wide-tile indexer prefill scorer over half-packed Q/K (bit-exact, +4.7% prefill at 64k)

### DIFF
--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -351,6 +351,10 @@ static id<MTLBuffer> g_router_weight_sum_buffer;
 static id<MTLBuffer> g_indexer_head_scores_buffer;
 static id<MTLBuffer> g_indexer_topk_buffer;
 static id<MTLBuffer> g_indexed_topk_buffer;
+static id<MTLBuffer> g_indexer_q16_buffer;
+static NSUInteger    g_indexer_q16_bytes;
+static id<MTLBuffer> g_indexer_k16_buffer;
+static NSUInteger    g_indexer_k16_bytes;
 static id<MTLBuffer> g_f16_round_scratch_buffer;
 static id<MTLBuffer> g_raw_store_round_buffer;
 static id<MTLBuffer> g_moe_gate_scratch_buffer;
@@ -17555,11 +17559,39 @@ static int ds4_gpu_indexer_scores_batch_tensor(
          * those paths keep the older direct/tiled score kernels.
          */
         const bool use_nax = ds4_gpu_mpp_available() && n_tokens >= 16u;
+        /* Wide-tile pre-M5 prefill scorer over half-packed Q/K: two f32->f16
+         * pack dispatches (the exact rounding the legacy kernel applied while
+         * staging, applied once instead of once per head per comp tile), then
+         * TN=64 tiles.  Bit-identical scores; the dominant Q re-read traffic
+         * drops ~4x.  DS4_METAL_DISABLE_INDEXER_SCORES_TILED2 rolls back. */
+        /* Read the rollback env per call: the ABBA variant bench toggles it
+         * between runs inside one process, and a cached read would silently
+         * compare the candidate against itself. */
+        const bool use_tiled2 = !use_nax && !g_quality_mode &&
+            n_tokens >= 32u &&
+            getenv("DS4_METAL_DISABLE_INDEXER_SCORES_TILED2") == NULL;
         id<MTLComputePipelineState> pipeline = ds4_gpu_get_pipeline(
             use_nax ? "kernel_dsv4_indexer_scores_nax" :
-            (g_quality_mode ? "kernel_dsv4_indexer_scores_tiled_f32"
-                            : "kernel_dsv4_indexer_scores_tiled"));
+            (g_quality_mode ? "kernel_dsv4_indexer_scores_tiled_f32" :
+             (use_tiled2 ? "kernel_dsv4_indexer_scores_tiled2_f16"
+                         : "kernel_dsv4_indexer_scores_tiled")));
         if (!pipeline) return 0;
+        if (use_tiled2) {
+            const NSUInteger q16_bytes =
+                (NSUInteger)n_tokens * n_head * head_dim * sizeof(uint16_t);
+            const NSUInteger k16_bytes =
+                (NSUInteger)n_comp * head_dim * sizeof(uint16_t);
+            if (!ds4_gpu_ensure_scratch_buffer(&g_indexer_q16_buffer,
+                                                 &g_indexer_q16_bytes,
+                                                 q16_bytes,
+                                                 "ds4_indexer_q16") ||
+                !ds4_gpu_ensure_scratch_buffer(&g_indexer_k16_buffer,
+                                                 &g_indexer_k16_bytes,
+                                                 k16_bytes,
+                                                 "ds4_indexer_k16")) {
+                return 0;
+            }
+        }
 
         ds4_gpu_dsv4_indexer_scores_fused_args args = {
             .n_comp = n_comp,
@@ -17580,12 +17612,38 @@ static int ds4_gpu_indexer_scores_batch_tensor(
         id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
         if (!cb) return 0;
 
+        if (use_tiled2) {
+            if (!ds4_gpu_encode_cpy_f32_f16_1d(cb,
+                                                 qbuf,
+                                                 ds4_gpu_tensor_offset(q),
+                                                 g_indexer_q16_buffer,
+                                                 0,
+                                                 n_tokens * n_head * head_dim) ||
+                !ds4_gpu_encode_cpy_f32_f16_1d(cb,
+                                                 compbuf,
+                                                 ds4_gpu_tensor_offset(index_comp),
+                                                 g_indexer_k16_buffer,
+                                                 0,
+                                                 n_comp * head_dim)) {
+                if (owned) (void)ds4_gpu_finish_command_buffer(cb, owned, "indexer scores pack");
+                return 0;
+            }
+        }
+
         id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:pipeline];
         [enc setBytes:&args length:sizeof(args) atIndex:0];
-        [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
+        if (use_tiled2) {
+            [enc setBuffer:g_indexer_q16_buffer offset:0 atIndex:1];
+        } else {
+            [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
+        }
         [enc setBuffer:wbuf offset:ds4_gpu_tensor_offset(weights) atIndex:2];
-        [enc setBuffer:compbuf offset:ds4_gpu_tensor_offset(index_comp) atIndex:3];
+        if (use_tiled2) {
+            [enc setBuffer:g_indexer_k16_buffer offset:0 atIndex:3];
+        } else {
+            [enc setBuffer:compbuf offset:ds4_gpu_tensor_offset(index_comp) atIndex:3];
+        }
         [enc setBuffer:scorebuf offset:ds4_gpu_tensor_offset(scores) atIndex:4];
         if (use_nax) {
             const NSUInteger q_shared = 2u * 32u * 32u;
@@ -17606,6 +17664,16 @@ static int ds4_gpu_indexer_scores_batch_tensor(
                                                   ((NSUInteger)n_tokens + 7u) / 8u,
                                                   1)
                  threadsPerThreadgroup:MTLSizeMake(32, 4, 1)];
+        } else if (use_tiled2) {
+            const NSUInteger q_shared = 8u * 128u;
+            const NSUInteger k_shared = 64u * 128u;
+            const NSUInteger dot_shared = 8u * 64u;
+            [enc setThreadgroupMemoryLength:(q_shared + k_shared) * sizeof(uint16_t) +
+                                            dot_shared * sizeof(float) atIndex:0];
+            [enc dispatchThreadgroups:MTLSizeMake(((NSUInteger)n_comp + 63u) / 64u,
+                                                  ((NSUInteger)n_tokens + 7u) / 8u,
+                                                  1)
+                 threadsPerThreadgroup:MTLSizeMake(32, 8, 1)];
         } else {
             const NSUInteger q_shared = 8u * 128u;
             const NSUInteger k_shared = 32u * 128u;

--- a/metal/dsv4_misc.metal
+++ b/metal/dsv4_misc.metal
@@ -6173,6 +6173,147 @@ kernel void kernel_dsv4_indexer_scores_tiled_f32(
     }
 }
 
+// Wide-tile variant of kernel_dsv4_indexer_scores_tiled fed by half-packed
+// Q and K (packed once per call by the host with the exact half(float)
+// rounding this kernel used to apply during staging, so every staged value
+// is bit-identical). TN doubles to 64, which halves the number of comp
+// tiles and with it the dominant device-traffic term: the legacy kernel
+// re-reads the full f32 Q tile from device once per head per 32-row comp
+// tile (~8 GB per layer per 2048-token chunk at 64k context). Per (token,
+// comp) pair the reduction is unchanged: heads ascending, sixteen 8x8
+// simdgroup MACs per head in the same order, relu(dot)*w accumulated in
+// float. Outputs are bit-identical to the legacy kernel.
+kernel void kernel_dsv4_indexer_scores_tiled2_f16(
+        constant ds4_metal_args_dsv4_indexer_scores_fused & args,
+        device const char *q16,
+        device const char *weights,
+        device const char *index_comp16,
+        device       char *scores,
+        threadgroup float *shared [[threadgroup(0)]],
+        uint2  tgpig [[threadgroup_position_in_grid]],
+        ushort tid   [[thread_index_in_threadgroup]],
+        ushort lane  [[thread_index_in_simdgroup]],
+        ushort sg    [[simdgroup_index_in_threadgroup]]) {
+    constexpr uint TM = 8;
+    constexpr uint TN = 64;
+    constexpr uint TS = 8;
+    constexpr uint D  = 128;
+    constexpr uint NT = 256;
+
+    const uint c0 = tgpig.x * TN;
+    const uint t0 = tgpig.y * TM;
+
+    threadgroup half *qtg = (threadgroup half *)shared; // [8][128]
+    threadgroup half *ktg = qtg + TM*D;                 // [64][128]
+    threadgroup float *dot = (threadgroup float *)(ktg + TN*D); // [8][64]
+
+    const uint last_token = min(t0 + TM, args.n_tokens);
+    const uint max_visible = last_token > t0 ?
+        min((args.pos0 + last_token) / args.ratio, args.n_comp) : 0u;
+
+    if (c0 >= max_visible) {
+        for (uint i = tid; i < TM*TN; i += NT) {
+            const uint r = i / TN;
+            const uint cc = i - r*TN;
+            const uint token = t0 + r;
+            const uint comp = c0 + cc;
+            if (token < args.n_tokens && comp < args.n_comp) {
+                device float *dst = (device float *)(scores +
+                    (uint64_t)token * args.score_token_stride) + comp;
+                *dst = -INFINITY;
+            }
+        }
+        return;
+    }
+
+    for (uint i = tid; i < TN*D; i += NT) {
+        const uint cc = i / D;
+        const uint d = i - cc*D;
+        const uint comp = c0 + cc;
+        half v = half(0.0f);
+        if (comp < args.n_comp) {
+            device const half *row = (device const half *)(index_comp16 +
+                (uint64_t)comp * (D * sizeof(half)));
+            v = row[d];
+        }
+        ktg[i] = v;
+    }
+
+    const uint cell0 = tid;
+    const uint cell1 = tid + NT;
+    const uint row0 = cell0 / TN;
+    const uint row1 = cell1 / TN;
+    const uint col0 = cell0 - row0*TN;
+    const uint col1 = cell1 - row1*TN;
+    const uint token0 = t0 + row0;
+    const uint token1 = t0 + row1;
+    const uint comp0 = c0 + col0;
+    const uint comp1 = c0 + col1;
+
+    float acc0 = 0.0f;
+    float acc1 = 0.0f;
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint head = 0; head < args.n_head; head++) {
+        for (uint i = tid; i < TM*D; i += NT) {
+            const uint r = i / D;
+            const uint d = i - r*D;
+            const uint token = t0 + r;
+            half v = half(0.0f);
+            if (token < args.n_tokens) {
+                device const half *qrow = (device const half *)(q16 +
+                    ((uint64_t)token * args.n_head + head) * (D * sizeof(half)));
+                v = qrow[d];
+            }
+            qtg[i] = v;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        simdgroup_float8x8 mdot = make_filled_simdgroup_matrix<float, 8>(0.0f);
+        for (uint db = 0; db < D/TS; db++) {
+            simdgroup_half8x8 mq;
+            simdgroup_half8x8 mk;
+            simdgroup_load(mq, qtg + db*TS, D, 0, false);
+            simdgroup_load(mk, ktg + ((uint)sg * TS) * D + db*TS, D, 0, true);
+            simdgroup_multiply_accumulate(mdot, mq, mk, mdot);
+        }
+
+        simdgroup_store(mdot, dot + (uint)sg * TS, TN, 0, false);
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (token0 < args.n_tokens && comp0 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token0 * args.weights_token_stride);
+            const float sc = dot[row0*TN + col0];
+            acc0 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+        if (token1 < args.n_tokens && comp1 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token1 * args.weights_token_stride);
+            const float sc = dot[row1*TN + col1];
+            acc1 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (token0 < args.n_tokens && comp0 < args.n_comp) {
+        const uint visible = min((args.pos0 + token0 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token0 * args.score_token_stride) + comp0;
+        *dst = comp0 < visible ? acc0 : -INFINITY;
+    }
+    if (token1 < args.n_tokens && comp1 < args.n_comp) {
+        const uint visible = min((args.pos0 + token1 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token1 * args.score_token_stride) + comp1;
+        *dst = comp1 < visible ? acc1 : -INFINITY;
+    }
+}
+
 kernel void kernel_dsv4_indexer_scores_tiled(
         constant ds4_metal_args_dsv4_indexer_scores_fused & args,
         device const char *q,


### PR DESCRIPTION
The pre-M5 prefill indexer scorer (`kernel_dsv4_indexer_scores_tiled`) re-reads the full f32 Q tile from device memory once per head per 32-row comp tile — about 1 KB of the ~1.1 KB it moves per scored (token, comp) pair. The kernel's own comment notes the score matrix "dominates the prefill slope"; this PR attacks the traffic term without touching the arithmetic.

Split it in two: a pair of `f32→f16` pack dispatches convert Q and the indexer K rows once per call, with exactly the `half(float)` rounding the kernel applied during staging (the rounding moves, the values don't), and a TN=64 variant (`kernel_dsv4_indexer_scores_tiled2_f16`, 256 threads, 8 simdgroups, 20.5 KB threadgroup memory) reads the packed halves. Half the comp tiles → half the Q re-reads, each moving half the bytes. Per (token, comp) pair the reduction is unchanged — heads ascending, sixteen 8×8 simdgroup MACs per head in the same order, `relu(dot)*w` accumulated in float — so scores are **bit-identical**. Gated on batched prefill (`n_tokens >= 32`), off in `--quality`; `DS4_METAL_DISABLE_INDEXER_SCORES_TILED2` rolls back, read per call so the variant bench can toggle it in-process.

Measured on Apple M3 Ultra (60-core GPU) 512 GB, DeepSeek V4 Flash 0731 native-MXFP4 GGUF (156 GB), base 84cc882:

Exactness: `metal_prefill_variant_bench --candidate-env DS4_METAL_DISABLE_INDEXER_SCORES_TILED2 --prefix-tokens 8192 --repeats 2` → 8/8 runs bit-exact, `exact_floats=1034240`, candidate (rollback) −0.62%. Full-vocab logits at frontiers 2048..8192 byte-identical to a build without the change (`ds4-bench --dump-frontier-logits-dir` byte-compare across binaries). Harness control-vs-control calibrated bit-exact on this box (see my comment in #793).

Speed — the CONTRIBUTING.md sweep (`--ctx-start 2048 --ctx-max 65536 --step-incr 2048 --gen-tokens 128`, ABBA pairs, quiet box), delta = this PR vs 84cc882:

| ctx | prefill t/s (main → PR) | Δ | gen Δ |
|---|---|---|---|
| 2048 | 666.3 → 666.0 | −0.0% | +0.1% |
| 8192 | 571.2 → 575.3 | +0.7% | +0.2% |
| 16384 | 537.2 → 544.8 | +1.4% | +0.1% |
| 32768 | 477.4 → 490.5 | +2.8% | −0.2% |
| 49152 | 430.3 → 446.6 | +3.8% | +0.1% |
| 65536 | 392.4 → 411.0 | **+4.7%** | −0.2% |

Monotone in context (it is a traffic fix for a term that grows with n_comp); generation deltas are noise. Single cold syncs at `--prefill-chunk 4096`: 16k 590→599, 32k 550→563, 64k 484→504 t/s. The `DS4_METAL_INDEXER_STAGE_PROFILE` split shows the score stage at 64k dropping 25.9 s → 20.6 s per full prefill (−21%).

`make test` targets green incl. `./ds4_test --server`; built with zero warnings. Running in production on the machine above. Scratch cost: two shared buffers, `n_tokens×n_head×128` and `n_comp×128` halves (~64 + ~67 MB at 1M ctx / 4096 chunk).

Related: this is the Metal analogue of the mxf4 indexer-scorer direction CUDA already took (56ec892, 08fecd9) but kept bit-exact; a follow-up porting the mxf4 encoding itself (matching CUDA's default, not bit-exact vs today's Metal) would cut the remaining byte term a further ~8x.
