### PR TITLE
dspark: stop skipping after a cold miss; decode 1-token drafts

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -49364,7 +49364,7 @@ static bool ds4_dspark_scheduler_enabled(void) {
 }
 
 static uint32_t ds4_dspark_scheduler_window(void) {
-    uint32_t v = ds4_dspark_env_u32("DS4_DSPARK_SCHEDULER_WINDOW", 4);
+    uint32_t v = ds4_dspark_env_u32("DS4_DSPARK_SCHEDULER_WINDOW", 8);
     return v ? v : 4;
 }
 
@@ -49377,7 +49377,7 @@ static uint32_t ds4_dspark_scheduler_slow_skip_cycles(void) {
 }
 
 static uint32_t ds4_dspark_scheduler_min_avg_milli(void) {
-    return ds4_dspark_env_u32("DS4_DSPARK_SCHEDULER_MIN_AVG_MILLI", 1500);
+    return ds4_dspark_env_u32("DS4_DSPARK_SCHEDULER_MIN_AVG_MILLI", 2000);
 }
 
 static uint32_t ds4_dspark_scheduler_max_ms_per_accept_milli(void) {
@@ -49395,7 +49395,7 @@ static uint32_t ds4_dspark_scheduler_break_even_window(void) {
 }
 
 static uint32_t ds4_dspark_scheduler_no_draft_skip_cycles(void) {
-    return ds4_dspark_env_u32("DS4_DSPARK_SCHEDULER_NO_DRAFT_SKIP", 3);
+    return ds4_dspark_env_u32("DS4_DSPARK_SCHEDULER_NO_DRAFT_SKIP", 0);
 }
 
 static uint32_t ds4_dspark_scheduler_short_accept_no_draft_skip_cycles(void) {
@@ -62695,6 +62695,25 @@ static int ds4_session_eval_dspark_speculative_argmax(
         return n_accept;
     }
     if (drafts[0] == eos_token) draft_n = 1;
+    if (draft_n == 1) {
+        if (ds4_session_eval_probe_tp(s, drafts[0], true, err, errlen) != 0) {
+            return -1;
+        }
+        if (n_accept < accepted_cap) accepted[n_accept++] = drafts[0];
+        if (stats_enabled) {
+            s->dspark_stats.full_accepts++;
+            s->dspark_stats.accepted_draft_tokens += 1;
+            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 1);
+        }
+        ds4_session_dspark_scheduler_note(s, 1, false, DS4_DSPARK_SCHED_EXTRA_MS());
+        if (spec_log) {
+            fprintf(stderr, "ds4: DSpark spec one-token decode accepted=%d\n",
+                    n_accept);
+        }
+        DS4_DSPARK_STATS_FINISH();
+        return n_accept;
+    }
+
 
     ds4_engine *e = s->engine;
     ds4_spec_frontier frontier;

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -183,7 +183,7 @@ static void print_model_runtime(FILE *fp, const help_colors *c,
             opt(fp, c, "--mtp-margin F", "Verifier confidence margin for fast MTP acceptance. Default: 3");
             opt(fp, c, "--glm-mtp", "Enable integrated greedy GLM MTP speculation.");
             opt(fp, c, "--glm-mtp-timing", "Enable GLM MTP and print acceptance/timing counters.");
-            opt(fp, c, "--dspark", "Enable DSpark using the support GGUF passed with --mtp.");
+            opt(fp, c, "--dspark", "Enable DSpark using the support GGUF passed with --mtp. Immediate no-draft skip is off; scheduler window=8 min-avg=2.0. One-token proposals use ordinary decode.");
             opt(fp, c, "--dspark-confidence F", "Enable DSpark with confidence pruning threshold 0..1. Default: Metal 0.6; CUDA/ROCm 0.7");
             opt(fp, c, "--dspark-strict", "Load DSpark support but keep target-only decode.");
         }


### PR DESCRIPTION
Immediate no-draft skip (default 3, plus cold-7) treats the first confidence prune as a failed cycle and throws away later 5-token accepts. This PR turns that skip off and widens the remaining window to 8 with min-avg 2.0 so low-accept prose still pauses.

A 1-token proposal that already matches argmax does not need the batched verifier: run ordinary decode. Metal verify cost is nearly width-flat, so this is the cheap miss path.

## Measured (M5 Max 128 GiB, Headroom128 + matching DSpark support, `--temp 0 --nothink` n=128)

Clean branch `25f520b` vs `origin/main` `84cc882`, same binary pair, one A/B:

| prompt | main | this |
|---|---|---|
| C `add` | 48.63 t/s, skip=7, avg 1.385 | **53.24 t/s**, skip=0, avg 2.875 |
| JSON | 56.87 t/s, avg 4.000 | 55.73 t/s, avg 4.000 |
| Redis prose | 41.61 t/s, verify 536 ms | **43.56 t/s**, verify 428 ms |

Earlier two repeats of the same policy (before isolating onto this branch) were C add 53.39/53.43 vs 50.56/50.68 and prose 44.55/44.23 vs 42.13/42.06. JSON is a wash either way.

`./ds4_test --metal-kernels` → `gtest: ok`.

Not included: path-select pair walk and `choose_k` depth policy. Both were measured losses or no-ops on this Metal path.