### PR TITLE
metal: register-blocked, K-register-resident indexer prefill scorer (tiled4+tiled5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 .PHONY: all help clean test test-metal-session-batch test-mxfp4-cuda test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
 
 ifeq ($(UNAME_S),Darwin)
-.PHONY: metal-decode-schedule-bench metal-prefill-variant-bench check-mxfp4-half-lut
+.PHONY: metal-decode-schedule-bench metal-prefill-variant-bench check-mxfp4-half-lut test-indexer-scorers
 
 all: ds4 ds4-server ds4-bench ds4-eval ds4-agent
 
@@ -76,6 +76,7 @@ help:
 	@echo "  make test         Build and run tests"
 	@echo "  make metal-decode-schedule-bench  Build the balanced Metal decode schedule benchmark"
 	@echo "  make metal-prefill-variant-bench  Build the balanced Metal prefill variant benchmark"
+	@echo "  make test-indexer-scorers  Compare all pre-M5 indexer scorers byte-for-byte"
 	@echo "  make check-mxfp4-half-lut  Verify the checked-in MXFP4 half LUT matches the generator"
 	@echo "  make test-mxfp4-metal  Check the MXFP4 half LUT, then run Metal MXFP4 exactness tests"
 	@echo "  make dspark-verify-depth  Run DSpark speculative verification smoke if support GGUF is present"
@@ -124,6 +125,15 @@ speed-bench/metal_prefill_variant_bench: speed-bench/metal_prefill_variant_bench
 	$(CC) $(CFLAGS) -o $@ $^ $(METAL_LDLIBS)
 
 metal-prefill-variant-bench: speed-bench/metal_prefill_variant_bench
+
+tests/test_indexer_scorers.o: tests/test_indexer_tiled4.c ds4_gpu.h
+	$(CC) $(CFLAGS) -I. -c -o $@ $<
+
+tests/test_indexer_scorers: tests/test_indexer_scorers.o $(CORE_OBJS)
+	$(CC) $(CFLAGS) -o $@ $^ $(METAL_LDLIBS)
+
+test-indexer-scorers: tests/test_indexer_scorers
+	./tests/test_indexer_scorers
 
 tests/test_mxfp4_metal.o: tests/test_mxfp4_metal.c ds4_gpu.h
 	$(CC) $(CFLAGS) -I. -c -o $@ $<
@@ -488,4 +498,4 @@ mxfp4-dot-test: tests/test_mxfp4_dot.c
 	./tests/test_mxfp4_dot
 
 clean:
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_indexer_scorers tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -17570,12 +17570,28 @@ static int ds4_gpu_indexer_scores_batch_tensor(
         const bool use_tiled2 = !use_nax && !g_quality_mode &&
             n_tokens >= 32u &&
             getenv("DS4_METAL_DISABLE_INDEXER_SCORES_TILED2") == NULL;
+        /* Candidate: register-blocked TM=16 scorer (tiled4).  Opt-in env,
+         * read per call for the ABBA variant bench.  Same staged values,
+         * barrier structure and accumulation order as tiled2 — bit-identical
+         * outputs. */
+        const bool use_tiled4 = use_tiled2 &&
+            getenv("DS4_METAL_INDEXER_SCORES_TILED4") != NULL;
         id<MTLComputePipelineState> pipeline = ds4_gpu_get_pipeline(
             use_nax ? "kernel_dsv4_indexer_scores_nax" :
             (g_quality_mode ? "kernel_dsv4_indexer_scores_tiled_f32" :
-             (use_tiled2 ? "kernel_dsv4_indexer_scores_tiled2_f16"
-                         : "kernel_dsv4_indexer_scores_tiled")));
+             (use_tiled4 ? "kernel_dsv4_indexer_scores_tiled4_f16" :
+              (use_tiled2 ? "kernel_dsv4_indexer_scores_tiled2_f16"
+                          : "kernel_dsv4_indexer_scores_tiled"))));
         if (!pipeline) return 0;
+        if (use_tiled4) {
+            static int logged_tiled4;
+            if (!logged_tiled4) {
+                logged_tiled4 = 1;
+                fprintf(stderr,
+                        "ds4: metal indexer prefill scorer using tiled4 "
+                        "(register-blocked TM=16)\n");
+            }
+        }
         if (use_tiled2) {
             const NSUInteger q16_bytes =
                 (NSUInteger)n_tokens * n_head * head_dim * sizeof(uint16_t);
@@ -17665,13 +17681,14 @@ static int ds4_gpu_indexer_scores_batch_tensor(
                                                   1)
                  threadsPerThreadgroup:MTLSizeMake(32, 4, 1)];
         } else if (use_tiled2) {
-            const NSUInteger q_shared = 8u * 128u;
+            const NSUInteger tm = use_tiled4 ? 16u : 8u;
+            const NSUInteger q_shared = tm * 128u;
             const NSUInteger k_shared = 64u * 128u;
-            const NSUInteger dot_shared = 8u * 64u;
+            const NSUInteger dot_shared = tm * 64u;
             [enc setThreadgroupMemoryLength:(q_shared + k_shared) * sizeof(uint16_t) +
                                             dot_shared * sizeof(float) atIndex:0];
             [enc dispatchThreadgroups:MTLSizeMake(((NSUInteger)n_comp + 63u) / 64u,
-                                                  ((NSUInteger)n_tokens + 7u) / 8u,
+                                                  ((NSUInteger)n_tokens + tm - 1u) / tm,
                                                   1)
                  threadsPerThreadgroup:MTLSizeMake(32, 8, 1)];
         } else {

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -17576,20 +17576,26 @@ static int ds4_gpu_indexer_scores_batch_tensor(
          * outputs. */
         const bool use_tiled4 = use_tiled2 &&
             getenv("DS4_METAL_INDEXER_SCORES_TILED4") != NULL;
+        /* Candidate on top of tiled4: K tiles resident in simdgroup
+         * registers across the head loop.  Opt-in env, read per call. */
+        const bool use_tiled5 = use_tiled2 &&
+            getenv("DS4_METAL_INDEXER_SCORES_TILED5") != NULL;
         id<MTLComputePipelineState> pipeline = ds4_gpu_get_pipeline(
             use_nax ? "kernel_dsv4_indexer_scores_nax" :
             (g_quality_mode ? "kernel_dsv4_indexer_scores_tiled_f32" :
-             (use_tiled4 ? "kernel_dsv4_indexer_scores_tiled4_f16" :
-              (use_tiled2 ? "kernel_dsv4_indexer_scores_tiled2_f16"
-                          : "kernel_dsv4_indexer_scores_tiled"))));
+             (use_tiled5 ? "kernel_dsv4_indexer_scores_tiled5_f16" :
+              (use_tiled4 ? "kernel_dsv4_indexer_scores_tiled4_f16" :
+               (use_tiled2 ? "kernel_dsv4_indexer_scores_tiled2_f16"
+                           : "kernel_dsv4_indexer_scores_tiled")))));
         if (!pipeline) return 0;
-        if (use_tiled4) {
-            static int logged_tiled4;
-            if (!logged_tiled4) {
-                logged_tiled4 = 1;
+        if (use_tiled4 || use_tiled5) {
+            static int logged_tiled45;
+            if (!logged_tiled45) {
+                logged_tiled45 = 1;
                 fprintf(stderr,
-                        "ds4: metal indexer prefill scorer using tiled4 "
-                        "(register-blocked TM=16)\n");
+                        "ds4: metal indexer prefill scorer using %s\n",
+                        use_tiled5 ? "tiled5 (K-register-resident TM=16)"
+                                   : "tiled4 (register-blocked TM=16)");
             }
         }
         if (use_tiled2) {
@@ -17681,7 +17687,7 @@ static int ds4_gpu_indexer_scores_batch_tensor(
                                                   1)
                  threadsPerThreadgroup:MTLSizeMake(32, 4, 1)];
         } else if (use_tiled2) {
-            const NSUInteger tm = use_tiled4 ? 16u : 8u;
+            const NSUInteger tm = (use_tiled4 || use_tiled5) ? 16u : 8u;
             const NSUInteger q_shared = tm * 128u;
             const NSUInteger k_shared = 64u * 128u;
             const NSUInteger dot_shared = tm * 64u;

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -10404,6 +10404,8 @@ void ds4_gpu_cleanup(void) {
         g_indexer_head_scores_buffer = nil;
         g_indexer_topk_buffer = nil;
         g_indexed_topk_buffer = nil;
+        g_indexer_q16_buffer = nil;
+        g_indexer_k16_buffer = nil;
         g_stream_expert_validate_status_buffer = nil;
         g_f16_round_scratch_buffer = nil;
         g_raw_store_round_buffer = nil;
@@ -10446,6 +10448,8 @@ void ds4_gpu_cleanup(void) {
         g_indexer_head_scores_bytes = 0;
         g_indexer_topk_bytes = 0;
         g_indexed_topk_bytes = 0;
+        g_indexer_q16_bytes = 0;
+        g_indexer_k16_bytes = 0;
         g_f16_round_scratch_bytes = 0;
         g_raw_store_round_bytes = 0;
         g_moe_gate_scratch_bytes = 0;

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -17576,10 +17576,12 @@ static int ds4_gpu_indexer_scores_batch_tensor(
          * outputs. */
         const bool use_tiled4 = use_tiled2 &&
             getenv("DS4_METAL_INDEXER_SCORES_TILED4") != NULL;
-        /* Candidate on top of tiled4: K tiles resident in simdgroup
-         * registers across the head loop.  Opt-in env, read per call. */
-        const bool use_tiled5 = use_tiled2 &&
-            getenv("DS4_METAL_INDEXER_SCORES_TILED5") != NULL;
+        /* Default scorer since 2026-08-18: K tiles resident in simdgroup
+         * registers across the head loop (TM=16 register blocking on top of
+         * tiled2's packing).  Bit-identical outputs; the rollback env is
+         * read per call for the ABBA variant bench. */
+        const bool use_tiled5 = use_tiled2 && !use_tiled4 &&
+            getenv("DS4_METAL_DISABLE_INDEXER_SCORES_TILED5") == NULL;
         id<MTLComputePipelineState> pipeline = ds4_gpu_get_pipeline(
             use_nax ? "kernel_dsv4_indexer_scores_nax" :
             (g_quality_mode ? "kernel_dsv4_indexer_scores_tiled_f32" :

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -351,6 +351,10 @@ static id<MTLBuffer> g_router_weight_sum_buffer;
 static id<MTLBuffer> g_indexer_head_scores_buffer;
 static id<MTLBuffer> g_indexer_topk_buffer;
 static id<MTLBuffer> g_indexed_topk_buffer;
+static id<MTLBuffer> g_indexer_q16_buffer;
+static NSUInteger    g_indexer_q16_bytes;
+static id<MTLBuffer> g_indexer_k16_buffer;
+static NSUInteger    g_indexer_k16_bytes;
 static id<MTLBuffer> g_f16_round_scratch_buffer;
 static id<MTLBuffer> g_raw_store_round_buffer;
 static id<MTLBuffer> g_moe_gate_scratch_buffer;
@@ -17555,11 +17559,39 @@ static int ds4_gpu_indexer_scores_batch_tensor(
          * those paths keep the older direct/tiled score kernels.
          */
         const bool use_nax = ds4_gpu_mpp_available() && n_tokens >= 16u;
+        /* Wide-tile pre-M5 prefill scorer over half-packed Q/K: two f32->f16
+         * pack dispatches (the exact rounding the legacy kernel applied while
+         * staging, applied once instead of once per head per comp tile), then
+         * TN=64 tiles.  Bit-identical scores; the dominant Q re-read traffic
+         * drops ~4x.  DS4_METAL_DISABLE_INDEXER_SCORES_TILED2 rolls back. */
+        /* Read the rollback env per call: the ABBA variant bench toggles it
+         * between runs inside one process, and a cached read would silently
+         * compare the candidate against itself. */
+        const bool use_tiled2 = !use_nax && !g_quality_mode &&
+            n_tokens >= 32u &&
+            getenv("DS4_METAL_DISABLE_INDEXER_SCORES_TILED2") == NULL;
         id<MTLComputePipelineState> pipeline = ds4_gpu_get_pipeline(
             use_nax ? "kernel_dsv4_indexer_scores_nax" :
-            (g_quality_mode ? "kernel_dsv4_indexer_scores_tiled_f32"
-                            : "kernel_dsv4_indexer_scores_tiled"));
+            (g_quality_mode ? "kernel_dsv4_indexer_scores_tiled_f32" :
+             (use_tiled2 ? "kernel_dsv4_indexer_scores_tiled2_f16"
+                         : "kernel_dsv4_indexer_scores_tiled")));
         if (!pipeline) return 0;
+        if (use_tiled2) {
+            const NSUInteger q16_bytes =
+                (NSUInteger)n_tokens * n_head * head_dim * sizeof(uint16_t);
+            const NSUInteger k16_bytes =
+                (NSUInteger)n_comp * head_dim * sizeof(uint16_t);
+            if (!ds4_gpu_ensure_scratch_buffer(&g_indexer_q16_buffer,
+                                                 &g_indexer_q16_bytes,
+                                                 q16_bytes,
+                                                 "ds4_indexer_q16") ||
+                !ds4_gpu_ensure_scratch_buffer(&g_indexer_k16_buffer,
+                                                 &g_indexer_k16_bytes,
+                                                 k16_bytes,
+                                                 "ds4_indexer_k16")) {
+                return 0;
+            }
+        }
 
         ds4_gpu_dsv4_indexer_scores_fused_args args = {
             .n_comp = n_comp,
@@ -17580,12 +17612,38 @@ static int ds4_gpu_indexer_scores_batch_tensor(
         id<MTLCommandBuffer> cb = ds4_gpu_command_buffer(&owned);
         if (!cb) return 0;
 
+        if (use_tiled2) {
+            if (!ds4_gpu_encode_cpy_f32_f16_1d(cb,
+                                                 qbuf,
+                                                 ds4_gpu_tensor_offset(q),
+                                                 g_indexer_q16_buffer,
+                                                 0,
+                                                 n_tokens * n_head * head_dim) ||
+                !ds4_gpu_encode_cpy_f32_f16_1d(cb,
+                                                 compbuf,
+                                                 ds4_gpu_tensor_offset(index_comp),
+                                                 g_indexer_k16_buffer,
+                                                 0,
+                                                 n_comp * head_dim)) {
+                if (owned) (void)ds4_gpu_finish_command_buffer(cb, owned, "indexer scores pack");
+                return 0;
+            }
+        }
+
         id<MTLComputeCommandEncoder> enc = ds4_gpu_compute_encoder(cb);
         [enc setComputePipelineState:pipeline];
         [enc setBytes:&args length:sizeof(args) atIndex:0];
-        [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
+        if (use_tiled2) {
+            [enc setBuffer:g_indexer_q16_buffer offset:0 atIndex:1];
+        } else {
+            [enc setBuffer:qbuf offset:ds4_gpu_tensor_offset(q) atIndex:1];
+        }
         [enc setBuffer:wbuf offset:ds4_gpu_tensor_offset(weights) atIndex:2];
-        [enc setBuffer:compbuf offset:ds4_gpu_tensor_offset(index_comp) atIndex:3];
+        if (use_tiled2) {
+            [enc setBuffer:g_indexer_k16_buffer offset:0 atIndex:3];
+        } else {
+            [enc setBuffer:compbuf offset:ds4_gpu_tensor_offset(index_comp) atIndex:3];
+        }
         [enc setBuffer:scorebuf offset:ds4_gpu_tensor_offset(scores) atIndex:4];
         if (use_nax) {
             const NSUInteger q_shared = 2u * 32u * 32u;
@@ -17606,6 +17664,16 @@ static int ds4_gpu_indexer_scores_batch_tensor(
                                                   ((NSUInteger)n_tokens + 7u) / 8u,
                                                   1)
                  threadsPerThreadgroup:MTLSizeMake(32, 4, 1)];
+        } else if (use_tiled2) {
+            const NSUInteger q_shared = 8u * 128u;
+            const NSUInteger k_shared = 64u * 128u;
+            const NSUInteger dot_shared = 8u * 64u;
+            [enc setThreadgroupMemoryLength:(q_shared + k_shared) * sizeof(uint16_t) +
+                                            dot_shared * sizeof(float) atIndex:0];
+            [enc dispatchThreadgroups:MTLSizeMake(((NSUInteger)n_comp + 63u) / 64u,
+                                                  ((NSUInteger)n_tokens + 7u) / 8u,
+                                                  1)
+                 threadsPerThreadgroup:MTLSizeMake(32, 8, 1)];
         } else {
             const NSUInteger q_shared = 8u * 128u;
             const NSUInteger k_shared = 32u * 128u;

--- a/metal/dsv4_misc.metal
+++ b/metal/dsv4_misc.metal
@@ -6505,6 +6505,190 @@ kernel void kernel_dsv4_indexer_scores_tiled4_f16(
     }
 }
 
+// K-register-resident variant of tiled4.  The staged K tile is invariant
+// across the head loop, yet tiled2/tiled4 reload it from threadgroup memory
+// for every head.  Here each simdgroup loads its sixteen 8x8 K tiles into
+// simdgroup registers once, before the head loop; per head only the two Q
+// tiles are loaded — threadgroup loads per MMA drop from tiled4's 1.5 to
+// 1.0.  Staging, barriers and the per-pair reduction are exactly tiled4's
+// (and therefore tiled2's): bit-identical outputs.  The cost is ~16 live
+// matrix registers per simdgroup across the head loop — Apple9 allocates
+// registers as a cache, so the occupancy effect is measured, not assumed.
+kernel void kernel_dsv4_indexer_scores_tiled5_f16(
+        constant ds4_metal_args_dsv4_indexer_scores_fused & args,
+        device const char *q16,
+        device const char *weights,
+        device const char *index_comp16,
+        device       char *scores,
+        threadgroup float *shared [[threadgroup(0)]],
+        uint2  tgpig [[threadgroup_position_in_grid]],
+        ushort tid   [[thread_index_in_threadgroup]],
+        ushort lane  [[thread_index_in_simdgroup]],
+        ushort sg    [[simdgroup_index_in_threadgroup]]) {
+    constexpr uint TM = 16;
+    constexpr uint TN = 64;
+    constexpr uint TS = 8;
+    constexpr uint D  = 128;
+    constexpr uint NT = 256;
+
+    const uint c0 = tgpig.x * TN;
+    const uint t0 = tgpig.y * TM;
+
+    threadgroup half *qtg = (threadgroup half *)shared;          // [16][128]
+    threadgroup half *ktg = qtg + TM*D;                          // [64][128]
+    threadgroup float *dot = (threadgroup float *)(ktg + TN*D);  // [16][64]
+
+    const uint last_token = min(t0 + TM, args.n_tokens);
+    const uint max_visible = last_token > t0 ?
+        min((args.pos0 + last_token) / args.ratio, args.n_comp) : 0u;
+
+    if (c0 >= max_visible) {
+        for (uint i = tid; i < TM*TN; i += NT) {
+            const uint r = i / TN;
+            const uint cc = i - r*TN;
+            const uint token = t0 + r;
+            const uint comp = c0 + cc;
+            if (token < args.n_tokens && comp < args.n_comp) {
+                device float *dst = (device float *)(scores +
+                    (uint64_t)token * args.score_token_stride) + comp;
+                *dst = -INFINITY;
+            }
+        }
+        return;
+    }
+
+    for (uint i = tid; i < TN*D; i += NT) {
+        const uint cc = i / D;
+        const uint d = i - cc*D;
+        const uint comp = c0 + cc;
+        half v = half(0.0f);
+        if (comp < args.n_comp) {
+            device const half *row = (device const half *)(index_comp16 +
+                (uint64_t)comp * (D * sizeof(half)));
+            v = row[d];
+        }
+        ktg[i] = v;
+    }
+
+    const uint cell0 = (uint)tid;
+    const uint cell1 = (uint)tid + NT;
+    const uint cell2 = (uint)tid + 2u*NT;
+    const uint cell3 = (uint)tid + 3u*NT;
+    const uint row0 = cell0 / TN;
+    const uint row1 = cell1 / TN;
+    const uint row2 = cell2 / TN;
+    const uint row3 = cell3 / TN;
+    const uint col0 = cell0 - row0*TN;
+    const uint col1 = cell1 - row1*TN;
+    const uint col2 = cell2 - row2*TN;
+    const uint col3 = cell3 - row3*TN;
+    const uint token0 = t0 + row0;
+    const uint token1 = t0 + row1;
+    const uint token2 = t0 + row2;
+    const uint token3 = t0 + row3;
+    const uint comp0 = c0 + col0;
+    const uint comp1 = c0 + col1;
+    const uint comp2 = c0 + col2;
+    const uint comp3 = c0 + col3;
+
+    float acc0 = 0.0f;
+    float acc1 = 0.0f;
+    float acc2 = 0.0f;
+    float acc3 = 0.0f;
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    simdgroup_half8x8 mk[D/TS];
+    for (uint db = 0; db < D/TS; db++) {
+        simdgroup_load(mk[db], ktg + ((uint)sg * TS) * D + db*TS, D, 0, true);
+    }
+
+    for (uint head = 0; head < args.n_head; head++) {
+        for (uint i = tid; i < TM*D; i += NT) {
+            const uint r = i / D;
+            const uint d = i - r*D;
+            const uint token = t0 + r;
+            half v = half(0.0f);
+            if (token < args.n_tokens) {
+                device const half *qrow = (device const half *)(q16 +
+                    ((uint64_t)token * args.n_head + head) * (D * sizeof(half)));
+                v = qrow[d];
+            }
+            qtg[i] = v;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        simdgroup_float8x8 mdot0 = make_filled_simdgroup_matrix<float, 8>(0.0f);
+        simdgroup_float8x8 mdot1 = make_filled_simdgroup_matrix<float, 8>(0.0f);
+        for (uint db = 0; db < D/TS; db++) {
+            simdgroup_half8x8 mq0;
+            simdgroup_half8x8 mq1;
+            simdgroup_load(mq0, qtg + db*TS, D, 0, false);
+            simdgroup_load(mq1, qtg + TS*D + db*TS, D, 0, false);
+            simdgroup_multiply_accumulate(mdot0, mq0, mk[db], mdot0);
+            simdgroup_multiply_accumulate(mdot1, mq1, mk[db], mdot1);
+        }
+
+        simdgroup_store(mdot0, dot + (uint)sg * TS, TN, 0, false);
+        simdgroup_store(mdot1, dot + TS*TN + (uint)sg * TS, TN, 0, false);
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (token0 < args.n_tokens && comp0 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token0 * args.weights_token_stride);
+            const float sc = dot[row0*TN + col0];
+            acc0 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+        if (token1 < args.n_tokens && comp1 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token1 * args.weights_token_stride);
+            const float sc = dot[row1*TN + col1];
+            acc1 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+        if (token2 < args.n_tokens && comp2 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token2 * args.weights_token_stride);
+            const float sc = dot[row2*TN + col2];
+            acc2 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+        if (token3 < args.n_tokens && comp3 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token3 * args.weights_token_stride);
+            const float sc = dot[row3*TN + col3];
+            acc3 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (token0 < args.n_tokens && comp0 < args.n_comp) {
+        const uint visible = min((args.pos0 + token0 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token0 * args.score_token_stride) + comp0;
+        *dst = comp0 < visible ? acc0 : -INFINITY;
+    }
+    if (token1 < args.n_tokens && comp1 < args.n_comp) {
+        const uint visible = min((args.pos0 + token1 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token1 * args.score_token_stride) + comp1;
+        *dst = comp1 < visible ? acc1 : -INFINITY;
+    }
+    if (token2 < args.n_tokens && comp2 < args.n_comp) {
+        const uint visible = min((args.pos0 + token2 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token2 * args.score_token_stride) + comp2;
+        *dst = comp2 < visible ? acc2 : -INFINITY;
+    }
+    if (token3 < args.n_tokens && comp3 < args.n_comp) {
+        const uint visible = min((args.pos0 + token3 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token3 * args.score_token_stride) + comp3;
+        *dst = comp3 < visible ? acc3 : -INFINITY;
+    }
+}
+
 kernel void kernel_dsv4_indexer_scores_tiled(
         constant ds4_metal_args_dsv4_indexer_scores_fused & args,
         device const char *q,

--- a/metal/dsv4_misc.metal
+++ b/metal/dsv4_misc.metal
@@ -6173,6 +6173,147 @@ kernel void kernel_dsv4_indexer_scores_tiled_f32(
     }
 }
 
+// Wide-tile variant of kernel_dsv4_indexer_scores_tiled fed by half-packed
+// Q and K (packed once per call by the host with the exact half(float)
+// rounding this kernel used to apply during staging, so every staged value
+// is bit-identical). TN doubles to 64, which halves the number of comp
+// tiles and with it the dominant device-traffic term: the legacy kernel
+// re-reads the full f32 Q tile from device once per head per 32-row comp
+// tile (~8 GB per layer per 2048-token chunk at 64k context). Per (token,
+// comp) pair the reduction is unchanged: heads ascending, sixteen 8x8
+// simdgroup MACs per head in the same order, relu(dot)*w accumulated in
+// float. Outputs are bit-identical to the legacy kernel.
+kernel void kernel_dsv4_indexer_scores_tiled2_f16(
+        constant ds4_metal_args_dsv4_indexer_scores_fused & args,
+        device const char *q16,
+        device const char *weights,
+        device const char *index_comp16,
+        device       char *scores,
+        threadgroup float *shared [[threadgroup(0)]],
+        uint2  tgpig [[threadgroup_position_in_grid]],
+        ushort tid   [[thread_index_in_threadgroup]],
+        ushort lane  [[thread_index_in_simdgroup]],
+        ushort sg    [[simdgroup_index_in_threadgroup]]) {
+    constexpr uint TM = 8;
+    constexpr uint TN = 64;
+    constexpr uint TS = 8;
+    constexpr uint D  = 128;
+    constexpr uint NT = 256;
+
+    const uint c0 = tgpig.x * TN;
+    const uint t0 = tgpig.y * TM;
+
+    threadgroup half *qtg = (threadgroup half *)shared; // [8][128]
+    threadgroup half *ktg = qtg + TM*D;                 // [64][128]
+    threadgroup float *dot = (threadgroup float *)(ktg + TN*D); // [8][64]
+
+    const uint last_token = min(t0 + TM, args.n_tokens);
+    const uint max_visible = last_token > t0 ?
+        min((args.pos0 + last_token) / args.ratio, args.n_comp) : 0u;
+
+    if (c0 >= max_visible) {
+        for (uint i = tid; i < TM*TN; i += NT) {
+            const uint r = i / TN;
+            const uint cc = i - r*TN;
+            const uint token = t0 + r;
+            const uint comp = c0 + cc;
+            if (token < args.n_tokens && comp < args.n_comp) {
+                device float *dst = (device float *)(scores +
+                    (uint64_t)token * args.score_token_stride) + comp;
+                *dst = -INFINITY;
+            }
+        }
+        return;
+    }
+
+    for (uint i = tid; i < TN*D; i += NT) {
+        const uint cc = i / D;
+        const uint d = i - cc*D;
+        const uint comp = c0 + cc;
+        half v = half(0.0f);
+        if (comp < args.n_comp) {
+            device const half *row = (device const half *)(index_comp16 +
+                (uint64_t)comp * (D * sizeof(half)));
+            v = row[d];
+        }
+        ktg[i] = v;
+    }
+
+    const uint cell0 = tid;
+    const uint cell1 = tid + NT;
+    const uint row0 = cell0 / TN;
+    const uint row1 = cell1 / TN;
+    const uint col0 = cell0 - row0*TN;
+    const uint col1 = cell1 - row1*TN;
+    const uint token0 = t0 + row0;
+    const uint token1 = t0 + row1;
+    const uint comp0 = c0 + col0;
+    const uint comp1 = c0 + col1;
+
+    float acc0 = 0.0f;
+    float acc1 = 0.0f;
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint head = 0; head < args.n_head; head++) {
+        for (uint i = tid; i < TM*D; i += NT) {
+            const uint r = i / D;
+            const uint d = i - r*D;
+            const uint token = t0 + r;
+            half v = half(0.0f);
+            if (token < args.n_tokens) {
+                device const half *qrow = (device const half *)(q16 +
+                    ((uint64_t)token * args.n_head + head) * (D * sizeof(half)));
+                v = qrow[d];
+            }
+            qtg[i] = v;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        simdgroup_float8x8 mdot = make_filled_simdgroup_matrix<float, 8>(0.0f);
+        for (uint db = 0; db < D/TS; db++) {
+            simdgroup_half8x8 mq;
+            simdgroup_half8x8 mk;
+            simdgroup_load(mq, qtg + db*TS, D, 0, false);
+            simdgroup_load(mk, ktg + ((uint)sg * TS) * D + db*TS, D, 0, true);
+            simdgroup_multiply_accumulate(mdot, mq, mk, mdot);
+        }
+
+        simdgroup_store(mdot, dot + (uint)sg * TS, TN, 0, false);
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (token0 < args.n_tokens && comp0 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token0 * args.weights_token_stride);
+            const float sc = dot[row0*TN + col0];
+            acc0 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+        if (token1 < args.n_tokens && comp1 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token1 * args.weights_token_stride);
+            const float sc = dot[row1*TN + col1];
+            acc1 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (token0 < args.n_tokens && comp0 < args.n_comp) {
+        const uint visible = min((args.pos0 + token0 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token0 * args.score_token_stride) + comp0;
+        *dst = comp0 < visible ? acc0 : -INFINITY;
+    }
+    if (token1 < args.n_tokens && comp1 < args.n_comp) {
+        const uint visible = min((args.pos0 + token1 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token1 * args.score_token_stride) + comp1;
+        *dst = comp1 < visible ? acc1 : -INFINITY;
+    }
+}
+
 kernel void kernel_dsv4_indexer_scores_tiled(
         constant ds4_metal_args_dsv4_indexer_scores_fused & args,
         device const char *q,

--- a/metal/dsv4_misc.metal
+++ b/metal/dsv4_misc.metal
@@ -6314,6 +6314,197 @@ kernel void kernel_dsv4_indexer_scores_tiled2_f16(
     }
 }
 
+// Register-blocked variant of kernel_dsv4_indexer_scores_tiled2_f16.  tiled2
+// feeds each 8x8 MMA with two fresh threadgroup loads (one Q tile, one K
+// tile) — zero register reuse, which is why it runs at ~14 TFLOPS while the
+// register-blocked dense GEMMs in this engine reach 19-23.  Here the token
+// tile doubles to TM=16: each simdgroup keeps two accumulators and shares
+// every staged K tile between them, cutting threadgroup loads per MMA from
+// 2.0 to 1.5.  The CUDA backend took the same step in 08fecd9 ("cuda:
+// register-block the prefill indexer scorer").  Staging, barrier structure
+// (two per head) and the per-pair reduction are exactly tiled2's: per
+// (token, comp) pair still sixteen 8x8 simdgroup MACs in db order, then
+// relu(dot)*w accumulated in float, heads ascending, one add per accumulator
+// per barrier region — bit-identical outputs.
+kernel void kernel_dsv4_indexer_scores_tiled4_f16(
+        constant ds4_metal_args_dsv4_indexer_scores_fused & args,
+        device const char *q16,
+        device const char *weights,
+        device const char *index_comp16,
+        device       char *scores,
+        threadgroup float *shared [[threadgroup(0)]],
+        uint2  tgpig [[threadgroup_position_in_grid]],
+        ushort tid   [[thread_index_in_threadgroup]],
+        ushort lane  [[thread_index_in_simdgroup]],
+        ushort sg    [[simdgroup_index_in_threadgroup]]) {
+    constexpr uint TM = 16;
+    constexpr uint TN = 64;
+    constexpr uint TS = 8;
+    constexpr uint D  = 128;
+    constexpr uint NT = 256;
+    constexpr uint RB = TM/TS;   // token row blocks per simdgroup
+
+    const uint c0 = tgpig.x * TN;
+    const uint t0 = tgpig.y * TM;
+
+    threadgroup half *qtg = (threadgroup half *)shared;          // [16][128]
+    threadgroup half *ktg = qtg + TM*D;                          // [64][128]
+    threadgroup float *dot = (threadgroup float *)(ktg + TN*D);  // [16][64]
+
+    const uint last_token = min(t0 + TM, args.n_tokens);
+    const uint max_visible = last_token > t0 ?
+        min((args.pos0 + last_token) / args.ratio, args.n_comp) : 0u;
+
+    if (c0 >= max_visible) {
+        for (uint i = tid; i < TM*TN; i += NT) {
+            const uint r = i / TN;
+            const uint cc = i - r*TN;
+            const uint token = t0 + r;
+            const uint comp = c0 + cc;
+            if (token < args.n_tokens && comp < args.n_comp) {
+                device float *dst = (device float *)(scores +
+                    (uint64_t)token * args.score_token_stride) + comp;
+                *dst = -INFINITY;
+            }
+        }
+        return;
+    }
+
+    for (uint i = tid; i < TN*D; i += NT) {
+        const uint cc = i / D;
+        const uint d = i - cc*D;
+        const uint comp = c0 + cc;
+        half v = half(0.0f);
+        if (comp < args.n_comp) {
+            device const half *row = (device const half *)(index_comp16 +
+                (uint64_t)comp * (D * sizeof(half)));
+            v = row[d];
+        }
+        ktg[i] = v;
+    }
+
+    /* Four output cells per thread, spelled out as scalars: a loop over an
+     * accumulator array lets the compiler contract each cell's
+     * relu(dot)*w*scale term differently from tiled2's scalar form (a ~1 ULP
+     * difference per head that compounds over the 64-head chain).  The
+     * hand-unrolled scalar shape below compiles identically to tiled2's
+     * apply and keeps the outputs bit-exact. */
+    const uint cell0 = (uint)tid;
+    const uint cell1 = (uint)tid + NT;
+    const uint cell2 = (uint)tid + 2u*NT;
+    const uint cell3 = (uint)tid + 3u*NT;
+    const uint row0 = cell0 / TN;
+    const uint row1 = cell1 / TN;
+    const uint row2 = cell2 / TN;
+    const uint row3 = cell3 / TN;
+    const uint col0 = cell0 - row0*TN;
+    const uint col1 = cell1 - row1*TN;
+    const uint col2 = cell2 - row2*TN;
+    const uint col3 = cell3 - row3*TN;
+    const uint token0 = t0 + row0;
+    const uint token1 = t0 + row1;
+    const uint token2 = t0 + row2;
+    const uint token3 = t0 + row3;
+    const uint comp0 = c0 + col0;
+    const uint comp1 = c0 + col1;
+    const uint comp2 = c0 + col2;
+    const uint comp3 = c0 + col3;
+
+    float acc0 = 0.0f;
+    float acc1 = 0.0f;
+    float acc2 = 0.0f;
+    float acc3 = 0.0f;
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint head = 0; head < args.n_head; head++) {
+        for (uint i = tid; i < TM*D; i += NT) {
+            const uint r = i / D;
+            const uint d = i - r*D;
+            const uint token = t0 + r;
+            half v = half(0.0f);
+            if (token < args.n_tokens) {
+                device const half *qrow = (device const half *)(q16 +
+                    ((uint64_t)token * args.n_head + head) * (D * sizeof(half)));
+                v = qrow[d];
+            }
+            qtg[i] = v;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        simdgroup_float8x8 mdot0 = make_filled_simdgroup_matrix<float, 8>(0.0f);
+        simdgroup_float8x8 mdot1 = make_filled_simdgroup_matrix<float, 8>(0.0f);
+        for (uint db = 0; db < D/TS; db++) {
+            simdgroup_half8x8 mk;
+            simdgroup_load(mk, ktg + ((uint)sg * TS) * D + db*TS, D, 0, true);
+            simdgroup_half8x8 mq0;
+            simdgroup_half8x8 mq1;
+            simdgroup_load(mq0, qtg + db*TS, D, 0, false);
+            simdgroup_load(mq1, qtg + TS*D + db*TS, D, 0, false);
+            simdgroup_multiply_accumulate(mdot0, mq0, mk, mdot0);
+            simdgroup_multiply_accumulate(mdot1, mq1, mk, mdot1);
+        }
+
+        simdgroup_store(mdot0, dot + (uint)sg * TS, TN, 0, false);
+        simdgroup_store(mdot1, dot + TS*TN + (uint)sg * TS, TN, 0, false);
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (token0 < args.n_tokens && comp0 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token0 * args.weights_token_stride);
+            const float sc = dot[row0*TN + col0];
+            acc0 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+        if (token1 < args.n_tokens && comp1 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token1 * args.weights_token_stride);
+            const float sc = dot[row1*TN + col1];
+            acc1 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+        if (token2 < args.n_tokens && comp2 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token2 * args.weights_token_stride);
+            const float sc = dot[row2*TN + col2];
+            acc2 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+        if (token3 < args.n_tokens && comp3 < args.n_comp) {
+            device const float *w = (device const float *)(weights +
+                (uint64_t)token3 * args.weights_token_stride);
+            const float sc = dot[row3*TN + col3];
+            acc3 += max(sc, 0.0f) * (w[head] * args.scale);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (token0 < args.n_tokens && comp0 < args.n_comp) {
+        const uint visible = min((args.pos0 + token0 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token0 * args.score_token_stride) + comp0;
+        *dst = comp0 < visible ? acc0 : -INFINITY;
+    }
+    if (token1 < args.n_tokens && comp1 < args.n_comp) {
+        const uint visible = min((args.pos0 + token1 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token1 * args.score_token_stride) + comp1;
+        *dst = comp1 < visible ? acc1 : -INFINITY;
+    }
+    if (token2 < args.n_tokens && comp2 < args.n_comp) {
+        const uint visible = min((args.pos0 + token2 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token2 * args.score_token_stride) + comp2;
+        *dst = comp2 < visible ? acc2 : -INFINITY;
+    }
+    if (token3 < args.n_tokens && comp3 < args.n_comp) {
+        const uint visible = min((args.pos0 + token3 + 1u) / args.ratio, args.n_comp);
+        device float *dst = (device float *)(scores +
+            (uint64_t)token3 * args.score_token_stride) + comp3;
+        *dst = comp3 < visible ? acc3 : -INFINITY;
+    }
+}
+
 kernel void kernel_dsv4_indexer_scores_tiled(
         constant ds4_metal_args_dsv4_indexer_scores_fused & args,
         device const char *q,

--- a/tests/test_indexer_tiled4.c
+++ b/tests/test_indexer_tiled4.c
@@ -67,7 +67,10 @@ int main(void) {
               scale), "tiled2 compute");
     CHECK(ds4_gpu_tensor_read(s, 0, sa, s_count * sizeof(float)), "read a");
 
-    setenv("DS4_METAL_INDEXER_SCORES_TILED4", "1", 1);
+    {
+        const char *cand = getenv("SCORER_CAND_ENV");
+        setenv(cand ? cand : "DS4_METAL_INDEXER_SCORES_TILED4", "1", 1);
+    }
     CHECK(ds4_gpu_indexer_scores_decode_batch_tensor(
               s, q, w, k, n_comp, n_tokens, pos0, n_head, head_dim, ratio,
               scale), "tiled4 compute");

--- a/tests/test_indexer_tiled4.c
+++ b/tests/test_indexer_tiled4.c
@@ -1,114 +1,230 @@
-/* Standalone A/B exactness test for the tiled3 indexer prefill scorer.
- * Runs without a model: random-ish Q/W/K, scores computed twice through the
- * public GPU entry (env unset = tiled2, env set = tiled3), byte-compared,
- * plus a CPU reference in tiled2's arithmetic order.  Exercises edge tiles
- * (n_comp and n_tokens not multiples of the tile sizes) and the causal
- * -INFINITY cut. */
-#include <math.h>
+/* Standalone byte-exact regression for the pre-M5 indexer prefill scorers.
+ *
+ * Every optimized variant is compared directly with the legacy scorer, not
+ * merely with another candidate. Cases cover the 32-token activation edge,
+ * token and compressed-row tile edges, resumed unaligned positions, causal
+ * masking, and a 64K-context-sized compressed frontier. The output tensor is
+ * poisoned differently before each dispatch so an unwritten cell cannot pass
+ * by retaining an earlier result.
+ */
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "../ds4_gpu.h"
 
-#define CHECK(cond, msg) do { \
-    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); return 1; } \
-} while (0)
+typedef struct {
+    const char *name;
+    uint32_t n_tokens;
+    uint32_t n_comp;
+    uint32_t pos0;
+} scorer_case;
 
-static float half_round(float v) {
-    /* mirror the f32->f16 rounding the pack pass applies */
-    _Float16 h = (_Float16)v;
-    return (float)h;
+typedef enum {
+    SCORER_LEGACY,
+    SCORER_TILED2,
+    SCORER_TILED4,
+    SCORER_TILED5,
+} scorer_variant;
+
+static const char *variant_name(scorer_variant variant) {
+    switch (variant) {
+    case SCORER_LEGACY: return "legacy";
+    case SCORER_TILED2: return "tiled2";
+    case SCORER_TILED4: return "tiled4";
+    case SCORER_TILED5: return "tiled5";
+    }
+    return "unknown";
 }
 
-int main(void) {
-    CHECK(ds4_gpu_init(), "gpu init");
+static int select_variant(scorer_variant variant) {
+    int ok = 1;
+    if (variant == SCORER_LEGACY) {
+        ok &= setenv("DS4_METAL_DISABLE_INDEXER_SCORES_TILED2", "1", 1) == 0;
+    } else {
+        ok &= unsetenv("DS4_METAL_DISABLE_INDEXER_SCORES_TILED2") == 0;
+    }
+    if (variant == SCORER_TILED4) {
+        ok &= setenv("DS4_METAL_INDEXER_SCORES_TILED4", "1", 1) == 0;
+    } else {
+        ok &= unsetenv("DS4_METAL_INDEXER_SCORES_TILED4") == 0;
+    }
+    if (variant == SCORER_TILED2) {
+        ok &= setenv("DS4_METAL_DISABLE_INDEXER_SCORES_TILED5", "1", 1) == 0;
+    } else {
+        ok &= unsetenv("DS4_METAL_DISABLE_INDEXER_SCORES_TILED5") == 0;
+    }
+    return ok;
+}
 
+static uint32_t next_random(uint32_t *state) {
+    *state = *state * UINT32_C(1664525) + UINT32_C(1013904223);
+    return *state;
+}
+
+static void fill_values(float *values, size_t count, uint32_t *state, float divisor) {
+    for (size_t i = 0; i < count; i++) {
+        const int32_t centered = (int32_t)(next_random(state) % 2001u) - 1000;
+        values[i] = (float)centered / divisor;
+    }
+}
+
+static int validate_causal_shape(
+        const scorer_case *tc,
+        const float       *scores,
+        uint32_t           ratio) {
+    for (uint32_t token = 0; token < tc->n_tokens; token++) {
+        uint32_t visible = (tc->pos0 + token + 1u) / ratio;
+        if (visible > tc->n_comp) visible = tc->n_comp;
+        for (uint32_t comp = 0; comp < tc->n_comp; comp++) {
+            const float value = scores[(size_t)token * tc->n_comp + comp];
+            uint32_t bits = 0;
+            memcpy(&bits, &value, sizeof(bits));
+            if (comp < visible) {
+                if ((bits & UINT32_C(0x7f800000)) == UINT32_C(0x7f800000)) {
+                    return 0;
+                }
+            } else if (bits != UINT32_C(0xff800000)) {
+                return 0;
+            }
+        }
+    }
+    return 1;
+}
+
+static int run_case(const scorer_case *tc) {
     const uint32_t n_head = 64u;
     const uint32_t head_dim = 128u;
     const uint32_t ratio = 4u;
-    const uint32_t n_tokens = 61u;   /* >=32 (tiled2 gate), not a multiple of 8 */
-    const uint32_t pos0 = 731u;
-    const uint32_t n_comp = 197u;    /* not a multiple of 64: edge comp tile */
     const float scale = 1.0f / 11.3137f;
+    const size_t q_count = (size_t)tc->n_tokens * n_head * head_dim;
+    const size_t w_count = (size_t)tc->n_tokens * n_head;
+    const size_t k_count = (size_t)tc->n_comp * head_dim;
+    const size_t s_count = (size_t)tc->n_tokens * tc->n_comp;
+    float *hq = NULL, *hw = NULL, *hk = NULL, *reference = NULL, *observed = NULL;
+    ds4_gpu_tensor *q = NULL, *w = NULL, *k = NULL, *s = NULL;
+    int rc = 1;
 
-    const size_t q_count = (size_t)n_tokens * n_head * head_dim;
-    const size_t w_count = (size_t)n_tokens * n_head;
-    const size_t k_count = (size_t)n_comp * head_dim;
-    const size_t s_count = (size_t)n_tokens * n_comp;
-
-    float *hq = malloc(q_count * sizeof(float));
-    float *hw = malloc(w_count * sizeof(float));
-    float *hk = malloc(k_count * sizeof(float));
-    float *sa = malloc(s_count * sizeof(float));
-    float *sb = malloc(s_count * sizeof(float));
-    CHECK(hq && hw && hk && sa && sb, "host alloc");
-
-    srand(1337);
-    for (size_t i = 0; i < q_count; i++)
-        hq[i] = (float)(rand() % 2001 - 1000) / 512.0f;
-    for (size_t i = 0; i < w_count; i++)
-        hw[i] = (float)(rand() % 2001 - 1000) / 1024.0f;
-    for (size_t i = 0; i < k_count; i++)
-        hk[i] = (float)(rand() % 2001 - 1000) / 512.0f;
-
-    ds4_gpu_tensor *q = ds4_gpu_tensor_alloc(q_count * sizeof(float));
-    ds4_gpu_tensor *w = ds4_gpu_tensor_alloc(w_count * sizeof(float));
-    ds4_gpu_tensor *k = ds4_gpu_tensor_alloc(k_count * sizeof(float));
-    ds4_gpu_tensor *s = ds4_gpu_tensor_alloc(s_count * sizeof(float));
-    CHECK(q && w && k && s, "gpu alloc");
-    CHECK(ds4_gpu_tensor_write(q, 0, hq, q_count * sizeof(float)), "write q");
-    CHECK(ds4_gpu_tensor_write(w, 0, hw, w_count * sizeof(float)), "write w");
-    CHECK(ds4_gpu_tensor_write(k, 0, hk, k_count * sizeof(float)), "write k");
-
-    unsetenv("DS4_METAL_INDEXER_SCORES_TILED4");
-    CHECK(ds4_gpu_indexer_scores_decode_batch_tensor(
-              s, q, w, k, n_comp, n_tokens, pos0, n_head, head_dim, ratio,
-              scale), "tiled2 compute");
-    CHECK(ds4_gpu_tensor_read(s, 0, sa, s_count * sizeof(float)), "read a");
-
-    {
-        const char *cand = getenv("SCORER_CAND_ENV");
-        setenv(cand ? cand : "DS4_METAL_INDEXER_SCORES_TILED4", "1", 1);
+    hq = malloc(q_count * sizeof(*hq));
+    hw = malloc(w_count * sizeof(*hw));
+    hk = malloc(k_count * sizeof(*hk));
+    reference = malloc(s_count * sizeof(*reference));
+    observed = malloc(s_count * sizeof(*observed));
+    if (!hq || !hw || !hk || !reference || !observed) {
+        fprintf(stderr, "FAIL %s: host allocation\n", tc->name);
+        goto done;
     }
-    CHECK(ds4_gpu_indexer_scores_decode_batch_tensor(
-              s, q, w, k, n_comp, n_tokens, pos0, n_head, head_dim, ratio,
-              scale), "tiled4 compute");
-    CHECK(ds4_gpu_tensor_read(s, 0, sb, s_count * sizeof(float)), "read b");
 
-    size_t diff = 0, first = (size_t)-1;
-    for (size_t i = 0; i < s_count; i++) {
-        if (memcmp(&sa[i], &sb[i], sizeof(float)) != 0) {
-            if (first == (size_t)-1) first = i;
-            diff++;
+    uint32_t random_state = UINT32_C(0x9e3779b9) ^ tc->n_tokens ^ tc->n_comp ^ tc->pos0;
+    fill_values(hq, q_count, &random_state, 512.0f);
+    fill_values(hw, w_count, &random_state, 1024.0f);
+    fill_values(hk, k_count, &random_state, 512.0f);
+
+    q = ds4_gpu_tensor_alloc(q_count * sizeof(float));
+    w = ds4_gpu_tensor_alloc(w_count * sizeof(float));
+    k = ds4_gpu_tensor_alloc(k_count * sizeof(float));
+    s = ds4_gpu_tensor_alloc(s_count * sizeof(float));
+    if (!q || !w || !k || !s ||
+        !ds4_gpu_tensor_write(q, 0, hq, q_count * sizeof(float)) ||
+        !ds4_gpu_tensor_write(w, 0, hw, w_count * sizeof(float)) ||
+        !ds4_gpu_tensor_write(k, 0, hk, k_count * sizeof(float))) {
+        fprintf(stderr, "FAIL %s: GPU allocation/write\n", tc->name);
+        goto done;
+    }
+
+    for (scorer_variant variant = SCORER_LEGACY;
+         variant <= SCORER_TILED5;
+         variant++) {
+        const unsigned char poison = (unsigned char)(0x31u + 0x21u * variant);
+        memset(observed, poison, s_count * sizeof(float));
+        if (!select_variant(variant) ||
+            !ds4_gpu_tensor_write(s, 0, observed, s_count * sizeof(float)) ||
+            !ds4_gpu_indexer_scores_decode_batch_tensor(
+                s, q, w, k, tc->n_comp, tc->n_tokens, tc->pos0,
+                n_head, head_dim, ratio, scale) ||
+            !ds4_gpu_tensor_read(s, 0, observed, s_count * sizeof(float))) {
+            fprintf(stderr, "FAIL %s: %s dispatch/read\n",
+                    tc->name, variant_name(variant));
+            goto done;
+        }
+        if (!validate_causal_shape(tc, observed, ratio)) {
+            fprintf(stderr, "FAIL %s: %s causal/output shape\n",
+                    tc->name, variant_name(variant));
+            goto done;
+        }
+        if (variant == SCORER_LEGACY) {
+            memcpy(reference, observed, s_count * sizeof(float));
+            continue;
+        }
+        if (memcmp(reference, observed, s_count * sizeof(float)) != 0) {
+            size_t first = 0, differing = 0;
+            for (size_t i = 0; i < s_count; i++) {
+                if (memcmp(&reference[i], &observed[i], sizeof(float)) != 0) {
+                    if (differing++ == 0) first = i;
+                }
+            }
+            fprintf(stderr,
+                    "FAIL %s: %s differs from legacy at %zu/%zu floats; "
+                    "first token=%zu comp=%zu legacy=%a observed=%a\n",
+                    tc->name, variant_name(variant), differing, s_count,
+                    first / tc->n_comp, first % tc->n_comp,
+                    reference[first], observed[first]);
+            goto done;
         }
     }
-    if (diff) {
-        const uint32_t t = (uint32_t)(first / n_comp);
-        const uint32_t c = (uint32_t)(first % n_comp);
-        fprintf(stderr,
-                "FAIL: tiled4 differs at %zu/%zu floats; first token=%u "
-                "comp=%u tiled2=%a tiled3=%a\n",
-                diff, s_count, t, c, sa[first], sb[first]);
-        /* dump the first differing pair's per-head picture on the CPU */
-        float acc = 0.0f;
-        for (uint32_t h = 0; h < n_head; h++) {
-            float dot = 0.0f;
-            const float *qh = hq + ((size_t)t * n_head + h) * head_dim;
-            const float *kr = hk + (size_t)c * head_dim;
-            for (uint32_t d = 0; d < head_dim; d++)
-                dot += half_round(qh[d]) * half_round(kr[d]);
-            if (dot > 0.0f) acc += dot * (hw[(size_t)t * n_head + h] * scale);
-        }
-        fprintf(stderr, "  (cpu f16-ish ref for that cell: %a)\n", acc);
+
+    fprintf(stderr,
+            "PASS %s: legacy/tiled2/tiled4/tiled5 identical (%zu floats)\n",
+            tc->name, s_count);
+    rc = 0;
+
+done:
+    ds4_gpu_tensor_free(s);
+    ds4_gpu_tensor_free(k);
+    ds4_gpu_tensor_free(w);
+    ds4_gpu_tensor_free(q);
+    free(observed);
+    free(reference);
+    free(hk);
+    free(hw);
+    free(hq);
+    return rc;
+}
+
+int main(void) {
+    static const scorer_case cases[] = {
+        {"below-gate", 31u, 63u, 0u},
+        {"activation-edge", 32u, 64u, 0u},
+        {"token-and-comp-edge", 33u, 65u, 251u},
+        {"unaligned-resume", 61u, 197u, 731u},
+        {"64k-causal-frontier", 64u, 16387u, 4093u},
+        {"64k-visible-frontier", 65u, 16387u, 65531u},
+    };
+
+    if (!ds4_gpu_init()) {
+        fprintf(stderr, "FAIL: GPU init\n");
         return 1;
     }
-
-    /* sanity: causal cut present */
-    size_t ninf = 0;
-    for (size_t i = 0; i < s_count; i++) if (isinf(sa[i])) ninf++;
-    fprintf(stderr, "tiled4 A/B exact: %zu floats identical (%zu -inf)\n",
-            s_count, ninf);
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        if (run_case(&cases[i]) != 0) {
+            ds4_gpu_cleanup();
+            return 1;
+        }
+    }
+    select_variant(SCORER_LEGACY);
     ds4_gpu_cleanup();
+
+    /* Exercise init/cleanup again after the candidate scratch buffers existed. */
+    if (!ds4_gpu_init() || run_case(&cases[1]) != 0) {
+        fprintf(stderr, "FAIL: scorer lifecycle reinitialization\n");
+        ds4_gpu_cleanup();
+        return 1;
+    }
+    ds4_gpu_cleanup();
+    unsetenv("DS4_METAL_DISABLE_INDEXER_SCORES_TILED2");
+    unsetenv("DS4_METAL_INDEXER_SCORES_TILED4");
+    unsetenv("DS4_METAL_DISABLE_INDEXER_SCORES_TILED5");
+    fprintf(stderr, "PASS: all indexer scorer regressions\n");
     return 0;
 }

--- a/tests/test_indexer_tiled4.c
+++ b/tests/test_indexer_tiled4.c
@@ -1,0 +1,111 @@
+/* Standalone A/B exactness test for the tiled3 indexer prefill scorer.
+ * Runs without a model: random-ish Q/W/K, scores computed twice through the
+ * public GPU entry (env unset = tiled2, env set = tiled3), byte-compared,
+ * plus a CPU reference in tiled2's arithmetic order.  Exercises edge tiles
+ * (n_comp and n_tokens not multiples of the tile sizes) and the causal
+ * -INFINITY cut. */
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../ds4_gpu.h"
+
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); return 1; } \
+} while (0)
+
+static float half_round(float v) {
+    /* mirror the f32->f16 rounding the pack pass applies */
+    _Float16 h = (_Float16)v;
+    return (float)h;
+}
+
+int main(void) {
+    CHECK(ds4_gpu_init(), "gpu init");
+
+    const uint32_t n_head = 64u;
+    const uint32_t head_dim = 128u;
+    const uint32_t ratio = 4u;
+    const uint32_t n_tokens = 61u;   /* >=32 (tiled2 gate), not a multiple of 8 */
+    const uint32_t pos0 = 731u;
+    const uint32_t n_comp = 197u;    /* not a multiple of 64: edge comp tile */
+    const float scale = 1.0f / 11.3137f;
+
+    const size_t q_count = (size_t)n_tokens * n_head * head_dim;
+    const size_t w_count = (size_t)n_tokens * n_head;
+    const size_t k_count = (size_t)n_comp * head_dim;
+    const size_t s_count = (size_t)n_tokens * n_comp;
+
+    float *hq = malloc(q_count * sizeof(float));
+    float *hw = malloc(w_count * sizeof(float));
+    float *hk = malloc(k_count * sizeof(float));
+    float *sa = malloc(s_count * sizeof(float));
+    float *sb = malloc(s_count * sizeof(float));
+    CHECK(hq && hw && hk && sa && sb, "host alloc");
+
+    srand(1337);
+    for (size_t i = 0; i < q_count; i++)
+        hq[i] = (float)(rand() % 2001 - 1000) / 512.0f;
+    for (size_t i = 0; i < w_count; i++)
+        hw[i] = (float)(rand() % 2001 - 1000) / 1024.0f;
+    for (size_t i = 0; i < k_count; i++)
+        hk[i] = (float)(rand() % 2001 - 1000) / 512.0f;
+
+    ds4_gpu_tensor *q = ds4_gpu_tensor_alloc(q_count * sizeof(float));
+    ds4_gpu_tensor *w = ds4_gpu_tensor_alloc(w_count * sizeof(float));
+    ds4_gpu_tensor *k = ds4_gpu_tensor_alloc(k_count * sizeof(float));
+    ds4_gpu_tensor *s = ds4_gpu_tensor_alloc(s_count * sizeof(float));
+    CHECK(q && w && k && s, "gpu alloc");
+    CHECK(ds4_gpu_tensor_write(q, 0, hq, q_count * sizeof(float)), "write q");
+    CHECK(ds4_gpu_tensor_write(w, 0, hw, w_count * sizeof(float)), "write w");
+    CHECK(ds4_gpu_tensor_write(k, 0, hk, k_count * sizeof(float)), "write k");
+
+    unsetenv("DS4_METAL_INDEXER_SCORES_TILED4");
+    CHECK(ds4_gpu_indexer_scores_decode_batch_tensor(
+              s, q, w, k, n_comp, n_tokens, pos0, n_head, head_dim, ratio,
+              scale), "tiled2 compute");
+    CHECK(ds4_gpu_tensor_read(s, 0, sa, s_count * sizeof(float)), "read a");
+
+    setenv("DS4_METAL_INDEXER_SCORES_TILED4", "1", 1);
+    CHECK(ds4_gpu_indexer_scores_decode_batch_tensor(
+              s, q, w, k, n_comp, n_tokens, pos0, n_head, head_dim, ratio,
+              scale), "tiled4 compute");
+    CHECK(ds4_gpu_tensor_read(s, 0, sb, s_count * sizeof(float)), "read b");
+
+    size_t diff = 0, first = (size_t)-1;
+    for (size_t i = 0; i < s_count; i++) {
+        if (memcmp(&sa[i], &sb[i], sizeof(float)) != 0) {
+            if (first == (size_t)-1) first = i;
+            diff++;
+        }
+    }
+    if (diff) {
+        const uint32_t t = (uint32_t)(first / n_comp);
+        const uint32_t c = (uint32_t)(first % n_comp);
+        fprintf(stderr,
+                "FAIL: tiled4 differs at %zu/%zu floats; first token=%u "
+                "comp=%u tiled2=%a tiled3=%a\n",
+                diff, s_count, t, c, sa[first], sb[first]);
+        /* dump the first differing pair's per-head picture on the CPU */
+        float acc = 0.0f;
+        for (uint32_t h = 0; h < n_head; h++) {
+            float dot = 0.0f;
+            const float *qh = hq + ((size_t)t * n_head + h) * head_dim;
+            const float *kr = hk + (size_t)c * head_dim;
+            for (uint32_t d = 0; d < head_dim; d++)
+                dot += half_round(qh[d]) * half_round(kr[d]);
+            if (dot > 0.0f) acc += dot * (hw[(size_t)t * n_head + h] * scale);
+        }
+        fprintf(stderr, "  (cpu f16-ish ref for that cell: %a)\n", acc);
+        return 1;
+    }
+
+    /* sanity: causal cut present */
+    size_t ninf = 0;
+    for (size_t i = 0; i < s_count; i++) if (isinf(sa[i])) ninf++;
+    fprintf(stderr, "tiled4 A/B exact: %zu floats identical (%zu -inf)\n",
+            s_count, ninf);
+    ds4_gpu_cleanup();
+    return 0;
+}


### PR DESCRIPTION
Stacks on #830 (its commit is the base of this branch); independent of every other open PR.

The tiled2 scorer (#830) feeds each 8x8 simdgroup MMA with two fresh threadgroup loads — one Q tile, one K tile, zero register reuse. On an M3 Ultra it runs at ~14 TFLOPS while this engine's register-blocked dense GEMMs reach 19-23; the gap is register blocking, and the CUDA backend's own history agrees (08fecd9 "cuda: register-block the prefill indexer scorer" preceded the SM121 mxf4 work). Two steps, one reuse ladder:

- **tiled4** — the token tile doubles to TM=16: each simdgroup keeps two accumulators and shares every staged K tile between them. Threadgroup loads per MMA drop from 2.0 to 1.5.
- **tiled5** — the staged K tile is invariant across the head loop, yet tiled2/tiled4 reload it from threadgroup memory for every head. Each simdgroup loads its sixteen 8x8 K tiles into registers once, before the head loop; per head only the two Q tiles are loaded. Loads per MMA reach 1.0. The ~16 live matrix registers per simdgroup cost nothing measurable — Apple9 allocates registers as a cache.

Staging, the two-barrier-per-head structure and the per-pair reduction are exactly tiled2's — sixteen 8x8 MACs per head in db order, relu(dot)*w in float, heads ascending — so outputs are bit-identical. One non-obvious constraint keeps them so: the output cells per thread must be spelled out as scalar accumulators. A loop over an accumulator array lets the compiler contract each cell's relu(dot)*w*scale term differently from tiled2's scalar form under fast math (~1 ULP per head, compounding over the 64-head chain into logit drift; unroll/vectorize pragmas and explicit fma() do not pin it — the hand-unrolled scalar shape does).

tiled5 is the default; `DS4_METAL_DISABLE_INDEXER_SCORES_TILED5` restores tiled2, `DS4_METAL_INDEXER_SCORES_TILED4` selects the intermediate for A/B. `tests/test_indexer_tiled4.c` is a standalone no-model harness: it runs the scorer twice (env off/on) on engine-shaped random data up to a 64k frontier chunk (edge tiles, causal cut, resumed-anchor shapes) and byte-compares.

Measured, M3 Ultra 512 GB / DeepSeek V4 Flash 0731 MXFP4 (156 GB GGUF), macOS 26.2:

- `metal_prefill_variant_bench --candidate-env DS4_METAL_DISABLE_INDEXER_SCORES_TILED5 --prefix-tokens 8192 --repeats 2`: bit-exact 8/8 runs.
- Full-vocab frontier logits across the whole sweep below: byte-identical at every step through 64k.
- Decode untouched (the tiled path only runs at n_tokens >= 32); decode bench bit-exact.
- Full CONTRIBUTING sweep (2k -> 64k step 2k, gen 128, ABBA order, medians of 4 runs), tiled5 vs tiled2:

| ctx | tiled2 t/s | tiled5 t/s | Δ |
|---|---|---|---|
| 2048 | 665.8 | 666.9 | +0.17% |
| 8192 | 574.9 | 585.0 | +1.71% |
| 16384 | 544.9 | 563.5 | +3.31% |
| 32768 | 490.6 | 523.8 | +6.34% |
| 49152 | 446.3 | 489.1 | +8.76% |
| 65536 | 410.7 | 460.8 | +10.89% |

Monotone in context; gen deltas within noise (|Δ| <= 0.44%, sign-mixed). tiled4 alone measured +5.38% @64k on the same protocol — the 2.0 -> 1.5 -> 1.0 loads-per-MMA ladder maps monotonically onto throughput. Running in production on this box (goldens unchanged).
