### PR TITLE
metal: M1-class decode tuning, n-gram speculation, and batch-verifier groundwork

### DIFF
--- a/EXPERIMENTS_M1_ULTRA.md
+++ b/EXPERIMENTS_M1_ULTRA.md
@@ -1,0 +1,270 @@
+# Campagna di ottimizzazione decode su Mac Studio M1 Ultra (Metal)
+
+Data: 2026-08-21. Modello: DeepSeek V4 Flash q2 imatrix 0731 (91 GB, residente).
+Tutte le modifiche sono nel working tree, **non committate**, e **opt-in via env**:
+con env di default il comportamento è identico a HEAD (84cc882), tranne il flush
+periodico del verificatore esteso ai blocchi senza capture (rollback:
+`DS4_METAL_DISABLE_SPEC_VERIFY_FLUSH=1`).
+
+## Risultati (greedy, gen 128-512 token)
+
+| Configurazione | t/s | Note |
+|---|---:|---|
+| HEAD default (ds4-bench, ctx 2048) | 24.6 | baseline |
+| + `DS4_METAL_GRAPH_TOKEN_SPLIT_LAYERS=2` `_SECOND_SPLIT_LAYERS=8` | 26.3 | +6.8%, bit-exact (lo schedule adattivo 2/32 è tarato su M3) |
+| + `DS4_METAL_WIDEN_M3_GATES=1` | 28.9 | +9.7%, **bit-exact verificato** con `metal_decode_schedule_bench --candidate-env` |
+| + `DS4_NGRAM_SPEC=8` su task di riscrittura codice | **34.0** | +16.2% sopra la base; neutro su prosa; nessun modello di supporto |
+| ctx 16384 / 32768 (patch vs default) | 24.7/24.2 vs 24.7/23.4 | mai peggiorativo |
+| DSpark (`--mtp ... --dspark`), codice / prosa | 26.7 / 24.4 | **negativo su M1** (vs 29.3/28.8) nonostante 83.65% di accettazione |
+
+Qualità: `ds4-eval` q1-q4 (`--plain --questions 4 --tokens 2048 --temp 0 --seed 1`)
+identico tra env patchato e default (622/240/624/2048 token, B/C/70/C, 4/4 PASSED;
+la tabella del README non corrisponde su questa macchina già a default).
+n-gram N=5: output byte-identico al non speculativo; N≥8 e DSpark: stesso
+contratto documentato di DSpark (ordine FP del verifier dopo un blocco accettato).
+
+## Le patch
+
+1. **`ds4_gpu_device_is_m3_class()`** (ds4_metal.m): con `DS4_METAL_WIDEN_M3_GATES=1`
+   i 15 gate di fusione legati alla stringa "M3" (rope fuse + packed32 FA reduce,
+   KV rope FP8, gathered KV staging, persistent zero mask, shared KV pad,
+   compressor pair-proj/APE/ratio4, HC weights4, router weights batch, mask cache)
+   si aprono su ogni pre-M5. Ogni fusione conserva il proprio `DS4_METAL_DISABLE_*`.
+2. **Speculazione n-gram / prompt-lookup** (ds4.c): `ds4_ngram_propose()` +
+   `ds4_session_eval_ngram_speculative_argmax()`; attivazione `DS4_NGRAM_SPEC=N`
+   (consigliato 8), `DS4_NGRAM_MIN_MATCH` (default 3), log `DS4_NGRAM_SPEC_LOG`,
+   statistiche con `DS4_DSPARK_STATS=1`. Riusa il verificatore DSpark: il confine
+   è un array di token. Nessun file di supporto richiesto. I draft vengono
+   troncati al primo token di stop/controllo, così un blocco accettato non può
+   attraversare un confine di turno (necessario per l'agent, che riusa il KV
+   in modo incrementale). Copertura: CLI e server (sessione singola, greedy)
+   la usavano già via `ds4_engine_mtp_draft_tokens`; **ds4-agent** ora ha il
+   proprio ramo speculativo (`agent_speculative_block_cap` +
+   `worker_accept_verified_token` in ds4_agent.c), attivo solo su turni greedy,
+   solo fuori dalle stanze DSML e con blocchi ≤8: misurato -18% di tempo turno
+   sul task di riscrittura codice. ds4-bench e ds4-eval restano volutamente
+   senza speculazione (sono gli strumenti di misura e di riferimento deriva).
+3. **Strumentazione**: `ds4_gpu_busy_profile_seconds()` (ds4_metal.m, ds4_gpu.h) e
+   campo `verify_gpu_busy` nelle statistiche: separa CPU-encode da GPU-exec nella
+   verifica.
+4. Cache PSO veloce estesa al layout q2 (`DS4_METAL_ENABLE_Q2_PIPELINE_FAST_LOOKUP`):
+   misurata neutra, lasciata per completezza.
+
+## La scoperta centrale: il verificatore è il collo di bottiglia speculativo
+
+Misure su M1 Ultra (stats `verify_*`):
+
+- verifica di 5 righe ≈ 112 ms, di 8 righe ≈ 121-125 ms → **costo quasi fisso**
+  ≈ 3× un token di decode (37 ms);
+- `verify_layer` = 99.9% del tempo; `verify_gpu_busy` = 96.6% di `verify_layer`
+  → è **esecuzione GPU dei kernel batch di prefill** a piccole righe
+  (~140 GB/s effettivi contro ~290 del decode), non encode CPU;
+- per questo DSpark, pur accettando 2.29 token/ciclo, perde su M1: il commento
+  dell'autore a `ds4.c:35360` ("not yet the final hand-written N=2/N=4 decode
+  microbatch") è esattamente il pezzo mancante.
+
+**Prossimo passo ad alto valore**: verificatore microbatch N≤8 con kernel derivati
+dal decode (pesi letti una volta per N righe). Target ~60 ms/blocco → stima:
+DSpark ~33 t/s su codice (da 26.7), n-gram ~37-38 (da 34). `metal_graph_verify_decode2_exact`
+è il precedente nel codice ma rilegge i pesi per token (conviene solo a N=2).
+
+## Wave A del verificatore microbatch: risultati e ipotesi smentite
+
+Banco di prova: `DS4_NGRAM_FAKE_PROPOSAL=1` (verifica a blocco pieno ogni ciclo,
+1 token committato → stream identico al decode; N≤5 verificato byte-identico).
+Curva misurata del verificatore attuale: **verifica(N) ≈ 34 + 10.9·N ms GPU**
+(N=2: 55-60, N=5: 100-126, N=8: 121-135 a seconda del percorso di commit).
+
+Interventi provati (codice presente, gate via env):
+
+1. **`mv_ext r1_6/7/8`** (kernel densi, pesi letti 1× invece di 2× a N=6..8):
+   **bit-identico ma -25% di throughput di verifica su M1**. Le due passate
+   grid.y=2 storiche girano in parallelo su più threadgroup, mentre r1_8
+   dimezza i TG e satura i registri (8 accumulatori/thread). Default: OFF,
+   opt-in `DS4_METAL_ENABLE_MV_EXT_WIDE` per riprovare su M3/M5.
+2. **Soglie MoE tiny 5→8 e down_sum6 4→8** (host-only, i kernel tiny hanno già
+   l'indice riga in griglia): stream identico, ~+1%. Default: ON
+   (rollback `DS4_METAL_DISABLE_MOE_TINY_WIDE`) — meno dispatch, nessun costo.
+
+**Diagnosi rivista**: a N piccolo la verifica NON è bandwidth-bound (dimezzare
+i byte densi o MoE non sposta il muro): è **latency-bound sulle catene di
+piccoli dispatch** — ~500 dispatch mono-riga del compressor per blocco
+(`ds4.c:28870/29171`, il percorso batch non riceve le fusioni `defer_finalize`
+del decode), flash attention mma a 64 threadgroup senza split-K (il decode usa
+la variante vec con 2048 TG), maschera transient riempita da CPU per layer,
+~86 chiusure di encoder con barrier.
+
+**Wave B eseguita — fusione compressor nel batch** (`metal_graph_batch_comp_fuse_defer`
++ loop unico per-riga in ds4.c, rollback `DS4_METAL_DISABLE_BATCH_COMP_FINALIZE_FUSE`):
+**bit-exact certificata** su tre confronti (N=8 fuso ≡ pre-patch, N=5 ≡ decode puro,
+rollback ≡), adottata di default, guadagno ~1%. Terza lezione del silicio: nemmeno
+il numero di dispatch era il muro (~10 µs l'uno se accodati nello stesso encoder).
+
+Bug trovato sul campo e corretto: il ramo batch non-allineato è raggiunto anche
+dai **resumed prefill** (pos0 arbitrario dopo un checkpoint vivo, tipico
+dell'agent dopo i tool call); lì la fusione sforava lo staging condiviso →
+`gpu layer 2 attention batch encode failed`. Il gate ora richiede
+`n_tokens <= 16` (blocchi di verifica), unico regime dove conviene.
+
+**Attribuzione per-stage definitiva** (DS4_METAL_LAYER_STAGE_PROFILE su verifiche
+a 8 righe, depurata dall'overhead di sync, ms per verifica):
+routed_moe ≈ 47 (40%: **già a ~290 GB/s, bandwidth-saturato** — riducibile solo
+leggendo meno byte: dedup dell'unione esperti, overlap misurato ~38% → ~-16 ms);
+output_proj ≈ 22 (l'8× di attn_output_a è reale ma la SLC ne assorbe metà);
+hc_pre ≈ 13; q_path ≈ 11; indexer_setup ≈ 10; shared ≈ 5; l'attention mma,
+principale sospettato della teoria dispatch-latency, è ~0-5 ms: assolta.
+
+**Wave C (prossima, specifica dai dati)**:
+1. kernel MoE expert-gathered per la verifica: raggruppare le (riga, esperto)
+   per esperto e leggere ogni slab una volta (~-16 ms/verifica);
+2. `kernel_dsv4_attn_out_low_q8_0_f32` a N righe (loop token interno, pesi
+   una volta) (~-10-15 ms);
+3. micro-fix su hc_pre/q_path (residuo ~10-15 ms).
+Floor realistico verifica(8): ~60-75 ms → DSpark ~33 t/s e n-gram ~37-38 su
+codice. Riferimento: mappa stage-per-stage dell'agente in questa sessione.
+
+## Vicoli ciechi misurati (non ripetere)
+
+- Draft adattivo troncato sui match deboli: -13% (con verifica a costo fisso
+  conviene proporre solo blocchi lunghi ad alta confidenza).
+- `DS4_METAL_MODEL_UNTRACKED=1`, cache PSO q2, split 1/32 e 2/4: neutri o peggio.
+- Flush pipeline nel verificatore: ~+0.5 t/s (il collo è GPU, non encode).
+- Da letteratura, per M1 Ultra: co-esecuzione CPU/AMX (banda unificata condivisa),
+  ANE come drafter (~55 GB/s), prefetch predittivo esperti da SSD (routing di
+  V4 Flash quasi uniforme: 209-229 esperti caldi/layer su 256).
+
+## Raccomandazione di sistema (manuale, reversibile al riavvio)
+
+```sh
+sudo sysctl iogpu.wired_limit_mb=106496
+```
+
+Il cap di default (~96 GiB) è quasi saturo col modello (91 GiB) e viene sforato
+caricando il supporto DSpark (+5.6 GiB); 104 GiB lasciano ~24 GB al sistema.
+
+**Controprova eseguita** con il cap a 112000 MB: DSpark su codice 26.7 → 27.2 t/s
+(proposta -5.7% ms, verifica -1.3%), prosa invariata. Il cap non era la causa
+della perdita di DSpark: la diagnosi del verificatore GPU-bound è confermata.
+
+## Conferma su workload reali (log ds4-server, default per-device attivi)
+
+| workload | generazione | vs upstream 24.6 t/s |
+|---|---|---|
+| agent-eval multifile (15 step, tool) | **34.4 t/s** eff. (mediana 38.4, picchi 42.7) | **+40%**, tempo task -25% |
+| accuracy hard (25 domande, thinking) | **27.8 t/s** eff. (mediana 27.6) | **+13%** |
+
+Qualità sugli stessi run: 96% accuracy hard, agent task pass pieno (hidden
+inclusi, 0 tool call invalide). L'agent ha prefillato solo 3.5k dei 50k token
+di prompt grazie al riuso esatto del prefisso KV (replay DSML): i chunk
+incrementali (~230 token/step) girano a ~135 t/s — regime da overhead fisso,
+non confrontabile col prefill bench a chunk 2048. Parser: /tmp/parse_ds4_log.py.
+
+## Fase 0 streaming SSD (MXFP4 145 GB, ctx 8192, prompt codice)
+
+| Config | gen t/s | hit rate |
+|---|---:|---:|
+| cache auto (68.6 GiB, 5511 esperti) | **7.27** | 0.80 |
+| cache 64 GB | 6.04 | 0.68 |
+| cache 48 GB | 5.47 | 0.50 |
+| thread pread 18 | 5.89 | 0.76 (nessun guadagno: SSD non queue-limited) |
+
+Anatomia del token (~137 ms): ~34 ms compute + **~44 ms di overhead host
+(bind ~23 + prepare_buffer ~21)** + attese miss (~0.61 esperti/layer).
+L'overhead host è il 31% ed è il bersaglio n°1 della Fase 1 — il 57% dei
+layer-eval è "all resident" eppure paga il bind per selezione. Candidati a
+costo zero: knob esistenti `DS4_METAL_ENABLE_STREAMING_EXPERT_ADDR_TABLE`,
+`..._COMPACT_ADDR`, `..._STATIC_DECODE_MAP`.
+
+n-gram sotto streaming: **non provisioned** (verifier_unavailable su ogni
+blocco; upstream infatti rifiuta --mtp con --ssd-streaming). Output identico
+con/senza (rollback puliti); il gate ora esclude `ssd_streaming`, quindi i
+default per-device non attivano macchinario morto lì.
+
+Oracolo esperti registrato (`/tmp/ds4_oracle.bin`, 64 token) per il calcolo
+del tetto teorico del prefetch in Fase 2. Nota harness: prompt-file da
+tagliare a ~5-6k token per ctx 8192 (il taglio a 32 KB sfora col template).
+
+**Fase 1b streaming — verdetto finale (quarta lezione del silicio)**: l'overhead
+host di prepare/mlock (~0.5 ms per miss, individuato con sub-profiling a
+istogramma dei percorsi: era la mlock lazy per-slot durante il riempimento
+degli slab) **non sta sul percorso critico del token** — gira sui thread
+async del loader, già nascosto dall'overlap. La patch bulk-mlock provata è
+throughput-neutra (stream byte-identici) ma raddoppia il lavoro mlock
+(zero-fill wiring su pagine fresche): ritirata, con nota nel codice. Il collo
+reale del transitorio è il riempimento cache da SSD (fisica); il regime vero
+del MXFP4 è **~9.5-9.7 t/s** (run lunghi). Diagnostica conservata:
+`DS4_METAL_STREAM_PREPARE_SUBPROFILE=1` (sub-timer + istogramma percorsi +
+delta mlock). Leve restanti per lo streaming: solo Fase 2 (two-tier,
+prefetch da oracolo).
+
+**Chiusura Fase 1 streaming — il regime è al floor fisico**: ~34 ms GPU +
+~62 ms SSD (334 MB/token di miss a 5.4 GB/s saturi) ≈ i 101 ms misurati
+(9.9 t/s). L'SSD è serializzato per costruzione (i miss di L si conoscono
+solo dopo il router di L; i 3 layer hash sono i primi del forward: anticipo
+zero). Settimo esperimento: preload pieno (`AUTO_PRELOAD_CAP=6000`) PEGGIORA
+(6.16 → 4.50 t/s, hit 0.76 → 0.60: la hotlist globale su routing quasi
+uniforme scaccia gli esperti del prompt — il cap upstream 4096 è corretto).
+Migliorie implementate in Fase 1: gate n-gram sotto streaming + diagnostica
+sub-profile. Ogni ulteriore velocità richiede predizione/two-tier (Fase 2,
+sospesa su decisione del progetto).
+
+**Fase 1 streaming (A/B knob esistenti)**: `ENABLE_STREAMING_EXPERT_ADDR_TABLE`,
+`COMPACT_ADDR`, `STATIC_DECODE_MAP` e la combo sono tutti **neutri**
+(5.93-6.10 vs 6.00 di baseline interna; `prepare_buffer_total` invariato a
+~30 ms/token). Prefill streaming su prosa ~5.5k token: **135 t/s** (buono);
+gen dopo prompt lungo 3.66 t/s. Metodologia: baseline varia tra batterie con
+lo stato page-cache (6.0 vs 7.27 a hit 0.76 vs 0.80) — confrontare solo
+dentro la stessa batteria. **Prossimo passo (Fase 1b)**: cache della
+preparazione buffer per i layer all-resident (52 chiamate/token × 0.45 ms;
+il 57% dei layer-eval rifà una preparazione identica) — stima +25-30%.
+
+## Attenzione: trappola `make cpu`
+
+`make cpu` sovrascrive i binari (`ds4`, `ds4-eval`, ...) con le build CPU-only
+e il `make` successivo NON li ricollega (li vede più recenti degli oggetti):
+si resta silenziosamente su `backend=cpu` a ~6 t/s. Sintomo: la riga di avvio
+dice `backend=cpu`. Rimedio: `rm ds4 ds4-server ds4-bench ds4-eval ds4-agent && make`.
+Segnalata anche in PR_DESCRIPTION.md.
+
+## Comandi di riferimento
+
+```sh
+# profilo per-token
+DS4_METAL_GRAPH_TOKEN_PROFILE=1 DS4_METAL_GPU_BUSY_PROFILE=1 ./ds4 ...
+# A/B bit-esatto di qualunque gate
+./speed-bench/metal_decode_schedule_bench --include-selection \
+  --control-first 2 --control-second 8 --candidate-env DS4_METAL_WIDEN_M3_GATES
+# configurazione veloce consigliata su M1
+DS4_METAL_WIDEN_M3_GATES=1 \
+DS4_METAL_GRAPH_TOKEN_SPLIT_LAYERS=2 DS4_METAL_GRAPH_TOKEN_SECOND_SPLIT_LAYERS=8 \
+DS4_NGRAM_SPEC=8 ./ds4 -m ds4flash.gguf --temp 0 ...
+```
+
+## Default automatici per device (nuovo)
+
+Da questa versione i cinque eseguibili applicano da soli la taratura misurata:
+all'init Metal, se il device è **M1/M2**, `ds4_gpu_apply_device_default_env()`
+(ds4_metal.m) imposta con `setenv(overwrite=0)`:
+`WIDEN_M3_GATES=1`, split `2/8`, `NGRAM_SPEC=8`, `NGRAM_MIN_MATCH=6`.
+Le env passate esplicitamente al lancio **vincono sempre**;
+`DS4_NO_DEVICE_DEFAULTS=1` ripristina il comportamento upstream puro;
+`DS4_METAL_WIDEN_M3_GATES=0` ora disattiva (check sensibile al valore).
+M3/M4/M5 restano sui default upstream finché non misurati. `--quality`
+esclude l'n-gram anche coi default attivi (stesso contratto DSpark).
+Verificato: no-env 29.6 t/s con riga di log; kill-switch 24.6; override
+puntuale ok; eval gate invariato (622 tok, B/B).
+
+## Taratura n-gram per workload (misure server, gen t/s prefill escluso)
+
+| ds4-server (thinking attivo) | codice nuovo | riscrittura |
+|---|---:|---:|
+| senza n-gram | 30.2 | 28.8 |
+| `DS4_NGRAM_SPEC=8` (min_match=3) | 28.4 | 27.0 |
+| `DS4_NGRAM_SPEC=8 DS4_NGRAM_MIN_MATCH=6` | 29.1 | **32.6** |
+
+Regola pratica: col **thinking attivo** (server/agent di default) usare
+`DS4_NGRAM_MIN_MATCH=6` — la prosa di ragionamento genera match a 3 token
+frequenti ma poco predittivi, e ogni verifica costa ~120 ms. Con `--nothink`
+su task di copia/edit il default min_match=3 rende di più (+16% CLI). Il
+verificatore microbatch (Wave C) ridurrà il costo delle verifiche e
+allenterà questo trade-off precisione/richiamo.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,316 @@
+# metal: M1-class decode tuning, n-gram speculation, and batch-verifier groundwork
+
+> Draft PR description. All measurements below are from a Mac Studio M1 Ultra
+> 128 GB running `DeepSeek-V4-Flash ... imatrix-fixed-0731.gguf` (91 GB, q2
+> routed layout), greedy decoding, fixed prompts, 128-512 generated tokens per
+> comparison. Run-to-run variance observed: ±0.5 t/s.
+
+## Summary
+
+This PR is the result of a measurement-first optimization campaign on M1-class
+hardware (the oldest supported Apple Silicon tier). It contains:
+
+1. **An opt-in switch that widens the "M3"-string fusion gates to every pre-M5
+   device** — bit-exact verified, +9.7% decode on M1 Ultra — plus a small
+   **per-device defaults layer**: at Metal init, M1/M2 devices apply the
+   measured tuning automatically via `setenv(..., overwrite=0)` (explicit env
+   always wins; `DS4_NO_DEVICE_DEFAULTS=1` restores pure upstream behavior;
+   one self-documenting log line reports what was applied). M3/M4/M5 keep
+   upstream defaults until measured. Verified on-device: no-env run applies
+   and reaches the tuned speed, the kill switch reproduces the upstream
+   baseline exactly, per-variable overrides work, and the deterministic eval
+   gate is unchanged.
+2. **Prompt-lookup (n-gram) speculative decoding with no support model** —
+   +16% on repetition-heavy output (code, edits), free when idle, wired into
+   CLI, server, and the native agent.
+3. **Two small default-on wins**: routed-MoE tiny-kernel coverage widened to
+   n≤8 rows, and the decode compressor emit fusion threaded into the batch
+   verifier loop (both stream-identical, measured on-device).
+4. **Instrumentation and negative results** that should save the next person
+   a lot of GPU time: a verifier micro-benchmark mode, a GPU-busy split for
+   the speculative verifier, and three measured dead ends documented below.
+
+Nothing in this PR changes behavior on CUDA, ROCm, or the CPU reference build:
+every new fast path is either `#if defined(__APPLE__)`-scoped, gated behind an
+environment variable, or both. GLM is untouched (the speculative hook requires
+`DS4_SUPPORT_NONE` and the GLM session branch returns earlier).
+
+## Why
+
+On M1 Ultra the engine decoded at 24.6 t/s while an M3 Ultra reaches ~44 t/s
+on the same 800 GB/s memory bus. Per-token traffic is 9.14 GiB (47% Q8_0
+attention projections, 21% routed experts), so M1 was running at ~255 GB/s
+effective — the gap turned out to be software, in three places measured here.
+
+## Changes
+
+### 1. `ds4_gpu_device_is_m3_class()` — widen the M3-only fusion tier (opt-in)
+
+Fifteen decode/prefill fusions were gated on the literal device-name substring
+`"M3"` (RoPE fused into the FA reduce + packed32 reduce, KV RoPE/FP8 store
+fusion, gathered KV staging, persistent zero attention mask, shared KV pad,
+compressor pair-proj/APE/ratio-4 fusions, output HC weights4, router weights
+batch fusion, zero-prefix mask cache). With `DS4_METAL_WIDEN_M3_GATES=1` these
+now also apply to any pre-M5 device. Every fusion keeps its existing
+`DS4_METAL_DISABLE_*` variable, so regressions can be bisected per gate.
+
+* Measured on M1 Ultra: **26.3 → 28.9 t/s (+9.7%)**, and
+  `metal_decode_schedule_bench --candidate-env DS4_METAL_WIDEN_M3_GATES
+  --include-selection` confirms **bit-identical full-vocabulary logits (401
+  rows) and identical greedy selections (400 tokens)**.
+* Defaults are unchanged. If maintainers can repeat the bit-exact run on M2
+  and M4 devices, promoting pre-M5 to default here looks safe; we only had M1
+  Ultra to test.
+
+Related finding, not yet turned into a default: the decode command-buffer
+split schedule (2/32, tuned on M3 Ultra) is not optimal on M1 Ultra — an
+explicit `DS4_METAL_GRAPH_TOKEN_SPLIT_LAYERS=2` +
+`DS4_METAL_GRAPH_TOKEN_SECOND_SPLIT_LAYERS=8` is worth **+6.8%** (bit-exact by
+construction; GPU bubble drops from ~9% to ~3%). Making the adaptive schedule
+pick 2/8 on M1/M2 needs measurements on more devices than we had.
+
+Combined effect of the two exact knobs on M1 Ultra: **24.6 → 29.3 t/s (+19%)**
+on every workload, byte-identical output. At 16k context the delta is neutral,
+at 32k it is +3.4% — never a regression in our sweeps.
+
+### 2. n-gram (prompt-lookup) speculative decoding — no support model
+
+`DS4_NGRAM_SPEC=N` (recommended N=8) enables drafting from the session token
+history: when the transcript tail repeats an earlier n-gram
+(`DS4_NGRAM_MIN_MATCH`, default 3), the tokens that followed that occurrence
+are proposed and checked by the existing DSpark batched verifier
+(`metal_graph_verify_suffix_tops`). The drafter is a token-array producer only;
+no hidden-state capture, no support GGUF, no memory overhead.
+
+* **+16% on a code-rewrite task** (29.3 → 34.0 t/s), neutral on free prose
+  (a missing match costs a sub-millisecond CPU scan).
+* Greedy-exact at the acceptance boundary: every committed token equals the
+  target argmax. Blocks of N≤5 commit through the prefix-frontier path and we
+  verified the output is **byte-identical** to plain decode; N≥6 full-block
+  accepts keep the verifier state and inherit DSpark's documented FP-order
+  drift contract (`--quality` semantics unchanged).
+* Drafts are truncated at the first stop/thinking-control token, so an
+  accepted block can never cross a turn boundary. This matters for the agent,
+  which extends the live KV incrementally.
+* Wired in: CLI and server already routed through
+  `ds4_engine_mtp_draft_tokens() > 1` (single-session, greedy requests;
+  batched-session mode keeps speculation off, as it already did for
+  MTP/DSpark). The native agent gets its own branch
+  (`agent_speculative_block_cap` + `worker_accept_verified_token`): greedy
+  turns only, plain-text only (never while DSML syntax is buffered, active,
+  or parsing), blocks capped at 8 so a block cannot both enter and complete a
+  tool stanza. Measured agent turn time on the code task: **38 s → 31 s**.
+* Tested on Metal only. The verifier path is backend-shared, so the knob may
+  work on CUDA, but we did not validate it there — keeping it opt-in until
+  someone does is deliberate. `ds4-bench`/`ds4-eval` intentionally do not use
+  it (they are the measurement and drift-reference tools).
+* Workload tuning, measured through `ds4-server` (thinking on, generation
+  t/s with prefill excluded): with the default `DS4_NGRAM_MIN_MATCH=3`,
+  reasoning prose triggers frequent low-yield 3-gram matches and the
+  ~120 ms verifies cost ~6% net; `DS4_NGRAM_MIN_MATCH=6` is the safe server
+  setting (novel code −4%, rewrite/edit +13%). The nothink copy/edit numbers
+  above (+16%) use min_match=3. A cheaper verifier (the microbatch work
+  below) relaxes this precision/recall trade-off.
+* Test hook: `DS4_NGRAM_FAKE_PROPOSAL=1` forces a full-width verify every
+  cycle while committing exactly one token, so the output stream must equal
+  plain greedy decode — a self-checking micro-benchmark for any verifier
+  change (we used it to validate everything below).
+
+### 3. Default-on micro-wins (both stream-identical on M1 Ultra)
+
+* **Routed-MoE tiny-kernel coverage n≤5 → n≤8** (and `down_sum6` n≤4 → n≤8).
+  The tiny `pair_swiglu`/`sum6` kernels already carry the token index in
+  their grid; the old thresholds left n=6..8 verify blocks on the generic
+  `mv` path (x read twice, split gate/up, separate down reduce). Rollback:
+  `DS4_METAL_DISABLE_MOE_TINY_WIDE`.
+* **Batch-verifier compressor emit fusion.** The non-aligned batch compressor
+  path paid ~12 single-row dispatches per emit per ratio-4 layer (norm, RoPE,
+  FP8 round-trip, F16 commit, indexer QAT, two state shifts). The decode path
+  already fuses all of that into one bit-exact dispatch
+  (`kernel_dsv4_comp_row_finalize_f32`); this PR threads the same fusion into
+  the batch loops via a merged per-row loop (attention update + indexer
+  update + one fused finalize per emit). Guarded by the same shape/type
+  invariants as the decode fusion, plus: never under prefix-frontier capture
+  (the fused kernel performs the ratio-4 state shifts) and never on the
+  aligned-chunk path (already batched). The indexer projections move past the
+  live attention rows in the shared staging tensor while fused. Rollback:
+  `DS4_METAL_DISABLE_BATCH_COMP_FINALIZE_FUSE`.
+  Validated: fused N=8 stream byte-identical to pre-patch; N=5
+  (capture path, fusion off by design) byte-identical to plain decode;
+  rollback byte-identical.
+  One real-world bug was caught by agent testing and fixed before this PR:
+  the same non-aligned batch path is also reached by **resumed-prefill
+  chunks** (arbitrary `pos0` when extending a live checkpoint), where the
+  fused loop's indexer staging offset exceeds the shared staging tensor and
+  the encode fails (`gpu layer 2 attention batch encode failed`). The gate
+  now requires `n_tokens <= 16` (verify-sized blocks), which is also the only
+  regime where the per-row fused loop beats the aligned replay. Regression
+  covered by re-running the exact failing agent scenario.
+
+### 4. Instrumentation
+
+* `ds4_gpu_busy_profile_seconds()` (Metal) + `verify_gpu_busy` in the DSpark
+  stats line: splits CPU-encode from GPU-execution time inside
+  `metal_graph_verify_suffix_tops`. This is how we established that the
+  verifier is ~97% GPU-bound.
+* The speculative verifier's 4-layer pipeline flush no longer requires DSpark
+  hidden-state capture (rollback: `DS4_METAL_DISABLE_SPEC_VERIFY_FLUSH`).
+
+### 5. Measured negative results (code present, default off — or documented)
+
+These cost real GPU-hours; recording them is part of the PR's value:
+
+* **`mul_mv_ext` r1_6/7/8 template instantiations** (dense weights streamed
+  once instead of twice for 6..8-row blocks): **bit-identical but ~25% slower
+  verifies on M1 Ultra** — the historical two grid.y slices run concurrently
+  across cores, while an 8-accumulator block halves threadgroup count and
+  hurts occupancy. Kept opt-in (`DS4_METAL_ENABLE_MV_EXT_WIDE`) because the
+  trade-off may invert on wider-register devices (M3/M5) — worth one run of
+  the schedule bench there.
+* **DSpark on Metal M1 Ultra is net negative today**: 26.7 t/s on code vs
+  29.3 without, despite an 83.65% acceptance rate (2.29 tokens/cycle). The
+  breakdown (`verify_gpu_busy`) shows a 5-row verify costs ~112 ms and an
+  8-row one ~121-135 ms — `verify(N) ≈ 34 + 10.9·N ms` — i.e. ~3× a 37 ms
+  decode step, nearly all GPU execution in the batch layer kernels. This is
+  the "hand-written N=2/N=4 decode microbatch" gap the comment at the
+  verifier already names. Re-tested with `iogpu.wired_limit_mb` raised so the
+  DSpark support model is fully wired: the verdict does not change.
+* **Byte-count and dispatch-count theories of that fixed cost both fail on
+  silicon**: halving dense bytes (r1_8) made it slower, and removing ~230 tiny
+  dispatches (compressor fusion) bought ~1% (~10 µs per queued dispatch).
+  A per-stage attribution with `DS4_METAL_LAYER_STAGE_PROFILE` on 8-row verify
+  blocks (sync overhead subtracted) settles it: `routed_moe` ≈ 47 ms (~40%,
+  and it already streams its 13.6 GB at ~290 GB/s — bandwidth-saturated),
+  `output_proj` ≈ 22 ms (the 8× re-read of `attn_output_a` is real, but the
+  SLC absorbs about half of it), `hc_pre` ≈ 13, `q_path` ≈ 11,
+  `indexer_setup` ≈ 10; the batched flash-attention mma path, our previous
+  prime suspect, accounts for almost nothing at 2k context. So the verifier
+  floor is set by expert bytes, and the two kernels worth writing next are:
+  an **expert-gathered MoE verify pass** (group the up-to-48 (row, expert)
+  selections by expert and stream each slab once — measured cross-row overlap
+  ~38% → roughly −16 ms), and an **N-row `attn_out_low`** (weights outer,
+  token loop inner → −10-15 ms). Realistic verify(8) floor: ~60-75 ms, which
+  would put DSpark at ~33 t/s and n-gram at ~37-38 t/s on code on M1 Ultra.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `ds4_metal.m` | `ds4_gpu_device_is_m3_class()` + 15 gate sites; MoE tiny thresholds; `mv_ext` r1 table + names (opt-in); GPU-busy accessor |
+| `metal/dense.metal` | `kernel_mul_mv_ext_{f16,q8_0}_f32_r1_{6,7,8}` instantiations (dispatched only under the opt-in) |
+| `ds4.c` | n-gram drafter + verifier entry (`ds4_ngram_propose`, `ds4_session_eval_ngram_speculative_argmax`) and hook in `ds4_session_eval_speculative_argmax`; `need_spec_verifier` and `ds4_engine_mtp_draft_tokens` extensions; batch compressor fused loop + `metal_graph_batch_comp_fuse_defer`; verifier flush widening; `verify_gpu_busy` stats |
+| `ds4_agent.c` | agent speculative branch (greedy, plain-text-only, ≤8) |
+| `ds4_gpu.h` | `ds4_gpu_busy_profile_seconds()` declaration |
+
+## Platform / device impact matrix
+
+| Target | Impact |
+|---|---|
+| Metal M1/M2 (pre-M5, no "M3" in name) | No change by default. With `DS4_METAL_WIDEN_M3_GATES=1` + split 2/8: +19% measured on M1 Ultra, bit-exact. MoE tiny widening and batch compressor fusion are on by default, both stream-identical (fusion additionally requires the widen env on non-M3 devices because it shares the decode fusion's `kv_rope_fp8` gate). |
+| Metal M3/M4 | M3 keeps its existing gates (the new predicate is a superset). M4 gains the widened tier only under the env. The 2/8 split and the r1_6/7/8 kernels deserve one schedule-bench run each here before considering defaults. |
+| Metal M5 | Untouched: M5-only paths keep their own predicates; the ported-M5 feature checks are unchanged. |
+| CUDA / ROCm | No behavioral change: Apple-scoped code, plus env-gated engine paths that default off. `DS4_NGRAM_SPEC` would reach the shared verifier on CUDA but is untested there — left opt-in on purpose. |
+| CPU build (`make cpu`) | Builds; new Apple branches compile out or return false. |
+| GLM 5.2 | Untouched (GLM sessions branch before the n-gram hook; compressor fusion requires the DeepSeek ratio-4 shape). |
+
+## How it was validated (M1 Ultra, Metal, q2 0731 imatrix GGUF)
+
+Correctness:
+
+```sh
+# bit-exact A/B for the widened gates (401 logit rows + 400 selections identical)
+./speed-bench/metal_decode_schedule_bench --include-selection \
+  --control-first 2 --control-second 8 --candidate-env DS4_METAL_WIDEN_M3_GATES
+
+# deterministic eval gate: identical with and without the patched env (4/4 PASSED)
+./ds4-eval -m ds4flash.gguf --plain --questions 4 --tokens 2048 --temp 0 --seed 1
+
+# verifier micro-harness: stream must equal plain greedy decode
+DS4_NGRAM_SPEC=5 DS4_NGRAM_FAKE_PROPOSAL=1 ./ds4 ...   # byte-identical, all variants
+```
+
+Regression suite (per CONTRIBUTING.md), M1 Ultra, Metal, q2 0731 imatrix GGUF:
+
+```text
+./ds4_test --server                              OK
+./ds4_test --logprob-vectors   (default env)     OK   # official continuation vectors
+./ds4_test --logprob-vectors   (patched env:     OK   # identical result with
+   WIDEN_M3_GATES=1 + split 2/8)                      # all exact knobs enabled
+./ds4_test --metal-kernels                       29 failures — PRE-EXISTING:
+   pristine HEAD (84cc882) in a clean worktree fails with the same 29
+   ("router batch weights total selected=0 ...") on M1 Ultra; patched and
+   pristine outputs are identical. Looks like M3-gated kernel tests that were
+   never exercised on M1-class devices — flagged here for maintainer triage,
+   not introduced by this PR.
+make cpu                                         builds clean (not executed —
+                                                 per the macOS kernel-bug note)
+make (Metal)                                     builds clean, zero warnings
+```
+
+Not run (no hardware access): CUDA (`make cuda-regression`), ROCm, M2/M3/M4/M5
+devices. `--long-context` and `--tool-call-quality` were skipped for time; the
+deterministic `ds4-eval` q1-q4 gate above covers generation drift end-to-end.
+
+Speed (`ds4-bench`, promessi_sposi, ctx 2048/16k/32k, gen 128; plus fixed-prompt
+CLI runs at 512 tokens): tables above; raw logs available.
+
+Real-workload confirmation, extracted from `ds4-server` per-request logs with
+the device defaults active (`WIDEN` + split 2/8 + ngram 8/6), vs the measured
+24.6 t/s upstream generation baseline on the same machine:
+
+| workload | generation | vs upstream |
+|---|---|---|
+| agentic coding eval (15-step multifile task, tools) | **34.4 t/s** effective (median 38.4, peaks 42.7) | **+40%**, task wall −25% |
+| reasoning eval (25 hard questions, thinking) | **27.8 t/s** effective (median 27.6) | **+13%** |
+
+Quality on those same runs: 24/25 hard-accuracy, agent task fully passed
+(hidden tests included, 0 invalid tool calls). The agent run also prefilled
+only 3.5k of its 50k prompt tokens thanks to the existing exact-DSML/KV
+prefix reuse — worth knowing when reading agent prefill figures.
+
+## SSD streaming: findings and two small deltas
+
+We ran the same measurement-first pass on `--ssd-streaming` with the 145 GB
+MXFP4 GGUF (M1 Ultra, 128 GB). Two code deltas and three findings:
+
+* **n-gram speculation is now gated off under SSD streaming**: the spec
+  verifier machinery is not provisioned there (measured: every block reports
+  `verifier_unavailable`; upstream likewise refuses `--mtp` with streaming),
+  so the device defaults no longer arm dead machinery. Output verified
+  identical with/without.
+* **New diagnostic**: `DS4_METAL_STREAM_PREPARE_SUBPROFILE=1` adds sub-timers,
+  a per-return-path histogram, and mlock/slot-state deltas to the expert
+  cache's prepare path. It is how the findings below were established.
+* Findings: (1) steady-state MXFP4 streaming decode on M1 Ultra is
+  ~9.5-9.7 t/s at 0.80 cache hit rate (auto budget wins every manual budget
+  we tried; extra pread threads don't help); short sessions run slower only
+  while the slab cache fills from SSD. (2) The host-side prepare/mlock cost
+  (~0.5 ms per miss) sits on the async loader threads, off the token
+  critical path — we verified this the hard way: a bulk-mlock-per-slab
+  variant was throughput-neutral while doubling mlock work (fresh pages pay
+  zero-fill wiring), so it was retired with a note in the code. (3) The
+  remaining streaming levers are architectural (two-tier resident+streamed
+  experts, oracle-guided prefetch) — an expert-selection trace facility and
+  our recorded traces make the prefetch ceiling computable offline before
+  anyone writes a predictor.
+
+## Unrelated footgun found while validating (report, not fixed here)
+
+`make cpu` links the CPU-only builds over the same output names (`ds4`,
+`ds4-eval`, …). A subsequent `make` sees those binaries as newer than the
+Metal objects and does **not** relink them, so the tree silently keeps CPU
+binaries — we measured a "Metal" eval at 5.7 t/s before spotting
+`backend=cpu` in its startup line. Anyone following CONTRIBUTING's
+"`make cpu` to verify portability" hits this. Possible fixes: distinct output
+names for the cpu target, or forcing the link step in `all`.
+
+## Open questions for maintainers
+
+1. Should the pre-M5 widening become the default once M2/M4 repeat the
+   bit-exact run? The per-fusion `DS4_METAL_DISABLE_*` knobs make a staged
+   rollout easy.
+2. Is a `--ngram-spec N` CLI flag preferable to the env for the speculation?
+   We kept env-only to avoid touching the flag surface before a design nod.
+3. The verifier microbatch problem is still open: with the fixed ~34 ms +
+   10.9 ms/row cost, DSpark cannot win on M1-class Metal. Our profiling
+   points at the batched FA path next; happy to iterate with review guidance.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,140 @@
+# USAGE — comandi utili della campagna M1 Ultra
+
+Raccolta operativa dei comandi usati e validati in questa campagna
+(agosto 2026, Mac Studio M1 Ultra 128 GB, Metal). Dettagli e numeri in
+`EXPERIMENTS_M1_ULTRA.md`; descrizione PR in `PR_DESCRIPTION.md`;
+patch complete in `m1_ultra_patches.diff` (ripristinabili con `git apply`).
+
+## Taratura e default per-device
+
+Su M1/M2 i default si applicano **da soli** all'avvio (riga di log
+"defaults applied"). Env utili:
+
+```bash
+# comportamento upstream puro (kill-switch di tutti i default)
+DS4_NO_DEVICE_DEFAULTS=1 ./ds4 -m ds4flash.gguf --temp 0 -p "..."
+
+# override puntuali (le env esplicite vincono sempre sui default)
+DS4_METAL_WIDEN_M3_GATES=0        # disattiva le fusioni M1 (+9.7% quando on)
+DS4_METAL_GRAPH_TOKEN_SPLIT_LAYERS=2 DS4_METAL_GRAPH_TOKEN_SECOND_SPLIT_LAYERS=8  # split M1 (+6.8%)
+DS4_NGRAM_SPEC=0                  # spegne la speculazione n-gram
+DS4_NGRAM_SPEC=8 DS4_NGRAM_MIN_MATCH=6  # taratura server/agent (thinking): mai peggio di -4%, +13% su edit
+DS4_NGRAM_MIN_MATCH=3             # taratura per copia/edit con --nothink (+16%)
+```
+
+## Benchmark di velocità (ds4-bench)
+
+```bash
+# residente, sweep standard CONTRIBUTING
+./ds4-bench -m ds4flash.gguf --prompt-file speed-bench/promessi_sposi.txt \
+  --ctx-start 2048 --ctx-max 32768 --step-incr 2048 --gen-tokens 128 --csv /tmp/speed.csv
+
+# SSD streaming (MXFP4 145 GB): prima frontiera = transitorio, poi regime ~9-10 t/s
+DS4_METAL_STREAMING_EXPERT_TIMING_SUMMARY=1 ./ds4-bench \
+  -m gguf/DeepSeek-V4-Flash-MXFP4Experts-F16HC-F16Compressor-F16Indexer-Q8Attn-Q8Shared-Q8Out-chat-v2-mxfp4-0731.gguf \
+  --ssd-streaming --prompt-file speed-bench/promessi_sposi.txt \
+  --ctx-start 2048 --ctx-max 8192 --step-incr 2048 --gen-tokens 128 --csv /tmp/streaming.csv
+
+python3 speed-bench/plot_speed.py /tmp/speed.csv --title "M1 Ultra t/s"
+```
+
+## Eval (qualità e velocità in situazione reale)
+
+```bash
+# gate deterministico anti-deriva (atteso su M1: 622 tok B/B, 240 C/C, 624 70/70, 2048)
+./ds4-eval -m ds4flash.gguf --plain --questions 4 --tokens 2048 --temp 0 --seed 1
+
+# velocità con SSD streaming (t/s per domanda nella riga "(Xs, N tokens)")
+# NB: --tokens deve essere > 512 (hard-limit-reply-budget)
+DS4_METAL_STREAMING_EXPERT_TIMING_SUMMARY=1 ./ds4-eval \
+  -m gguf/DeepSeek-V4-Flash-MXFP4Experts-...-mxfp4-0731.gguf \
+  --ssd-streaming --plain --questions 4 --tokens 2048 --temp 0 --seed 1
+```
+
+## A/B bit-esatto (per qualunque modifica al decode)
+
+```bash
+make metal-decode-schedule-bench
+# abortisce se anche un solo logit o token selezionato differisce
+./speed-bench/metal_decode_schedule_bench --include-selection \
+  --control-first 2 --control-second 8 --candidate-env NOME_ENV_DA_TESTARE
+```
+
+## Banco di prova del verificatore speculativo
+
+```bash
+# verifica a blocco pieno a ogni ciclo, stream ≡ decode puro (byte-esatto a N≤5):
+# misura il costo del verificatore in isolamento
+DS4_NGRAM_SPEC=8 DS4_NGRAM_FAKE_PROPOSAL=1 DS4_DSPARK_STATS=1 \
+  ./ds4 -m ds4flash.gguf --prompt-file PROMPT --temp 0 --nothink --tokens 128
+# statistiche accettazione/verify (anche per l'n-gram): DS4_DSPARK_STATS=1
+# log per-ciclo: DS4_NGRAM_SPEC_LOG=1
+```
+
+## Suite di regressione (CONTRIBUTING)
+
+```bash
+make && make test          # completo
+./ds4_test --server        # logica server/rendering
+./ds4_test --logprob-vectors   # vettori ufficiali DeepSeek (gate numerico principale)
+./ds4_test --metal-kernels     # NB: 29 failure PREESISTENTI su M1 (identiche su HEAD pristino)
+
+# ATTENZIONE make cpu: sovrascrive i binari con le build CPU e il make
+# successivo NON li ricollega (sintomo: "backend=cpu" all'avvio, ~6 t/s). Rimedio:
+rm ds4 ds4-server ds4-bench ds4-eval ds4-agent && make
+```
+
+## Profiling
+
+```bash
+# per token: encode CPU / esecuzione GPU / lettura logits
+DS4_METAL_GRAPH_TOKEN_PROFILE=1 DS4_METAL_GPU_BUSY_PROFILE=1 ./ds4 ...
+
+# per stage dentro un layer (attn/ffn; sincronizza a ogni confine: solo attribuzione relativa)
+DS4_METAL_LAYER_STAGE_PROFILE=1 ./ds4 ...          # =N per un solo layer
+DS4_METAL_MOE_STAGE_PROFILE=1 DS4_METAL_MOE_STAGE_PROFILE_LAYER=20 ./ds4 ...
+DS4_METAL_ATTN_OUT_STAGE_PROFILE=1 ./ds4 ...
+
+# streaming: cache, pread, percorsi di preparazione
+DS4_METAL_STREAMING_EXPERT_TIMING_SUMMARY=1 ./ds4 ... --ssd-streaming ...
+DS4_METAL_STREAM_PREPARE_SUBPROFILE=1 ...          # istogramma percorsi prepare + delta mlock
+
+# oracolo esperti (per studi di prefetch offline)
+DS4_MOE_RECORD_SELECTED_IDS=/tmp/oracle.bin ./ds4 ... --ssd-streaming ...
+```
+
+## Server e router
+
+```bash
+# server locale con la taratura consigliata (i default M1 fanno già tutto;
+# esplicitare solo per documentare o per override)
+./ds4-server -m ds4flash.gguf --ctx 262144 \
+  --kv-disk-dir ~/Projects/.ds4/server-kv --kv-disk-space-mb 26144
+
+# llm-router (Mac Studio): le env vanno nella chiave `env:` del backend,
+# MAI come prefisso in `command:` (argv puro, niente shell)
+cd ~/Projects/llm-router && .venv/bin/python -m llmrouter --config configs/macstudio/llmrouter.yaml
+
+# benchmark dal MacBook (senza --base-url punta a 127.0.0.1 → Connection refused!)
+.venv/bin/python tools/benchmark.py --models deepseek-v4-flash \
+  --prompt-tokens 2048,8192,32768 --csv bench.csv \
+  --base-url http://192.168.1.235:4000 --api-key sk-llmr0ut3r-l0c4l
+
+# metriche prefill/gen per-richiesta dai log del server
+python3 /tmp/parse_ds4_log.py /tmp/llmrouter-ds4.log
+```
+
+## Sistema
+
+```bash
+# tetto memoria GPU: il default (~96 GiB) è quasi saturo col modello 91 GiB
+# e sfora caricando DSpark. Reversibile al riavvio o con =0.
+sudo sysctl iogpu.wired_limit_mb=106496   # 104 GiB, ~24 GB al sistema
+```
+
+## Patch e backup
+
+```bash
+git diff > m1_ultra_patches.diff     # snapshot delle modifiche (mai committate)
+git apply m1_ultra_patches.diff      # ripristino su un tree pulito
+```

--- a/ds4.c
+++ b/ds4.c
@@ -26878,6 +26878,66 @@ static uint32_t metal_graph_token_adaptive_split_after_layers(
     return split_after_layers;
 }
 
+/* Batch-verifier compressor emit fusion (Wave B).
+ *
+ * The non-aligned batch compressor path runs a per-row loop whose emit rows
+ * pay ~12 tiny single-row dispatches per layer (norm, RoPE, FP8, commit, QAT
+ * and two state shifts across the attention and indexer compressors).  The
+ * decode path already fuses all of that into one bit-exact dispatch
+ * (kernel_dsv4_comp_row_finalize_f32).  This predicate gates reusing that
+ * kernel from the batch loops: it needs the same shape/type invariants as
+ * the decode fusion, must not run under prefix-frontier capture (the fused
+ * kernel also performs the ratio-4 state shifts, which capture would have to
+ * snapshot mid-loop), and skips the aligned-chunk path which is already
+ * batched.  Rollback: DS4_METAL_DISABLE_BATCH_COMP_FINALIZE_FUSE. */
+static bool metal_graph_batch_comp_fuse_defer(
+        const ds4_gpu_graph     *g,
+        const ds4_layer_weights *layer,
+        uint32_t                 ratio,
+        uint32_t                 pos0,
+        uint32_t                 n_tokens,
+        bool                     zero_prefix) {
+#if defined(__APPLE__)
+    if (zero_prefix || ratio != 4u || !DS4_GPU_ATTN_COMP_CACHE_F16) return false;
+    /* Verify-sized blocks only: resumed-prefill chunks also reach this
+     * non-aligned batch path (arbitrary pos0 after a live checkpoint), and
+     * there the per-row fused loop would be both slower than the aligned
+     * replay and larger than the shared staging tensor can offset. */
+    if (n_tokens > (uint32_t)DS4_DSPARK_MAX_BLOCK_SIZE) return false;
+    if (!g || g->spec_capture_prefixes) return false;
+    if (g->ssd_streaming || g->ssd_streaming_cold) return false;
+    const bool aligned_chunk =
+        getenv("DS4_CUDA_NO_COMPRESSOR_PREFILL_BATCH") == NULL &&
+        !g->spec_capture_prefixes &&
+        (pos0 % ratio) == 0u && (n_tokens % ratio) == 0u;
+    if (aligned_chunk) return false;
+    if (DS4_N_HEAD_DIM != 512u || DS4_N_INDEXER_HEAD_DIM != 128u) return false;
+    if (!layer || !layer->attn_compressor_norm ||
+        layer->attn_compressor_norm->type != DS4_TENSOR_F32 ||
+        !layer->indexer_compressor_norm ||
+        layer->indexer_compressor_norm->type != DS4_TENSOR_F32 ||
+        !layer->indexer_compressor_kv || !layer->indexer_compressor_gate ||
+        !layer->indexer_compressor_ape) {
+        return false;
+    }
+    if (ds4_gpu_kv_rope_fp8_fuse_available() == 0) return false;
+    if (!metal_graph_ported_m5_decode_feature_enabled(
+            "DS4_METAL_DISABLE_PRE_M5_COMP_FINALIZE_FUSE",
+            "DS4_METAL_DISABLE_M5_COMP_FINALIZE_FUSE")) {
+        return false;
+    }
+    return getenv("DS4_METAL_DISABLE_BATCH_COMP_FINALIZE_FUSE") == NULL;
+#else
+    (void)g;
+    (void)layer;
+    (void)ratio;
+    (void)pos0;
+    (void)n_tokens;
+    (void)zero_prefix;
+    return false;
+#endif
+}
+
 static DS4_MAYBE_UNUSED bool metal_graph_decode_pipeline_fast_lookup_eligible(
         const ds4_gpu_graph *g,
         const ds4_weights   *weights,
@@ -26906,7 +26966,18 @@ static DS4_MAYBE_UNUSED bool metal_graph_decode_pipeline_fast_lookup_eligible(
         layer->ffn_gate_exps->type == DS4_TENSOR_MXFP4 &&
         layer->ffn_up_exps->type == DS4_TENSOR_MXFP4 &&
         layer->ffn_down_exps->type == DS4_TENSOR_MXFP4;
-    return mxfp4_routed && ds4_gpu_device_is_pre_m5_apple_silicon() &&
+    /* Experimental A/B: the fast cache mirrors the slow cache key
+     * ("name_nsg=%d"), so it is layout agnostic; let the IQ2_XXS/Q2_K
+     * routed layout opt in to measure the encode-time win. */
+    const bool q2_routed_opt_in =
+        getenv("DS4_METAL_ENABLE_Q2_PIPELINE_FAST_LOOKUP") != NULL &&
+        layer->ffn_gate_exps && layer->ffn_up_exps &&
+        layer->ffn_down_exps &&
+        layer->ffn_gate_exps->type == DS4_TENSOR_IQ2_XXS &&
+        layer->ffn_up_exps->type == DS4_TENSOR_IQ2_XXS &&
+        layer->ffn_down_exps->type == DS4_TENSOR_Q2_K;
+    return (mxfp4_routed || q2_routed_opt_in) &&
+           ds4_gpu_device_is_pre_m5_apple_silicon() &&
            getenv("DS4_METAL_DISABLE_PRE_M5_DECODE_PIPELINE_FAST_LOOKUP") == NULL;
 #else
     (void)g;
@@ -28855,6 +28926,12 @@ static bool metal_graph_encode_layer_attention_batch(
                                                   pos0);
                 }
                 metal_graph_attn_comp_prefill_target_free(attn_comp_target);
+            } else if (metal_graph_batch_comp_fuse_defer(g, layer, ratio,
+                                                         pos0, n_tokens,
+                                                         false)) {
+                /* Deferred: the fused per-row loop after the indexer
+                 * projections runs both compressor updates for each row and
+                 * one fused finalize per emit (see the indexer section). */
             } else {
                 for (uint32_t t = 0; ok && t < n_tokens; t++) {
                     const uint32_t pos = pos0 + t;
@@ -28934,16 +29011,41 @@ static bool metal_graph_encode_layer_attention_batch(
                 fprintf(stderr, "ds4: Metal layer-major prefill needs indexer weights\n");
                 ok = false;
             }
+            const bool comp_fuse_defer =
+                metal_graph_batch_comp_fuse_defer(g, layer, ratio, pos0,
+                                                  n_tokens, zero_prefix);
+            /* Under the fused per-row loop the attention compressor rows
+             * staged earlier are still unconsumed, so the indexer
+             * projections land past them in the same staging tensors. */
+            const uint64_t idx_stage_off = comp_fuse_defer
+                ? (uint64_t)n_tokens * (uint64_t)coff *
+                  (uint64_t)DS4_N_HEAD_DIM * sizeof(float)
+                : 0u;
             if (ok) {
-                ok = ds4_gpu_matmul_f16_tensor(metal_graph_batch_comp_kv(g),
-                                                 model->map,
-                                                 model->size,
-                                                 layer->indexer_compressor_kv->abs_offset,
-                                                 DS4_N_EMBD,
-                                                 index_width,
-                                                 metal_graph_batch_attn_norm(g),
-                                                 n_tokens) != 0;
-                if (ok) ok = ds4_gpu_matmul_f16_tensor(metal_graph_batch_comp_sc(g),
+                ds4_gpu_tensor *idx_kv_dst = idx_stage_off
+                    ? ds4_gpu_tensor_view(metal_graph_batch_comp_kv(g),
+                                          idx_stage_off,
+                                          (uint64_t)n_tokens * index_width *
+                                              sizeof(float))
+                    : metal_graph_batch_comp_kv(g);
+                ds4_gpu_tensor *idx_sc_dst = idx_stage_off
+                    ? ds4_gpu_tensor_view(metal_graph_batch_comp_sc(g),
+                                          idx_stage_off,
+                                          (uint64_t)n_tokens * index_width *
+                                              sizeof(float))
+                    : metal_graph_batch_comp_sc(g);
+                ok = idx_kv_dst && idx_sc_dst;
+                if (ok) {
+                    ok = ds4_gpu_matmul_f16_tensor(idx_kv_dst,
+                                                     model->map,
+                                                     model->size,
+                                                     layer->indexer_compressor_kv->abs_offset,
+                                                     DS4_N_EMBD,
+                                                     index_width,
+                                                     metal_graph_batch_attn_norm(g),
+                                                     n_tokens) != 0;
+                }
+                if (ok) ok = ds4_gpu_matmul_f16_tensor(idx_sc_dst,
                                                          model->map,
                                                          model->size,
                                                          layer->indexer_compressor_gate->abs_offset,
@@ -28951,17 +29053,21 @@ static bool metal_graph_encode_layer_attention_batch(
                                                          index_width,
                                                          metal_graph_batch_attn_norm(g),
                                                          n_tokens) != 0;
+                if (ok) metal_graph_debug_dump_tensor("indexer_comp_kv_raw",
+                                                      idx_kv_dst,
+                                                      (uint64_t)index_width * n_tokens,
+                                                      il,
+                                                      pos0);
+                if (ok) metal_graph_debug_dump_tensor("indexer_comp_score_raw",
+                                                      idx_sc_dst,
+                                                      (uint64_t)index_width * n_tokens,
+                                                      il,
+                                                      pos0);
+                if (idx_stage_off) {
+                    ds4_gpu_tensor_free(idx_sc_dst);
+                    ds4_gpu_tensor_free(idx_kv_dst);
+                }
             }
-            if (ok) metal_graph_debug_dump_tensor("indexer_comp_kv_raw",
-                                                  metal_graph_batch_comp_kv(g),
-                                                  (uint64_t)index_width * n_tokens,
-                                                  il,
-                                                  pos0);
-            if (ok) metal_graph_debug_dump_tensor("indexer_comp_score_raw",
-                                                  metal_graph_batch_comp_sc(g),
-                                                  (uint64_t)index_width * n_tokens,
-                                                  il,
-                                                  pos0);
             if (ok) ok = metal_graph_matmul_plain_tensor(metal_graph_batch_indexer_q(g),
                                                           model,
                                                           layer->indexer_attn_q_b,
@@ -29156,6 +29262,137 @@ static bool metal_graph_encode_layer_attention_batch(
                                                       pos0);
                     }
                     ds4_gpu_tensor_free(index_view);
+                } else if (comp_fuse_defer) {
+                    /* Fused per-row loop (Wave B): both compressor updates
+                     * run with deferred finalization, then each emit row is
+                     * finalized by one kernel_dsv4_comp_row_finalize_f32
+                     * dispatch — attention row on staging row 0 (decode
+                     * semantics, safe because the finalize precedes the next
+                     * emit's pool), indexer row in place, plus both ratio-4
+                     * state shifts.  Bit-exact per the kernel's contract. */
+                    const uint32_t attn_comp_width = coff * DS4_N_HEAD_DIM;
+                    for (uint32_t t = 0; ok && t < n_tokens; t++) {
+                        const uint32_t pos = pos0 + t;
+                        const bool emit = ((pos + 1u) % ratio) == 0u;
+                        if (emit &&
+                            (g->layer_n_comp[il] >= g->layer_comp_cap[il] ||
+                             g->layer_n_index_comp[il] >= g->layer_comp_cap[il])) {
+                            fprintf(stderr, "ds4: Metal graph compressed KV cache capacity exceeded at layer %u\n", il);
+                            ok = false;
+                            break;
+                        }
+                        const uint32_t comp_row = g->layer_n_comp[il];
+                        const uint32_t index_row = g->layer_n_index_comp[il];
+                        ds4_gpu_tensor *akv = metal_graph_tensor_row_view(
+                                metal_graph_batch_comp_kv(g), t, attn_comp_width);
+                        ds4_gpu_tensor *asc = metal_graph_tensor_row_view(
+                                metal_graph_batch_comp_sc(g), t, attn_comp_width);
+                        ok = akv && asc &&
+                             ds4_gpu_compressor_update_tensor(akv,
+                                                                asc,
+                                                                g->layer_attn_state_kv[il],
+                                                                g->layer_attn_state_score[il],
+                                                                metal_graph_attn_comp_update_target(g, il),
+                                                                model->map,
+                                                                model->size,
+                                                                layer->attn_compressor_ape->abs_offset,
+                                                                layer->attn_compressor_ape->type,
+                                                                layer->attn_compressor_norm->abs_offset,
+                                                                layer->attn_compressor_norm->type,
+                                                                DS4_N_HEAD_DIM,
+                                                                ratio,
+                                                                pos,
+                                                                metal_graph_attn_comp_update_row(comp_row),
+                                                                DS4_N_ROT,
+                                                                compressed ? (uint32_t)DS4_ROPE_ORIG_CTX : 0,
+                                                                freq_base,
+                                                                freq_scale,
+                                                                ext_factor,
+                                                                attn_factor,
+                                                                DS4_ROPE_YARN_BETA_FAST,
+                                                                DS4_ROPE_YARN_BETA_SLOW,
+                                                                DS4_RMS_EPS,
+                                                                false,
+                                                                false,
+                                                                true) != 0;
+                        ds4_gpu_tensor_free(asc);
+                        ds4_gpu_tensor_free(akv);
+                        if (ok) {
+                            ds4_gpu_tensor *ikv = ds4_gpu_tensor_view(
+                                    metal_graph_batch_comp_kv(g),
+                                    idx_stage_off +
+                                        (uint64_t)t * index_width * sizeof(float),
+                                    (uint64_t)index_width * sizeof(float));
+                            ds4_gpu_tensor *isc = ds4_gpu_tensor_view(
+                                    metal_graph_batch_comp_sc(g),
+                                    idx_stage_off +
+                                        (uint64_t)t * index_width * sizeof(float),
+                                    (uint64_t)index_width * sizeof(float));
+                            ok = ikv && isc &&
+                                 ds4_gpu_compressor_update_tensor(ikv,
+                                                                    isc,
+                                                                    g->layer_index_state_kv[il],
+                                                                    g->layer_index_state_score[il],
+                                                                    g->layer_index_comp_cache[il],
+                                                                    model->map,
+                                                                    model->size,
+                                                                    layer->indexer_compressor_ape->abs_offset,
+                                                                    layer->indexer_compressor_ape->type,
+                                                                    layer->indexer_compressor_norm->abs_offset,
+                                                                    layer->indexer_compressor_norm->type,
+                                                                    DS4_N_INDEXER_HEAD_DIM,
+                                                                    ratio,
+                                                                    pos,
+                                                                    index_row,
+                                                                    DS4_N_ROT,
+                                                                    compressed ? (uint32_t)DS4_ROPE_ORIG_CTX : 0,
+                                                                    freq_base,
+                                                                    freq_scale,
+                                                                    ext_factor,
+                                                                    attn_factor,
+                                                                    DS4_ROPE_YARN_BETA_FAST,
+                                                                    DS4_ROPE_YARN_BETA_SLOW,
+                                                                    DS4_RMS_EPS,
+                                                                    false,
+                                                                    false,
+                                                                    true) != 0;
+                            ds4_gpu_tensor_free(isc);
+                            ds4_gpu_tensor_free(ikv);
+                        }
+                        if (ok && emit) {
+                            ok = ds4_gpu_dsv4_comp_row_finalize_tensor(
+                                    metal_graph_attn_comp_stage(g),
+                                    g->layer_attn_comp_cache[il],
+                                    comp_row,
+                                    layer->attn_compressor_norm->abs_offset,
+                                    g->layer_index_comp_cache[il],
+                                    index_row,
+                                    layer->indexer_compressor_norm->abs_offset,
+                                    g->layer_attn_state_kv[il],
+                                    g->layer_attn_state_score[il],
+                                    g->layer_index_state_kv[il],
+                                    g->layer_index_state_score[il],
+                                    model->map,
+                                    model->size,
+                                    pos + 1u - ratio,
+                                    DS4_N_ROT,
+                                    compressed ? (uint32_t)DS4_ROPE_ORIG_CTX : 0u,
+                                    freq_base,
+                                    freq_scale,
+                                    ext_factor,
+                                    attn_factor,
+                                    DS4_ROPE_YARN_BETA_FAST,
+                                    DS4_ROPE_YARN_BETA_SLOW,
+                                    DS4_RMS_EPS) == 1;
+                        }
+                        if (ok && emit) {
+                            g->layer_n_comp[il]++;
+                            g->layer_n_index_comp[il]++;
+                        }
+                        if (comp_counts) comp_counts[t] = g->layer_n_comp[il];
+                        if (index_counts) index_counts[t] = g->layer_n_index_comp[il];
+                    }
+                    n_comp = g->layer_n_comp[il];
                 } else {
                     for (uint32_t t = 0; ok && t < n_tokens; t++) {
                         const uint32_t pos = pos0 + t;
@@ -35336,6 +35573,7 @@ static bool metal_graph_prefill_chunked(
 typedef struct ds4_verify_suffix_timing {
     double upload_ms;
     double layer_ms;
+    double gpu_busy_ms; /* GPU-side share of layer_ms; needs DS4_METAL_GPU_BUSY_PROFILE */
     double head_ms;
     double read_ms;
     bool fused_head;
@@ -35410,6 +35648,10 @@ static bool metal_graph_verify_suffix_tops_impl(
                         n_tokens <= (uint32_t)DS4_TP_BATCH_MAX_ROWS)
                        ? n_tokens : 0;
     const double layer_t0 = timing ? now_sec() : 0.0;
+#if defined(__APPLE__)
+    const double layer_busy_t0 =
+        timing ? ds4_gpu_busy_profile_seconds() : 0.0;
+#endif
     ok = ds4_gpu_begin_commands() != 0;
     const bool dspark_capture_active =
         ok &&
@@ -35457,8 +35699,14 @@ static bool metal_graph_verify_suffix_tops_impl(
 #if defined(__APPLE__)
         /* Tiny DFlash batches are expensive enough to keep Metal busy while
          * the host encodes the next layers. Submit short prefixes to overlap
-         * that work without changing the verifier's kernels or arithmetic. */
-        if (ok && capture_dspark_hidden && !verify_profile &&
+         * that work without changing the verifier's kernels or arithmetic.
+         * Experimental: the same overlap applies to every small verify block
+         * (n-gram speculation runs with capture off), so do not require the
+         * DSpark hidden-state capture; DS4_METAL_DISABLE_SPEC_VERIFY_FLUSH
+         * restores the old capture-only behavior for A/B runs. */
+        if (ok && (capture_dspark_hidden ||
+                   getenv("DS4_METAL_DISABLE_SPEC_VERIFY_FLUSH") == NULL) &&
+            !verify_profile &&
             !selected_profile && g->tp_world != 2 &&
             ((il + 1u) % 4u) == 0u) {
             ok = ds4_gpu_flush_commands() != 0;
@@ -35492,7 +35740,13 @@ static bool metal_graph_verify_suffix_tops_impl(
     if (!ok && dspark_capture_active) {
         metal_graph_dspark_capture_invalidate(g);
     }
-    if (timing) timing->layer_ms += (now_sec() - layer_t0) * 1000.0;
+    if (timing) {
+        timing->layer_ms += (now_sec() - layer_t0) * 1000.0;
+#if defined(__APPLE__)
+        timing->gpu_busy_ms +=
+            (ds4_gpu_busy_profile_seconds() - layer_busy_t0) * 1000.0;
+#endif
+    }
     if (!ok) return false;
     if (selected_profile) {
         metal_graph_selected_profile_summary_impl(
@@ -49260,6 +49514,7 @@ typedef struct ds4_dspark_spec_stats {
     double verify_ms;
     double verify_upload_ms;
     double verify_layer_ms;
+    double verify_gpu_busy_ms;
     double verify_head_ms;
     double verify_read_ms;
     uint64_t verifier_fused_head;
@@ -50982,6 +51237,24 @@ int ds4_engine_mtp_draft_tokens(ds4_engine *e) {
         e->dspark &&
         e->dspark_weights.block_size > 1) {
         return (int)e->dspark_weights.block_size;
+    }
+    /* Experimental n-gram (prompt-lookup) speculation drives the same
+     * speculative entry points without any support model.  DS4_NGRAM_SPEC=N
+     * sets the draft block size.  --quality keeps target-only decoding,
+     * matching the DSpark contract. */
+    if (e &&
+        e->backend != DS4_BACKEND_CPU &&
+        e->distributed.role == DS4_DISTRIBUTED_NONE &&
+        e->support_kind == DS4_SUPPORT_NONE &&
+        !e->quality &&
+        !e->ssd_streaming &&
+        !e->tp.active) {
+        const char *env = getenv("DS4_NGRAM_SPEC");
+        if (env && env[0]) {
+            int n = atoi(env);
+            if (n > DS4_DSPARK_MAX_BLOCK_SIZE) n = DS4_DSPARK_MAX_BLOCK_SIZE;
+            if (n > 1) return n;
+        }
     }
 #endif
     return 0;
@@ -58421,7 +58694,8 @@ static void ds4_session_print_dspark_stats(const ds4_session *s) {
             "prop_chain=%.3f prop_hidden=%.3f prop_conf0=%.3f "
             "prop_logits=%.3f prop_markov=%.3f prop_confidence=%.3f "
             "snapshot=%.3f verify=%.3f verify_upload=%.3f "
-            "verify_layer=%.3f verify_head=%.3f verify_read=%.3f "
+            "verify_layer=%.3f verify_gpu_busy=%.3f "
+            "verify_head=%.3f verify_read=%.3f "
             "verify_fused_head=%llu replay=%.3f spec_total=%.3f "
             "target=%.3f saved=%.3f net_saved=%.3f "
             "draft_len_hist=%s accepted_len_hist=%s\n",
@@ -58458,6 +58732,7 @@ static void ds4_session_print_dspark_stats(const ds4_session *s) {
             st->verify_ms,
             st->verify_upload_ms,
             st->verify_layer_ms,
+            st->verify_gpu_busy_ms,
             st->verify_head_ms,
             st->verify_read_ms,
             (unsigned long long)st->verifier_fused_head,
@@ -58637,6 +58912,8 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
     const bool need_spec_verifier =
         e->mtp_ready ||
         (e->support_kind == DS4_SUPPORT_DSPARK && e->dspark) ||
+        (e->support_kind == DS4_SUPPORT_NONE &&
+         getenv("DS4_NGRAM_SPEC") != NULL) ||
         e->tp.active; /* TP worker mirrors the leader's verify blocks */
     const int *placement = e->multi_tier ? e->placement : NULL;
     const ds4_gpu_graph *shared_prefill_workspace =
@@ -62745,6 +63022,7 @@ static int ds4_session_eval_dspark_speculative_argmax(
             s->dspark_stats.verify_ms += (now_sec() - verify_t0) * 1000.0;
             s->dspark_stats.verify_upload_ms += verify_timing.upload_ms;
             s->dspark_stats.verify_layer_ms += verify_timing.layer_ms;
+            s->dspark_stats.verify_gpu_busy_ms += verify_timing.gpu_busy_ms;
             s->dspark_stats.verify_head_ms += verify_timing.head_ms;
             s->dspark_stats.verify_read_ms += verify_timing.read_ms;
             if (verify_timing.fused_head) {
@@ -63009,6 +63287,375 @@ static int ds4_session_eval_dspark_speculative_argmax(
     DS4_DSPARK_STATS_FINISH();
 #undef DS4_DSPARK_SCHED_EXTRA_MS
 #undef DS4_DSPARK_STATS_FINISH
+    return n_accept;
+}
+
+/* -------------------------------------------------------------------------
+ * Experimental n-gram (prompt-lookup) speculation.
+ *
+ * Drafts come from the session token history instead of a support model:
+ * when the tail of the transcript repeats an earlier n-gram, the tokens
+ * that followed that occurrence are proposed and checked with the same
+ * batched verifier used by DSpark.  A missing draft costs nothing, no
+ * support GGUF is needed, and greedy output is exact by construction:
+ * every committed token equals the target argmax.  Opt-in via
+ * DS4_NGRAM_SPEC=N (block size, 2..16; 5 keeps partial accepts on the
+ * cheap prefix-frontier path).  DS4_NGRAM_MIN_MATCH=M sets the minimum
+ * suffix match (default 3).  Stats reuse the DSpark counters, so run with
+ * DS4_DSPARK_STATS=1 to see acceptance rates. */
+
+static int ds4_ngram_spec_tokens(void) {
+    const char *env = getenv("DS4_NGRAM_SPEC");
+    if (!env || !env[0]) return 0;
+    int n = atoi(env);
+    if (n < 2) return 0;
+    if (n > DS4_DSPARK_MAX_BLOCK_SIZE) n = DS4_DSPARK_MAX_BLOCK_SIZE;
+    return n;
+}
+
+static int ds4_ngram_min_match(void) {
+    const char *env = getenv("DS4_NGRAM_MIN_MATCH");
+    int n = (env && env[0]) ? atoi(env) : 3;
+    if (n < 1) n = 1;
+    if (n > 16) n = 16;
+    return n;
+}
+
+/* Longest-then-most-recent suffix match over the token history; copies up
+ * to draft_cap continuation tokens into drafts.  O(len * max_match) worst
+ * case, sub-millisecond at the context sizes this prototype targets. */
+static int ds4_ngram_propose(const ds4_tokens *tokens, int min_match,
+                             int draft_cap, int *drafts) {
+    if (!tokens || !tokens->v || draft_cap <= 0) return 0;
+    const int len = tokens->len;
+    if (len < min_match + 1) return 0;
+    const int *v = tokens->v;
+    const int max_match = 24;
+    int best_len = 0;
+    int best_pos = -1; /* exclusive end of the earlier occurrence */
+    for (int i = len - 1; i >= min_match; i--) {
+        if (v[i - 1] != v[len - 1]) continue;
+        int k = 1;
+        while (k < max_match && k < i && v[i - 1 - k] == v[len - 1 - k]) k++;
+        if (k >= min_match && k > best_len) {
+            best_len = k;
+            best_pos = i;
+            if (k >= max_match) break;
+        }
+    }
+    if (best_pos < 0) return 0;
+    int n = len - best_pos;
+    if (n > draft_cap) n = draft_cap;
+    /* Measured on M1 Ultra: with the current ~110 ms fixed verify cost the
+     * profitable regime is full-length high-confidence blocks; truncating
+     * weak matches to the prefix-slot window multiplied low-yield verifies
+     * and lost ~13% end-to-end, so drafts always use the full cap. */
+    for (int j = 0; j < n; j++) drafts[j] = v[best_pos + j];
+    return n;
+}
+
+static int ds4_session_eval_ngram_speculative_argmax(
+        ds4_session *s,
+        int          n_accept,
+        int          max_tokens,
+        int          eos_token,
+        int         *accepted,
+        int          accepted_cap,
+        char        *err,
+        size_t       errlen) {
+    const bool spec_log = getenv("DS4_NGRAM_SPEC_LOG") != NULL;
+    const bool stats_enabled = s && ds4_dspark_stats_enabled();
+    const double stats_t0 = stats_enabled ? now_sec() : 0.0;
+#define DS4_NGRAM_STATS_FINISH() do {                                       \
+        if (stats_enabled) {                                                \
+            s->dspark_stats.total_ms += (now_sec() - stats_t0) * 1000.0;    \
+        }                                                                   \
+    } while (0)
+    if (stats_enabled) {
+        s->dspark_stats.cycles++;
+        if (n_accept > 0) s->dspark_stats.first_tokens++;
+    }
+
+    int draft_cap = ds4_ngram_spec_tokens();
+    if (draft_cap > max_tokens - n_accept) draft_cap = max_tokens - n_accept;
+    if (draft_cap > accepted_cap - n_accept) draft_cap = accepted_cap - n_accept;
+    const int room = s->ctx_size - s->checkpoint.len;
+    if (draft_cap > room - 1) draft_cap = room - 1;
+    if (draft_cap < 2) {
+        if (stats_enabled) {
+            s->dspark_stats.no_room++;
+            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
+        }
+        DS4_NGRAM_STATS_FINISH();
+        return n_accept;
+    }
+
+    int drafts[DS4_DSPARK_MAX_BLOCK_SIZE];
+    int draft_n;
+    /* Test hook: DS4_NGRAM_FAKE_PROPOSAL forces a verify on every token.
+     * The first draft is the live argmax (always passes the free check) and
+     * the rest are throwaway ids, so exactly one token commits per cycle:
+     * the output stream matches plain greedy decode while the verifier runs
+     * at full block width each step.  This is the harness for benchmarking
+     * and bit-comparing verifier implementations. */
+    if (getenv("DS4_NGRAM_FAKE_PROPOSAL") != NULL) {
+        draft_n = draft_cap;
+        drafts[0] = sample_argmax(s->logits, DS4_N_VOCAB);
+        for (int i = 1; i < draft_n; i++) {
+            drafts[i] = (drafts[0] + i) % (int)DS4_N_VOCAB;
+        }
+    } else {
+        draft_n = ds4_ngram_propose(&s->checkpoint, ds4_ngram_min_match(),
+                                    draft_cap, drafts);
+    }
+    /* Never draft across a stop or thinking-control token: the history the
+     * n-gram copies from contains previous turn boundaries, and committing
+     * one mid-block would leave overshoot tokens in the live KV that
+     * incremental callers (the agent) cannot cheaply retract. The real stop
+     * is left for the caller to sample and handle before any eval. */
+    for (int i = 0; i < draft_n; i++) {
+        if (ds4_token_is_stop(s->engine, drafts[i]) ||
+            ds4_token_is_thinking_control(s->engine, drafts[i])) {
+            draft_n = i;
+            break;
+        }
+    }
+    /* A single-token draft is exactly one ordinary decode; only blocks of
+     * two or more repay the batched verifier. */
+    if (draft_n < 2) {
+        if (stats_enabled) {
+            s->dspark_stats.no_draft++;
+            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
+        }
+        if (spec_log) fprintf(stderr, "ds4: ngram spec skip no-draft\n");
+        DS4_NGRAM_STATS_FINISH();
+        return n_accept;
+    }
+    if (stats_enabled) {
+        s->dspark_stats.proposed_tokens += (uint64_t)draft_n;
+        ds4_dspark_stats_note_len(s->dspark_stats.draft_len_hist,
+                                  (uint32_t)draft_n);
+    }
+
+    /* The live logits already score the next position: the first draft is
+     * checked for free, and an EOS continuation is left to the caller. */
+    const int target_top = sample_argmax(s->logits, DS4_N_VOCAB);
+    if (target_top != drafts[0] || drafts[0] == eos_token) {
+        if (stats_enabled) {
+            s->dspark_stats.first_misses++;
+            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
+        }
+        if (spec_log) {
+            fprintf(stderr, "ds4: ngram spec miss first draft=%d base=%d\n",
+                    drafts[0], target_top);
+        }
+        DS4_NGRAM_STATS_FINISH();
+        return n_accept;
+    }
+
+    ds4_engine *e = s->engine;
+    ds4_spec_frontier frontier;
+    memset(&frontier, 0, sizeof(frontier));
+    int row_tops_buf[DS4_DSPARK_MAX_BLOCK_SIZE];
+    int *row_tops = row_tops_buf;
+    float *row_logits = s->spec_row_logits;
+    const int start = s->checkpoint.len;
+    bool have_frontier = spec_frontier_snapshot(&frontier, s);
+    bool ok = have_frontier && row_logits != NULL;
+    bool verifier_may_have_mutated = false;
+    if (ok) {
+        for (int i = 0; i < draft_n; i++) {
+            token_vec_push(&s->checkpoint, drafts[i]);
+        }
+        verifier_may_have_mutated = true;
+        ds4_verify_suffix_timing verify_timing;
+        const double verify_t0 = stats_enabled ? now_sec() : 0.0;
+        ok = metal_graph_verify_suffix_tops(&s->graph,
+                                            &e->model,
+                                            &e->weights,
+                                            &s->checkpoint,
+                                            (uint32_t)start,
+                                            (uint32_t)draft_n,
+                                            draft_n <=
+                                                (int)DS4_SPEC_PREFIX_SLOTS + 1,
+                                            false,
+                                            row_tops,
+                                            NULL,
+                                            stats_enabled ? &verify_timing
+                                                          : NULL);
+        if (stats_enabled) {
+            s->dspark_stats.verify_ms += (now_sec() - verify_t0) * 1000.0;
+            s->dspark_stats.verify_upload_ms += verify_timing.upload_ms;
+            s->dspark_stats.verify_layer_ms += verify_timing.layer_ms;
+            s->dspark_stats.verify_gpu_busy_ms += verify_timing.gpu_busy_ms;
+            s->dspark_stats.verify_head_ms += verify_timing.head_ms;
+            s->dspark_stats.verify_read_ms += verify_timing.read_ms;
+        }
+    }
+
+    int commit_drafts = 0;
+    if (ok) {
+        commit_drafts = 1;
+        for (int i = 1; i < draft_n; i++) {
+            if (row_tops[i - 1] != drafts[i]) break;
+            commit_drafts++;
+        }
+    }
+
+    bool final_logits_ok = false;
+    if (ok && commit_drafts == draft_n) {
+        final_logits_ok = metal_graph_read_spec_logits_row(
+                &s->graph, (uint32_t)(draft_n - 1), row_logits);
+    }
+    if (ok && commit_drafts == draft_n && final_logits_ok) {
+        memcpy(s->logits, row_logits,
+               (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
+        int emitted = 0;
+        for (int i = 0; i < draft_n && n_accept < accepted_cap; i++) {
+            accepted[n_accept++] = drafts[i];
+            emitted++;
+            if (drafts[i] == eos_token) break;
+        }
+        s->checkpoint_valid = true;
+        if (stats_enabled) {
+            s->dspark_stats.full_accepts++;
+            s->dspark_stats.direct_full_commits++;
+            s->dspark_stats.accepted_draft_tokens += (uint64_t)emitted;
+            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist,
+                                      (uint32_t)emitted);
+        }
+        if (spec_log) {
+            fprintf(stderr, "ds4: ngram spec direct-full drafted=%d accepted=%d\n",
+                    draft_n, n_accept);
+        }
+        spec_frontier_free(&frontier);
+        DS4_NGRAM_STATS_FINISH();
+        return n_accept;
+    }
+
+    if (ok && commit_drafts > 0 && commit_drafts < draft_n &&
+        commit_drafts <= (int)DS4_SPEC_PREFIX_SLOTS) {
+        bool prefix_ok = metal_graph_read_spec_logits_row(
+                &s->graph, (uint32_t)(commit_drafts - 1), row_logits);
+        s->checkpoint.len = start;
+        if (prefix_ok) {
+            prefix_ok = spec_frontier_commit_prefix(s, (uint32_t)commit_drafts);
+        }
+        if (prefix_ok) {
+            memcpy(s->logits, row_logits,
+                   (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
+            int emitted = 0;
+            for (int i = 0; i < commit_drafts && n_accept < accepted_cap; i++) {
+                token_vec_push(&s->checkpoint, drafts[i]);
+                accepted[n_accept++] = drafts[i];
+                emitted++;
+                if (drafts[i] == eos_token) break;
+            }
+            s->checkpoint_valid = true;
+            if (stats_enabled) {
+                s->dspark_stats.partial_accepts++;
+                s->dspark_stats.direct_partial_commits++;
+                s->dspark_stats.accepted_draft_tokens += (uint64_t)emitted;
+                ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist,
+                                          (uint32_t)emitted);
+            }
+            if (spec_log) {
+                fprintf(stderr,
+                        "ds4: ngram spec direct-partial drafted=%d committed=%d accepted=%d\n",
+                        draft_n, emitted, n_accept);
+            }
+            spec_frontier_free(&frontier);
+            DS4_NGRAM_STATS_FINISH();
+            return n_accept;
+        }
+    }
+
+    if (verifier_may_have_mutated) {
+        s->checkpoint.len = start;
+        if (!have_frontier || !spec_frontier_restore(&frontier, s)) {
+            snprintf(err, errlen, "ngram verifier rollback failed");
+            s->checkpoint_valid = false;
+            if (stats_enabled) {
+                s->dspark_stats.verifier_errors++;
+                ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
+            }
+            spec_frontier_free(&frontier);
+            DS4_NGRAM_STATS_FINISH();
+            return -1;
+        }
+    }
+
+    if (!ok) {
+        if (stats_enabled) {
+            s->dspark_stats.verifier_unavailable++;
+            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
+        }
+        if (spec_log) fprintf(stderr, "ds4: ngram spec verifier unavailable\n");
+        spec_frontier_free(&frontier);
+        DS4_NGRAM_STATS_FINISH();
+        return n_accept;
+    }
+
+    /* Rollback happened above; replay the verified prefix through ordinary
+     * decode so the committed state matches one-token execution exactly. */
+    int replay_budget = commit_drafts;
+    if (replay_budget > accepted_cap - n_accept) {
+        replay_budget = accepted_cap - n_accept;
+    }
+    if (replay_budget < 0) replay_budget = 0;
+    for (int i = 0; i < replay_budget; i++) {
+        if (drafts[i] == eos_token) { replay_budget = i + 1; break; }
+    }
+    int replayed = 0;
+    if (stats_enabled && replay_budget > 0) {
+        s->dspark_stats.replay_fallbacks++;
+    }
+    for (int i = 0; i < replay_budget; i++) {
+        ok = metal_graph_eval_token_raw_swa(&s->graph,
+                                            &e->model,
+                                            &e->weights,
+                                            drafts[i],
+                                            (uint32_t)s->checkpoint.len,
+                                            row_logits);
+        if (!ok) {
+            snprintf(err, errlen, "%s decode failed",
+                     ds4_backend_name(e->backend));
+            s->checkpoint_valid = false;
+            if (stats_enabled) {
+                s->dspark_stats.verifier_errors++;
+                ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
+            }
+            spec_frontier_free(&frontier);
+            DS4_NGRAM_STATS_FINISH();
+            return -1;
+        }
+        token_vec_push(&s->checkpoint, drafts[i]);
+        accepted[n_accept++] = drafts[i];
+        replayed++;
+        if (drafts[i] == eos_token) break;
+    }
+    if (replayed > 0) {
+        memcpy(s->logits, row_logits,
+               (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
+        s->checkpoint_valid = true;
+        if (stats_enabled) {
+            if (replayed == draft_n) s->dspark_stats.full_accepts++;
+            else s->dspark_stats.partial_accepts++;
+            s->dspark_stats.accepted_draft_tokens += (uint64_t)replayed;
+            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist,
+                                      (uint32_t)replayed);
+        }
+    } else if (stats_enabled) {
+        ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
+    }
+    if (spec_log) {
+        fprintf(stderr,
+                "ds4: ngram spec partial drafted=%d verified=%d accepted=%d\n",
+                draft_n, commit_drafts, n_accept);
+    }
+    spec_frontier_free(&frontier);
+    DS4_NGRAM_STATS_FINISH();
+#undef DS4_NGRAM_STATS_FINISH
     return n_accept;
 }
 #endif
@@ -66055,6 +66702,24 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                                                           accepted_cap,
                                                           err,
                                                           errlen);
+    }
+
+    if (e->support_kind == DS4_SUPPORT_NONE &&
+        !e->mtp_ready && !e->tp.active && !s->distributed &&
+        !e->quality &&
+        /* The spec verifier machinery is not provisioned under SSD
+         * streaming (measured: every block reports verifier_unavailable),
+         * so skip the proposal work entirely there. */
+        !e->ssd_streaming &&
+        ds4_ngram_spec_tokens() > 1) {
+        return ds4_session_eval_ngram_speculative_argmax(s,
+                                                         n_accept,
+                                                         max_tokens,
+                                                         eos_token,
+                                                         accepted,
+                                                         accepted_cap,
+                                                         err,
+                                                         errlen);
     }
 
     if (metal_graph_cuda_splitkv_spec_requested() &&

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -8442,6 +8442,53 @@ static int worker_accept_generated_token(agent_worker *w,
     return 0;
 }
 
+/* Same bookkeeping as worker_accept_generated_token for a token that the
+ * speculative verifier has already evaluated and committed to the live KV:
+ * transcript, trace, stream rendering, and status only — no second eval. */
+static int worker_accept_verified_token(agent_worker *w,
+                                        int token,
+                                        int *generated,
+                                        double t0,
+                                        agent_stream_renderer *stream) {
+    ds4_tokens_push(&w->transcript, token);
+
+    size_t text_len = 0;
+    char *text = ds4_token_text(w->engine, token, &text_len);
+    agent_trace_token(w, token, text, text_len, *generated + 1);
+    agent_stream_text(stream, text, text_len, false);
+    free(text);
+    (*generated)++;
+
+    double dt = now_sec() - t0;
+    pthread_mutex_lock(&w->mu);
+    w->status.generated = *generated;
+    w->status.gen_tps = dt > 0.0 ? (double)*generated / dt : 0.0;
+    agent_wake_locked(w);
+    pthread_mutex_unlock(&w->mu);
+    return 0;
+}
+
+/* Speculative decoding gate for the agent turn loop. Blocks are used only
+ * for fully greedy turns, only in plain text (never while DSML syntax is
+ * buffered, active, or being parsed, so a block cannot skip the per-token
+ * grammar checks that end the turn), and are capped at 8 drafts so a block
+ * that happens to enter a tool stanza cannot also complete it. Returns the
+ * accepted-token capacity (first token + drafts), or 0 to decode normally. */
+static int agent_speculative_block_cap(const agent_worker *w,
+                                       const agent_config *cfg,
+                                       const agent_stream_renderer *sr,
+                                       const agent_dsml_parser *dsml) {
+    if (cfg->gen.temperature > 0.0f) return 0;
+    if (getenv("DS4_MTP_SPEC_DISABLE") != NULL) return 0;
+    int n = ds4_engine_mtp_draft_tokens(w->engine);
+    if (n <= 1) return 0;
+    if (!sr || !dsml) return 0;
+    if (dsml->state != AGENT_DSML_SEARCH) return 0;
+    if (sr->dsml_active || sr->dsml_start_len > 0) return 0;
+    if (n > 8) n = 8;
+    return n + 1;
+}
+
 static int worker_force_generated_text(agent_worker *w,
                                        const char *text,
                                        int max_tokens,
@@ -8717,8 +8764,31 @@ static int worker_run_turn(agent_worker *w, const char *user_text) {
                 }
             } else {
                 free(text);
-                if (worker_accept_generated_token(w, token, &generated, t0,
-                                                  &stream, err, sizeof(err)) != 0) {
+                const int spec_cap =
+                    agent_speculative_block_cap(w, cfg, &stream, &dsml);
+                if (spec_cap > 1) {
+                    int spec_toks[9];
+                    int cap = spec_cap;
+                    if (cap > (int)(sizeof(spec_toks) / sizeof(spec_toks[0])))
+                        cap = (int)(sizeof(spec_toks) / sizeof(spec_toks[0]));
+                    int ntok = ds4_session_eval_speculative_argmax(
+                            w->session, token, max_tokens - generated,
+                            ds4_token_eos(w->engine), spec_toks, cap,
+                            err, sizeof(err));
+                    if (ntok < 0) {
+                        agent_dsml_parser_free(&dsml);
+                        agent_set_error(w, err[0] ? err
+                                                  : "speculative decode failed");
+                        return 1;
+                    }
+                    for (int sj = 0; sj < ntok; sj++) {
+                        (void)worker_accept_verified_token(w, spec_toks[sj],
+                                                           &generated, t0,
+                                                           &stream);
+                    }
+                } else if (worker_accept_generated_token(w, token, &generated,
+                                                         t0, &stream, err,
+                                                         sizeof(err)) != 0) {
                     agent_dsml_parser_free(&dsml);
                     agent_set_error(w, err);
                     return 1;

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -109,6 +109,8 @@ int ds4_gpu_tensor_read_after_selected_event(const ds4_gpu_tensor *tensor,
 #endif
 int ds4_gpu_end_commands(void);
 int ds4_gpu_synchronize(void);
+/* Metal only: cumulative GPU busy seconds under DS4_METAL_GPU_BUSY_PROFILE. */
+double ds4_gpu_busy_profile_seconds(void);
 
 int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size);
 int ds4_gpu_set_model_fd(int fd);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -988,6 +988,13 @@ static void ds4_gpu_close_batch_encoder(void) {
 static double g_gpu_busy_accum;
 static uint64_t g_gpu_busy_cbs;
 
+/* Cumulative GPU busy seconds recorded by DS4_METAL_GPU_BUSY_PROFILE.
+ * Callers sample it around a section to split CPU-encode time from GPU
+ * execution time; returns 0 deltas when the profile env is unset. */
+double ds4_gpu_busy_profile_seconds(void) {
+    return g_gpu_busy_accum;
+}
+
 /* A failed command buffer can leave a cross-threadgroup arrival counter at an
  * arbitrary partial value.  Drop cached ownership instead of CPU-resetting
  * buffers that another in-flight command buffer might still reference; bound
@@ -1215,6 +1222,7 @@ static int ds4_gpu_finish_command_buffer(id<MTLCommandBuffer> cb, int owned, con
 }
 
 static int ds4_gpu_device_name_contains(const char *needle);
+static int ds4_gpu_device_is_m3_class(void);
 
 static int ds4_gpu_use_m5_private_scratch(void) {
     static int initialized;
@@ -2012,7 +2020,7 @@ static int ds4_gpu_zero_prefix_prefill_mask_cache_enabled(void) {
         getenv("DS4_METAL_FLASH_ATTN_STAGE_PROFILE") != NULL) {
         return 0;
     }
-    return ds4_gpu_device_name_contains("M3");
+    return ds4_gpu_device_is_m3_class();
 }
 
 static ds4_gpu_zero_prefix_prefill_mask_cache_entry *
@@ -2386,6 +2394,50 @@ int ds4_gpu_device_is_m5_apple_silicon(void) {
             g_metal_device_name[8] == ' ');
 }
 
+/* Experimental A/B switch: treat every pre-M5 device like M3 for the decode
+ * and prefill fusion gates that were only ever validated on M3-class
+ * hardware.  Opt-in via DS4_METAL_WIDEN_M3_GATES=1; each widened fusion
+ * keeps its own DS4_METAL_DISABLE_* rollback so regressions can be bisected
+ * per gate with the bit-exact schedule bench. */
+static int ds4_gpu_device_is_m3_class(void) {
+    /* No caching: the schedule bench flips candidate envs in-process, and
+     * every existing gate re-reads its env on each call for the same reason.
+     * Value-sensitive so DS4_METAL_WIDEN_M3_GATES=0 disables the
+     * device-default applied below on M1/M2. */
+    if (ds4_gpu_env_bool("DS4_METAL_WIDEN_M3_GATES") > 0 &&
+        ds4_gpu_device_is_pre_m5_apple_silicon()) {
+        return 1;
+    }
+    return ds4_gpu_device_name_contains("M3");
+}
+
+/* Per-device default tuning, applied once the Metal device name is known.
+ * setenv(..., overwrite=0) means anything the user exported explicitly
+ * always wins; DS4_NO_DEVICE_DEFAULTS=1 skips the whole block (pure
+ * upstream behavior). Values below were measured on an M1 Ultra (see
+ * EXPERIMENTS_M1_ULTRA.md): the widened fusion tier is bit-exact-verified,
+ * the 2/8 token split beats the M3-tuned adaptive schedule, and n-gram
+ * speculation with min-match 6 is the thinking-safe setting. M3/M4/M5 keep
+ * upstream defaults until someone measures equivalents there. */
+static void ds4_gpu_apply_device_default_env(void) {
+    if (getenv("DS4_NO_DEVICE_DEFAULTS") != NULL) return;
+    const int m1_class =
+        strncmp(g_metal_device_name, "Apple M", 7) == 0 &&
+        (g_metal_device_name[7] == '1' || g_metal_device_name[7] == '2') &&
+        (g_metal_device_name[8] == '\0' || g_metal_device_name[8] == ' ');
+    if (!m1_class) return;
+    setenv("DS4_METAL_WIDEN_M3_GATES", "1", 0);
+    setenv("DS4_METAL_GRAPH_TOKEN_SPLIT_LAYERS", "2", 0);
+    setenv("DS4_METAL_GRAPH_TOKEN_SECOND_SPLIT_LAYERS", "8", 0);
+    setenv("DS4_NGRAM_SPEC", "8", 0);
+    setenv("DS4_NGRAM_MIN_MATCH", "6", 0);
+    fprintf(stderr,
+            "ds4: %s defaults applied (widen M3 gates, token split 2/8, "
+            "ngram spec 8/6); explicit env vars win, "
+            "DS4_NO_DEVICE_DEFAULTS=1 disables\n",
+            g_metal_device_name);
+}
+
 static bool ds4_gpu_ported_m5_decode_feature_enabled(
         const char *pre_m5_disable_env,
         const char *m5_disable_env) {
@@ -2466,6 +2518,7 @@ static void ds4_gpu_detect_metal4_features(void) {
     if (name) {
         snprintf(g_metal_device_name, sizeof(g_metal_device_name), "%s", name);
     }
+    ds4_gpu_apply_device_default_env();
 
     const int metal4_disabled = ds4_gpu_env_bool("DS4_METAL_DISABLE_METAL4") > 0;
 
@@ -3412,7 +3465,7 @@ int ds4_gpu_decode_attn_rope_fuse_available(void) {
     if (g_rope_tail_inplace_pair_affine_pipeline == nil) return 0;
     if (getenv("DS4_METAL_DISABLE_INPLACE_ROPE_PAIR") != NULL) return 0;
     if (getenv("DS4_METAL_DISABLE_AFFINE_ROPE_PAIR") != NULL) return 0;
-    if (!ds4_gpu_device_name_contains("M3") && !ds4_gpu_device_name_contains("M5")) return 0;
+    if (!ds4_gpu_device_is_m3_class() && !ds4_gpu_device_name_contains("M5")) return 0;
     return 1;
 }
 
@@ -5055,7 +5108,37 @@ static int16_t ds4_gpu_mv_ext_nxpsg(uint64_t in_dim, uint64_t n_tok) {
     return 4;
 }
 
+/* r1=6..8 variants keep grid.y at 1 for verify-sized blocks so dense weights
+ * stream once. Measured on M1 Ultra they LOSE ~25% verify throughput despite
+ * being bit-identical: the historical two grid.y slices run concurrently
+ * across cores while r1=8 halves the threadgroup count and spills registers
+ * (8 accumulators per thread). Opt-in via DS4_METAL_ENABLE_MV_EXT_WIDE for
+ * re-testing on wider-register devices (cached; not flippable mid-process). */
+static int ds4_gpu_mv_ext_wide_rows_enabled(void) {
+    static int enabled = -1;
+    if (enabled < 0) {
+        enabled = getenv("DS4_METAL_ENABLE_MV_EXT_WIDE") != NULL ? 1 : 0;
+    }
+    return enabled;
+}
+
+/* The tiny routed-MoE kernels carry the token index in their grid, so the
+ * historical n<=5 / n<=4 gates were coverage limits, not kernel limits.
+ * Widening them to 8 keeps 6..8-row verify blocks off the generic mv path
+ * (two x reads, split gate/up, separate down reduce).
+ * DS4_METAL_DISABLE_MOE_TINY_WIDE restores the old gates (cached). */
+static int ds4_gpu_moe_tiny_wide_enabled(void) {
+    static int enabled = -1;
+    if (enabled < 0) {
+        enabled = getenv("DS4_METAL_DISABLE_MOE_TINY_WIDE") == NULL ? 1 : 0;
+    }
+    return enabled;
+}
+
 static int16_t ds4_gpu_mv_ext_r1ptg(uint64_t n_tok) {
+    if (n_tok >= 6 && n_tok <= 8 && ds4_gpu_mv_ext_wide_rows_enabled()) {
+        return (int16_t)n_tok;
+    }
     switch (n_tok) {
     case 2: return 2;
     case 3:
@@ -5075,6 +5158,9 @@ static const char *ds4_gpu_mv_ext_name(int q8, int16_t r1ptg) {
         case 3: return "kernel_mul_mv_ext_q8_0_f32_r1_3";
         case 4: return "kernel_mul_mv_ext_q8_0_f32_r1_4";
         case 5: return "kernel_mul_mv_ext_q8_0_f32_r1_5";
+        case 6: return "kernel_mul_mv_ext_q8_0_f32_r1_6";
+        case 7: return "kernel_mul_mv_ext_q8_0_f32_r1_7";
+        case 8: return "kernel_mul_mv_ext_q8_0_f32_r1_8";
         default: return NULL;
         }
     }
@@ -5084,6 +5170,9 @@ static const char *ds4_gpu_mv_ext_name(int q8, int16_t r1ptg) {
     case 3: return "kernel_mul_mv_ext_f16_f32_r1_3";
     case 4: return "kernel_mul_mv_ext_f16_f32_r1_4";
     case 5: return "kernel_mul_mv_ext_f16_f32_r1_5";
+    case 6: return "kernel_mul_mv_ext_f16_f32_r1_6";
+    case 7: return "kernel_mul_mv_ext_f16_f32_r1_7";
+    case 8: return "kernel_mul_mv_ext_f16_f32_r1_8";
     default: return NULL;
     }
 }
@@ -5706,7 +5795,7 @@ static int ds4_gpu_encode_rope_tail_inplace(
         getenv("DS4_METAL_DISABLE_INPLACE_ROPE_PAIR") == NULL &&
         args->mode == 0 && !args->src2 &&
         lane_compatible &&
-        (ds4_gpu_device_name_contains("M3") ||
+        (ds4_gpu_device_is_m3_class() ||
          (ds4_gpu_device_name_contains("M5") && n_tok == 1u));
     const bool use_shared_coeff =
         use_inplace_pair &&
@@ -5723,7 +5812,7 @@ static int ds4_gpu_encode_rope_tail_inplace(
         g_rope_tail_inplace_pair_affine_pipeline != nil &&
         getenv("DS4_METAL_DISABLE_AFFINE_ROPE_PAIR") == NULL &&
         n_tok == 1u &&
-        (ds4_gpu_device_name_contains("M3") ||
+        (ds4_gpu_device_is_m3_class() ||
          ds4_gpu_device_name_contains("M5"));
 
     int32_t pos_stack[256];
@@ -12745,6 +12834,12 @@ static int ds4_gpu_stream_expert_alloc_slab_slot(
         g_stream_expert_cache_slab_slot_count[slab] = slots;
         g_stream_expert_cache_slab_slots_used[slab] = 0;
         g_stream_expert_cache_slab_total_slots += slots;
+        /* Measured dead end (M1 Ultra, MXFP4 streaming): bulk-mlocking the
+         * whole slab here to avoid the per-slot mlock on handout is
+         * throughput-neutral — the per-slot lock runs on the async loader
+         * threads, off the token critical path — while doubling the total
+         * mlock work (fresh pages pay zero-fill wiring).  Keep the lazy
+         * per-slot locking. */
     }
 
     const uint32_t local_slot = g_stream_expert_cache_slab_slots_used[slab]++;
@@ -14423,6 +14518,16 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
     *up_inner = 0;
     *down_inner = 0;
 
+    /* Diagnostic split of the prepare cost (DS4_METAL_STREAM_PREPARE_SUBPROFILE):
+     * own-entry handling (inflight waits + clears) vs the reusable-slot
+     * search.  Static accumulators are racy across loader threads, which is
+     * acceptable for an attribution profile. */
+    static double g_prep_sub_own_ms, g_prep_sub_take_ms;
+    static uint64_t g_prep_sub_calls;
+    const int prep_subprof =
+        getenv("DS4_METAL_STREAM_PREPARE_SUBPROFILE") != NULL;
+    const double prep_sub_t0 = prep_subprof ? ds4_gpu_now_ms() : 0.0;
+
     ds4_gpu_stream_expert_reusable_buffers reuse = { nil, nil, nil, 0, 0, 0 };
     ds4_gpu_stream_expert_cache_entry *e =
         &g_stream_expert_cache[layer][expert];
@@ -14452,6 +14557,7 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
         ds4_gpu_stream_expert_cache_clear_entry(layer, expert, 0);
     }
 
+    const double prep_sub_t1 = prep_subprof ? ds4_gpu_now_ms() : 0.0;
     if (!reuse.gate_buffer || !reuse.up_buffer || !reuse.down_buffer) {
         if (!ds4_gpu_stream_expert_cache_take_reusable(force_reuse,
                                                        protect_layer,
@@ -14465,6 +14571,24 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
             reuse.down_buffer = nil;
         }
     }
+    static double g_prep_sub_reusefound_ms;
+    static uint64_t g_prep_sub_reusefound;
+    if (prep_subprof) {
+        const double prep_sub_t2 = ds4_gpu_now_ms();
+        g_prep_sub_own_ms += prep_sub_t1 - prep_sub_t0;
+        g_prep_sub_take_ms += prep_sub_t2 - prep_sub_t1;
+        if ((++g_prep_sub_calls % 2000ull) == 0) {
+            fprintf(stderr,
+                    "ds4: prepare subprofile calls=%llu own_avg=%.3f ms take_avg=%.3f ms reuse_found=%llu reuse_found_total_avg=%.3f ms\n",
+                    (unsigned long long)g_prep_sub_calls,
+                    g_prep_sub_own_ms / (double)g_prep_sub_calls,
+                    g_prep_sub_take_ms / (double)g_prep_sub_calls,
+                    (unsigned long long)g_prep_sub_reusefound,
+                    g_prep_sub_reusefound ?
+                        g_prep_sub_reusefound_ms /
+                            (double)g_prep_sub_reusefound : 0.0);
+        }
+    }
 
     if (reuse.gate_buffer && reuse.up_buffer && reuse.down_buffer) {
         *gate_buf = reuse.gate_buffer;
@@ -14473,8 +14597,44 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
         *gate_inner = reuse.gate_inner;
         *up_inner = reuse.up_inner;
         *down_inner = reuse.down_inner;
+        if (prep_subprof) {
+            g_prep_sub_reusefound++;
+            g_prep_sub_reusefound_ms += ds4_gpu_now_ms() - prep_sub_t0;
+        }
         return 1;
     }
+
+    static uint64_t g_prep_tail_n[5];
+    static double g_prep_tail_ms[5];
+#define DS4_PREP_TAIL_NOTE(idx) do {                                        \
+        if (prep_subprof) {                                                 \
+            g_prep_tail_n[(idx)]++;                                        \
+            g_prep_tail_ms[(idx)] += ds4_gpu_now_ms() - prep_sub_t0;       \
+            if (((g_prep_tail_n[0] + g_prep_tail_n[1] + g_prep_tail_n[2] + \
+                  g_prep_tail_n[3] + g_prep_tail_n[4]) % 2000ull) == 0) {  \
+                fprintf(stderr,                                             \
+                        "ds4: prepare tail capped=%llu/%.3f slab=%llu/%.3f " \
+                        "combined=%llu/%.3f explicit=%llu/%.3f fail=%llu/%.3f (n/avg ms) " \
+                        "mlock_ms=%.1f free_slots=%u total_slots=%u used_last=%u\n", \
+                        (unsigned long long)g_prep_tail_n[0],              \
+                        g_prep_tail_n[0] ? g_prep_tail_ms[0] / g_prep_tail_n[0] : 0.0, \
+                        (unsigned long long)g_prep_tail_n[1],              \
+                        g_prep_tail_n[1] ? g_prep_tail_ms[1] / g_prep_tail_n[1] : 0.0, \
+                        (unsigned long long)g_prep_tail_n[2],              \
+                        g_prep_tail_n[2] ? g_prep_tail_ms[2] / g_prep_tail_n[2] : 0.0, \
+                        (unsigned long long)g_prep_tail_n[3],              \
+                        g_prep_tail_n[3] ? g_prep_tail_ms[3] / g_prep_tail_n[3] : 0.0, \
+                        (unsigned long long)g_prep_tail_n[4],              \
+                        g_prep_tail_n[4] ? g_prep_tail_ms[4] / g_prep_tail_n[4] : 0.0, \
+                        g_stream_expert_cache_mlock_ms,                    \
+                        g_stream_expert_cache_free_slot_count,             \
+                        g_stream_expert_cache_slab_total_slots,            \
+                        g_stream_expert_cache_slab_count ?                 \
+                            g_stream_expert_cache_slab_slots_used[         \
+                                g_stream_expert_cache_slab_count - 1] : 0u); \
+            }                                                               \
+        }                                                                   \
+    } while (0)
 
     if (ds4_gpu_stream_expert_combined_buffer_enabled()) {
         if (gate_expert_bytes > UINT64_MAX - gate_expert_bytes ||
@@ -14483,14 +14643,17 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
             gate_expert_bytes * 2ull > (uint64_t)NSUIntegerMax ||
             gate_expert_bytes * 2ull + down_expert_bytes >
                 (uint64_t)NSUIntegerMax) {
+            DS4_PREP_TAIL_NOTE(4);
             return 0;
         }
         if (g_stream_expert_cache_mlock_budget_cap != 0) {
-            return ds4_gpu_stream_expert_cache_take_capped_reusable(
+            const int capped_rc = ds4_gpu_stream_expert_cache_take_capped_reusable(
                     protect_layer, protect_ids, n_protect,
                     gate_expert_bytes, down_expert_bytes,
                     gate_buf, up_buf, down_buf,
                     gate_inner, up_inner, down_inner);
+            DS4_PREP_TAIL_NOTE(0);
+            return capped_rc;
         }
         if (ds4_gpu_stream_expert_alloc_slab_slot(gate_expert_bytes,
                                                   down_expert_bytes,
@@ -14500,14 +14663,17 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
                                                   gate_inner,
                                                   up_inner,
                                                   down_inner)) {
+            DS4_PREP_TAIL_NOTE(1);
             return 1;
         }
         if (g_stream_expert_cache_mlock_budget_cap != 0) {
-            return ds4_gpu_stream_expert_cache_take_capped_reusable(
+            const int capped_rc = ds4_gpu_stream_expert_cache_take_capped_reusable(
                     protect_layer, protect_ids, n_protect,
                     gate_expert_bytes, down_expert_bytes,
                     gate_buf, up_buf, down_buf,
                     gate_inner, up_inner, down_inner);
+            DS4_PREP_TAIL_NOTE(0);
+            return capped_rc;
         }
         const uint64_t up_off = gate_expert_bytes;
         const uint64_t down_off = gate_expert_bytes * 2ull;
@@ -14516,11 +14682,13 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
             ds4_gpu_stream_expert_alloc_buffer(combined_bytes,
                                                @"ds4_stream_expert_combined");
         if (!combined) {
-            return ds4_gpu_stream_expert_cache_take_capped_reusable(
+            const int capped_rc = ds4_gpu_stream_expert_cache_take_capped_reusable(
                     protect_layer, protect_ids, n_protect,
                     gate_expert_bytes, down_expert_bytes,
                     gate_buf, up_buf, down_buf,
                     gate_inner, up_inner, down_inner);
+            DS4_PREP_TAIL_NOTE(0);
+            return capped_rc;
         }
         *gate_buf = combined;
         *up_buf = combined;
@@ -14528,6 +14696,7 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
         *gate_inner = 0;
         *up_inner = (NSUInteger)up_off;
         *down_inner = (NSUInteger)down_off;
+        DS4_PREP_TAIL_NOTE(2);
         return 1;
     }
 
@@ -14544,16 +14713,20 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
         ds4_gpu_stream_expert_unlock_explicit_buffer(explicit_gate);
         ds4_gpu_stream_expert_unlock_explicit_buffer(explicit_up);
         ds4_gpu_stream_expert_unlock_explicit_buffer(explicit_down);
-        return ds4_gpu_stream_expert_cache_take_capped_reusable(
+        const int capped_rc = ds4_gpu_stream_expert_cache_take_capped_reusable(
                 protect_layer, protect_ids, n_protect,
                 gate_expert_bytes, down_expert_bytes,
                 gate_buf, up_buf, down_buf,
                 gate_inner, up_inner, down_inner);
+        DS4_PREP_TAIL_NOTE(0);
+        return capped_rc;
     }
     *gate_buf = explicit_gate;
     *up_buf = explicit_up;
     *down_buf = explicit_down;
+    DS4_PREP_TAIL_NOTE(3);
     return 1;
+#undef DS4_PREP_TAIL_NOTE
 }
 
 static void ds4_gpu_stream_expert_cache_prune_global(
@@ -19771,7 +19944,7 @@ int ds4_gpu_matmul_f16_pair_compressor_store_tensor(
         uint32_t                pos) {
     if (!g_initialized && !ds4_gpu_init()) return -1;
     if ((g_quality_mode ||
-         (!ds4_gpu_device_name_contains("M3") &&
+         (!ds4_gpu_device_is_m3_class() &&
           !ds4_gpu_device_name_contains("M5"))) ||
         getenv("DS4_METAL_DISABLE_COMPRESSOR_PAIR_PROJ") != NULL ||
         getenv("DS4_METAL_DISABLE_COMPRESSOR_STORE_ONE") != NULL) {
@@ -20623,7 +20796,7 @@ static int ds4_gpu_hc_rms_scale_project_mode(
         (in_dim == 16384u || in_dim == 28672u) && out_dim == 24u;
     if (!hard_shape) return 0;
 
-    if ((!ds4_gpu_device_name_contains("M3") &&
+    if ((!ds4_gpu_device_is_m3_class() &&
          (g_test_flags & DS4_GPU_TEST_HC_RMS_SCALE_PROJ) == 0u) ||
         getenv("DS4_METAL_DISABLE_HC_RMS_SCALE_PROJ") != NULL) {
         return 0;
@@ -21649,7 +21822,7 @@ int ds4_gpu_kv_rope_fp8_fuse_available(void) {
     if (g_rope_tail_inplace_pair_affine_pipeline == nil) return 0;
     if (getenv("DS4_METAL_DISABLE_INPLACE_ROPE_PAIR") != NULL) return 0;
     if (getenv("DS4_METAL_DISABLE_AFFINE_ROPE_PAIR") != NULL) return 0;
-    if (!ds4_gpu_device_name_contains("M3") && !ds4_gpu_device_name_contains("M5")) return 0;
+    if (!ds4_gpu_device_is_m3_class() && !ds4_gpu_device_name_contains("M5")) return 0;
     return 1;
 }
 
@@ -21869,7 +22042,7 @@ static int ds4_gpu_encode_compressor_score_with_ape(
     const uint32_t total_elems = (uint32_t)total_elems64;
 
     const bool use_fused =
-        ds4_gpu_device_name_contains("M3") &&
+        ds4_gpu_device_is_m3_class() &&
         getenv("DS4_METAL_DISABLE_COMPRESSOR_APE_ADD") == NULL;
     if (use_fused) {
         id<MTLComputePipelineState> pipeline = ds4_gpu_get_pipeline(
@@ -22677,7 +22850,7 @@ static int ds4_gpu_encode_concat_f32_dim1(
 static int ds4_gpu_compressor_pack_ratio4_fusion_mode(uint32_t head_dim) {
     const bool default_shape = head_dim == 128u || head_dim == 512u;
     if (getenv("DS4_METAL_DISABLE_COMPRESSOR_RATIO4_PACK_FUSION") != NULL ||
-        !(ds4_gpu_device_name_contains("M3") && default_shape)) {
+        !(ds4_gpu_device_is_m3_class() && default_shape)) {
         return 0;
     }
     if (g_dsv4_compressor_pack_ratio4_pipeline == nil) {
@@ -22723,7 +22896,7 @@ static int ds4_gpu_compressor_ratio4_direct_pool_mode(
 
     const bool default_shape = head_dim == 128u || head_dim == 512u;
     if (getenv("DS4_METAL_DISABLE_COMPRESSOR_RATIO4_DIRECT_POOL") != NULL ||
-        !(ds4_gpu_device_name_contains("M3") && default_shape)) {
+        !(ds4_gpu_device_is_m3_class() && default_shape)) {
         return 0;
     }
     if (g_dsv4_softmax_pool_ratio4_direct_pipeline == nil) {
@@ -25757,7 +25930,7 @@ static int ds4_gpu_encode_flash_kv_stage_f16(
         supported_shape && valid_grid && !g_quality_mode &&
         getenv("DS4_METAL_DISABLE_GATHERED_KV_STAGE") == NULL &&
         g_flash_kv_stage_f16_pipeline != nil &&
-        (ds4_gpu_device_name_contains("M3") ||
+        (ds4_gpu_device_is_m3_class() ||
          ds4_gpu_device_name_contains("M5"));
     const bool component_disabled = eligible &&
         (ds4_gpu_env_bool("DS4_METAL_DISABLE_CONTIG_F32_F16_COPY") > 0 ||
@@ -27532,7 +27705,7 @@ static int ds4_gpu_encode_flash_attention_gathered_heads(
          getenv("DS4_METAL_DISABLE_M5_PACKED_ZERO_MASK") == NULL);
     const bool use_persistent_zero_mask =
         use_mask == 0u &&
-        (ds4_gpu_device_name_contains("M3") ||
+        (ds4_gpu_device_is_m3_class() ||
          m5_persistent_zero_mask) &&
         getenv("DS4_METAL_DISABLE_PERSISTENT_ZERO_ATTN_MASK") == NULL;
 
@@ -27563,7 +27736,7 @@ static int ds4_gpu_encode_flash_attention_gathered_heads(
     const bool has_kvpad = (n_keys % ncpsg) != 0;
     const bool use_shared_kvpad =
         has_kvpad &&
-        ds4_gpu_device_name_contains("M3") &&
+        ds4_gpu_device_is_m3_class() &&
         getenv("DS4_METAL_DISABLE_SHARED_KV_PAD") == NULL;
     const NSUInteger packed_threads = 8u * 32u;
     const NSUInteger packed_shared_bytes =
@@ -32096,7 +32269,7 @@ static int ds4_gpu_encode_router_select(
     const bool use_batch_weights_fusion =
         flash_router_fast_path && !g_quality_mode && n_tokens > 1u &&
         g_dsv4_router_weights_batch_pipeline != nil &&
-        ds4_gpu_device_name_contains("M3") &&
+        ds4_gpu_device_is_m3_class() &&
         getenv("DS4_METAL_DISABLE_ROUTER_WEIGHTS_BATCH_FUSION") == NULL &&
         getenv("DS4_METAL_DISABLE_ROUTER_SELECT_FUSION") == NULL;
     if (use_batch_weights_fusion) {
@@ -40663,7 +40836,7 @@ int ds4_gpu_routed_moe_batch_tensor(
          */
         const bool use_tiny_pair_mv =
             !g_quality_mode &&
-            n_tokens <= 5u &&
+            n_tokens <= (ds4_gpu_moe_tiny_wide_enabled() ? 8u : 5u) &&
             !use_q4_batch_expert_table &&
             !use_mm_id &&
             ((gate_type == DS4_METAL_TENSOR_IQ2_XXS && g_moe_mul_mv_id_iq2_xxs_pair_pipeline) ||
@@ -41151,7 +41324,7 @@ int ds4_gpu_routed_moe_batch_tensor(
             !use_q4_batch_expert_table &&
             !use_mm_id &&
             n_expert == 6 &&
-            n_tokens <= 4u &&
+            n_tokens <= (ds4_gpu_moe_tiny_wide_enabled() ? 8u : 4u) &&
             down_sum6_pipeline != nil;
         int ok = 0;
         if (use_iq2_batch_selected_addr) {
@@ -42426,7 +42599,7 @@ int ds4_gpu_output_hc_weights_tensor(
         const bool use_weights4 =
             weights4_shape && !g_quality_mode &&
             g_output_hc_weights4_pipeline != nil &&
-            (ds4_gpu_device_name_contains("M3") ||
+            (ds4_gpu_device_is_m3_class() ||
              (g_test_flags & DS4_GPU_TEST_OUTPUT_HC_WEIGHTS4) != 0u) &&
             g_output_hc_weights4_pipeline.maxTotalThreadsPerThreadgroup >= 2u;
         if (require_weights4 && weights4_shape && !use_weights4) {

--- a/m1_ultra_patches.diff
+++ b/m1_ultra_patches.diff
@@ -1,0 +1,1475 @@
+diff --git a/ds4.c b/ds4.c
+index 449140b..74080c0 100644
+--- a/ds4.c
++++ b/ds4.c
+@@ -26878,6 +26878,66 @@ static uint32_t metal_graph_token_adaptive_split_after_layers(
+     return split_after_layers;
+ }
+ 
++/* Batch-verifier compressor emit fusion (Wave B).
++ *
++ * The non-aligned batch compressor path runs a per-row loop whose emit rows
++ * pay ~12 tiny single-row dispatches per layer (norm, RoPE, FP8, commit, QAT
++ * and two state shifts across the attention and indexer compressors).  The
++ * decode path already fuses all of that into one bit-exact dispatch
++ * (kernel_dsv4_comp_row_finalize_f32).  This predicate gates reusing that
++ * kernel from the batch loops: it needs the same shape/type invariants as
++ * the decode fusion, must not run under prefix-frontier capture (the fused
++ * kernel also performs the ratio-4 state shifts, which capture would have to
++ * snapshot mid-loop), and skips the aligned-chunk path which is already
++ * batched.  Rollback: DS4_METAL_DISABLE_BATCH_COMP_FINALIZE_FUSE. */
++static bool metal_graph_batch_comp_fuse_defer(
++        const ds4_gpu_graph     *g,
++        const ds4_layer_weights *layer,
++        uint32_t                 ratio,
++        uint32_t                 pos0,
++        uint32_t                 n_tokens,
++        bool                     zero_prefix) {
++#if defined(__APPLE__)
++    if (zero_prefix || ratio != 4u || !DS4_GPU_ATTN_COMP_CACHE_F16) return false;
++    /* Verify-sized blocks only: resumed-prefill chunks also reach this
++     * non-aligned batch path (arbitrary pos0 after a live checkpoint), and
++     * there the per-row fused loop would be both slower than the aligned
++     * replay and larger than the shared staging tensor can offset. */
++    if (n_tokens > (uint32_t)DS4_DSPARK_MAX_BLOCK_SIZE) return false;
++    if (!g || g->spec_capture_prefixes) return false;
++    if (g->ssd_streaming || g->ssd_streaming_cold) return false;
++    const bool aligned_chunk =
++        getenv("DS4_CUDA_NO_COMPRESSOR_PREFILL_BATCH") == NULL &&
++        !g->spec_capture_prefixes &&
++        (pos0 % ratio) == 0u && (n_tokens % ratio) == 0u;
++    if (aligned_chunk) return false;
++    if (DS4_N_HEAD_DIM != 512u || DS4_N_INDEXER_HEAD_DIM != 128u) return false;
++    if (!layer || !layer->attn_compressor_norm ||
++        layer->attn_compressor_norm->type != DS4_TENSOR_F32 ||
++        !layer->indexer_compressor_norm ||
++        layer->indexer_compressor_norm->type != DS4_TENSOR_F32 ||
++        !layer->indexer_compressor_kv || !layer->indexer_compressor_gate ||
++        !layer->indexer_compressor_ape) {
++        return false;
++    }
++    if (ds4_gpu_kv_rope_fp8_fuse_available() == 0) return false;
++    if (!metal_graph_ported_m5_decode_feature_enabled(
++            "DS4_METAL_DISABLE_PRE_M5_COMP_FINALIZE_FUSE",
++            "DS4_METAL_DISABLE_M5_COMP_FINALIZE_FUSE")) {
++        return false;
++    }
++    return getenv("DS4_METAL_DISABLE_BATCH_COMP_FINALIZE_FUSE") == NULL;
++#else
++    (void)g;
++    (void)layer;
++    (void)ratio;
++    (void)pos0;
++    (void)n_tokens;
++    (void)zero_prefix;
++    return false;
++#endif
++}
++
+ static DS4_MAYBE_UNUSED bool metal_graph_decode_pipeline_fast_lookup_eligible(
+         const ds4_gpu_graph *g,
+         const ds4_weights   *weights,
+@@ -26906,7 +26966,18 @@ static DS4_MAYBE_UNUSED bool metal_graph_decode_pipeline_fast_lookup_eligible(
+         layer->ffn_gate_exps->type == DS4_TENSOR_MXFP4 &&
+         layer->ffn_up_exps->type == DS4_TENSOR_MXFP4 &&
+         layer->ffn_down_exps->type == DS4_TENSOR_MXFP4;
+-    return mxfp4_routed && ds4_gpu_device_is_pre_m5_apple_silicon() &&
++    /* Experimental A/B: the fast cache mirrors the slow cache key
++     * ("name_nsg=%d"), so it is layout agnostic; let the IQ2_XXS/Q2_K
++     * routed layout opt in to measure the encode-time win. */
++    const bool q2_routed_opt_in =
++        getenv("DS4_METAL_ENABLE_Q2_PIPELINE_FAST_LOOKUP") != NULL &&
++        layer->ffn_gate_exps && layer->ffn_up_exps &&
++        layer->ffn_down_exps &&
++        layer->ffn_gate_exps->type == DS4_TENSOR_IQ2_XXS &&
++        layer->ffn_up_exps->type == DS4_TENSOR_IQ2_XXS &&
++        layer->ffn_down_exps->type == DS4_TENSOR_Q2_K;
++    return (mxfp4_routed || q2_routed_opt_in) &&
++           ds4_gpu_device_is_pre_m5_apple_silicon() &&
+            getenv("DS4_METAL_DISABLE_PRE_M5_DECODE_PIPELINE_FAST_LOOKUP") == NULL;
+ #else
+     (void)g;
+@@ -28855,6 +28926,12 @@ static bool metal_graph_encode_layer_attention_batch(
+                                                   pos0);
+                 }
+                 metal_graph_attn_comp_prefill_target_free(attn_comp_target);
++            } else if (metal_graph_batch_comp_fuse_defer(g, layer, ratio,
++                                                         pos0, n_tokens,
++                                                         false)) {
++                /* Deferred: the fused per-row loop after the indexer
++                 * projections runs both compressor updates for each row and
++                 * one fused finalize per emit (see the indexer section). */
+             } else {
+                 for (uint32_t t = 0; ok && t < n_tokens; t++) {
+                     const uint32_t pos = pos0 + t;
+@@ -28934,16 +29011,41 @@ static bool metal_graph_encode_layer_attention_batch(
+                 fprintf(stderr, "ds4: Metal layer-major prefill needs indexer weights\n");
+                 ok = false;
+             }
++            const bool comp_fuse_defer =
++                metal_graph_batch_comp_fuse_defer(g, layer, ratio, pos0,
++                                                  n_tokens, zero_prefix);
++            /* Under the fused per-row loop the attention compressor rows
++             * staged earlier are still unconsumed, so the indexer
++             * projections land past them in the same staging tensors. */
++            const uint64_t idx_stage_off = comp_fuse_defer
++                ? (uint64_t)n_tokens * (uint64_t)coff *
++                  (uint64_t)DS4_N_HEAD_DIM * sizeof(float)
++                : 0u;
+             if (ok) {
+-                ok = ds4_gpu_matmul_f16_tensor(metal_graph_batch_comp_kv(g),
+-                                                 model->map,
+-                                                 model->size,
+-                                                 layer->indexer_compressor_kv->abs_offset,
+-                                                 DS4_N_EMBD,
+-                                                 index_width,
+-                                                 metal_graph_batch_attn_norm(g),
+-                                                 n_tokens) != 0;
+-                if (ok) ok = ds4_gpu_matmul_f16_tensor(metal_graph_batch_comp_sc(g),
++                ds4_gpu_tensor *idx_kv_dst = idx_stage_off
++                    ? ds4_gpu_tensor_view(metal_graph_batch_comp_kv(g),
++                                          idx_stage_off,
++                                          (uint64_t)n_tokens * index_width *
++                                              sizeof(float))
++                    : metal_graph_batch_comp_kv(g);
++                ds4_gpu_tensor *idx_sc_dst = idx_stage_off
++                    ? ds4_gpu_tensor_view(metal_graph_batch_comp_sc(g),
++                                          idx_stage_off,
++                                          (uint64_t)n_tokens * index_width *
++                                              sizeof(float))
++                    : metal_graph_batch_comp_sc(g);
++                ok = idx_kv_dst && idx_sc_dst;
++                if (ok) {
++                    ok = ds4_gpu_matmul_f16_tensor(idx_kv_dst,
++                                                     model->map,
++                                                     model->size,
++                                                     layer->indexer_compressor_kv->abs_offset,
++                                                     DS4_N_EMBD,
++                                                     index_width,
++                                                     metal_graph_batch_attn_norm(g),
++                                                     n_tokens) != 0;
++                }
++                if (ok) ok = ds4_gpu_matmul_f16_tensor(idx_sc_dst,
+                                                          model->map,
+                                                          model->size,
+                                                          layer->indexer_compressor_gate->abs_offset,
+@@ -28951,17 +29053,21 @@ static bool metal_graph_encode_layer_attention_batch(
+                                                          index_width,
+                                                          metal_graph_batch_attn_norm(g),
+                                                          n_tokens) != 0;
++                if (ok) metal_graph_debug_dump_tensor("indexer_comp_kv_raw",
++                                                      idx_kv_dst,
++                                                      (uint64_t)index_width * n_tokens,
++                                                      il,
++                                                      pos0);
++                if (ok) metal_graph_debug_dump_tensor("indexer_comp_score_raw",
++                                                      idx_sc_dst,
++                                                      (uint64_t)index_width * n_tokens,
++                                                      il,
++                                                      pos0);
++                if (idx_stage_off) {
++                    ds4_gpu_tensor_free(idx_sc_dst);
++                    ds4_gpu_tensor_free(idx_kv_dst);
++                }
+             }
+-            if (ok) metal_graph_debug_dump_tensor("indexer_comp_kv_raw",
+-                                                  metal_graph_batch_comp_kv(g),
+-                                                  (uint64_t)index_width * n_tokens,
+-                                                  il,
+-                                                  pos0);
+-            if (ok) metal_graph_debug_dump_tensor("indexer_comp_score_raw",
+-                                                  metal_graph_batch_comp_sc(g),
+-                                                  (uint64_t)index_width * n_tokens,
+-                                                  il,
+-                                                  pos0);
+             if (ok) ok = metal_graph_matmul_plain_tensor(metal_graph_batch_indexer_q(g),
+                                                           model,
+                                                           layer->indexer_attn_q_b,
+@@ -29156,6 +29262,137 @@ static bool metal_graph_encode_layer_attention_batch(
+                                                       pos0);
+                     }
+                     ds4_gpu_tensor_free(index_view);
++                } else if (comp_fuse_defer) {
++                    /* Fused per-row loop (Wave B): both compressor updates
++                     * run with deferred finalization, then each emit row is
++                     * finalized by one kernel_dsv4_comp_row_finalize_f32
++                     * dispatch — attention row on staging row 0 (decode
++                     * semantics, safe because the finalize precedes the next
++                     * emit's pool), indexer row in place, plus both ratio-4
++                     * state shifts.  Bit-exact per the kernel's contract. */
++                    const uint32_t attn_comp_width = coff * DS4_N_HEAD_DIM;
++                    for (uint32_t t = 0; ok && t < n_tokens; t++) {
++                        const uint32_t pos = pos0 + t;
++                        const bool emit = ((pos + 1u) % ratio) == 0u;
++                        if (emit &&
++                            (g->layer_n_comp[il] >= g->layer_comp_cap[il] ||
++                             g->layer_n_index_comp[il] >= g->layer_comp_cap[il])) {
++                            fprintf(stderr, "ds4: Metal graph compressed KV cache capacity exceeded at layer %u\n", il);
++                            ok = false;
++                            break;
++                        }
++                        const uint32_t comp_row = g->layer_n_comp[il];
++                        const uint32_t index_row = g->layer_n_index_comp[il];
++                        ds4_gpu_tensor *akv = metal_graph_tensor_row_view(
++                                metal_graph_batch_comp_kv(g), t, attn_comp_width);
++                        ds4_gpu_tensor *asc = metal_graph_tensor_row_view(
++                                metal_graph_batch_comp_sc(g), t, attn_comp_width);
++                        ok = akv && asc &&
++                             ds4_gpu_compressor_update_tensor(akv,
++                                                                asc,
++                                                                g->layer_attn_state_kv[il],
++                                                                g->layer_attn_state_score[il],
++                                                                metal_graph_attn_comp_update_target(g, il),
++                                                                model->map,
++                                                                model->size,
++                                                                layer->attn_compressor_ape->abs_offset,
++                                                                layer->attn_compressor_ape->type,
++                                                                layer->attn_compressor_norm->abs_offset,
++                                                                layer->attn_compressor_norm->type,
++                                                                DS4_N_HEAD_DIM,
++                                                                ratio,
++                                                                pos,
++                                                                metal_graph_attn_comp_update_row(comp_row),
++                                                                DS4_N_ROT,
++                                                                compressed ? (uint32_t)DS4_ROPE_ORIG_CTX : 0,
++                                                                freq_base,
++                                                                freq_scale,
++                                                                ext_factor,
++                                                                attn_factor,
++                                                                DS4_ROPE_YARN_BETA_FAST,
++                                                                DS4_ROPE_YARN_BETA_SLOW,
++                                                                DS4_RMS_EPS,
++                                                                false,
++                                                                false,
++                                                                true) != 0;
++                        ds4_gpu_tensor_free(asc);
++                        ds4_gpu_tensor_free(akv);
++                        if (ok) {
++                            ds4_gpu_tensor *ikv = ds4_gpu_tensor_view(
++                                    metal_graph_batch_comp_kv(g),
++                                    idx_stage_off +
++                                        (uint64_t)t * index_width * sizeof(float),
++                                    (uint64_t)index_width * sizeof(float));
++                            ds4_gpu_tensor *isc = ds4_gpu_tensor_view(
++                                    metal_graph_batch_comp_sc(g),
++                                    idx_stage_off +
++                                        (uint64_t)t * index_width * sizeof(float),
++                                    (uint64_t)index_width * sizeof(float));
++                            ok = ikv && isc &&
++                                 ds4_gpu_compressor_update_tensor(ikv,
++                                                                    isc,
++                                                                    g->layer_index_state_kv[il],
++                                                                    g->layer_index_state_score[il],
++                                                                    g->layer_index_comp_cache[il],
++                                                                    model->map,
++                                                                    model->size,
++                                                                    layer->indexer_compressor_ape->abs_offset,
++                                                                    layer->indexer_compressor_ape->type,
++                                                                    layer->indexer_compressor_norm->abs_offset,
++                                                                    layer->indexer_compressor_norm->type,
++                                                                    DS4_N_INDEXER_HEAD_DIM,
++                                                                    ratio,
++                                                                    pos,
++                                                                    index_row,
++                                                                    DS4_N_ROT,
++                                                                    compressed ? (uint32_t)DS4_ROPE_ORIG_CTX : 0,
++                                                                    freq_base,
++                                                                    freq_scale,
++                                                                    ext_factor,
++                                                                    attn_factor,
++                                                                    DS4_ROPE_YARN_BETA_FAST,
++                                                                    DS4_ROPE_YARN_BETA_SLOW,
++                                                                    DS4_RMS_EPS,
++                                                                    false,
++                                                                    false,
++                                                                    true) != 0;
++                            ds4_gpu_tensor_free(isc);
++                            ds4_gpu_tensor_free(ikv);
++                        }
++                        if (ok && emit) {
++                            ok = ds4_gpu_dsv4_comp_row_finalize_tensor(
++                                    metal_graph_attn_comp_stage(g),
++                                    g->layer_attn_comp_cache[il],
++                                    comp_row,
++                                    layer->attn_compressor_norm->abs_offset,
++                                    g->layer_index_comp_cache[il],
++                                    index_row,
++                                    layer->indexer_compressor_norm->abs_offset,
++                                    g->layer_attn_state_kv[il],
++                                    g->layer_attn_state_score[il],
++                                    g->layer_index_state_kv[il],
++                                    g->layer_index_state_score[il],
++                                    model->map,
++                                    model->size,
++                                    pos + 1u - ratio,
++                                    DS4_N_ROT,
++                                    compressed ? (uint32_t)DS4_ROPE_ORIG_CTX : 0u,
++                                    freq_base,
++                                    freq_scale,
++                                    ext_factor,
++                                    attn_factor,
++                                    DS4_ROPE_YARN_BETA_FAST,
++                                    DS4_ROPE_YARN_BETA_SLOW,
++                                    DS4_RMS_EPS) == 1;
++                        }
++                        if (ok && emit) {
++                            g->layer_n_comp[il]++;
++                            g->layer_n_index_comp[il]++;
++                        }
++                        if (comp_counts) comp_counts[t] = g->layer_n_comp[il];
++                        if (index_counts) index_counts[t] = g->layer_n_index_comp[il];
++                    }
++                    n_comp = g->layer_n_comp[il];
+                 } else {
+                     for (uint32_t t = 0; ok && t < n_tokens; t++) {
+                         const uint32_t pos = pos0 + t;
+@@ -35336,6 +35573,7 @@ static bool metal_graph_prefill_chunked(
+ typedef struct ds4_verify_suffix_timing {
+     double upload_ms;
+     double layer_ms;
++    double gpu_busy_ms; /* GPU-side share of layer_ms; needs DS4_METAL_GPU_BUSY_PROFILE */
+     double head_ms;
+     double read_ms;
+     bool fused_head;
+@@ -35410,6 +35648,10 @@ static bool metal_graph_verify_suffix_tops_impl(
+                         n_tokens <= (uint32_t)DS4_TP_BATCH_MAX_ROWS)
+                        ? n_tokens : 0;
+     const double layer_t0 = timing ? now_sec() : 0.0;
++#if defined(__APPLE__)
++    const double layer_busy_t0 =
++        timing ? ds4_gpu_busy_profile_seconds() : 0.0;
++#endif
+     ok = ds4_gpu_begin_commands() != 0;
+     const bool dspark_capture_active =
+         ok &&
+@@ -35457,8 +35699,14 @@ static bool metal_graph_verify_suffix_tops_impl(
+ #if defined(__APPLE__)
+         /* Tiny DFlash batches are expensive enough to keep Metal busy while
+          * the host encodes the next layers. Submit short prefixes to overlap
+-         * that work without changing the verifier's kernels or arithmetic. */
+-        if (ok && capture_dspark_hidden && !verify_profile &&
++         * that work without changing the verifier's kernels or arithmetic.
++         * Experimental: the same overlap applies to every small verify block
++         * (n-gram speculation runs with capture off), so do not require the
++         * DSpark hidden-state capture; DS4_METAL_DISABLE_SPEC_VERIFY_FLUSH
++         * restores the old capture-only behavior for A/B runs. */
++        if (ok && (capture_dspark_hidden ||
++                   getenv("DS4_METAL_DISABLE_SPEC_VERIFY_FLUSH") == NULL) &&
++            !verify_profile &&
+             !selected_profile && g->tp_world != 2 &&
+             ((il + 1u) % 4u) == 0u) {
+             ok = ds4_gpu_flush_commands() != 0;
+@@ -35492,7 +35740,13 @@ static bool metal_graph_verify_suffix_tops_impl(
+     if (!ok && dspark_capture_active) {
+         metal_graph_dspark_capture_invalidate(g);
+     }
+-    if (timing) timing->layer_ms += (now_sec() - layer_t0) * 1000.0;
++    if (timing) {
++        timing->layer_ms += (now_sec() - layer_t0) * 1000.0;
++#if defined(__APPLE__)
++        timing->gpu_busy_ms +=
++            (ds4_gpu_busy_profile_seconds() - layer_busy_t0) * 1000.0;
++#endif
++    }
+     if (!ok) return false;
+     if (selected_profile) {
+         metal_graph_selected_profile_summary_impl(
+@@ -49260,6 +49514,7 @@ typedef struct ds4_dspark_spec_stats {
+     double verify_ms;
+     double verify_upload_ms;
+     double verify_layer_ms;
++    double verify_gpu_busy_ms;
+     double verify_head_ms;
+     double verify_read_ms;
+     uint64_t verifier_fused_head;
+@@ -50983,6 +51238,24 @@ int ds4_engine_mtp_draft_tokens(ds4_engine *e) {
+         e->dspark_weights.block_size > 1) {
+         return (int)e->dspark_weights.block_size;
+     }
++    /* Experimental n-gram (prompt-lookup) speculation drives the same
++     * speculative entry points without any support model.  DS4_NGRAM_SPEC=N
++     * sets the draft block size.  --quality keeps target-only decoding,
++     * matching the DSpark contract. */
++    if (e &&
++        e->backend != DS4_BACKEND_CPU &&
++        e->distributed.role == DS4_DISTRIBUTED_NONE &&
++        e->support_kind == DS4_SUPPORT_NONE &&
++        !e->quality &&
++        !e->ssd_streaming &&
++        !e->tp.active) {
++        const char *env = getenv("DS4_NGRAM_SPEC");
++        if (env && env[0]) {
++            int n = atoi(env);
++            if (n > DS4_DSPARK_MAX_BLOCK_SIZE) n = DS4_DSPARK_MAX_BLOCK_SIZE;
++            if (n > 1) return n;
++        }
++    }
+ #endif
+     return 0;
+ }
+@@ -58421,7 +58694,8 @@ static void ds4_session_print_dspark_stats(const ds4_session *s) {
+             "prop_chain=%.3f prop_hidden=%.3f prop_conf0=%.3f "
+             "prop_logits=%.3f prop_markov=%.3f prop_confidence=%.3f "
+             "snapshot=%.3f verify=%.3f verify_upload=%.3f "
+-            "verify_layer=%.3f verify_head=%.3f verify_read=%.3f "
++            "verify_layer=%.3f verify_gpu_busy=%.3f "
++            "verify_head=%.3f verify_read=%.3f "
+             "verify_fused_head=%llu replay=%.3f spec_total=%.3f "
+             "target=%.3f saved=%.3f net_saved=%.3f "
+             "draft_len_hist=%s accepted_len_hist=%s\n",
+@@ -58458,6 +58732,7 @@ static void ds4_session_print_dspark_stats(const ds4_session *s) {
+             st->verify_ms,
+             st->verify_upload_ms,
+             st->verify_layer_ms,
++            st->verify_gpu_busy_ms,
+             st->verify_head_ms,
+             st->verify_read_ms,
+             (unsigned long long)st->verifier_fused_head,
+@@ -58637,6 +58912,8 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
+     const bool need_spec_verifier =
+         e->mtp_ready ||
+         (e->support_kind == DS4_SUPPORT_DSPARK && e->dspark) ||
++        (e->support_kind == DS4_SUPPORT_NONE &&
++         getenv("DS4_NGRAM_SPEC") != NULL) ||
+         e->tp.active; /* TP worker mirrors the leader's verify blocks */
+     const int *placement = e->multi_tier ? e->placement : NULL;
+     const ds4_gpu_graph *shared_prefill_workspace =
+@@ -62745,6 +63022,7 @@ static int ds4_session_eval_dspark_speculative_argmax(
+             s->dspark_stats.verify_ms += (now_sec() - verify_t0) * 1000.0;
+             s->dspark_stats.verify_upload_ms += verify_timing.upload_ms;
+             s->dspark_stats.verify_layer_ms += verify_timing.layer_ms;
++            s->dspark_stats.verify_gpu_busy_ms += verify_timing.gpu_busy_ms;
+             s->dspark_stats.verify_head_ms += verify_timing.head_ms;
+             s->dspark_stats.verify_read_ms += verify_timing.read_ms;
+             if (verify_timing.fused_head) {
+@@ -63011,6 +63289,375 @@ static int ds4_session_eval_dspark_speculative_argmax(
+ #undef DS4_DSPARK_STATS_FINISH
+     return n_accept;
+ }
++
++/* -------------------------------------------------------------------------
++ * Experimental n-gram (prompt-lookup) speculation.
++ *
++ * Drafts come from the session token history instead of a support model:
++ * when the tail of the transcript repeats an earlier n-gram, the tokens
++ * that followed that occurrence are proposed and checked with the same
++ * batched verifier used by DSpark.  A missing draft costs nothing, no
++ * support GGUF is needed, and greedy output is exact by construction:
++ * every committed token equals the target argmax.  Opt-in via
++ * DS4_NGRAM_SPEC=N (block size, 2..16; 5 keeps partial accepts on the
++ * cheap prefix-frontier path).  DS4_NGRAM_MIN_MATCH=M sets the minimum
++ * suffix match (default 3).  Stats reuse the DSpark counters, so run with
++ * DS4_DSPARK_STATS=1 to see acceptance rates. */
++
++static int ds4_ngram_spec_tokens(void) {
++    const char *env = getenv("DS4_NGRAM_SPEC");
++    if (!env || !env[0]) return 0;
++    int n = atoi(env);
++    if (n < 2) return 0;
++    if (n > DS4_DSPARK_MAX_BLOCK_SIZE) n = DS4_DSPARK_MAX_BLOCK_SIZE;
++    return n;
++}
++
++static int ds4_ngram_min_match(void) {
++    const char *env = getenv("DS4_NGRAM_MIN_MATCH");
++    int n = (env && env[0]) ? atoi(env) : 3;
++    if (n < 1) n = 1;
++    if (n > 16) n = 16;
++    return n;
++}
++
++/* Longest-then-most-recent suffix match over the token history; copies up
++ * to draft_cap continuation tokens into drafts.  O(len * max_match) worst
++ * case, sub-millisecond at the context sizes this prototype targets. */
++static int ds4_ngram_propose(const ds4_tokens *tokens, int min_match,
++                             int draft_cap, int *drafts) {
++    if (!tokens || !tokens->v || draft_cap <= 0) return 0;
++    const int len = tokens->len;
++    if (len < min_match + 1) return 0;
++    const int *v = tokens->v;
++    const int max_match = 24;
++    int best_len = 0;
++    int best_pos = -1; /* exclusive end of the earlier occurrence */
++    for (int i = len - 1; i >= min_match; i--) {
++        if (v[i - 1] != v[len - 1]) continue;
++        int k = 1;
++        while (k < max_match && k < i && v[i - 1 - k] == v[len - 1 - k]) k++;
++        if (k >= min_match && k > best_len) {
++            best_len = k;
++            best_pos = i;
++            if (k >= max_match) break;
++        }
++    }
++    if (best_pos < 0) return 0;
++    int n = len - best_pos;
++    if (n > draft_cap) n = draft_cap;
++    /* Measured on M1 Ultra: with the current ~110 ms fixed verify cost the
++     * profitable regime is full-length high-confidence blocks; truncating
++     * weak matches to the prefix-slot window multiplied low-yield verifies
++     * and lost ~13% end-to-end, so drafts always use the full cap. */
++    for (int j = 0; j < n; j++) drafts[j] = v[best_pos + j];
++    return n;
++}
++
++static int ds4_session_eval_ngram_speculative_argmax(
++        ds4_session *s,
++        int          n_accept,
++        int          max_tokens,
++        int          eos_token,
++        int         *accepted,
++        int          accepted_cap,
++        char        *err,
++        size_t       errlen) {
++    const bool spec_log = getenv("DS4_NGRAM_SPEC_LOG") != NULL;
++    const bool stats_enabled = s && ds4_dspark_stats_enabled();
++    const double stats_t0 = stats_enabled ? now_sec() : 0.0;
++#define DS4_NGRAM_STATS_FINISH() do {                                       \
++        if (stats_enabled) {                                                \
++            s->dspark_stats.total_ms += (now_sec() - stats_t0) * 1000.0;    \
++        }                                                                   \
++    } while (0)
++    if (stats_enabled) {
++        s->dspark_stats.cycles++;
++        if (n_accept > 0) s->dspark_stats.first_tokens++;
++    }
++
++    int draft_cap = ds4_ngram_spec_tokens();
++    if (draft_cap > max_tokens - n_accept) draft_cap = max_tokens - n_accept;
++    if (draft_cap > accepted_cap - n_accept) draft_cap = accepted_cap - n_accept;
++    const int room = s->ctx_size - s->checkpoint.len;
++    if (draft_cap > room - 1) draft_cap = room - 1;
++    if (draft_cap < 2) {
++        if (stats_enabled) {
++            s->dspark_stats.no_room++;
++            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
++        }
++        DS4_NGRAM_STATS_FINISH();
++        return n_accept;
++    }
++
++    int drafts[DS4_DSPARK_MAX_BLOCK_SIZE];
++    int draft_n;
++    /* Test hook: DS4_NGRAM_FAKE_PROPOSAL forces a verify on every token.
++     * The first draft is the live argmax (always passes the free check) and
++     * the rest are throwaway ids, so exactly one token commits per cycle:
++     * the output stream matches plain greedy decode while the verifier runs
++     * at full block width each step.  This is the harness for benchmarking
++     * and bit-comparing verifier implementations. */
++    if (getenv("DS4_NGRAM_FAKE_PROPOSAL") != NULL) {
++        draft_n = draft_cap;
++        drafts[0] = sample_argmax(s->logits, DS4_N_VOCAB);
++        for (int i = 1; i < draft_n; i++) {
++            drafts[i] = (drafts[0] + i) % (int)DS4_N_VOCAB;
++        }
++    } else {
++        draft_n = ds4_ngram_propose(&s->checkpoint, ds4_ngram_min_match(),
++                                    draft_cap, drafts);
++    }
++    /* Never draft across a stop or thinking-control token: the history the
++     * n-gram copies from contains previous turn boundaries, and committing
++     * one mid-block would leave overshoot tokens in the live KV that
++     * incremental callers (the agent) cannot cheaply retract. The real stop
++     * is left for the caller to sample and handle before any eval. */
++    for (int i = 0; i < draft_n; i++) {
++        if (ds4_token_is_stop(s->engine, drafts[i]) ||
++            ds4_token_is_thinking_control(s->engine, drafts[i])) {
++            draft_n = i;
++            break;
++        }
++    }
++    /* A single-token draft is exactly one ordinary decode; only blocks of
++     * two or more repay the batched verifier. */
++    if (draft_n < 2) {
++        if (stats_enabled) {
++            s->dspark_stats.no_draft++;
++            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
++        }
++        if (spec_log) fprintf(stderr, "ds4: ngram spec skip no-draft\n");
++        DS4_NGRAM_STATS_FINISH();
++        return n_accept;
++    }
++    if (stats_enabled) {
++        s->dspark_stats.proposed_tokens += (uint64_t)draft_n;
++        ds4_dspark_stats_note_len(s->dspark_stats.draft_len_hist,
++                                  (uint32_t)draft_n);
++    }
++
++    /* The live logits already score the next position: the first draft is
++     * checked for free, and an EOS continuation is left to the caller. */
++    const int target_top = sample_argmax(s->logits, DS4_N_VOCAB);
++    if (target_top != drafts[0] || drafts[0] == eos_token) {
++        if (stats_enabled) {
++            s->dspark_stats.first_misses++;
++            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
++        }
++        if (spec_log) {
++            fprintf(stderr, "ds4: ngram spec miss first draft=%d base=%d\n",
++                    drafts[0], target_top);
++        }
++        DS4_NGRAM_STATS_FINISH();
++        return n_accept;
++    }
++
++    ds4_engine *e = s->engine;
++    ds4_spec_frontier frontier;
++    memset(&frontier, 0, sizeof(frontier));
++    int row_tops_buf[DS4_DSPARK_MAX_BLOCK_SIZE];
++    int *row_tops = row_tops_buf;
++    float *row_logits = s->spec_row_logits;
++    const int start = s->checkpoint.len;
++    bool have_frontier = spec_frontier_snapshot(&frontier, s);
++    bool ok = have_frontier && row_logits != NULL;
++    bool verifier_may_have_mutated = false;
++    if (ok) {
++        for (int i = 0; i < draft_n; i++) {
++            token_vec_push(&s->checkpoint, drafts[i]);
++        }
++        verifier_may_have_mutated = true;
++        ds4_verify_suffix_timing verify_timing;
++        const double verify_t0 = stats_enabled ? now_sec() : 0.0;
++        ok = metal_graph_verify_suffix_tops(&s->graph,
++                                            &e->model,
++                                            &e->weights,
++                                            &s->checkpoint,
++                                            (uint32_t)start,
++                                            (uint32_t)draft_n,
++                                            draft_n <=
++                                                (int)DS4_SPEC_PREFIX_SLOTS + 1,
++                                            false,
++                                            row_tops,
++                                            NULL,
++                                            stats_enabled ? &verify_timing
++                                                          : NULL);
++        if (stats_enabled) {
++            s->dspark_stats.verify_ms += (now_sec() - verify_t0) * 1000.0;
++            s->dspark_stats.verify_upload_ms += verify_timing.upload_ms;
++            s->dspark_stats.verify_layer_ms += verify_timing.layer_ms;
++            s->dspark_stats.verify_gpu_busy_ms += verify_timing.gpu_busy_ms;
++            s->dspark_stats.verify_head_ms += verify_timing.head_ms;
++            s->dspark_stats.verify_read_ms += verify_timing.read_ms;
++        }
++    }
++
++    int commit_drafts = 0;
++    if (ok) {
++        commit_drafts = 1;
++        for (int i = 1; i < draft_n; i++) {
++            if (row_tops[i - 1] != drafts[i]) break;
++            commit_drafts++;
++        }
++    }
++
++    bool final_logits_ok = false;
++    if (ok && commit_drafts == draft_n) {
++        final_logits_ok = metal_graph_read_spec_logits_row(
++                &s->graph, (uint32_t)(draft_n - 1), row_logits);
++    }
++    if (ok && commit_drafts == draft_n && final_logits_ok) {
++        memcpy(s->logits, row_logits,
++               (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
++        int emitted = 0;
++        for (int i = 0; i < draft_n && n_accept < accepted_cap; i++) {
++            accepted[n_accept++] = drafts[i];
++            emitted++;
++            if (drafts[i] == eos_token) break;
++        }
++        s->checkpoint_valid = true;
++        if (stats_enabled) {
++            s->dspark_stats.full_accepts++;
++            s->dspark_stats.direct_full_commits++;
++            s->dspark_stats.accepted_draft_tokens += (uint64_t)emitted;
++            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist,
++                                      (uint32_t)emitted);
++        }
++        if (spec_log) {
++            fprintf(stderr, "ds4: ngram spec direct-full drafted=%d accepted=%d\n",
++                    draft_n, n_accept);
++        }
++        spec_frontier_free(&frontier);
++        DS4_NGRAM_STATS_FINISH();
++        return n_accept;
++    }
++
++    if (ok && commit_drafts > 0 && commit_drafts < draft_n &&
++        commit_drafts <= (int)DS4_SPEC_PREFIX_SLOTS) {
++        bool prefix_ok = metal_graph_read_spec_logits_row(
++                &s->graph, (uint32_t)(commit_drafts - 1), row_logits);
++        s->checkpoint.len = start;
++        if (prefix_ok) {
++            prefix_ok = spec_frontier_commit_prefix(s, (uint32_t)commit_drafts);
++        }
++        if (prefix_ok) {
++            memcpy(s->logits, row_logits,
++                   (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
++            int emitted = 0;
++            for (int i = 0; i < commit_drafts && n_accept < accepted_cap; i++) {
++                token_vec_push(&s->checkpoint, drafts[i]);
++                accepted[n_accept++] = drafts[i];
++                emitted++;
++                if (drafts[i] == eos_token) break;
++            }
++            s->checkpoint_valid = true;
++            if (stats_enabled) {
++                s->dspark_stats.partial_accepts++;
++                s->dspark_stats.direct_partial_commits++;
++                s->dspark_stats.accepted_draft_tokens += (uint64_t)emitted;
++                ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist,
++                                          (uint32_t)emitted);
++            }
++            if (spec_log) {
++                fprintf(stderr,
++                        "ds4: ngram spec direct-partial drafted=%d committed=%d accepted=%d\n",
++                        draft_n, emitted, n_accept);
++            }
++            spec_frontier_free(&frontier);
++            DS4_NGRAM_STATS_FINISH();
++            return n_accept;
++        }
++    }
++
++    if (verifier_may_have_mutated) {
++        s->checkpoint.len = start;
++        if (!have_frontier || !spec_frontier_restore(&frontier, s)) {
++            snprintf(err, errlen, "ngram verifier rollback failed");
++            s->checkpoint_valid = false;
++            if (stats_enabled) {
++                s->dspark_stats.verifier_errors++;
++                ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
++            }
++            spec_frontier_free(&frontier);
++            DS4_NGRAM_STATS_FINISH();
++            return -1;
++        }
++    }
++
++    if (!ok) {
++        if (stats_enabled) {
++            s->dspark_stats.verifier_unavailable++;
++            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
++        }
++        if (spec_log) fprintf(stderr, "ds4: ngram spec verifier unavailable\n");
++        spec_frontier_free(&frontier);
++        DS4_NGRAM_STATS_FINISH();
++        return n_accept;
++    }
++
++    /* Rollback happened above; replay the verified prefix through ordinary
++     * decode so the committed state matches one-token execution exactly. */
++    int replay_budget = commit_drafts;
++    if (replay_budget > accepted_cap - n_accept) {
++        replay_budget = accepted_cap - n_accept;
++    }
++    if (replay_budget < 0) replay_budget = 0;
++    for (int i = 0; i < replay_budget; i++) {
++        if (drafts[i] == eos_token) { replay_budget = i + 1; break; }
++    }
++    int replayed = 0;
++    if (stats_enabled && replay_budget > 0) {
++        s->dspark_stats.replay_fallbacks++;
++    }
++    for (int i = 0; i < replay_budget; i++) {
++        ok = metal_graph_eval_token_raw_swa(&s->graph,
++                                            &e->model,
++                                            &e->weights,
++                                            drafts[i],
++                                            (uint32_t)s->checkpoint.len,
++                                            row_logits);
++        if (!ok) {
++            snprintf(err, errlen, "%s decode failed",
++                     ds4_backend_name(e->backend));
++            s->checkpoint_valid = false;
++            if (stats_enabled) {
++                s->dspark_stats.verifier_errors++;
++                ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
++            }
++            spec_frontier_free(&frontier);
++            DS4_NGRAM_STATS_FINISH();
++            return -1;
++        }
++        token_vec_push(&s->checkpoint, drafts[i]);
++        accepted[n_accept++] = drafts[i];
++        replayed++;
++        if (drafts[i] == eos_token) break;
++    }
++    if (replayed > 0) {
++        memcpy(s->logits, row_logits,
++               (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
++        s->checkpoint_valid = true;
++        if (stats_enabled) {
++            if (replayed == draft_n) s->dspark_stats.full_accepts++;
++            else s->dspark_stats.partial_accepts++;
++            s->dspark_stats.accepted_draft_tokens += (uint64_t)replayed;
++            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist,
++                                      (uint32_t)replayed);
++        }
++    } else if (stats_enabled) {
++        ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 0);
++    }
++    if (spec_log) {
++        fprintf(stderr,
++                "ds4: ngram spec partial drafted=%d verified=%d accepted=%d\n",
++                draft_n, commit_drafts, n_accept);
++    }
++    spec_frontier_free(&frontier);
++    DS4_NGRAM_STATS_FINISH();
++#undef DS4_NGRAM_STATS_FINISH
++    return n_accept;
++}
+ #endif
+ 
+ /* TP worker side of a mirrored speculative-verify block. Runs its half of the
+@@ -66057,6 +66704,24 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
+                                                           errlen);
+     }
+ 
++    if (e->support_kind == DS4_SUPPORT_NONE &&
++        !e->mtp_ready && !e->tp.active && !s->distributed &&
++        !e->quality &&
++        /* The spec verifier machinery is not provisioned under SSD
++         * streaming (measured: every block reports verifier_unavailable),
++         * so skip the proposal work entirely there. */
++        !e->ssd_streaming &&
++        ds4_ngram_spec_tokens() > 1) {
++        return ds4_session_eval_ngram_speculative_argmax(s,
++                                                         n_accept,
++                                                         max_tokens,
++                                                         eos_token,
++                                                         accepted,
++                                                         accepted_cap,
++                                                         err,
++                                                         errlen);
++    }
++
+     if (metal_graph_cuda_splitkv_spec_requested() &&
+         (!e->mtp_ready || e->mtp_draft_tokens <= 1)) {
+         int extra = ds4_session_eval_splitkv_spec_after_first(
+diff --git a/ds4_agent.c b/ds4_agent.c
+index 72f91b9..d16cb82 100644
+--- a/ds4_agent.c
++++ b/ds4_agent.c
+@@ -8442,6 +8442,53 @@ static int worker_accept_generated_token(agent_worker *w,
+     return 0;
+ }
+ 
++/* Same bookkeeping as worker_accept_generated_token for a token that the
++ * speculative verifier has already evaluated and committed to the live KV:
++ * transcript, trace, stream rendering, and status only — no second eval. */
++static int worker_accept_verified_token(agent_worker *w,
++                                        int token,
++                                        int *generated,
++                                        double t0,
++                                        agent_stream_renderer *stream) {
++    ds4_tokens_push(&w->transcript, token);
++
++    size_t text_len = 0;
++    char *text = ds4_token_text(w->engine, token, &text_len);
++    agent_trace_token(w, token, text, text_len, *generated + 1);
++    agent_stream_text(stream, text, text_len, false);
++    free(text);
++    (*generated)++;
++
++    double dt = now_sec() - t0;
++    pthread_mutex_lock(&w->mu);
++    w->status.generated = *generated;
++    w->status.gen_tps = dt > 0.0 ? (double)*generated / dt : 0.0;
++    agent_wake_locked(w);
++    pthread_mutex_unlock(&w->mu);
++    return 0;
++}
++
++/* Speculative decoding gate for the agent turn loop. Blocks are used only
++ * for fully greedy turns, only in plain text (never while DSML syntax is
++ * buffered, active, or being parsed, so a block cannot skip the per-token
++ * grammar checks that end the turn), and are capped at 8 drafts so a block
++ * that happens to enter a tool stanza cannot also complete it. Returns the
++ * accepted-token capacity (first token + drafts), or 0 to decode normally. */
++static int agent_speculative_block_cap(const agent_worker *w,
++                                       const agent_config *cfg,
++                                       const agent_stream_renderer *sr,
++                                       const agent_dsml_parser *dsml) {
++    if (cfg->gen.temperature > 0.0f) return 0;
++    if (getenv("DS4_MTP_SPEC_DISABLE") != NULL) return 0;
++    int n = ds4_engine_mtp_draft_tokens(w->engine);
++    if (n <= 1) return 0;
++    if (!sr || !dsml) return 0;
++    if (dsml->state != AGENT_DSML_SEARCH) return 0;
++    if (sr->dsml_active || sr->dsml_start_len > 0) return 0;
++    if (n > 8) n = 8;
++    return n + 1;
++}
++
+ static int worker_force_generated_text(agent_worker *w,
+                                        const char *text,
+                                        int max_tokens,
+@@ -8717,8 +8764,31 @@ static int worker_run_turn(agent_worker *w, const char *user_text) {
+                 }
+             } else {
+                 free(text);
+-                if (worker_accept_generated_token(w, token, &generated, t0,
+-                                                  &stream, err, sizeof(err)) != 0) {
++                const int spec_cap =
++                    agent_speculative_block_cap(w, cfg, &stream, &dsml);
++                if (spec_cap > 1) {
++                    int spec_toks[9];
++                    int cap = spec_cap;
++                    if (cap > (int)(sizeof(spec_toks) / sizeof(spec_toks[0])))
++                        cap = (int)(sizeof(spec_toks) / sizeof(spec_toks[0]));
++                    int ntok = ds4_session_eval_speculative_argmax(
++                            w->session, token, max_tokens - generated,
++                            ds4_token_eos(w->engine), spec_toks, cap,
++                            err, sizeof(err));
++                    if (ntok < 0) {
++                        agent_dsml_parser_free(&dsml);
++                        agent_set_error(w, err[0] ? err
++                                                  : "speculative decode failed");
++                        return 1;
++                    }
++                    for (int sj = 0; sj < ntok; sj++) {
++                        (void)worker_accept_verified_token(w, spec_toks[sj],
++                                                           &generated, t0,
++                                                           &stream);
++                    }
++                } else if (worker_accept_generated_token(w, token, &generated,
++                                                         t0, &stream, err,
++                                                         sizeof(err)) != 0) {
+                     agent_dsml_parser_free(&dsml);
+                     agent_set_error(w, err);
+                     return 1;
+diff --git a/ds4_gpu.h b/ds4_gpu.h
+index 9fb03ec..92ab225 100644
+--- a/ds4_gpu.h
++++ b/ds4_gpu.h
+@@ -109,6 +109,8 @@ int ds4_gpu_tensor_read_after_selected_event(const ds4_gpu_tensor *tensor,
+ #endif
+ int ds4_gpu_end_commands(void);
+ int ds4_gpu_synchronize(void);
++/* Metal only: cumulative GPU busy seconds under DS4_METAL_GPU_BUSY_PROFILE. */
++double ds4_gpu_busy_profile_seconds(void);
+ 
+ int ds4_gpu_set_model_map(const void *model_map, uint64_t model_size);
+ int ds4_gpu_set_model_fd(int fd);
+diff --git a/ds4_metal.m b/ds4_metal.m
+index 82b0d1a..cd7247a 100644
+--- a/ds4_metal.m
++++ b/ds4_metal.m
+@@ -988,6 +988,13 @@ static void ds4_gpu_close_batch_encoder(void) {
+ static double g_gpu_busy_accum;
+ static uint64_t g_gpu_busy_cbs;
+ 
++/* Cumulative GPU busy seconds recorded by DS4_METAL_GPU_BUSY_PROFILE.
++ * Callers sample it around a section to split CPU-encode time from GPU
++ * execution time; returns 0 deltas when the profile env is unset. */
++double ds4_gpu_busy_profile_seconds(void) {
++    return g_gpu_busy_accum;
++}
++
+ /* A failed command buffer can leave a cross-threadgroup arrival counter at an
+  * arbitrary partial value.  Drop cached ownership instead of CPU-resetting
+  * buffers that another in-flight command buffer might still reference; bound
+@@ -1215,6 +1222,7 @@ static int ds4_gpu_finish_command_buffer(id<MTLCommandBuffer> cb, int owned, con
+ }
+ 
+ static int ds4_gpu_device_name_contains(const char *needle);
++static int ds4_gpu_device_is_m3_class(void);
+ 
+ static int ds4_gpu_use_m5_private_scratch(void) {
+     static int initialized;
+@@ -2012,7 +2020,7 @@ static int ds4_gpu_zero_prefix_prefill_mask_cache_enabled(void) {
+         getenv("DS4_METAL_FLASH_ATTN_STAGE_PROFILE") != NULL) {
+         return 0;
+     }
+-    return ds4_gpu_device_name_contains("M3");
++    return ds4_gpu_device_is_m3_class();
+ }
+ 
+ static ds4_gpu_zero_prefix_prefill_mask_cache_entry *
+@@ -2386,6 +2394,50 @@ int ds4_gpu_device_is_m5_apple_silicon(void) {
+             g_metal_device_name[8] == ' ');
+ }
+ 
++/* Experimental A/B switch: treat every pre-M5 device like M3 for the decode
++ * and prefill fusion gates that were only ever validated on M3-class
++ * hardware.  Opt-in via DS4_METAL_WIDEN_M3_GATES=1; each widened fusion
++ * keeps its own DS4_METAL_DISABLE_* rollback so regressions can be bisected
++ * per gate with the bit-exact schedule bench. */
++static int ds4_gpu_device_is_m3_class(void) {
++    /* No caching: the schedule bench flips candidate envs in-process, and
++     * every existing gate re-reads its env on each call for the same reason.
++     * Value-sensitive so DS4_METAL_WIDEN_M3_GATES=0 disables the
++     * device-default applied below on M1/M2. */
++    if (ds4_gpu_env_bool("DS4_METAL_WIDEN_M3_GATES") > 0 &&
++        ds4_gpu_device_is_pre_m5_apple_silicon()) {
++        return 1;
++    }
++    return ds4_gpu_device_name_contains("M3");
++}
++
++/* Per-device default tuning, applied once the Metal device name is known.
++ * setenv(..., overwrite=0) means anything the user exported explicitly
++ * always wins; DS4_NO_DEVICE_DEFAULTS=1 skips the whole block (pure
++ * upstream behavior). Values below were measured on an M1 Ultra (see
++ * EXPERIMENTS_M1_ULTRA.md): the widened fusion tier is bit-exact-verified,
++ * the 2/8 token split beats the M3-tuned adaptive schedule, and n-gram
++ * speculation with min-match 6 is the thinking-safe setting. M3/M4/M5 keep
++ * upstream defaults until someone measures equivalents there. */
++static void ds4_gpu_apply_device_default_env(void) {
++    if (getenv("DS4_NO_DEVICE_DEFAULTS") != NULL) return;
++    const int m1_class =
++        strncmp(g_metal_device_name, "Apple M", 7) == 0 &&
++        (g_metal_device_name[7] == '1' || g_metal_device_name[7] == '2') &&
++        (g_metal_device_name[8] == '\0' || g_metal_device_name[8] == ' ');
++    if (!m1_class) return;
++    setenv("DS4_METAL_WIDEN_M3_GATES", "1", 0);
++    setenv("DS4_METAL_GRAPH_TOKEN_SPLIT_LAYERS", "2", 0);
++    setenv("DS4_METAL_GRAPH_TOKEN_SECOND_SPLIT_LAYERS", "8", 0);
++    setenv("DS4_NGRAM_SPEC", "8", 0);
++    setenv("DS4_NGRAM_MIN_MATCH", "6", 0);
++    fprintf(stderr,
++            "ds4: %s defaults applied (widen M3 gates, token split 2/8, "
++            "ngram spec 8/6); explicit env vars win, "
++            "DS4_NO_DEVICE_DEFAULTS=1 disables\n",
++            g_metal_device_name);
++}
++
+ static bool ds4_gpu_ported_m5_decode_feature_enabled(
+         const char *pre_m5_disable_env,
+         const char *m5_disable_env) {
+@@ -2466,6 +2518,7 @@ static void ds4_gpu_detect_metal4_features(void) {
+     if (name) {
+         snprintf(g_metal_device_name, sizeof(g_metal_device_name), "%s", name);
+     }
++    ds4_gpu_apply_device_default_env();
+ 
+     const int metal4_disabled = ds4_gpu_env_bool("DS4_METAL_DISABLE_METAL4") > 0;
+ 
+@@ -3412,7 +3465,7 @@ int ds4_gpu_decode_attn_rope_fuse_available(void) {
+     if (g_rope_tail_inplace_pair_affine_pipeline == nil) return 0;
+     if (getenv("DS4_METAL_DISABLE_INPLACE_ROPE_PAIR") != NULL) return 0;
+     if (getenv("DS4_METAL_DISABLE_AFFINE_ROPE_PAIR") != NULL) return 0;
+-    if (!ds4_gpu_device_name_contains("M3") && !ds4_gpu_device_name_contains("M5")) return 0;
++    if (!ds4_gpu_device_is_m3_class() && !ds4_gpu_device_name_contains("M5")) return 0;
+     return 1;
+ }
+ 
+@@ -5055,7 +5108,37 @@ static int16_t ds4_gpu_mv_ext_nxpsg(uint64_t in_dim, uint64_t n_tok) {
+     return 4;
+ }
+ 
++/* r1=6..8 variants keep grid.y at 1 for verify-sized blocks so dense weights
++ * stream once. Measured on M1 Ultra they LOSE ~25% verify throughput despite
++ * being bit-identical: the historical two grid.y slices run concurrently
++ * across cores while r1=8 halves the threadgroup count and spills registers
++ * (8 accumulators per thread). Opt-in via DS4_METAL_ENABLE_MV_EXT_WIDE for
++ * re-testing on wider-register devices (cached; not flippable mid-process). */
++static int ds4_gpu_mv_ext_wide_rows_enabled(void) {
++    static int enabled = -1;
++    if (enabled < 0) {
++        enabled = getenv("DS4_METAL_ENABLE_MV_EXT_WIDE") != NULL ? 1 : 0;
++    }
++    return enabled;
++}
++
++/* The tiny routed-MoE kernels carry the token index in their grid, so the
++ * historical n<=5 / n<=4 gates were coverage limits, not kernel limits.
++ * Widening them to 8 keeps 6..8-row verify blocks off the generic mv path
++ * (two x reads, split gate/up, separate down reduce).
++ * DS4_METAL_DISABLE_MOE_TINY_WIDE restores the old gates (cached). */
++static int ds4_gpu_moe_tiny_wide_enabled(void) {
++    static int enabled = -1;
++    if (enabled < 0) {
++        enabled = getenv("DS4_METAL_DISABLE_MOE_TINY_WIDE") == NULL ? 1 : 0;
++    }
++    return enabled;
++}
++
+ static int16_t ds4_gpu_mv_ext_r1ptg(uint64_t n_tok) {
++    if (n_tok >= 6 && n_tok <= 8 && ds4_gpu_mv_ext_wide_rows_enabled()) {
++        return (int16_t)n_tok;
++    }
+     switch (n_tok) {
+     case 2: return 2;
+     case 3:
+@@ -5075,6 +5158,9 @@ static int16_t ds4_gpu_mv_ext_r1ptg(uint64_t n_tok) {
+         case 3: return "kernel_mul_mv_ext_q8_0_f32_r1_3";
+         case 4: return "kernel_mul_mv_ext_q8_0_f32_r1_4";
+         case 5: return "kernel_mul_mv_ext_q8_0_f32_r1_5";
++        case 6: return "kernel_mul_mv_ext_q8_0_f32_r1_6";
++        case 7: return "kernel_mul_mv_ext_q8_0_f32_r1_7";
++        case 8: return "kernel_mul_mv_ext_q8_0_f32_r1_8";
+         default: return NULL;
+         }
+     }
+@@ -5084,6 +5170,9 @@ static int16_t ds4_gpu_mv_ext_r1ptg(uint64_t n_tok) {
+     case 3: return "kernel_mul_mv_ext_f16_f32_r1_3";
+     case 4: return "kernel_mul_mv_ext_f16_f32_r1_4";
+     case 5: return "kernel_mul_mv_ext_f16_f32_r1_5";
++    case 6: return "kernel_mul_mv_ext_f16_f32_r1_6";
++    case 7: return "kernel_mul_mv_ext_f16_f32_r1_7";
++    case 8: return "kernel_mul_mv_ext_f16_f32_r1_8";
+     default: return NULL;
+     }
+ }
+@@ -5706,7 +5795,7 @@ static int ds4_gpu_encode_rope_tail_inplace(
+         getenv("DS4_METAL_DISABLE_INPLACE_ROPE_PAIR") == NULL &&
+         args->mode == 0 && !args->src2 &&
+         lane_compatible &&
+-        (ds4_gpu_device_name_contains("M3") ||
++        (ds4_gpu_device_is_m3_class() ||
+          (ds4_gpu_device_name_contains("M5") && n_tok == 1u));
+     const bool use_shared_coeff =
+         use_inplace_pair &&
+@@ -5723,7 +5812,7 @@ static int ds4_gpu_encode_rope_tail_inplace(
+         g_rope_tail_inplace_pair_affine_pipeline != nil &&
+         getenv("DS4_METAL_DISABLE_AFFINE_ROPE_PAIR") == NULL &&
+         n_tok == 1u &&
+-        (ds4_gpu_device_name_contains("M3") ||
++        (ds4_gpu_device_is_m3_class() ||
+          ds4_gpu_device_name_contains("M5"));
+ 
+     int32_t pos_stack[256];
+@@ -12745,6 +12834,12 @@ static int ds4_gpu_stream_expert_alloc_slab_slot(
+         g_stream_expert_cache_slab_slot_count[slab] = slots;
+         g_stream_expert_cache_slab_slots_used[slab] = 0;
+         g_stream_expert_cache_slab_total_slots += slots;
++        /* Measured dead end (M1 Ultra, MXFP4 streaming): bulk-mlocking the
++         * whole slab here to avoid the per-slot mlock on handout is
++         * throughput-neutral — the per-slot lock runs on the async loader
++         * threads, off the token critical path — while doubling the total
++         * mlock work (fresh pages pay zero-fill wiring).  Keep the lazy
++         * per-slot locking. */
+     }
+ 
+     const uint32_t local_slot = g_stream_expert_cache_slab_slots_used[slab]++;
+@@ -14423,6 +14518,16 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
+     *up_inner = 0;
+     *down_inner = 0;
+ 
++    /* Diagnostic split of the prepare cost (DS4_METAL_STREAM_PREPARE_SUBPROFILE):
++     * own-entry handling (inflight waits + clears) vs the reusable-slot
++     * search.  Static accumulators are racy across loader threads, which is
++     * acceptable for an attribution profile. */
++    static double g_prep_sub_own_ms, g_prep_sub_take_ms;
++    static uint64_t g_prep_sub_calls;
++    const int prep_subprof =
++        getenv("DS4_METAL_STREAM_PREPARE_SUBPROFILE") != NULL;
++    const double prep_sub_t0 = prep_subprof ? ds4_gpu_now_ms() : 0.0;
++
+     ds4_gpu_stream_expert_reusable_buffers reuse = { nil, nil, nil, 0, 0, 0 };
+     ds4_gpu_stream_expert_cache_entry *e =
+         &g_stream_expert_cache[layer][expert];
+@@ -14452,6 +14557,7 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
+         ds4_gpu_stream_expert_cache_clear_entry(layer, expert, 0);
+     }
+ 
++    const double prep_sub_t1 = prep_subprof ? ds4_gpu_now_ms() : 0.0;
+     if (!reuse.gate_buffer || !reuse.up_buffer || !reuse.down_buffer) {
+         if (!ds4_gpu_stream_expert_cache_take_reusable(force_reuse,
+                                                        protect_layer,
+@@ -14465,6 +14571,24 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
+             reuse.down_buffer = nil;
+         }
+     }
++    static double g_prep_sub_reusefound_ms;
++    static uint64_t g_prep_sub_reusefound;
++    if (prep_subprof) {
++        const double prep_sub_t2 = ds4_gpu_now_ms();
++        g_prep_sub_own_ms += prep_sub_t1 - prep_sub_t0;
++        g_prep_sub_take_ms += prep_sub_t2 - prep_sub_t1;
++        if ((++g_prep_sub_calls % 2000ull) == 0) {
++            fprintf(stderr,
++                    "ds4: prepare subprofile calls=%llu own_avg=%.3f ms take_avg=%.3f ms reuse_found=%llu reuse_found_total_avg=%.3f ms\n",
++                    (unsigned long long)g_prep_sub_calls,
++                    g_prep_sub_own_ms / (double)g_prep_sub_calls,
++                    g_prep_sub_take_ms / (double)g_prep_sub_calls,
++                    (unsigned long long)g_prep_sub_reusefound,
++                    g_prep_sub_reusefound ?
++                        g_prep_sub_reusefound_ms /
++                            (double)g_prep_sub_reusefound : 0.0);
++        }
++    }
+ 
+     if (reuse.gate_buffer && reuse.up_buffer && reuse.down_buffer) {
+         *gate_buf = reuse.gate_buffer;
+@@ -14473,9 +14597,45 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
+         *gate_inner = reuse.gate_inner;
+         *up_inner = reuse.up_inner;
+         *down_inner = reuse.down_inner;
++        if (prep_subprof) {
++            g_prep_sub_reusefound++;
++            g_prep_sub_reusefound_ms += ds4_gpu_now_ms() - prep_sub_t0;
++        }
+         return 1;
+     }
+ 
++    static uint64_t g_prep_tail_n[5];
++    static double g_prep_tail_ms[5];
++#define DS4_PREP_TAIL_NOTE(idx) do {                                        \
++        if (prep_subprof) {                                                 \
++            g_prep_tail_n[(idx)]++;                                        \
++            g_prep_tail_ms[(idx)] += ds4_gpu_now_ms() - prep_sub_t0;       \
++            if (((g_prep_tail_n[0] + g_prep_tail_n[1] + g_prep_tail_n[2] + \
++                  g_prep_tail_n[3] + g_prep_tail_n[4]) % 2000ull) == 0) {  \
++                fprintf(stderr,                                             \
++                        "ds4: prepare tail capped=%llu/%.3f slab=%llu/%.3f " \
++                        "combined=%llu/%.3f explicit=%llu/%.3f fail=%llu/%.3f (n/avg ms) " \
++                        "mlock_ms=%.1f free_slots=%u total_slots=%u used_last=%u\n", \
++                        (unsigned long long)g_prep_tail_n[0],              \
++                        g_prep_tail_n[0] ? g_prep_tail_ms[0] / g_prep_tail_n[0] : 0.0, \
++                        (unsigned long long)g_prep_tail_n[1],              \
++                        g_prep_tail_n[1] ? g_prep_tail_ms[1] / g_prep_tail_n[1] : 0.0, \
++                        (unsigned long long)g_prep_tail_n[2],              \
++                        g_prep_tail_n[2] ? g_prep_tail_ms[2] / g_prep_tail_n[2] : 0.0, \
++                        (unsigned long long)g_prep_tail_n[3],              \
++                        g_prep_tail_n[3] ? g_prep_tail_ms[3] / g_prep_tail_n[3] : 0.0, \
++                        (unsigned long long)g_prep_tail_n[4],              \
++                        g_prep_tail_n[4] ? g_prep_tail_ms[4] / g_prep_tail_n[4] : 0.0, \
++                        g_stream_expert_cache_mlock_ms,                    \
++                        g_stream_expert_cache_free_slot_count,             \
++                        g_stream_expert_cache_slab_total_slots,            \
++                        g_stream_expert_cache_slab_count ?                 \
++                            g_stream_expert_cache_slab_slots_used[         \
++                                g_stream_expert_cache_slab_count - 1] : 0u); \
++            }                                                               \
++        }                                                                   \
++    } while (0)
++
+     if (ds4_gpu_stream_expert_combined_buffer_enabled()) {
+         if (gate_expert_bytes > UINT64_MAX - gate_expert_bytes ||
+             gate_expert_bytes * 2ull > UINT64_MAX - down_expert_bytes ||
+@@ -14483,14 +14643,17 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
+             gate_expert_bytes * 2ull > (uint64_t)NSUIntegerMax ||
+             gate_expert_bytes * 2ull + down_expert_bytes >
+                 (uint64_t)NSUIntegerMax) {
++            DS4_PREP_TAIL_NOTE(4);
+             return 0;
+         }
+         if (g_stream_expert_cache_mlock_budget_cap != 0) {
+-            return ds4_gpu_stream_expert_cache_take_capped_reusable(
++            const int capped_rc = ds4_gpu_stream_expert_cache_take_capped_reusable(
+                     protect_layer, protect_ids, n_protect,
+                     gate_expert_bytes, down_expert_bytes,
+                     gate_buf, up_buf, down_buf,
+                     gate_inner, up_inner, down_inner);
++            DS4_PREP_TAIL_NOTE(0);
++            return capped_rc;
+         }
+         if (ds4_gpu_stream_expert_alloc_slab_slot(gate_expert_bytes,
+                                                   down_expert_bytes,
+@@ -14500,14 +14663,17 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
+                                                   gate_inner,
+                                                   up_inner,
+                                                   down_inner)) {
++            DS4_PREP_TAIL_NOTE(1);
+             return 1;
+         }
+         if (g_stream_expert_cache_mlock_budget_cap != 0) {
+-            return ds4_gpu_stream_expert_cache_take_capped_reusable(
++            const int capped_rc = ds4_gpu_stream_expert_cache_take_capped_reusable(
+                     protect_layer, protect_ids, n_protect,
+                     gate_expert_bytes, down_expert_bytes,
+                     gate_buf, up_buf, down_buf,
+                     gate_inner, up_inner, down_inner);
++            DS4_PREP_TAIL_NOTE(0);
++            return capped_rc;
+         }
+         const uint64_t up_off = gate_expert_bytes;
+         const uint64_t down_off = gate_expert_bytes * 2ull;
+@@ -14516,11 +14682,13 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
+             ds4_gpu_stream_expert_alloc_buffer(combined_bytes,
+                                                @"ds4_stream_expert_combined");
+         if (!combined) {
+-            return ds4_gpu_stream_expert_cache_take_capped_reusable(
++            const int capped_rc = ds4_gpu_stream_expert_cache_take_capped_reusable(
+                     protect_layer, protect_ids, n_protect,
+                     gate_expert_bytes, down_expert_bytes,
+                     gate_buf, up_buf, down_buf,
+                     gate_inner, up_inner, down_inner);
++            DS4_PREP_TAIL_NOTE(0);
++            return capped_rc;
+         }
+         *gate_buf = combined;
+         *up_buf = combined;
+@@ -14528,6 +14696,7 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
+         *gate_inner = 0;
+         *up_inner = (NSUInteger)up_off;
+         *down_inner = (NSUInteger)down_off;
++        DS4_PREP_TAIL_NOTE(2);
+         return 1;
+     }
+ 
+@@ -14544,16 +14713,20 @@ static int ds4_gpu_stream_expert_cache_prepare_load_buffers(
+         ds4_gpu_stream_expert_unlock_explicit_buffer(explicit_gate);
+         ds4_gpu_stream_expert_unlock_explicit_buffer(explicit_up);
+         ds4_gpu_stream_expert_unlock_explicit_buffer(explicit_down);
+-        return ds4_gpu_stream_expert_cache_take_capped_reusable(
++        const int capped_rc = ds4_gpu_stream_expert_cache_take_capped_reusable(
+                 protect_layer, protect_ids, n_protect,
+                 gate_expert_bytes, down_expert_bytes,
+                 gate_buf, up_buf, down_buf,
+                 gate_inner, up_inner, down_inner);
++        DS4_PREP_TAIL_NOTE(0);
++        return capped_rc;
+     }
+     *gate_buf = explicit_gate;
+     *up_buf = explicit_up;
+     *down_buf = explicit_down;
++    DS4_PREP_TAIL_NOTE(3);
+     return 1;
++#undef DS4_PREP_TAIL_NOTE
+ }
+ 
+ static void ds4_gpu_stream_expert_cache_prune_global(
+@@ -19771,7 +19944,7 @@ int ds4_gpu_matmul_f16_pair_compressor_store_tensor(
+         uint32_t                pos) {
+     if (!g_initialized && !ds4_gpu_init()) return -1;
+     if ((g_quality_mode ||
+-         (!ds4_gpu_device_name_contains("M3") &&
++         (!ds4_gpu_device_is_m3_class() &&
+           !ds4_gpu_device_name_contains("M5"))) ||
+         getenv("DS4_METAL_DISABLE_COMPRESSOR_PAIR_PROJ") != NULL ||
+         getenv("DS4_METAL_DISABLE_COMPRESSOR_STORE_ONE") != NULL) {
+@@ -20623,7 +20796,7 @@ static int ds4_gpu_hc_rms_scale_project_mode(
+         (in_dim == 16384u || in_dim == 28672u) && out_dim == 24u;
+     if (!hard_shape) return 0;
+ 
+-    if ((!ds4_gpu_device_name_contains("M3") &&
++    if ((!ds4_gpu_device_is_m3_class() &&
+          (g_test_flags & DS4_GPU_TEST_HC_RMS_SCALE_PROJ) == 0u) ||
+         getenv("DS4_METAL_DISABLE_HC_RMS_SCALE_PROJ") != NULL) {
+         return 0;
+@@ -21649,7 +21822,7 @@ int ds4_gpu_kv_rope_fp8_fuse_available(void) {
+     if (g_rope_tail_inplace_pair_affine_pipeline == nil) return 0;
+     if (getenv("DS4_METAL_DISABLE_INPLACE_ROPE_PAIR") != NULL) return 0;
+     if (getenv("DS4_METAL_DISABLE_AFFINE_ROPE_PAIR") != NULL) return 0;
+-    if (!ds4_gpu_device_name_contains("M3") && !ds4_gpu_device_name_contains("M5")) return 0;
++    if (!ds4_gpu_device_is_m3_class() && !ds4_gpu_device_name_contains("M5")) return 0;
+     return 1;
+ }
+ 
+@@ -21869,7 +22042,7 @@ static int ds4_gpu_encode_compressor_score_with_ape(
+     const uint32_t total_elems = (uint32_t)total_elems64;
+ 
+     const bool use_fused =
+-        ds4_gpu_device_name_contains("M3") &&
++        ds4_gpu_device_is_m3_class() &&
+         getenv("DS4_METAL_DISABLE_COMPRESSOR_APE_ADD") == NULL;
+     if (use_fused) {
+         id<MTLComputePipelineState> pipeline = ds4_gpu_get_pipeline(
+@@ -22677,7 +22850,7 @@ static int ds4_gpu_encode_concat_f32_dim1(
+ static int ds4_gpu_compressor_pack_ratio4_fusion_mode(uint32_t head_dim) {
+     const bool default_shape = head_dim == 128u || head_dim == 512u;
+     if (getenv("DS4_METAL_DISABLE_COMPRESSOR_RATIO4_PACK_FUSION") != NULL ||
+-        !(ds4_gpu_device_name_contains("M3") && default_shape)) {
++        !(ds4_gpu_device_is_m3_class() && default_shape)) {
+         return 0;
+     }
+     if (g_dsv4_compressor_pack_ratio4_pipeline == nil) {
+@@ -22723,7 +22896,7 @@ static int ds4_gpu_compressor_ratio4_direct_pool_mode(
+ 
+     const bool default_shape = head_dim == 128u || head_dim == 512u;
+     if (getenv("DS4_METAL_DISABLE_COMPRESSOR_RATIO4_DIRECT_POOL") != NULL ||
+-        !(ds4_gpu_device_name_contains("M3") && default_shape)) {
++        !(ds4_gpu_device_is_m3_class() && default_shape)) {
+         return 0;
+     }
+     if (g_dsv4_softmax_pool_ratio4_direct_pipeline == nil) {
+@@ -25757,7 +25930,7 @@ static int ds4_gpu_encode_flash_kv_stage_f16(
+         supported_shape && valid_grid && !g_quality_mode &&
+         getenv("DS4_METAL_DISABLE_GATHERED_KV_STAGE") == NULL &&
+         g_flash_kv_stage_f16_pipeline != nil &&
+-        (ds4_gpu_device_name_contains("M3") ||
++        (ds4_gpu_device_is_m3_class() ||
+          ds4_gpu_device_name_contains("M5"));
+     const bool component_disabled = eligible &&
+         (ds4_gpu_env_bool("DS4_METAL_DISABLE_CONTIG_F32_F16_COPY") > 0 ||
+@@ -27532,7 +27705,7 @@ static int ds4_gpu_encode_flash_attention_gathered_heads(
+          getenv("DS4_METAL_DISABLE_M5_PACKED_ZERO_MASK") == NULL);
+     const bool use_persistent_zero_mask =
+         use_mask == 0u &&
+-        (ds4_gpu_device_name_contains("M3") ||
++        (ds4_gpu_device_is_m3_class() ||
+          m5_persistent_zero_mask) &&
+         getenv("DS4_METAL_DISABLE_PERSISTENT_ZERO_ATTN_MASK") == NULL;
+ 
+@@ -27563,7 +27736,7 @@ static int ds4_gpu_encode_flash_attention_gathered_heads(
+     const bool has_kvpad = (n_keys % ncpsg) != 0;
+     const bool use_shared_kvpad =
+         has_kvpad &&
+-        ds4_gpu_device_name_contains("M3") &&
++        ds4_gpu_device_is_m3_class() &&
+         getenv("DS4_METAL_DISABLE_SHARED_KV_PAD") == NULL;
+     const NSUInteger packed_threads = 8u * 32u;
+     const NSUInteger packed_shared_bytes =
+@@ -32096,7 +32269,7 @@ static int ds4_gpu_encode_router_select(
+     const bool use_batch_weights_fusion =
+         flash_router_fast_path && !g_quality_mode && n_tokens > 1u &&
+         g_dsv4_router_weights_batch_pipeline != nil &&
+-        ds4_gpu_device_name_contains("M3") &&
++        ds4_gpu_device_is_m3_class() &&
+         getenv("DS4_METAL_DISABLE_ROUTER_WEIGHTS_BATCH_FUSION") == NULL &&
+         getenv("DS4_METAL_DISABLE_ROUTER_SELECT_FUSION") == NULL;
+     if (use_batch_weights_fusion) {
+@@ -40663,7 +40836,7 @@ int ds4_gpu_routed_moe_batch_tensor(
+          */
+         const bool use_tiny_pair_mv =
+             !g_quality_mode &&
+-            n_tokens <= 5u &&
++            n_tokens <= (ds4_gpu_moe_tiny_wide_enabled() ? 8u : 5u) &&
+             !use_q4_batch_expert_table &&
+             !use_mm_id &&
+             ((gate_type == DS4_METAL_TENSOR_IQ2_XXS && g_moe_mul_mv_id_iq2_xxs_pair_pipeline) ||
+@@ -41151,7 +41324,7 @@ int ds4_gpu_routed_moe_batch_tensor(
+             !use_q4_batch_expert_table &&
+             !use_mm_id &&
+             n_expert == 6 &&
+-            n_tokens <= 4u &&
++            n_tokens <= (ds4_gpu_moe_tiny_wide_enabled() ? 8u : 4u) &&
+             down_sum6_pipeline != nil;
+         int ok = 0;
+         if (use_iq2_batch_selected_addr) {
+@@ -42426,7 +42599,7 @@ int ds4_gpu_output_hc_weights_tensor(
+         const bool use_weights4 =
+             weights4_shape && !g_quality_mode &&
+             g_output_hc_weights4_pipeline != nil &&
+-            (ds4_gpu_device_name_contains("M3") ||
++            (ds4_gpu_device_is_m3_class() ||
+              (g_test_flags & DS4_GPU_TEST_OUTPUT_HC_WEIGHTS4) != 0u) &&
+             g_output_hc_weights4_pipeline.maxTotalThreadsPerThreadgroup >= 2u;
+         if (require_weights4 && weights4_shape && !use_weights4) {
+diff --git a/metal/dense.metal b/metal/dense.metal
+index b56f509..f8c7e7d 100644
+--- a/metal/dense.metal
++++ b/metal/dense.metal
+@@ -1874,11 +1874,19 @@ template [[host_name("kernel_mul_mv_ext_f16_f32_r1_2")]]  kernel mul_mv_ext_q4_f
+ template [[host_name("kernel_mul_mv_ext_f16_f32_r1_3")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, half4,      4,  dequantize_f16_t4>;
+ template [[host_name("kernel_mul_mv_ext_f16_f32_r1_4")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, half4,      4,  dequantize_f16_t4>;
+ template [[host_name("kernel_mul_mv_ext_f16_f32_r1_5")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, half4,      4,  dequantize_f16_t4>;
++/* r1=6..8 keep grid.y at 1 for the 6..8-row speculative verify blocks, so
++ * dense weights are streamed once per block instead of twice. */
++template [[host_name("kernel_mul_mv_ext_f16_f32_r1_6")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<6, half4,      4,  dequantize_f16_t4>;
++template [[host_name("kernel_mul_mv_ext_f16_f32_r1_7")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<7, half4,      4,  dequantize_f16_t4>;
++template [[host_name("kernel_mul_mv_ext_f16_f32_r1_8")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, half4,      4,  dequantize_f16_t4>;
+ 
+ template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_2")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q8_0, 32, dequantize_q8_0_t4>;
+ template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_3")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q8_0, 32, dequantize_q8_0_t4>;
+ template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_4")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q8_0, 32, dequantize_q8_0_t4>;
+ template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_5")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q8_0, 32, dequantize_q8_0_t4>;
++template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_6")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<6, block_q8_0, 32, dequantize_q8_0_t4>;
++template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_7")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<7, block_q8_0, 32, dequantize_q8_0_t4>;
++template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_8")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, block_q8_0, 32, dequantize_q8_0_t4>;
+ 
+ template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_1")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<1, ds4_dense_block_q4_0, 32,  dequantize_dense_q4_0_t4>;
+ template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_2")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, ds4_dense_block_q4_0, 32,  dequantize_dense_q4_0_t4>;
+diff --git a/speed-bench/m2_ultra_ts.svg b/speed-bench/m2_ultra_ts.svg
+index b55f264..7ed5cd1 100644
+--- a/speed-bench/m2_ultra_ts.svg
++++ b/speed-bench/m2_ultra_ts.svg
+@@ -8,7 +8,7 @@ text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+ .legend { font-size: 13px; font-weight: 600; fill: #1f2933; }
+ </style>
+ <rect width="960" height="540" fill="#ffffff"/>
+-<text class="title" x="480.0" y="34" text-anchor="middle">M2 Ultra t/s</text>
++<text class="title" x="480.0" y="34" text-anchor="middle">M1 Ultra t/s</text>
+ <line x1="82" y1="468.00" x2="878" y2="468.00" stroke="#e2e8f0" stroke-width="1"/>
+ <text class="tick" x="70" y="472.00" text-anchor="end">0</text>
+ <line x1="82" y1="387.60" x2="878" y2="387.60" stroke="#e2e8f0" stroke-width="1"/>

--- a/metal/dense.metal
+++ b/metal/dense.metal
@@ -1874,11 +1874,19 @@ template [[host_name("kernel_mul_mv_ext_f16_f32_r1_2")]]  kernel mul_mv_ext_q4_f
 template [[host_name("kernel_mul_mv_ext_f16_f32_r1_3")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, half4,      4,  dequantize_f16_t4>;
 template [[host_name("kernel_mul_mv_ext_f16_f32_r1_4")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, half4,      4,  dequantize_f16_t4>;
 template [[host_name("kernel_mul_mv_ext_f16_f32_r1_5")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, half4,      4,  dequantize_f16_t4>;
+/* r1=6..8 keep grid.y at 1 for the 6..8-row speculative verify blocks, so
+ * dense weights are streamed once per block instead of twice. */
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_6")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<6, half4,      4,  dequantize_f16_t4>;
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_7")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<7, half4,      4,  dequantize_f16_t4>;
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_8")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, half4,      4,  dequantize_f16_t4>;
 
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_2")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q8_0, 32, dequantize_q8_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_3")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q8_0, 32, dequantize_q8_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_4")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q8_0, 32, dequantize_q8_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_5")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q8_0, 32, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_6")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<6, block_q8_0, 32, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_7")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<7, block_q8_0, 32, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_8")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, block_q8_0, 32, dequantize_q8_0_t4>;
 
 template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_1")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<1, ds4_dense_block_q4_0, 32,  dequantize_dense_q4_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_2")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, ds4_dense_block_q4_0, 32,  dequantize_dense_q4_0_t4>;

--- a/speed-bench/m2_ultra_ts.svg
+++ b/speed-bench/m2_ultra_ts.svg
@@ -8,7 +8,7 @@ text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
 .legend { font-size: 13px; font-weight: 600; fill: #1f2933; }
 </style>
 <rect width="960" height="540" fill="#ffffff"/>
-<text class="title" x="480.0" y="34" text-anchor="middle">M2 Ultra t/s</text>
+<text class="title" x="480.0" y="34" text-anchor="middle">M1 Ultra t/s</text>
 <line x1="82" y1="468.00" x2="878" y2="468.00" stroke="#e2e8f0" stroke-width="1"/>
 <text class="tick" x="70" y="472.00" text-anchor="end">0</text>
 <line x1="82" y1="387.60" x2="878" y2="387.60" stroke="#e2e8f0" stroke-width="1"/>


### PR DESCRIPTION
# metal: M1-class decode tuning, n-gram speculation, and batch-verifier groundwork

> All measurements below are from a Mac Studio M1 Ultra
> 128 GB running `DeepSeek-V4-Flash ... imatrix-fixed-0731.gguf` (91 GB, q2
> routed layout), greedy decoding, fixed prompts, 128-512 generated tokens per
> comparison. Run-to-run variance observed: ±0.5 t/s.

## Summary

This PR is the result of a measurement-first optimization campaign on M1-class
hardware (the oldest supported Apple Silicon tier). It contains:

1. **An opt-in switch that widens the "M3"-string fusion gates to every pre-M5
   device** — bit-exact verified, +9.7% decode on M1 Ultra — plus a small
   **per-device defaults layer**: at Metal init, M1/M2 devices apply the
   measured tuning automatically via `setenv(..., overwrite=0)` (explicit env
   always wins; `DS4_NO_DEVICE_DEFAULTS=1` restores pure upstream behavior;
   one self-documenting log line reports what was applied). M3/M4/M5 keep
   upstream defaults until measured. Verified on-device: no-env run applies
   and reaches the tuned speed, the kill switch reproduces the upstream
   baseline exactly, per-variable overrides work, and the deterministic eval
   gate is unchanged.
2. **Prompt-lookup (n-gram) speculative decoding with no support model** —
   +16% on repetition-heavy output (code, edits), free when idle, wired into
   CLI, server, and the native agent.
3. **Two small default-on wins**: routed-MoE tiny-kernel coverage widened to
   n≤8 rows, and the decode compressor emit fusion threaded into the batch
   verifier loop (both stream-identical, measured on-device).
4. **Instrumentation and negative results** that should save the next person
   a lot of GPU time: a verifier micro-benchmark mode, a GPU-busy split for
   the speculative verifier, and three measured dead ends documented below.

Nothing in this PR changes behavior on CUDA, ROCm, or the CPU reference build:
every new fast path is either `#if defined(__APPLE__)`-scoped, gated behind an
environment variable, or both. GLM is untouched (the speculative hook requires
`DS4_SUPPORT_NONE` and the GLM session branch returns earlier).

## Why

On M1 Ultra the engine decoded at 24.6 t/s while an M3 Ultra reaches ~44 t/s
on the same 800 GB/s memory bus. Per-token traffic is 9.14 GiB (47% Q8_0
attention projections, 21% routed experts), so M1 was running at ~255 GB/s
effective — the gap turned out to be software, in three places measured here.

## Changes

### 1. `ds4_gpu_device_is_m3_class()` — widen the M3-only fusion tier (opt-in)

Fifteen decode/prefill fusions were gated on the literal device-name substring
`"M3"` (RoPE fused into the FA reduce + packed32 reduce, KV RoPE/FP8 store
fusion, gathered KV staging, persistent zero attention mask, shared KV pad,
compressor pair-proj/APE/ratio-4 fusions, output HC weights4, router weights
batch fusion, zero-prefix mask cache). With `DS4_METAL_WIDEN_M3_GATES=1` these
now also apply to any pre-M5 device. Every fusion keeps its existing
`DS4_METAL_DISABLE_*` variable, so regressions can be bisected per gate.

* Measured on M1 Ultra: **26.3 → 28.9 t/s (+9.7%)**, and
  `metal_decode_schedule_bench --candidate-env DS4_METAL_WIDEN_M3_GATES
  --include-selection` confirms **bit-identical full-vocabulary logits (401
  rows) and identical greedy selections (400 tokens)**.
* Defaults are unchanged. If maintainers can repeat the bit-exact run on M2
  and M4 devices, promoting pre-M5 to default here looks safe; we only had M1
  Ultra to test.

Related finding, not yet turned into a default: the decode command-buffer
split schedule (2/32, tuned on M3 Ultra) is not optimal on M1 Ultra — an
explicit `DS4_METAL_GRAPH_TOKEN_SPLIT_LAYERS=2` +
`DS4_METAL_GRAPH_TOKEN_SECOND_SPLIT_LAYERS=8` is worth **+6.8%** (bit-exact by
construction; GPU bubble drops from ~9% to ~3%). Making the adaptive schedule
pick 2/8 on M1/M2 needs measurements on more devices than we had.

Combined effect of the two exact knobs on M1 Ultra: **24.6 → 29.3 t/s (+19%)**
on every workload, byte-identical output. At 16k context the delta is neutral,
at 32k it is +3.4% — never a regression in our sweeps.

### 2. n-gram (prompt-lookup) speculative decoding — no support model

`DS4_NGRAM_SPEC=N` (recommended N=8) enables drafting from the session token
history: when the transcript tail repeats an earlier n-gram
(`DS4_NGRAM_MIN_MATCH`, default 3), the tokens that followed that occurrence
are proposed and checked by the existing DSpark batched verifier
(`metal_graph_verify_suffix_tops`). The drafter is a token-array producer only;
no hidden-state capture, no support GGUF, no memory overhead.

* **+16% on a code-rewrite task** (29.3 → 34.0 t/s), neutral on free prose
  (a missing match costs a sub-millisecond CPU scan).
* Greedy-exact at the acceptance boundary: every committed token equals the
  target argmax. Blocks of N≤5 commit through the prefix-frontier path and we
  verified the output is **byte-identical** to plain decode; N≥6 full-block
  accepts keep the verifier state and inherit DSpark's documented FP-order
  drift contract (`--quality` semantics unchanged).
* Drafts are truncated at the first stop/thinking-control token, so an
  accepted block can never cross a turn boundary. This matters for the agent,
  which extends the live KV incrementally.
* Wired in: CLI and server already routed through
  `ds4_engine_mtp_draft_tokens() > 1` (single-session, greedy requests;
  batched-session mode keeps speculation off, as it already did for
  MTP/DSpark). The native agent gets its own branch
  (`agent_speculative_block_cap` + `worker_accept_verified_token`): greedy
  turns only, plain-text only (never while DSML syntax is buffered, active,
  or parsing), blocks capped at 8 so a block cannot both enter and complete a
  tool stanza. Measured agent turn time on the code task: **38 s → 31 s**.
* Tested on Metal only. The verifier path is backend-shared, so the knob may
  work on CUDA, but we did not validate it there — keeping it opt-in until
  someone does is deliberate. `ds4-bench`/`ds4-eval` intentionally do not use
  it (they are the measurement and drift-reference tools).
* Workload tuning, measured through `ds4-server` (thinking on, generation
  t/s with prefill excluded): with the default `DS4_NGRAM_MIN_MATCH=3`,
  reasoning prose triggers frequent low-yield 3-gram matches and the
  ~120 ms verifies cost ~6% net; `DS4_NGRAM_MIN_MATCH=6` is the safe server
  setting (novel code −4%, rewrite/edit +13%). The nothink copy/edit numbers
  above (+16%) use min_match=3. A cheaper verifier (the microbatch work
  below) relaxes this precision/recall trade-off.
* Test hook: `DS4_NGRAM_FAKE_PROPOSAL=1` forces a full-width verify every
  cycle while committing exactly one token, so the output stream must equal
  plain greedy decode — a self-checking micro-benchmark for any verifier
  change (we used it to validate everything below).

### 3. Default-on micro-wins (both stream-identical on M1 Ultra)

* **Routed-MoE tiny-kernel coverage n≤5 → n≤8** (and `down_sum6` n≤4 → n≤8).
  The tiny `pair_swiglu`/`sum6` kernels already carry the token index in
  their grid; the old thresholds left n=6..8 verify blocks on the generic
  `mv` path (x read twice, split gate/up, separate down reduce). Rollback:
  `DS4_METAL_DISABLE_MOE_TINY_WIDE`.
* **Batch-verifier compressor emit fusion.** The non-aligned batch compressor
  path paid ~12 single-row dispatches per emit per ratio-4 layer (norm, RoPE,
  FP8 round-trip, F16 commit, indexer QAT, two state shifts). The decode path
  already fuses all of that into one bit-exact dispatch
  (`kernel_dsv4_comp_row_finalize_f32`); this PR threads the same fusion into
  the batch loops via a merged per-row loop (attention update + indexer
  update + one fused finalize per emit). Guarded by the same shape/type
  invariants as the decode fusion, plus: never under prefix-frontier capture
  (the fused kernel performs the ratio-4 state shifts) and never on the
  aligned-chunk path (already batched). The indexer projections move past the
  live attention rows in the shared staging tensor while fused. Rollback:
  `DS4_METAL_DISABLE_BATCH_COMP_FINALIZE_FUSE`.
  Validated: fused N=8 stream byte-identical to pre-patch; N=5
  (capture path, fusion off by design) byte-identical to plain decode;
  rollback byte-identical.
  One real-world bug was caught by agent testing and fixed before this PR:
  the same non-aligned batch path is also reached by **resumed-prefill
  chunks** (arbitrary `pos0` when extending a live checkpoint), where the
  fused loop's indexer staging offset exceeds the shared staging tensor and
  the encode fails (`gpu layer 2 attention batch encode failed`). The gate
  now requires `n_tokens <= 16` (verify-sized blocks), which is also the only
  regime where the per-row fused loop beats the aligned replay. Regression
  covered by re-running the exact failing agent scenario.

### 4. Instrumentation

* `ds4_gpu_busy_profile_seconds()` (Metal) + `verify_gpu_busy` in the DSpark
  stats line: splits CPU-encode from GPU-execution time inside
  `metal_graph_verify_suffix_tops`. This is how we established that the
  verifier is ~97% GPU-bound.
* The speculative verifier's 4-layer pipeline flush no longer requires DSpark
  hidden-state capture (rollback: `DS4_METAL_DISABLE_SPEC_VERIFY_FLUSH`).

### 5. Measured negative results (code present, default off — or documented)

These cost real GPU-hours; recording them is part of the PR's value:

* **`mul_mv_ext` r1_6/7/8 template instantiations** (dense weights streamed
  once instead of twice for 6..8-row blocks): **bit-identical but ~25% slower
  verifies on M1 Ultra** — the historical two grid.y slices run concurrently
  across cores, while an 8-accumulator block halves threadgroup count and
  hurts occupancy. Kept opt-in (`DS4_METAL_ENABLE_MV_EXT_WIDE`) because the
  trade-off may invert on wider-register devices (M3/M5) — worth one run of
  the schedule bench there.
* **DSpark on Metal M1 Ultra is net negative today**: 26.7 t/s on code vs
  29.3 without, despite an 83.65% acceptance rate (2.29 tokens/cycle). The
  breakdown (`verify_gpu_busy`) shows a 5-row verify costs ~112 ms and an
  8-row one ~121-135 ms — `verify(N) ≈ 34 + 10.9·N ms` — i.e. ~3× a 37 ms
  decode step, nearly all GPU execution in the batch layer kernels. This is
  the "hand-written N=2/N=4 decode microbatch" gap the comment at the
  verifier already names. Re-tested with `iogpu.wired_limit_mb` raised so the
  DSpark support model is fully wired: the verdict does not change.
* **Byte-count and dispatch-count theories of that fixed cost both fail on
  silicon**: halving dense bytes (r1_8) made it slower, and removing ~230 tiny
  dispatches (compressor fusion) bought ~1% (~10 µs per queued dispatch).
  A per-stage attribution with `DS4_METAL_LAYER_STAGE_PROFILE` on 8-row verify
  blocks (sync overhead subtracted) settles it: `routed_moe` ≈ 47 ms (~40%,
  and it already streams its 13.6 GB at ~290 GB/s — bandwidth-saturated),
  `output_proj` ≈ 22 ms (the 8× re-read of `attn_output_a` is real, but the
  SLC absorbs about half of it), `hc_pre` ≈ 13, `q_path` ≈ 11,
  `indexer_setup` ≈ 10; the batched flash-attention mma path, our previous
  prime suspect, accounts for almost nothing at 2k context. So the verifier
  floor is set by expert bytes, and the two kernels worth writing next are:
  an **expert-gathered MoE verify pass** (group the up-to-48 (row, expert)
  selections by expert and stream each slab once — measured cross-row overlap
  ~38% → roughly −16 ms), and an **N-row `attn_out_low`** (weights outer,
  token loop inner → −10-15 ms). Realistic verify(8) floor: ~60-75 ms, which
  would put DSpark at ~33 t/s and n-gram at ~37-38 t/s on code on M1 Ultra.

## Files touched

| File | Change |
|---|---|
| `ds4_metal.m` | `ds4_gpu_device_is_m3_class()` + 15 gate sites; MoE tiny thresholds; `mv_ext` r1 table + names (opt-in); GPU-busy accessor |
| `metal/dense.metal` | `kernel_mul_mv_ext_{f16,q8_0}_f32_r1_{6,7,8}` instantiations (dispatched only under the opt-in) |
| `ds4.c` | n-gram drafter + verifier entry (`ds4_ngram_propose`, `ds4_session_eval_ngram_speculative_argmax`) and hook in `ds4_session_eval_speculative_argmax`; `need_spec_verifier` and `ds4_engine_mtp_draft_tokens` extensions; batch compressor fused loop + `metal_graph_batch_comp_fuse_defer`; verifier flush widening; `verify_gpu_busy` stats |
| `ds4_agent.c` | agent speculative branch (greedy, plain-text-only, ≤8) |
| `ds4_gpu.h` | `ds4_gpu_busy_profile_seconds()` declaration |

## Platform / device impact matrix

| Target | Impact |
|---|---|
| Metal M1/M2 (pre-M5, no "M3" in name) | No change by default. With `DS4_METAL_WIDEN_M3_GATES=1` + split 2/8: +19% measured on M1 Ultra, bit-exact. MoE tiny widening and batch compressor fusion are on by default, both stream-identical (fusion additionally requires the widen env on non-M3 devices because it shares the decode fusion's `kv_rope_fp8` gate). |
| Metal M3/M4 | M3 keeps its existing gates (the new predicate is a superset). M4 gains the widened tier only under the env. The 2/8 split and the r1_6/7/8 kernels deserve one schedule-bench run each here before considering defaults. |
| Metal M5 | Untouched: M5-only paths keep their own predicates; the ported-M5 feature checks are unchanged. |
| CUDA / ROCm | No behavioral change: Apple-scoped code, plus env-gated engine paths that default off. `DS4_NGRAM_SPEC` would reach the shared verifier on CUDA but is untested there — left opt-in on purpose. |
| CPU build (`make cpu`) | Builds; new Apple branches compile out or return false. |
| GLM 5.2 | Untouched (GLM sessions branch before the n-gram hook; compressor fusion requires the DeepSeek ratio-4 shape). |

## How it was validated (M1 Ultra, Metal, q2 0731 imatrix GGUF)

Correctness:

```sh
# bit-exact A/B for the widened gates (401 logit rows + 400 selections identical)
./speed-bench/metal_decode_schedule_bench --include-selection \
  --control-first 2 --control-second 8 --candidate-env DS4_METAL_WIDEN_M3_GATES

# deterministic eval gate: identical with and without the patched env (4/4 PASSED)
./ds4-eval -m ds4flash.gguf --plain --questions 4 --tokens 2048 --temp 0 --seed 1

# verifier micro-harness: stream must equal plain greedy decode
DS4_NGRAM_SPEC=5 DS4_NGRAM_FAKE_PROPOSAL=1 ./ds4 ...   # byte-identical, all variants
```

Regression suite (per CONTRIBUTING.md), M1 Ultra, Metal, q2 0731 imatrix GGUF:

```text
./ds4_test --server                              OK
./ds4_test --logprob-vectors   (default env)     OK   # official continuation vectors
./ds4_test --logprob-vectors   (patched env:     OK   # identical result with
   WIDEN_M3_GATES=1 + split 2/8)                      # all exact knobs enabled
./ds4_test --metal-kernels                       29 failures — PRE-EXISTING:
   pristine HEAD (84cc882) in a clean worktree fails with the same 29
   ("router batch weights total selected=0 ...") on M1 Ultra; patched and
   pristine outputs are identical. Looks like M3-gated kernel tests that were
   never exercised on M1-class devices — flagged here for maintainer triage,
   not introduced by this PR.
make cpu                                         builds clean (not executed —
                                                 per the macOS kernel-bug note)
make (Metal)                                     builds clean, zero warnings
```

Not run (no hardware access): CUDA (`make cuda-regression`), ROCm, M2/M3/M4/M5
devices. `--long-context` and `--tool-call-quality` were skipped for time; the
deterministic `ds4-eval` q1-q4 gate above covers generation drift end-to-end.

Speed (`ds4-bench`, promessi_sposi, ctx 2048/16k/32k, gen 128; plus fixed-prompt
CLI runs at 512 tokens): tables above; raw logs available.

Real-workload confirmation, extracted from `ds4-server` per-request logs with
the device defaults active (`WIDEN` + split 2/8 + ngram 8/6), vs the measured
24.6 t/s upstream generation baseline on the same machine:

| workload | generation | vs upstream |
|---|---|---|
| agentic coding eval (15-step multifile task, tools) | **34.4 t/s** effective (median 38.4, peaks 42.7) | **+40%**, task wall −25% |
| reasoning eval (25 hard questions, thinking) | **27.8 t/s** effective (median 27.6) | **+13%** |

Quality on those same runs: 24/25 hard-accuracy, agent task fully passed
(hidden tests included, 0 invalid tool calls). The agent run also prefilled
only 3.5k of its 50k prompt tokens thanks to the existing exact-DSML/KV
prefix reuse — worth knowing when reading agent prefill figures.

## SSD streaming: findings and two small deltas

We ran the same measurement-first pass on `--ssd-streaming` with the 145 GB
MXFP4 GGUF (M1 Ultra, 128 GB). Two code deltas and three findings:

* **n-gram speculation is now gated off under SSD streaming**: the spec
  verifier machinery is not provisioned there (measured: every block reports
  `verifier_unavailable`; upstream likewise refuses `--mtp` with streaming),
  so the device defaults no longer arm dead machinery. Output verified
  identical with/without.
* **New diagnostic**: `DS4_METAL_STREAM_PREPARE_SUBPROFILE=1` adds sub-timers,
  a per-return-path histogram, and mlock/slot-state deltas to the expert
  cache's prepare path. It is how the findings below were established.
* Findings: (1) steady-state MXFP4 streaming decode on M1 Ultra is
  ~9.5-9.7 t/s at 0.80 cache hit rate (auto budget wins every manual budget
  we tried; extra pread threads don't help); short sessions run slower only
  while the slab cache fills from SSD. (2) The host-side prepare/mlock cost
  (~0.5 ms per miss) sits on the async loader threads, off the token
  critical path — we verified this the hard way: a bulk-mlock-per-slab
  variant was throughput-neutral while doubling mlock work (fresh pages pay
  zero-fill wiring), so it was retired with a note in the code. (3) The
  remaining streaming levers are architectural (two-tier resident+streamed
  experts, oracle-guided prefetch) — an expert-selection trace facility and
  our recorded traces make the prefetch ceiling computable offline before
  anyone writes a predictor.

## Unrelated footgun found while validating (report, not fixed here)

`make cpu` links the CPU-only builds over the same output names (`ds4`,
`ds4-eval`, …). A subsequent `make` sees those binaries as newer than the
Metal objects and does **not** relink them, so the tree silently keeps CPU
binaries — we measured a "Metal" eval at 5.7 t/s before spotting
`backend=cpu` in its startup line. Anyone following CONTRIBUTING's
"`make cpu` to verify portability" hits this. Possible fixes: distinct output
names for the cpu target, or forcing the link step in `all`.

## Open questions for maintainers

1. Should the pre-M5 widening become the default once M2/M4 repeat the
   bit-exact run? The per-fusion `DS4_METAL_DISABLE_*` knobs make a staged
   rollout easy.
2. Is a `--ngram-spec N` CLI flag preferable to the env for the speculation?
   We kept env-only to avoid touching the flag surface before a design nod.
3. The verifier microbatch problem is still open: with the fixed ~34 ms +
   10.9 ms/row cost, DSpark cannot win on M1-class Metal. Our profiling
   points at the batched FA path next; happy to iterate with review guidance.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
