### PR TITLE
engine: skip the single-instance lock for --inspect

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -57206,7 +57206,10 @@ static int ds4_engine_open_internal(ds4_engine **out,
     e->placement_ctx_hint = opt->placement_ctx_hint;
     e->placement_session_count_hint = opt->placement_session_count_hint;
     e->share_session_prefill_workspace = opt->share_session_prefill_workspace;
-    ds4_acquire_instance_lock();
+    /* --inspect only reads GGUF metadata and returns before any residency or
+     * GPU allocation, so it does not need the single-instance guard. Taking it
+     * would make inspecting a model impossible while a server is running. */
+    if (!opt->inspect_only) ds4_acquire_instance_lock();
 
     if (opt->simulate_used_memory_bytes != 0 &&
         !ds4_ssd_memory_lock_acquire(&e->simulated_memory,


### PR DESCRIPTION
`--inspect` only reads GGUF metadata and returns from `ds4_engine_open` before any prefetch, residency, or GPU allocation, so the single-instance guard that protects against a second multi-GiB run does not apply. Taking the lock made it impossible to inspect a model while `ds4-server` was running.

`ds4_release_instance_lock()` is a no-op when the lock was never taken (`g_ds4_lock_fd` stays `-1`), so acquire/release pairing is unchanged.

Verified with an exclusive lock held on DS4_LOCK_FILE: a normal run is still refused with exit 2, while --inspect prints the summary and exits 0.