### PR TITLE
samplers: adds top-n-sigma sampler

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -38614,6 +38614,47 @@ static int sample_full_vocab(
     return id;
 }
 
+/* Top-n-sigma truncation (arXiv:2411.07641).  Logits split into a
+ * Gaussian-distributed noisy region and a small informative region; the
+ * cutoff max - n*sigma sits at that boundary.  Mean and standard deviation
+ * are computed over the finite logits only, matching llama.cpp.  Working on
+ * raw logits is equivalent to the paper's temperature-scaled version: both
+ * max and sigma scale with 1/T, so the surviving set is temperature-
+ * invariant by construction (Theorem 4 of the paper). */
+static const float *sample_top_n_sigma_mask(
+        const float *logits,
+        uint32_t     n_vocab,
+        float        n,
+        float       *out) {
+    float max_logit = DS4_NEG_INF;
+    double sum = 0.0;
+    uint32_t finite = 0;
+    for (uint32_t i = 0; i < n_vocab; i++) {
+        const float v = logits[i];
+        if (!isfinite(v)) continue;
+        finite++;
+        if (v > max_logit) max_logit = v;
+        sum += v;
+    }
+    if (finite == 0) return logits;
+
+    const float mean = (float)(sum / (double)finite);
+    double acc = 0.0;
+    for (uint32_t i = 0; i < n_vocab; i++) {
+        const float v = logits[i];
+        if (!isfinite(v)) continue;
+        const float d = v - mean;
+        acc += (double)d * (double)d;
+    }
+    const float sigma = (float)sqrt(acc / (double)finite);
+    const float cutoff = max_logit - n * sigma;
+    for (uint32_t i = 0; i < n_vocab; i++) {
+        const float v = logits[i];
+        out[i] = isfinite(v) && v < cutoff ? -INFINITY : v;
+    }
+    return out;
+}
+
 static int sample_top_p_min_p(
         const float *logits,
         uint32_t     n_vocab,
@@ -38621,19 +38662,32 @@ static int sample_top_p_min_p(
         int          top_k,
         float        top_p,
         float        min_p,
+        float        top_n_sigma,
         uint64_t    *rng,
         float       *prob_scratch) {
     if (temperature <= 0.0f) return sample_argmax(logits, n_vocab);
     if (top_p <= 0.0f || top_p > 1.0f) top_p = 1.0f;
     if (min_p < 0.0f) min_p = 0.0f;
+
+    /* Mask into a private copy so the caller's logits stay untouched; the
+     * downstream paths already skip non-finite entries, so a masked vector
+     * is a drop-in input. */
+    float *masked = NULL;
+    if (top_n_sigma > 0.0f) {
+        masked = xmalloc((size_t)n_vocab * sizeof(masked[0]));
+        logits = sample_top_n_sigma_mask(logits, n_vocab, top_n_sigma, masked);
+    }
+
+    int token;
     if (top_k <= 0) {
         const bool owned_scratch = prob_scratch == NULL;
         if (owned_scratch) {
             prob_scratch = xmalloc((size_t)n_vocab * sizeof(prob_scratch[0]));
         }
-        const int token = sample_full_vocab(logits, n_vocab, temperature,
-                                            top_p, min_p, rng, prob_scratch);
+        token = sample_full_vocab(logits, n_vocab, temperature,
+                                  top_p, min_p, rng, prob_scratch);
         if (owned_scratch) free(prob_scratch);
+        free(masked);
         return token;
     }
     if (top_k > 1024) top_k = 1024;
@@ -38655,7 +38709,10 @@ static int sample_top_p_min_p(
         vals[j] = v;
         ids[j] = (int)i;
     }
-    if (n == 0) return sample_argmax(logits, n_vocab);
+    if (n == 0) {
+        token = sample_argmax(logits, n_vocab);
+        goto done;
+    }
 
     float probs[1024];
     const float max_logit = vals[0];
@@ -38664,7 +38721,10 @@ static int sample_top_p_min_p(
         probs[i] = expf((vals[i] - max_logit) / temperature);
         sum += probs[i];
     }
-    if (sum <= 0.0f || !isfinite(sum)) return ids[0];
+    if (sum <= 0.0f || !isfinite(sum)) {
+        token = ids[0];
+        goto done;
+    }
 
     const float min_prob = (probs[0] / sum) * min_p;
     float filtered_sum = 0.0f;
@@ -38676,24 +38736,34 @@ static int sample_top_p_min_p(
         filtered++;
         if (filtered_sum / sum >= top_p) break;
     }
-    if (filtered <= 0) return ids[0];
+    if (filtered <= 0) {
+        token = ids[0];
+        goto done;
+    }
 
     float r = sample_rng_f32(rng) * filtered_sum;
     for (int i = 0; i < filtered; i++) {
         r -= probs[i];
-        if (r <= 0.0f) return ids[i];
+        if (r <= 0.0f) {
+            token = ids[i];
+            goto done;
+        }
     }
-    return ids[filtered - 1];
+    token = ids[filtered - 1];
+done:
+    free(masked);
+    return token;
 }
 
 #ifdef DS4_TEST_HOOKS
 int ds4_test_sample_logits(const float *logits, uint32_t n_vocab,
                            float temperature, int top_k,
-                           float top_p, float min_p, uint64_t *rng,
+                           float top_p, float min_p, float top_n_sigma,
+                           uint64_t *rng,
                            float *prob_scratch) {
     if (!logits || !rng || n_vocab == 0) return -1;
     return sample_top_p_min_p(logits, n_vocab, temperature, top_k,
-                              top_p, min_p, rng, prob_scratch);
+                              top_p, min_p, top_n_sigma, rng, prob_scratch);
 }
 
 int ds4_test_argmax_excluding_logits(const float *logits, uint32_t n_vocab,
@@ -60732,19 +60802,20 @@ int ds4_session_argmax_excluding(ds4_session *s, int excluded_id) {
 }
 
 int ds4_sample_logits(const float *logits, int n_vocab, float temperature,
-                      int top_k, float top_p, float min_p, uint64_t *rng) {
+                      int top_k, float top_p, float min_p, float top_n_sigma,
+                      uint64_t *rng) {
     if (!logits || n_vocab <= 0) return 0;
     float *scratch = xmalloc((size_t)n_vocab * sizeof(scratch[0]));
     const int token = sample_top_p_min_p(logits, (uint32_t)n_vocab,
                                          temperature, top_k, top_p, min_p,
-                                         rng, scratch);
+                                         top_n_sigma, rng, scratch);
     free(scratch);
     return token;
 }
 
-int ds4_session_sample(ds4_session *s, float temperature, int top_k, float top_p, float min_p, uint64_t *rng) {
+int ds4_session_sample(ds4_session *s, float temperature, int top_k, float top_p, float min_p, float top_n_sigma, uint64_t *rng) {
     return sample_top_p_min_p(s->logits, DS4_N_VOCAB, temperature, top_k,
-                              top_p, min_p, rng, s->sample_probs);
+                              top_p, min_p, top_n_sigma, rng, s->sample_probs);
 }
 
 int ds4_session_top_logprobs(ds4_session *s, ds4_token_score *out, int k) {

--- a/ds4.h
+++ b/ds4.h
@@ -366,12 +366,14 @@ int ds4_session_common_prefix(ds4_session *s, const ds4_tokens *prompt);
 int ds4_session_argmax(ds4_session *s);
 int ds4_session_argmax_excluding(ds4_session *s, int excluded_id);
 int ds4_sample_logits(const float *logits, int n_vocab, float temperature,
-                      int top_k, float top_p, float min_p, uint64_t *rng);
-int ds4_session_sample(ds4_session *s, float temperature, int top_k, float top_p, float min_p, uint64_t *rng);
+                      int top_k, float top_p, float min_p, float top_n_sigma,
+                      uint64_t *rng);
+int ds4_session_sample(ds4_session *s, float temperature, int top_k, float top_p, float min_p, float top_n_sigma, uint64_t *rng);
 #ifdef DS4_TEST_HOOKS
 int ds4_test_sample_logits(const float *logits, uint32_t n_vocab,
                            float temperature, int top_k,
-                           float top_p, float min_p, uint64_t *rng,
+                           float top_p, float min_p, float top_n_sigma,
+                           uint64_t *rng,
                            float *prob_scratch);
 int ds4_test_argmax_excluding_logits(const float *logits, uint32_t n_vocab,
                                      int excluded_id);

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -58,9 +58,11 @@ typedef struct {
     float temperature;
     float top_p;
     float min_p;
+    float top_n_sigma;
     bool temperature_set;
     bool top_p_set;
     bool min_p_set;
+    bool top_n_sigma_set;
     uint64_t seed;
     ds4_think_mode think_mode;
 } agent_generation_options;
@@ -575,6 +577,7 @@ static agent_config parse_options(int argc, char **argv) {
             .temperature = DS4_DEFAULT_TEMPERATURE,
             .top_p = DS4_DEFAULT_TOP_P,
             .min_p = DS4_DEFAULT_MIN_P,
+            .top_n_sigma = 0.0f,
             .think_mode = DS4_THINK_HIGH,
         },
     };
@@ -653,6 +656,9 @@ static agent_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--min-p")) {
             c.gen.min_p = parse_float_range(need_arg(&i, argc, argv, arg), arg, 0.0f, 1.0f);
             c.gen.min_p_set = true;
+        } else if (!strcmp(arg, "--top-n-sigma")) {
+            c.gen.top_n_sigma = parse_float_range(need_arg(&i, argc, argv, arg), arg, 0.0f, 100.0f);
+            c.gen.top_n_sigma_set = true;
         } else if (!strcmp(arg, "--seed")) {
             c.gen.seed = parse_u64(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--think")) {
@@ -746,6 +752,11 @@ static agent_config parse_options(int argc, char **argv) {
 
     if (c.engine.directional_steering_file && !steering_scale_set)
         c.engine.directional_steering_ffn = 1.0f;
+    /* Top-n-sigma is a truncation sampler in its own right: an explicit
+     * --top-n-sigma replaces the implicit min-p default so temperature and
+     * top-n-sigma alone shape the distribution.  An explicit --min-p still
+     * wins. */
+    if (c.gen.top_n_sigma_set && !c.gen.min_p_set) c.gen.min_p = 0.0f;
     char dist_err[256];
     if (ds4_dist_prepare_engine_options(&c.engine.distributed,
                                         &c.engine,
@@ -774,6 +785,7 @@ static void agent_apply_model_sampling_defaults(
     if (!gen->temperature_set) gen->temperature = 1.0f;
     if (!gen->top_p_set) gen->top_p = 0.95f;
     if (!gen->min_p_set) gen->min_p = 0.0f;
+    if (!gen->top_n_sigma_set) gen->top_n_sigma = 0.0f;
 }
 
 static ds4_think_mode effective_think_mode(const agent_config *cfg) {
@@ -8511,6 +8523,7 @@ static int worker_sample_with_mode(agent_worker *w, const agent_config *cfg,
                               0,
                               greedy ? 1.0f : cfg->gen.top_p,
                               greedy ? 0.0f : cfg->gen.min_p,
+                              greedy ? 0.0f : cfg->gen.top_n_sigma,
                               rng);
 }
 
@@ -8934,6 +8947,7 @@ static int worker_run_raw_prompt(agent_worker *w, const char *user_text) {
                                        0,
                                        cfg->gen.top_p,
                                        cfg->gen.min_p,
+                                       cfg->gen.top_n_sigma,
                                        &rng);
         if (ds4_token_is_stop(w->engine, token)) break;
 

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -67,9 +67,11 @@ typedef struct {
     float temperature;
     float top_p;
     float min_p;
+    float top_n_sigma;
     bool temperature_set;
     bool top_p_set;
     bool min_p_set;
+    bool top_n_sigma_set;
     uint64_t seed;
     bool dump_tokens;
     const char *dump_logits_path;
@@ -516,6 +518,7 @@ static void cli_apply_model_sampling_defaults(
     if (!gen->temperature_set) gen->temperature = 1.0f;
     if (!gen->top_p_set) gen->top_p = 0.95f;
     if (!gen->min_p_set) gen->min_p = 0.0f;
+    if (!gen->top_n_sigma_set) gen->top_n_sigma = 0.0f;
 }
 
 static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, const ds4_tokens *prompt) {
@@ -591,7 +594,8 @@ static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, con
             have_greedy_next = false;
         } else {
             token = ds4_session_sample(session, cfg->gen.temperature, 0,
-                                       cfg->gen.top_p, cfg->gen.min_p, &rng);
+                                       cfg->gen.top_p, cfg->gen.min_p,
+                                       cfg->gen.top_n_sigma, &rng);
         }
         if (ds4_token_is_stop_for_think_mode(engine, token, think_mode)) break;
 
@@ -1499,6 +1503,7 @@ static int run_chat_turn(ds4_engine *engine, cli_config *cfg, repl_chat *chat, c
                                        0,
                                        cfg->gen.top_p,
                                        cfg->gen.min_p,
+                                       cfg->gen.top_n_sigma,
                                        &rng);
         }
         if (ds4_token_is_stop_for_think_mode(engine, token, think_mode)) break;
@@ -1770,6 +1775,7 @@ static cli_config parse_options(int argc, char **argv) {
             .temperature = DS4_DEFAULT_TEMPERATURE,
             .top_p = DS4_DEFAULT_TOP_P,
             .min_p = DS4_DEFAULT_MIN_P,
+            .top_n_sigma = 0.0f,
             .dump_logprobs_top_k = 20,
             .think_mode = DS4_THINK_HIGH,
         },
@@ -1871,6 +1877,9 @@ static cli_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--min-p")) {
             c.gen.min_p = parse_float_range(need_arg(&i, argc, argv, arg), arg, 0.0f, 1.0f);
             c.gen.min_p_set = true;
+        } else if (!strcmp(arg, "--top-n-sigma")) {
+            c.gen.top_n_sigma = parse_float_range(need_arg(&i, argc, argv, arg), arg, 0.0f, 100.0f);
+            c.gen.top_n_sigma_set = true;
         } else if (!strcmp(arg, "--seed")) {
             c.gen.seed = parse_u64(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--quality")) {
@@ -2024,6 +2033,11 @@ static cli_config parse_options(int argc, char **argv) {
     if (c.engine.directional_steering_file && !directional_steering_scale_set) {
         c.engine.directional_steering_ffn = 1.0f;
     }
+    /* Top-n-sigma is a truncation sampler in its own right: an explicit
+     * --top-n-sigma replaces the implicit min-p default so temperature and
+     * top-n-sigma alone shape the distribution.  An explicit --min-p still
+     * wins. */
+    if (c.gen.top_n_sigma_set && !c.gen.min_p_set) c.gen.min_p = 0.0f;
     if (c.gen.imatrix_output_path && !c.gen.imatrix_dataset_path) {
         fprintf(stderr, "ds4: --imatrix-out requires --imatrix-dataset\n");
         exit(2);
@@ -2163,6 +2177,7 @@ int main(int argc, char **argv) {
             .temperature = cfg.gen.temperature,
             .top_p = cfg.gen.top_p,
             .min_p = cfg.gen.min_p,
+            .top_n_sigma = cfg.gen.top_n_sigma,
             .seed = cfg.gen.seed,
             .think_mode = cfg.gen.think_mode,
         };

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -4037,6 +4037,7 @@ static int dist_run_coordinator_generation(
                                       0,
                                       gen->top_p,
                                       gen->min_p,
+                                      gen->top_n_sigma,
                                       &rng);
         if (token == eos) break;
 

--- a/ds4_distributed.h
+++ b/ds4_distributed.h
@@ -29,6 +29,7 @@ typedef struct {
     float temperature;
     float top_p;
     float min_p;
+    float top_n_sigma;
     uint64_t seed;
     ds4_think_mode think_mode;
 } ds4_dist_generation_options;

--- a/ds4_eval.c
+++ b/ds4_eval.c
@@ -1204,6 +1204,8 @@ typedef struct {
     float temperature;
     float top_p;
     float min_p;
+    float top_n_sigma;
+    bool min_p_set;
     uint64_t seed;
     int pause_ms;
     int power_percent;
@@ -1518,6 +1520,7 @@ static eval_config parse_options(int argc, char **argv) {
         .max_tokens = 16000,
         .top_p = DS4_DEFAULT_TOP_P,
         .min_p = DS4_DEFAULT_MIN_P,
+        .top_n_sigma = 0.0f,
         .pause_ms = 350,
         .soft_limit_reply_budget = 1024,
         .hard_limit_reply_budget = 512,
@@ -1568,6 +1571,13 @@ static eval_config parse_options(int argc, char **argv) {
             c.top_p = parse_float_arg(need_arg(&i, argc, argv, arg), arg, 0.0f, 1.0f);
         } else if (!strcmp(arg, "--min-p")) {
             c.min_p = parse_float_arg(need_arg(&i, argc, argv, arg), arg, 0.0f, 1.0f);
+            c.min_p_set = true;
+        } else if (!strcmp(arg, "--top-n-sigma")) {
+            c.top_n_sigma = parse_float_arg(need_arg(&i, argc, argv, arg), arg, 0.0f, 100.0f);
+            /* Top-n-sigma is a truncation sampler in its own right: an
+             * explicit --top-n-sigma replaces the implicit min-p default so
+             * temperature and top-n-sigma alone shape the distribution. */
+            if (!c.min_p_set) c.min_p = 0.0f;
         } else if (!strcmp(arg, "--seed")) {
             c.seed = parse_u64_arg(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--trace")) {
@@ -2571,6 +2581,7 @@ static void trace_write_header(FILE *trace, const eval_config *cfg,
             "temperature: %.6g\n"
             "top_p: %.6g\n"
             "min_p: %.6g\n"
+            "top_n_sigma: %.6g\n"
             "seed: %llu\n"
             "think_mode_requested: %s\n"
             "soft_limit_reply_budget: %d\n"
@@ -2588,6 +2599,7 @@ static void trace_write_header(FILE *trace, const eval_config *cfg,
             cfg->temperature,
             cfg->top_p,
             cfg->min_p,
+            cfg->top_n_sigma,
             (unsigned long long)cfg->seed,
             ds4_think_mode_name(cfg->think_mode),
             cfg->soft_limit_reply_budget,
@@ -2630,6 +2642,7 @@ static void trace_write_case(FILE *trace,
             "temperature: %.6g\n"
             "top_p: %.6g\n"
             "min_p: %.6g\n"
+            "top_n_sigma: %.6g\n"
             "think_mode_effective: %s\n",
             idx + 1, ncases, tc->source, tc->id,
             (long long)time(NULL),
@@ -2646,6 +2659,7 @@ static void trace_write_case(FILE *trace,
             cfg->temperature,
             cfg->top_p,
             cfg->min_p,
+            cfg->top_n_sigma,
             ds4_think_mode_name(effective_think_mode));
     if (think_close && think_close->kind != EVAL_THINK_CLOSE_NONE) {
         fprintf(trace,
@@ -3872,7 +3886,8 @@ static eval_run_result run_one_case(ds4_engine *engine, ds4_session *session,
         }
         if (token < 0)
             token = ds4_session_sample(session, cfg->temperature, 0,
-                                       cfg->top_p, cfg->min_p, rng);
+                                       cfg->top_p, cfg->min_p,
+                                       cfg->top_n_sigma, rng);
         if (ds4_token_is_stop(engine, token)) break;
         if (close_kind != EVAL_THINK_CLOSE_NONE &&
             think_close.kind == EVAL_THINK_CLOSE_NONE) {

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -202,6 +202,7 @@ static void print_sampling(FILE *fp, const help_colors *c, bool full) {
     opt(fp, c, "--temp F", "Sampling temperature. 0 is greedy/deterministic.");
     opt(fp, c, "--top-p F", "Nucleus sampling probability.");
     opt(fp, c, "--min-p F", "Keep tokens scoring at least F times the top token.");
+    opt(fp, c, "--top-n-sigma F", "Keep tokens within F standard deviations of the top logit (arXiv:2411.07641). Disables the min-p default.");
     opt(fp, c, "--seed N", "Sampling seed for reproducible non-greedy runs.");
     para(fp, c, "GLM CLI and agent runs default to temperature 1.0, top-p 0.95, and min-p 0 unless those options are set explicitly.");
     opt(fp, c, "--think", "Use normal thinking mode.");

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -656,11 +656,13 @@ typedef struct {
     float temperature;
     float top_p;
     float min_p;
+    float top_n_sigma;
     /* Explicit client sampling wins even in thinking mode; the fixed
      * DeepSeek-style thinking defaults apply only to omitted knobs. */
     bool temperature_set;
     bool top_p_set;
     bool min_p_set;
+    bool top_n_sigma_set;
     bool top_k_set;
     uint64_t seed;
     bool stream;
@@ -821,6 +823,7 @@ static void request_init(request *r, req_kind kind, int max_tokens) {
     r->temperature = DS4_DEFAULT_TEMPERATURE;
     r->top_p = DS4_DEFAULT_TOP_P;
     r->min_p = DS4_DEFAULT_MIN_P;
+    r->top_n_sigma = 0.0f;
     r->think_mode = DS4_THINK_HIGH;
 }
 
@@ -3057,6 +3060,14 @@ static bool parse_chat_request(ds4_engine *e, server *s, const char *body, int d
             }
             r->min_p = (float)v;
             r->min_p_set = true;
+        } else if (!strcmp(key, "top_n_sigma")) {
+            double v = 0.0;
+            if (!json_number(&p, &v)) {
+                free(key);
+                goto bad;
+            }
+            r->top_n_sigma = (float)v;
+            r->top_n_sigma_set = true;
         } else if (!strcmp(key, "top_k")) {
             if (!json_int(&p, &r->top_k)) {
                 free(key);
@@ -3267,6 +3278,14 @@ static bool parse_anthropic_request(ds4_engine *e, server *s, const char *body, 
             }
             r->top_p = (float)v;
             r->top_p_set = true;
+        } else if (!strcmp(key, "top_n_sigma")) {
+            double v = 0.0;
+            if (!json_number(&p, &v)) {
+                free(key);
+                goto bad;
+            }
+            r->top_n_sigma = (float)v;
+            r->top_n_sigma_set = true;
         } else if (!strcmp(key, "top_k")) {
             if (!json_int(&p, &r->top_k)) {
                 free(key);
@@ -4167,6 +4186,14 @@ static bool parse_responses_request(ds4_engine *e, server *s, const char *body, 
             }
             r->top_p = (float)v;
             r->top_p_set = true;
+        } else if (!strcmp(key, "top_n_sigma")) {
+            double v = 0.0;
+            if (!json_number(&p, &v)) {
+                free(key);
+                goto bad;
+            }
+            r->top_n_sigma = (float)v;
+            r->top_n_sigma_set = true;
         } else if (!strcmp(key, "stream")) {
             if (!json_bool(&p, &r->stream)) {
                 free(key);
@@ -4399,6 +4426,14 @@ static bool parse_completion_request(ds4_engine *e, const char *body, int def_to
             }
             r->min_p = (float)v;
             r->min_p_set = true;
+        } else if (!strcmp(key, "top_n_sigma")) {
+            double v = 0.0;
+            if (!json_number(&p, &v)) {
+                free(key);
+                goto bad;
+            }
+            r->top_n_sigma = (float)v;
+            r->top_n_sigma_set = true;
         } else if (!strcmp(key, "top_k")) {
             if (!json_int(&p, &r->top_k)) {
                 free(key);
@@ -10067,7 +10102,7 @@ static uint64_t trace_begin(
     fprintf(s->trace, "\n===== request %llu ", (unsigned long long)id);
     trace_time(s->trace);
     fprintf(s->trace,
-            " =====\nkind: %s\nmodel: %s\nstream: %d\ntools: %d\nthink_mode: %s\nprompt_tokens: %d\neffective_prompt_tokens: %d\ncached_tokens: %d\nmax_tokens: %d\ntemperature: %.3f\ntop_k: %d\ntop_p: %.3f\nmin_p: %.3f\nseed: %llu\n",
+            " =====\nkind: %s\nmodel: %s\nstream: %d\ntools: %d\nthink_mode: %s\nprompt_tokens: %d\neffective_prompt_tokens: %d\ncached_tokens: %d\nmax_tokens: %d\ntemperature: %.3f\ntop_k: %d\ntop_p: %.3f\nmin_p: %.3f\ntop_n_sigma: %.3f\nseed: %llu\n",
             j->req.kind == REQ_CHAT ? "chat" : "completion",
             j->req.model ? j->req.model : "",
             j->req.stream ? 1 : 0,
@@ -10081,6 +10116,7 @@ static uint64_t trace_begin(
             j->req.top_k,
             j->req.top_p,
             j->req.min_p,
+            j->req.top_n_sigma,
             (unsigned long long)j->req.seed);
     fprintf(s->trace, "stream_include_usage: %d\n",
             j->req.stream_include_usage ? 1 : 0);
@@ -11644,6 +11680,7 @@ decode_again:
         int top_k = j->req.top_k;
         float top_p = j->req.top_p;
         float min_p = j->req.min_p;
+        float top_n_sigma = j->req.top_n_sigma;
         if (ds4_think_mode_enabled(j->req.think_mode)) {
             /* Thinking keeps the fixed DeepSeek-style sampling defaults, but
              * only for knobs the client left out: an explicit request value
@@ -11653,12 +11690,18 @@ decode_again:
             if (!j->req.top_k_set) top_k = 0;
             if (!j->req.top_p_set) top_p = DS4_DEFAULT_TOP_P;
             if (!j->req.min_p_set) min_p = DS4_DEFAULT_MIN_P;
+            if (!j->req.top_n_sigma_set) top_n_sigma = 0.0f;
         }
+        /* Top-n-sigma is a truncation sampler in its own right: an explicit
+         * top_n_sigma replaces the implicit min-p default so temperature and
+         * top-n-sigma alone shape the distribution.  An explicit min_p from
+         * the client still wins. */
+        if (top_n_sigma > 0.0f && !j->req.min_p_set) min_p = 0.0f;
         if (in_tool_call && !dsml_decode_state_uses_payload_sampling(dsml_state)) {
             temperature = 0.0f;
         }
         int token = ds4_session_sample(slot->session, temperature, top_k,
-                                       top_p, min_p, &rng);
+                                       top_p, min_p, top_n_sigma, &rng);
         if (ds4_token_is_stop_for_think_mode(s->engine,
                                              token,
                                              j->req.think_mode)) {
@@ -12641,6 +12684,7 @@ static void append_model_json_values(buf *b, const char *id, const char *name,
             "\"top_p\","
             "\"top_k\","
             "\"min_p\","
+            "\"top_n_sigma\","
             "\"stop\","
             "\"seed\","
             "\"stream\","
@@ -14932,6 +14976,7 @@ static void test_request_defaults_use_min_p_filtering(void) {
     TEST_ASSERT(r.top_p == DS4_DEFAULT_TOP_P);
     TEST_ASSERT(r.top_k == 0);
     TEST_ASSERT(r.min_p == DS4_DEFAULT_MIN_P);
+    TEST_ASSERT(r.top_n_sigma == 0.0f);
     request_free(&r);
 }
 

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -4794,7 +4794,7 @@ static void test_long_story_fact_recall(void) {
     int generated = 0;
     bool decode_ok = true;
     for (; generated < 350; generated++) {
-        int token = ds4_session_sample(session, 0.0f, 0, 1.0f, 0.0f, &rng);
+        int token = ds4_session_sample(session, 0.0f, 0, 1.0f, 0.0f, 0.0f, &rng);
         if (token == ds4_token_eos(engine)) break;
 
         size_t piece_len = 0;
@@ -6014,7 +6014,7 @@ static bool test_generate_chat_turn(ds4_engine *engine, ds4_session *session,
 
     for (int i = 0; i < r->max_tokens; i++) {
         int token = ds4_session_sample(session, r->temperature, r->top_k,
-                                       r->top_p, r->min_p, &rng);
+                                       r->top_p, r->min_p, 0.0f, &rng);
         if (ds4_token_is_stop_for_think_mode(engine, token, r->think_mode)) {
             finish = "stop";
             break;

--- a/tests/test_sampling.c
+++ b/tests/test_sampling.c
@@ -59,10 +59,45 @@ static int reference_candidate_cmp_desc(const void *a, const void *b) {
     return (ca->id > cb->id) - (ca->id < cb->id);
 }
 
+/* Top-n-sigma reference mask: population sigma over the finite logits with
+ * double accumulation, mirroring the optimized implementation exactly. */
+static const float *reference_top_n_sigma_mask(const float *logits,
+                                               uint32_t n_vocab,
+                                               float n,
+                                               float *out) {
+    float max_logit = -INFINITY;
+    double sum = 0.0;
+    uint32_t finite = 0;
+    for (uint32_t i = 0; i < n_vocab; i++) {
+        const float v = logits[i];
+        if (!isfinite(v)) continue;
+        finite++;
+        if (v > max_logit) max_logit = v;
+        sum += v;
+    }
+    if (finite == 0) return logits;
+
+    const float mean = (float)(sum / (double)finite);
+    double acc = 0.0;
+    for (uint32_t i = 0; i < n_vocab; i++) {
+        const float v = logits[i];
+        if (!isfinite(v)) continue;
+        const float d = v - mean;
+        acc += (double)d * (double)d;
+    }
+    const float sigma = (float)sqrt(acc / (double)finite);
+    const float cutoff = max_logit - n * sigma;
+    for (uint32_t i = 0; i < n_vocab; i++) {
+        const float v = logits[i];
+        out[i] = isfinite(v) && v < cutoff ? -INFINITY : v;
+    }
+    return out;
+}
+
 /* This is the sampler immediately before the optimized implementation. */
-static int reference_sample(const float *logits, uint32_t n_vocab,
-                            float temperature, int top_k,
-                            float top_p, float min_p, uint64_t *rng) {
+static int reference_sample_inner(const float *logits, uint32_t n_vocab,
+                                  float temperature, int top_k,
+                                  float top_p, float min_p, uint64_t *rng) {
     if (temperature <= 0.0f) return reference_argmax(logits, n_vocab);
     if (top_p <= 0.0f || top_p > 1.0f) top_p = 1.0f;
     if (min_p < 0.0f) min_p = 0.0f;
@@ -192,6 +227,26 @@ static int reference_sample(const float *logits, uint32_t n_vocab,
     return id;
 }
 
+static int reference_sample(const float *logits, uint32_t n_vocab,
+                            float temperature, int top_k,
+                            float top_p, float min_p, float top_n_sigma,
+                            uint64_t *rng) {
+    if (temperature <= 0.0f) return reference_argmax(logits, n_vocab);
+
+    float *masked = NULL;
+    if (top_n_sigma > 0.0f) {
+        masked = malloc((size_t)n_vocab * sizeof(*masked));
+        CHECK(masked != NULL, "reference top-n-sigma mask allocation");
+        if (!masked) return reference_argmax(logits, n_vocab);
+        logits = reference_top_n_sigma_mask(logits, n_vocab, top_n_sigma,
+                                            masked);
+    }
+    const int token = reference_sample_inner(logits, n_vocab, temperature,
+                                             top_k, top_p, min_p, rng);
+    free(masked);
+    return token;
+}
+
 static uint64_t data_rng_next(uint64_t *state) {
     *state = *state * 6364136223846793005ULL + 1442695040888963407ULL;
     return *state;
@@ -209,14 +264,16 @@ static void fill_logits(float *logits, uint32_t n, uint64_t seed) {
 
 static void compare_case(const float *logits, float *scratch, uint32_t n,
                          float temperature, int top_k,
-                         float top_p, float min_p, const char *label) {
+                         float top_p, float min_p, float top_n_sigma,
+                         const char *label) {
     for (uint64_t seed = 0; seed < 256; seed++) {
         uint64_t ref_rng = seed;
         uint64_t opt_rng = seed;
         const int ref = reference_sample(logits, n, temperature, top_k,
-                                         top_p, min_p, &ref_rng);
+                                         top_p, min_p, top_n_sigma, &ref_rng);
         const int opt = ds4_test_sample_logits(logits, n, temperature, top_k,
-                                               top_p, min_p, &opt_rng, scratch);
+                                               top_p, min_p, top_n_sigma,
+                                               &opt_rng, scratch);
         CHECK(ref == opt,
               "%s seed=%llu token reference=%d optimized=%d",
               label, (unsigned long long)seed, ref, opt);
@@ -234,11 +291,11 @@ static void check_greedy_argmax_case(const float *logits, uint32_t n,
     CHECK(unsetenv("DS4_CPU_DISABLE_UNROLLED_ARGMAX") == 0,
           "%s select unrolled argmax", label);
     const int unrolled = ds4_test_sample_logits(
-            logits, n, 0.0f, 0, 1.0f, 0.0f, &unrolled_rng, NULL);
+            logits, n, 0.0f, 0, 1.0f, 0.0f, 0.0f, &unrolled_rng, NULL);
     CHECK(setenv("DS4_CPU_DISABLE_UNROLLED_ARGMAX", "1", 1) == 0,
           "%s select scalar argmax", label);
     const int scalar = ds4_test_sample_logits(
-            logits, n, 0.0f, 0, 1.0f, 0.0f, &scalar_rng, NULL);
+            logits, n, 0.0f, 0, 1.0f, 0.0f, 0.0f, &scalar_rng, NULL);
     CHECK(unsetenv("DS4_CPU_DISABLE_UNROLLED_ARGMAX") == 0,
           "%s restore unrolled argmax", label);
     CHECK(unrolled == scalar,
@@ -284,23 +341,38 @@ int main(void) {
     if (!logits || !scratch) return 1;
     fill_logits(logits, semantic_n, 0x123456789abcdef0ULL);
 
-    compare_case(logits, scratch, semantic_n, 1.0f, 0, 1.0f, 0.05f,
+    compare_case(logits, scratch, semantic_n, 1.0f, 0, 1.0f, 0.05f, 0.0f,
                  "default-min-p");
-    compare_case(logits, scratch, semantic_n, 0.7f, 0, 1.0f, 0.0f,
+    compare_case(logits, scratch, semantic_n, 0.7f, 0, 1.0f, 0.0f, 0.0f,
                  "full-softmax");
-    compare_case(logits, scratch, semantic_n, 1.3f, 0, 0.9f, 0.05f,
+    compare_case(logits, scratch, semantic_n, 1.3f, 0, 0.9f, 0.05f, 0.0f,
                  "top-p-min-p");
-    compare_case(logits, scratch, semantic_n, 0.9f, 0, 0.95f, 0.0f,
+    compare_case(logits, scratch, semantic_n, 0.9f, 0, 0.95f, 0.0f, 0.0f,
                  "top-p");
-    compare_case(logits, scratch, semantic_n, 0.8f, 64, 0.9f, 0.05f,
+    compare_case(logits, scratch, semantic_n, 0.8f, 64, 0.9f, 0.05f, 0.0f,
                  "top-k");
+    /* Top-n-sigma parity against the reference mask at several n values,
+     * alone, stacked with the other truncation samplers, and across
+     * temperatures. */
+    compare_case(logits, scratch, semantic_n, 1.5f, 0, 1.0f, 0.0f, 1.0f,
+                 "top-n-sigma-1.5");
+    compare_case(logits, scratch, semantic_n, 1.0f, 0, 1.0f, 0.0f, 2.0f,
+                 "top-n-sigma-2");
+    compare_case(logits, scratch, semantic_n, 1.5f, 0, 0.95f, 0.05f, 1.0f,
+                 "top-n-sigma+top-p+min-p");
+    compare_case(logits, scratch, semantic_n, 0.9f, 64, 0.9f, 0.05f, 1.0f,
+                 "top-k+top-n-sigma");
+    compare_case(logits, scratch, semantic_n, 0.5f, 0, 1.0f, 0.0f, 0.1f,
+                 "top-n-sigma-tiny-n");
+    compare_case(logits, scratch, semantic_n, 3.0f, 0, 1.0f, 0.0f, 20.0f,
+                 "top-n-sigma-huge-n");
     CHECK(unsetenv("DS4_CPU_DISABLE_UNROLLED_ARGMAX") == 0,
           "select unrolled argmax default");
-    compare_case(logits, scratch, semantic_n, 0.0f, 0, 1.0f, 0.05f,
+    compare_case(logits, scratch, semantic_n, 0.0f, 0, 1.0f, 0.05f, 0.0f,
                  "greedy");
     CHECK(setenv("DS4_CPU_DISABLE_UNROLLED_ARGMAX", "1", 1) == 0,
           "set scalar argmax control");
-    compare_case(logits, scratch, semantic_n, 0.0f, 0, 1.0f, 0.05f,
+    compare_case(logits, scratch, semantic_n, 0.0f, 0, 1.0f, 0.05f, 0.0f,
                  "greedy-scalar-control");
     CHECK(unsetenv("DS4_CPU_DISABLE_UNROLLED_ARGMAX") == 0,
           "restore unrolled argmax default");
@@ -379,7 +451,7 @@ int main(void) {
     float boundary_scratch[sizeof(boundary_logits) / sizeof(boundary_logits[0])];
     compare_case(boundary_logits, boundary_scratch,
                  (uint32_t)(sizeof(boundary_logits) / sizeof(boundary_logits[0])),
-                 1.0f, 0, 1.0f, 0.05f, "min-p-boundary");
+                 1.0f, 0, 1.0f, 0.05f, 0.0f, "min-p-boundary");
 
     const float tied_logits[] = {
         2.0f, 2.0f, 2.0f, 1.0f, 1.0f, 0.0f, -INFINITY, NAN,
@@ -387,30 +459,96 @@ int main(void) {
     float tied_scratch[sizeof(tied_logits) / sizeof(tied_logits[0])];
     compare_case(tied_logits, tied_scratch,
                  (uint32_t)(sizeof(tied_logits) / sizeof(tied_logits[0])),
-                 1.0f, 0, 1.0f, 0.05f, "equal-logits-default");
+                 1.0f, 0, 1.0f, 0.05f, 0.0f, "equal-logits-default");
     compare_case(tied_logits, tied_scratch,
                  (uint32_t)(sizeof(tied_logits) / sizeof(tied_logits[0])),
-                 1.0f, 0, 0.8f, 0.05f, "equal-logits-top-p");
+                 1.0f, 0, 0.8f, 0.05f, 0.0f, "equal-logits-top-p");
     compare_case(tied_logits, tied_scratch,
                  (uint32_t)(sizeof(tied_logits) / sizeof(tied_logits[0])),
-                 0.01f, 0, 1.0f, 0.05f, "low-temperature");
+                 0.01f, 0, 1.0f, 0.05f, 0.0f, "low-temperature");
     compare_case(tied_logits, tied_scratch,
                  (uint32_t)(sizeof(tied_logits) / sizeof(tied_logits[0])),
-                 100.0f, 0, 1.0f, 0.05f, "high-temperature");
+                 100.0f, 0, 1.0f, 0.05f, 0.0f, "high-temperature");
     compare_case(tied_logits, tied_scratch,
                  (uint32_t)(sizeof(tied_logits) / sizeof(tied_logits[0])),
-                 1.0f, 0, 1.0f, 1.0f, "min-p-one");
+                 1.0f, 0, 1.0f, 1.0f, 0.0f, "min-p-one");
+
+    /* Top-n-sigma temperature invariance: with min-p and top-p off, the
+     * nucleus is exactly the surviving set, and that set must not change
+     * with temperature (Theorem 4 of the paper).  For tied_logits at n=1
+     * the cutoff is max - 1*sigma = 2 - 0.7454 = 1.2546, so only the three
+     * logit-2.0 tokens survive. */
+    float tied_masked[sizeof(tied_logits) / sizeof(tied_logits[0])];
+    reference_top_n_sigma_mask(
+            tied_logits,
+            (uint32_t)(sizeof(tied_logits) / sizeof(tied_logits[0])),
+            1.0f, tied_masked);
+    uint64_t seen_t1 = 0, seen_t15 = 0;
+    for (uint64_t seed = 0; seed < 2048; seed++) {
+        uint64_t rng1 = seed;
+        uint64_t rng2 = seed;
+        const int t1 = ds4_test_sample_logits(
+                tied_logits,
+                (uint32_t)(sizeof(tied_logits) / sizeof(tied_logits[0])),
+                1.0f, 0, 1.0f, 0.0f, 1.0f, &rng1, tied_scratch);
+        const int t15 = ds4_test_sample_logits(
+                tied_logits,
+                (uint32_t)(sizeof(tied_logits) / sizeof(tied_logits[0])),
+                1.5f, 0, 1.0f, 0.0f, 1.0f, &rng2, tied_scratch);
+        CHECK(t1 >= 0 && t1 < 8 && t15 >= 0 && t15 < 8,
+              "top-n-sigma sampled out of range");
+        CHECK(t1 >= 0 && t1 < 8 && isfinite(tied_masked[t1]),
+              "top-n-sigma sampled a masked-out token at T=1.0");
+        CHECK(t15 >= 0 && t15 < 8 && isfinite(tied_masked[t15]),
+              "top-n-sigma sampled a masked-out token at T=1.5");
+        seen_t1 |= 1ull << (uint32_t)t1;
+        seen_t15 |= 1ull << (uint32_t)t15;
+    }
+    const uint64_t expected_n1 = (1u << 0) | (1u << 1) | (1u << 2);
+    CHECK(seen_t1 == expected_n1,
+          "top-n-sigma T=1.0 nucleus=%llx expected=%llx",
+          (unsigned long long)seen_t1, (unsigned long long)expected_n1);
+    CHECK(seen_t15 == expected_n1,
+          "top-n-sigma T=1.5 nucleus=%llx expected=%llx",
+          (unsigned long long)seen_t15, (unsigned long long)expected_n1);
+
+    /* The mask must not modify the caller's logits. */
+    float copy_check[sizeof(tied_logits) / sizeof(tied_logits[0])];
+    memcpy(copy_check, tied_logits, sizeof(tied_logits));
+    uint64_t check_rng = 7;
+    (void)ds4_test_sample_logits(
+            tied_logits,
+            (uint32_t)(sizeof(tied_logits) / sizeof(tied_logits[0])),
+            1.5f, 0, 1.0f, 0.0f, 1.0f, &check_rng, tied_scratch);
+    CHECK(memcmp(copy_check, tied_logits, sizeof(tied_logits)) == 0,
+          "top-n-sigma modified the caller logits");
+
+    /* A single dominant outlier: n-sigma keeps only the outlier and its
+     * immediate neighbors; the Gaussian body is cut. */
+    const float outlier_logits[] = {
+        0.0f, 0.1f, -0.2f, 0.05f, 10.0f, 0.3f, -0.1f, 0.2f,
+    };
+    float outlier_scratch[sizeof(outlier_logits) /
+                          sizeof(outlier_logits[0])];
+    compare_case(outlier_logits, outlier_scratch,
+                 (uint32_t)(sizeof(outlier_logits) /
+                            sizeof(outlier_logits[0])),
+                 1.5f, 0, 1.0f, 0.0f, 1.0f, "outlier-top-n-sigma");
+    compare_case(outlier_logits, outlier_scratch,
+                 (uint32_t)(sizeof(outlier_logits) /
+                            sizeof(outlier_logits[0])),
+                 1.5f, 0, 1.0f, 0.0f, 3.0f, "outlier-top-n-sigma-3");
 
     uint64_t null_ref_rng = 42;
     uint64_t null_opt_rng = 42;
     const int null_ref = reference_sample(
             tied_logits,
             (uint32_t)(sizeof(tied_logits) / sizeof(tied_logits[0])),
-            1.0f, 0, 1.0f, 0.05f, &null_ref_rng);
+            1.0f, 0, 1.0f, 0.05f, 0.0f, &null_ref_rng);
     const int null_opt = ds4_test_sample_logits(
             tied_logits,
             (uint32_t)(sizeof(tied_logits) / sizeof(tied_logits[0])),
-            1.0f, 0, 1.0f, 0.05f, &null_opt_rng, NULL);
+            1.0f, 0, 1.0f, 0.05f, 0.0f, &null_opt_rng, NULL);
     CHECK(null_ref == null_opt && null_ref_rng == null_opt_rng,
           "null probability scratch fallback mismatch");
 
@@ -420,7 +558,7 @@ int main(void) {
     compare_case(nonfinite_logits, nonfinite_scratch,
                  (uint32_t)(sizeof(nonfinite_logits) /
                             sizeof(nonfinite_logits[0])),
-                 1.0f, 0, 1.0f, 0.05f, "all-nonfinite");
+                 1.0f, 0, 1.0f, 0.05f, 0.0f, "all-nonfinite");
 
     free(logits);
     free(scratch);
@@ -438,7 +576,7 @@ int main(void) {
     double start = now_sec();
     for (int i = 0; i < iterations; i++) {
         checksum += (uint64_t)reference_sample(logits, perf_n, 1.0f, 0,
-                                               1.0f, 0.05f, &ref_rng);
+                                               1.0f, 0.05f, 0.0f, &ref_rng);
     }
     const double reference_ms = (now_sec() - start) * 1000.0;
 
@@ -446,7 +584,7 @@ int main(void) {
     start = now_sec();
     for (int i = 0; i < iterations; i++) {
         checksum += (uint64_t)ds4_test_sample_logits(logits, perf_n, 1.0f, 0,
-                                                     1.0f, 0.05f,
+                                                     1.0f, 0.05f, 0.0f,
                                                      &opt_rng, scratch);
     }
     const double optimized_ms = (now_sec() - start) * 1000.0;
@@ -460,7 +598,7 @@ int main(void) {
     start = now_sec();
     for (int i = 0; i < iterations; i++) {
         checksum += (uint64_t)reference_sample(logits, perf_n, 1.0f, 0,
-                                               0.9f, 0.05f, &ref_rng);
+                                               0.9f, 0.05f, 0.0f, &ref_rng);
     }
     const double reference_top_p_ms = (now_sec() - start) * 1000.0;
 
@@ -468,7 +606,7 @@ int main(void) {
     start = now_sec();
     for (int i = 0; i < iterations; i++) {
         checksum += (uint64_t)ds4_test_sample_logits(logits, perf_n, 1.0f, 0,
-                                                     0.9f, 0.05f,
+                                                     0.9f, 0.05f, 0.0f,
                                                      &opt_rng, scratch);
     }
     const double optimized_top_p_ms = (now_sec() - start) * 1000.0;
@@ -476,6 +614,29 @@ int main(void) {
     printf("sampling top-p+min-p: reference %.3f ms, optimized %.3f ms, %.2fx, checksum=%llu\n",
            reference_top_p_ms, optimized_top_p_ms,
            optimized_top_p_ms > 0.0 ? reference_top_p_ms / optimized_top_p_ms : 0.0,
+           (unsigned long long)checksum);
+
+    ref_rng = 9012;
+    start = now_sec();
+    for (int i = 0; i < iterations; i++) {
+        checksum += (uint64_t)reference_sample(logits, perf_n, 1.5f, 0,
+                                               1.0f, 0.0f, 1.0f, &ref_rng);
+    }
+    const double reference_top_n_sigma_ms = (now_sec() - start) * 1000.0;
+
+    opt_rng = 9012;
+    start = now_sec();
+    for (int i = 0; i < iterations; i++) {
+        checksum += (uint64_t)ds4_test_sample_logits(logits, perf_n, 1.5f, 0,
+                                                     1.0f, 0.0f, 1.0f,
+                                                     &opt_rng, scratch);
+    }
+    const double optimized_top_n_sigma_ms = (now_sec() - start) * 1000.0;
+    CHECK(ref_rng == opt_rng, "top-n-sigma performance RNG state mismatch");
+    printf("sampling top-n-sigma: reference %.3f ms, optimized %.3f ms, %.2fx, checksum=%llu\n",
+           reference_top_n_sigma_ms, optimized_top_n_sigma_ms,
+           optimized_top_n_sigma_ms > 0.0 ?
+               reference_top_n_sigma_ms / optimized_top_n_sigma_ms : 0.0,
            (unsigned long long)checksum);
 
     free(logits);


### PR DESCRIPTION
Experimental: top n sigma sampler from https://arxiv.org/abs/2411.07641 samples logits: keeps tokens with `logit >= max(logit) - n * std(logit)` masks the rest to -inf and temperature softmax samples from these candidates.

Why it's an interesting sampler for ds4 and in use in a coding harness
1. when the model is certain it's similar to greedy decoding; code stays exact
2. when the model is uncertain e.g. in taking decisions the temp tunes exploration

Try it out e.g. by passing to the API `"temperature":1.5,"top_n_sigma":1`; recommended `0.5 < n < 2*sqrt(3)`.

Here's how to set this up in pi.dev https://pi.dev/docs/latest/models#sampling-parameters:

    "samplingParams": { "temperature": 1.5, "top_n_sigma": 1 },

We need to experiment and see how it behaves especially with the heavily quantized versions.

---

I've experimentig with it for a while now via https://github.com/ggml-org/llama.cpp/pull/11223 and there's more context here
1. https://gist.github.com/Hellisotherpeople/71ba712f9f899adcb08b94bce20d5397
3. https://news.ycombinator.com/item?id=43887637

> As one of the min_p authors, I can confirm that Top N sigma is currently the best general purpose sampler by far. Also, temperature can and should be scaled far higher than it is today. Temps of 100 are totally fine with techniques like min_p and top N sigma.

---

Confirmed working on amd strix halo; fedora needs fixes https://github.com/antirez/ds4/pull/552 pi.dev needs config https://github.com/antirez/ds4/pull/561

Disclaimer: I have used deepseek-v4-flash with pi as a tool to assist in writing this changeset.