### PR TITLE
ssd streaming: packed expert file, +10.7% on DeepSeek V4 Flash (output byte identical)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@
 *.dSYM/
 __pycache__/
 *.pyc
-/misc/
+!/misc/
+/misc/*
+!/misc/pack_experts.py
 .*.swp
 .DS_Store

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -14,6 +14,7 @@
 #include <limits.h>
 #include <time.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <unistd.h>
 #include <sys/mman.h>
 #include <sys/sysctl.h>
@@ -11801,8 +11802,174 @@ static int ds4_gpu_stream_expert_readahead_enabled(void) {
            getenv("DS4_METAL_DISABLE_STREAMING_EXPERT_READAHEAD") == NULL;
 }
 
-static void ds4_gpu_stream_expert_readahead_range(uint64_t offset, uint64_t len) {
-    if (!ds4_gpu_stream_expert_readahead_enabled() || g_model_fd < 0 || len == 0) {
+
+/* Packed expert file (DSP1).
+ *
+ * GGUF stores an MoE layer's gate, up and down matrices as three separate
+ * multi-gigabyte tensors, so the three slices belonging to ONE expert sit
+ * about a tensor apart on disk and a single expert miss costs three distant
+ * reads.  misc/pack_experts.py copies those bytes into a second file where
+ * each expert's three slices are adjacent:
+ *
+ *     expert 0: gate | up | down
+ *     expert 1: gate | up | down
+ *
+ * The bytes are copied exactly, nothing is requantized or transformed, so
+ * this only changes where a read lands, never what it returns.  Measured on
+ * DeepSeek V4 Flash: average expert load 5.01 ms against 5.68 ms unpacked.
+ *
+ * The file is found automatically as <model path>.dsp, or explicitly via
+ * DS4_EXPERT_PACKED_SIDECAR.  Without it everything behaves as before. */
+typedef struct {
+    uint64_t gate_gguf_off;
+    uint64_t up_gguf_off;
+    uint64_t down_gguf_off;
+    uint64_t gate_len;
+    uint64_t down_len;
+    uint64_t packed_off;
+} ds4_packed_expert_entry;
+
+static int g_packed_expert_state;
+static int g_packed_expert_fd = -1;
+static ds4_packed_expert_entry *g_packed_expert_index;
+static uint64_t g_packed_expert_count;
+static pthread_mutex_t g_packed_expert_mutex = PTHREAD_MUTEX_INITIALIZER;
+static _Atomic uint64_t g_packed_expert_reads;
+
+static int ds4_packed_expert_entry_cmp(const void *a, const void *b) {
+    const uint64_t ka = ((const ds4_packed_expert_entry *)a)->gate_gguf_off;
+    const uint64_t kb = ((const ds4_packed_expert_entry *)b)->gate_gguf_off;
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+}
+
+static int ds4_gpu_packed_expert_active(void) {
+    return g_packed_expert_state == 1;
+}
+
+static void ds4_gpu_packed_expert_report(void) {
+    fprintf(stderr, "ds4: packed expert file final: reads=%llu\n",
+            (unsigned long long)atomic_load(&g_packed_expert_reads));
+}
+
+static void ds4_gpu_packed_expert_load_file(const char *path,
+                                            int announce_missing);
+
+static void ds4_gpu_packed_expert_init_locked(void) {
+    g_packed_expert_state = -1;
+    const char *path = getenv("DS4_EXPERT_PACKED_SIDECAR");
+    if (path && path[0]) {
+        /* An explicit "0" or "none" ignores the packed file entirely, which
+         * makes it easy to measure with and without. */
+        if (strcmp(path, "0") == 0 || strcmp(path, "none") == 0) return;
+        ds4_gpu_packed_expert_load_file(path, 1);
+        return;
+    }
+    /* No explicit path given: look for <model path>.dsp next to the model
+     * file, so the packed expert file works without any configuration. */
+    if (g_model_fd >= 0) {
+        char model_path[1024];
+        model_path[0] = 0;
+        if (fcntl(g_model_fd, F_GETPATH, model_path) == 0 && model_path[0]) {
+            char auto_path[1024 + 8];
+            snprintf(auto_path, sizeof(auto_path), "%s.dsp", model_path);
+            ds4_gpu_packed_expert_load_file(auto_path, 0);
+        }
+    }
+}
+
+static void ds4_gpu_packed_expert_load_file(const char *path,
+                                            int announce_missing) {
+    const int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        if (announce_missing)
+            fprintf(stderr, "ds4: packed expert file: cannot open %s\n", path);
+        return;
+    }
+    uint8_t header[32];
+    if (pread(fd, header, sizeof(header), 0) != (ssize_t)sizeof(header) ||
+        memcmp(header, "DSP1", 4) != 0) {
+        fprintf(stderr, "ds4: packed expert file: bad header in %s\n", path);
+        close(fd);
+        return;
+    }
+    uint32_t version = 0;
+    uint64_t index_off = 0, count = 0;
+    memcpy(&version, header + 4, sizeof(version));
+    memcpy(&index_off, header + 8, sizeof(index_off));
+    memcpy(&count, header + 16, sizeof(count));
+    if (version != 1 || count == 0 || count > 100000 ||
+        count > SIZE_MAX / sizeof(ds4_packed_expert_entry)) {
+        fprintf(stderr, "ds4: packed expert file: invalid index\n");
+        close(fd);
+        return;
+    }
+    ds4_packed_expert_entry *index =
+        malloc((size_t)count * sizeof(*index));
+    const size_t index_bytes = (size_t)count * sizeof(*index);
+    if (!index || pread(fd, index, index_bytes, (off_t)index_off) !=
+                      (ssize_t)index_bytes) {
+        fprintf(stderr, "ds4: packed expert file: index read failed\n");
+        free(index);
+        close(fd);
+        return;
+    }
+    qsort(index, (size_t)count, sizeof(*index),
+          ds4_packed_expert_entry_cmp);
+    g_packed_expert_fd = fd;
+    g_packed_expert_index = index;
+    g_packed_expert_count = count;
+    g_packed_expert_state = 1;
+    atexit(ds4_gpu_packed_expert_report);
+    fprintf(stderr,
+            "ds4: packed expert file active: %s (%llu experts)\n",
+            path, (unsigned long long)count);
+}
+
+static const ds4_packed_expert_entry *ds4_gpu_packed_expert_lookup(
+        uint64_t gate_off, uint64_t up_off, uint64_t down_off,
+        uint64_t gate_len, uint64_t down_len) {
+    if (g_packed_expert_state == 0) {
+        pthread_mutex_lock(&g_packed_expert_mutex);
+        if (g_packed_expert_state == 0) ds4_gpu_packed_expert_init_locked();
+        pthread_mutex_unlock(&g_packed_expert_mutex);
+    }
+    if (g_packed_expert_state != 1) return NULL;
+    uint64_t lo = 0, hi = g_packed_expert_count;
+    while (lo < hi) {
+        const uint64_t mid = (lo + hi) / 2;
+        if (g_packed_expert_index[mid].gate_gguf_off < gate_off) lo = mid + 1;
+        else hi = mid;
+    }
+    if (lo >= g_packed_expert_count) return NULL;
+    const ds4_packed_expert_entry *e = &g_packed_expert_index[lo];
+    return e->gate_gguf_off == gate_off && e->up_gguf_off == up_off &&
+           e->down_gguf_off == down_off && e->gate_len == gate_len &&
+           e->down_len == down_len ? e : NULL;
+}
+
+/* If the packed expert file covers this expert, rewrite the three offsets to
+ * point into it and return its descriptor; otherwise leave them alone and
+ * return the model file.  Callers use the returned descriptor for both the
+ * read and its readahead hint. */
+static int ds4_gpu_packed_expert_redirect(uint64_t *gate_off,
+                                          uint64_t *up_off,
+                                          uint64_t *down_off,
+                                          uint64_t gate_len,
+                                          uint64_t down_len) {
+    const ds4_packed_expert_entry *e =
+        ds4_gpu_packed_expert_lookup(*gate_off, *up_off, *down_off,
+                                     gate_len, down_len);
+    if (!e) return g_model_fd;
+    *gate_off = e->packed_off;
+    *up_off = e->packed_off + gate_len;
+    *down_off = e->packed_off + gate_len * 2ull;
+    return g_packed_expert_fd;
+}
+
+/* Warm one range of whichever file it lives in. */
+static void ds4_gpu_stream_expert_readahead_range(int fd, uint64_t offset,
+                                                  uint64_t len) {
+    if (!ds4_gpu_stream_expert_readahead_enabled() || fd < 0 || len == 0) {
         return;
     }
 
@@ -11819,7 +11986,7 @@ static void ds4_gpu_stream_expert_readahead_range(uint64_t offset, uint64_t len)
         struct radvisory ra;
         ra.ra_offset = (off_t)pos;
         ra.ra_count = (int)chunk64;
-        (void)fcntl(g_model_fd, F_RDADVISE, &ra);
+        (void)fcntl(fd, F_RDADVISE, &ra);
 
         pos += chunk64;
         rem -= chunk64;
@@ -11835,6 +12002,22 @@ static void ds4_gpu_stream_expert_readahead_range(uint64_t offset, uint64_t len)
 #endif
 }
 
+/* Warm an expert's three slices, following the packed expert file when it
+ * covers them, since that is where the read will come from. */
+static void ds4_gpu_stream_expert_readahead_expert(uint64_t gate_off,
+                                                   uint64_t up_off,
+                                                   uint64_t down_off,
+                                                   uint64_t gate_len,
+                                                   uint64_t down_len) {
+    if (!ds4_gpu_stream_expert_readahead_enabled()) return;
+    const int fd = ds4_gpu_packed_expert_redirect(&gate_off, &up_off,
+                                                  &down_off, gate_len,
+                                                  down_len);
+    ds4_gpu_stream_expert_readahead_range(fd, gate_off, gate_len);
+    ds4_gpu_stream_expert_readahead_range(fd, up_off, gate_len);
+    ds4_gpu_stream_expert_readahead_range(fd, down_off, down_len);
+}
+
 typedef struct {
     uint64_t offset;
     uint64_t len;
@@ -11842,6 +12025,9 @@ typedef struct {
     uint64_t read_bytes;
     double ms;
     int ok;
+    /* Which file `offset` belongs to.  0 means the model file, which is what
+     * every task gets unless the packed expert file covers it. */
+    int read_fd;
 } ds4_gpu_stream_expert_pread_task;
 
 typedef struct {
@@ -11941,7 +12127,10 @@ static uint32_t ds4_gpu_stream_expert_pread_thread_count(uint32_t n_tasks) {
     return threads;
 }
 
+static _Atomic int g_stream_expert_gguf_zero_guard_done;
+
 static int ds4_gpu_stream_expert_pread_into(
+        int       fd,
         uint64_t  offset,
         uint64_t  len,
         uint8_t  *dst,
@@ -11949,7 +12138,7 @@ static int ds4_gpu_stream_expert_pread_into(
         double   *ms_out) {
     if (read_bytes) *read_bytes = 0;
     if (ms_out) *ms_out = 0.0;
-    if (g_model_fd < 0 ||
+    if (fd < 0 ||
         !dst ||
         len == 0 ||
         offset > (uint64_t)LLONG_MAX ||
@@ -11957,6 +12146,7 @@ static int ds4_gpu_stream_expert_pread_into(
         return 0;
     }
 
+    if (fd == g_packed_expert_fd) atomic_fetch_add(&g_packed_expert_reads, 1);
     const double t0 = ds4_gpu_now_ms();
     uint64_t pos = 0;
     int ok = 1;
@@ -11965,7 +12155,7 @@ static int ds4_gpu_stream_expert_pread_into(
         const size_t want = rem > (uint64_t)SSIZE_MAX ? (size_t)SSIZE_MAX : (size_t)rem;
         ssize_t nread;
         do {
-            nread = pread(g_model_fd, dst + pos, want, (off_t)(offset + pos));
+            nread = pread(fd, dst + pos, want, (off_t)(offset + pos));
         } while (nread < 0 && errno == EINTR);
         if (nread <= 0) {
             ok = 0;
@@ -11976,6 +12166,28 @@ static int ds4_gpu_stream_expert_pread_into(
     const double dt = ds4_gpu_now_ms() - t0;
     if (read_bytes) *read_bytes = pos;
     if (ms_out) *ms_out = dt;
+    /* One-time check on the first sizeable expert read from the model file.
+     * misc/pack_experts.py frees the expert space inside the GGUF once the
+     * bytes are safely in the packed file, and reads there come back as
+     * zeros.  Generating from zeroed weights would look like a broken model
+     * rather than a missing file, so say what happened.  A real expert slice
+     * is never all zeros. */
+    if (ok && pos == len && fd == g_model_fd && !ds4_gpu_packed_expert_active() &&
+        len >= (1ull << 20) &&
+        !atomic_exchange(&g_stream_expert_gguf_zero_guard_done, 1)) {
+        uint64_t i = 0;
+        while (i < len && dst[i] == 0) i++;
+        if (i == len) {
+            fprintf(stderr,
+                "ds4: the first expert read from the GGUF came back as all zeros.\n"
+                "ds4: this usually means the expert weights were moved into a packed\n"
+                "ds4: expert file (.dsp) and it cannot be found.  Put it next to the\n"
+                "ds4: model as <model>.dsp, or set DS4_EXPERT_PACKED_SIDECAR to its\n"
+                "ds4: path.  To move the bytes back into the GGUF:\n"
+                "ds4:     python3 misc/pack_experts.py --restore <model.gguf>\n");
+            exit(1);
+        }
+    }
     if (!ok || pos != len) {
         fprintf(stderr,
                 "ds4: Metal streaming expert explicit pread failed offset=%.2f GiB len=%.2f MiB read=%.2f MiB\n",
@@ -11992,11 +12204,13 @@ static void *ds4_gpu_stream_expert_pread_worker(void *arg) {
         (ds4_gpu_stream_expert_pread_worker_args *)arg;
     for (uint32_t i = wa->worker_index; i < wa->n_tasks; i += wa->n_workers) {
         ds4_gpu_stream_expert_pread_task *task = &wa->tasks[i];
-        task->ok = ds4_gpu_stream_expert_pread_into(task->offset,
-                                                    task->len,
-                                                    task->dst,
-                                                    &task->read_bytes,
-                                                    &task->ms);
+        task->ok = ds4_gpu_stream_expert_pread_into(
+                task->read_fd > 0 ? task->read_fd : g_model_fd,
+                task->offset,
+                task->len,
+                task->dst,
+                &task->read_bytes,
+                &task->ms);
     }
     return NULL;
 }
@@ -12051,11 +12265,13 @@ static void *ds4_gpu_stream_expert_pread_pool_worker(void *arg) {
                 &g_stream_expert_pread_pool_tasks[task_index];
             pthread_mutex_unlock(&g_stream_expert_pread_pool_mutex);
 
-            task->ok = ds4_gpu_stream_expert_pread_into(task->offset,
-                                                        task->len,
-                                                        task->dst,
-                                                        &task->read_bytes,
-                                                        &task->ms);
+            task->ok = ds4_gpu_stream_expert_pread_into(
+                    task->read_fd > 0 ? task->read_fd : g_model_fd,
+                    task->offset,
+                    task->len,
+                    task->dst,
+                    &task->read_bytes,
+                    &task->ms);
 
             pthread_mutex_lock(&g_stream_expert_pread_pool_mutex);
         }
@@ -14809,9 +15025,10 @@ static ds4_gpu_stream_expert_cache_entry *ds4_gpu_stream_expert_cache_get_protec
         return e;
     }
 
-    ds4_gpu_stream_expert_readahead_range(gate_abs_offset, gate_expert_bytes);
-    ds4_gpu_stream_expert_readahead_range(up_abs_offset, gate_expert_bytes);
-    ds4_gpu_stream_expert_readahead_range(down_abs_offset, down_expert_bytes);
+    ds4_gpu_stream_expert_readahead_expert(gate_abs_offset, up_abs_offset,
+                                           down_abs_offset,
+                                           gate_expert_bytes,
+                                           down_expert_bytes);
 
     id<MTLBuffer> gate_buf = nil;
     id<MTLBuffer> up_buf = nil;
@@ -14851,21 +15068,33 @@ static ds4_gpu_stream_expert_cache_entry *ds4_gpu_stream_expert_cache_get_protec
     uint8_t *down_dst = (uint8_t *)[down_buf contents] + down_inner;
     if (!gate_dst || !up_dst || !down_dst) return NULL;
 
+    /* One expert's three slices are adjacent in the packed expert file and a
+     * tensor apart in the GGUF, so ask whichever file holds them. */
+    uint64_t read_gate_off = gate_abs_offset;
+    uint64_t read_up_off = up_abs_offset;
+    uint64_t read_down_off = down_abs_offset;
+    const int read_fd =
+        ds4_gpu_packed_expert_redirect(&read_gate_off, &read_up_off,
+                                       &read_down_off, gate_expert_bytes,
+                                       down_expert_bytes);
     ds4_gpu_stream_expert_pread_task tasks[3] = {
         {
-            .offset = gate_abs_offset,
+            .offset = read_gate_off,
             .len = gate_expert_bytes,
             .dst = gate_dst,
+            .read_fd = read_fd,
         },
         {
-            .offset = up_abs_offset,
+            .offset = read_up_off,
             .len = gate_expert_bytes,
             .dst = up_dst,
+            .read_fd = read_fd,
         },
         {
-            .offset = down_abs_offset,
+            .offset = read_down_off,
             .len = down_expert_bytes,
             .dst = down_dst,
+            .read_fd = read_fd,
         },
     };
     uint64_t read_bytes = 0;
@@ -15273,12 +15502,11 @@ int ds4_gpu_stream_expert_cache_begin_selected_load(
         const int force_reuse =
             cache_budget != 0 && reserved_entries >= cache_budget;
 
-        ds4_gpu_stream_expert_readahead_range(p->gate_abs_offsets[slot],
-                                              gate_expert_bytes);
-        ds4_gpu_stream_expert_readahead_range(p->up_abs_offsets[slot],
-                                              gate_expert_bytes);
-        ds4_gpu_stream_expert_readahead_range(p->down_abs_offsets[slot],
-                                              down_expert_bytes);
+        ds4_gpu_stream_expert_readahead_expert(p->gate_abs_offsets[slot],
+                                               p->up_abs_offsets[slot],
+                                               p->down_abs_offsets[slot],
+                                               gate_expert_bytes,
+                                               down_expert_bytes);
 
         if (load_i < batch_reuse_count &&
             batch_reuse[load_i].gate_buffer &&
@@ -15330,20 +15558,30 @@ int ds4_gpu_stream_expert_cache_begin_selected_load(
             return 0;
         }
         const double task_t0 = load_timing ? ds4_gpu_now_ms() : 0.0;
+        uint64_t read_gate_off = p->gate_abs_offsets[slot];
+        uint64_t read_up_off = p->up_abs_offsets[slot];
+        uint64_t read_down_off = p->down_abs_offsets[slot];
+        const int read_fd =
+            ds4_gpu_packed_expert_redirect(&read_gate_off, &read_up_off,
+                                           &read_down_off, gate_expert_bytes,
+                                           down_expert_bytes);
         p->tasks[p->n_tasks++] = (ds4_gpu_stream_expert_pread_task) {
-            .offset = p->gate_abs_offsets[slot],
+            .offset = read_gate_off,
             .len = gate_expert_bytes,
             .dst = gate_dst,
+            .read_fd = read_fd,
         };
         p->tasks[p->n_tasks++] = (ds4_gpu_stream_expert_pread_task) {
-            .offset = p->up_abs_offsets[slot],
+            .offset = read_up_off,
             .len = gate_expert_bytes,
             .dst = up_dst,
+            .read_fd = read_fd,
         };
         p->tasks[p->n_tasks++] = (ds4_gpu_stream_expert_pread_task) {
-            .offset = p->down_abs_offsets[slot],
+            .offset = read_down_off,
             .len = down_expert_bytes,
             .dst = down_dst,
+            .read_fd = read_fd,
         };
         if (load_timing) {
             ds4_gpu_stream_expert_timing_note_prepare_task(
@@ -15565,12 +15803,11 @@ static int ds4_gpu_stream_expert_cache_load_selected_missing_with_source(
             cache_budget != 0 && reserved_entries >= cache_budget;
 
         if (!gpu_copy_source) {
-            ds4_gpu_stream_expert_readahead_range(gate_abs_offsets[slot],
-                                                  gate_expert_bytes);
-            ds4_gpu_stream_expert_readahead_range(up_abs_offsets[slot],
-                                                  gate_expert_bytes);
-            ds4_gpu_stream_expert_readahead_range(down_abs_offsets[slot],
-                                                  down_expert_bytes);
+            ds4_gpu_stream_expert_readahead_expert(gate_abs_offsets[slot],
+                                                   up_abs_offsets[slot],
+                                                   down_abs_offsets[slot],
+                                                   gate_expert_bytes,
+                                                   down_expert_bytes);
         }
 
         if (load_i < batch_reuse_count &&
@@ -16184,12 +16421,11 @@ static int ds4_gpu_stream_expert_cache_prepare_selected_batch(
 
             const int force_reuse =
                 cache_budget != 0 && reserved_entries >= cache_budget;
-            ds4_gpu_stream_expert_readahead_range(unique_gate_offsets[u],
-                                                  gate_expert_bytes);
-            ds4_gpu_stream_expert_readahead_range(unique_up_offsets[u],
-                                                  gate_expert_bytes);
-            ds4_gpu_stream_expert_readahead_range(unique_down_offsets[u],
-                                                  down_expert_bytes);
+            ds4_gpu_stream_expert_readahead_expert(unique_gate_offsets[u],
+                                                   unique_up_offsets[u],
+                                                   unique_down_offsets[u],
+                                                   gate_expert_bytes,
+                                                   down_expert_bytes);
             const double buffer_t0 = load_timing ? ds4_gpu_now_ms() : 0.0;
             const int prepared =
                 ds4_gpu_stream_expert_cache_prepare_load_buffers(layer,

--- a/misc/pack_experts.py
+++ b/misc/pack_experts.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Pack the expert weights of a GGUF into one flat file for faster SSD streaming.
+
+In the GGUF, one expert's gate, up and down matrices live in three separate
+tensors, about a gigabyte apart on disk. So loading one expert during SSD
+streaming costs three scattered reads. This tool copies the bytes of every
+expert into a second file (model.gguf.dsp) where the three slices of each
+expert sit next to each other:
+
+    expert 0: gate | up | down
+    expert 1: gate | up | down
+    ...
+
+The engine then loads an expert with one contiguous read. The bytes are copied
+exactly, nothing is quantized or transformed, and the engine finds the .dsp
+file automatically when it sits next to the model.
+
+By default, after every byte has been verified, the tool releases the expert
+space inside the GGUF so you do not store 137 GB twice. The GGUF file stays
+and keeps working with this engine, it just shrinks on disk. This is fully
+reversible with --restore as long as the .dsp file exists. If you want to keep
+the GGUF complete (for example to keep using it with other software), pass
+--keep-gguf-experts.
+
+Typical use:
+
+    python3 misc/pack_experts.py model.gguf              # pack, verify, release
+    python3 misc/pack_experts.py model.gguf --keep-gguf-experts
+    python3 misc/pack_experts.py model.gguf --restore    # put the bytes back
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import importlib.util
+import os
+import platform
+import re
+import struct
+import sys
+from pathlib import Path
+
+
+HEADER_SIZE = 32
+ENTRY = struct.Struct("<6Q")
+ALIGNMENT = 4096
+N_EXPERT = 256
+
+
+def align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def align_down(value: int, alignment: int) -> int:
+    return value // alignment * alignment
+
+
+def parse_layers(spec: str) -> list[int]:
+    layers: set[int] = set()
+    for item in spec.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if "-" in item:
+            lo_text, hi_text = item.split("-", 1)
+            lo, hi = int(lo_text), int(hi_text)
+            if hi < lo:
+                raise ValueError(f"descending layer range: {item}")
+            layers.update(range(lo, hi + 1))
+        else:
+            layers.add(int(item))
+    if not layers:
+        raise ValueError("no layers selected")
+    return sorted(layers)
+
+
+def load_parser(script_dir: Path):
+    parser_path = (
+        script_dir.parent
+        / "gguf-tools"
+        / "mixed"
+        / "splice_mixed_expert_layers_gguf.py"
+    )
+    spec = importlib.util.spec_from_file_location("ds4_gguf_parser", parser_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load GGUF parser at {parser_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    # DeepSeek V4 Flash MXFP4: 32 values in one 17-byte block.
+    module.GGML_QUANT_SIZES[39] = (32, 17, "MXFP4")
+    return module
+
+
+def discover_layers(by_name: dict) -> list[int]:
+    layers = []
+    pattern = re.compile(r"^blk\.(\d+)\.ffn_gate_exps\.weight$")
+    for name in by_name:
+        m = pattern.match(name)
+        if m:
+            layers.append(int(m.group(1)))
+    return sorted(layers)
+
+
+def release_range(fd: int, offset: int, length: int) -> bool:
+    """Release the disk space of a byte range, so reads there return zeros.
+
+    Only the 4096-aligned interior of the range is released. Returns False if
+    the file system cannot do this, and the file is left untouched then.
+    """
+    start = align_up(offset, ALIGNMENT)
+    end = align_down(offset + length, ALIGNMENT)
+    if end <= start:
+        return True
+    if platform.system() == "Darwin":
+        import fcntl as fcntl_mod
+
+        F_PUNCHHOLE = 99
+        # struct fpunchhole: fp_flags u32, reserved u32, fp_offset i64,
+        # fp_length i64. Passed through Python's fcntl, which hands the
+        # kernel a pointer to a copy of these bytes.
+        arg = struct.pack("<IIqq", 0, 0, start, end - start)
+        try:
+            fcntl_mod.fcntl(fd, F_PUNCHHOLE, arg)
+            return True
+        except OSError:
+            return False
+    if platform.system() == "Linux":
+        libc = ctypes.CDLL(None, use_errno=True)
+        FALLOC_FL_KEEP_SIZE = 1
+        FALLOC_FL_PUNCH_HOLE = 2
+        libc.fallocate.restype = ctypes.c_int
+        libc.fallocate.argtypes = [
+            ctypes.c_int, ctypes.c_int, ctypes.c_int64, ctypes.c_int64,
+        ]
+        return libc.fallocate(
+            fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE, start, end - start
+        ) == 0
+    return False
+
+
+def disk_usage_gib(path: Path) -> float:
+    st = os.stat(path)
+    return st.st_blocks * 512 / (1 << 30)
+
+
+def read_exact(fd: int, length: int, offset: int) -> bytes:
+    data = os.pread(fd, length, offset)
+    if len(data) != length:
+        raise EOFError(f"short read of {length} bytes at offset {offset}")
+    return data
+
+
+def write_exact(fd: int, data: bytes, offset: int) -> None:
+    written = 0
+    while written < len(data):
+        n = os.pwrite(fd, data[written:], offset + written)
+        if n <= 0:
+            raise OSError("short write")
+        written += n
+
+
+def read_index(dsp_fd: int) -> list[tuple[int, ...]]:
+    header = read_exact(dsp_fd, HEADER_SIZE, 0)
+    if header[:4] != b"DSP1":
+        raise ValueError("this is not a packed expert file (bad header)")
+    version, index_off, count = struct.unpack_from("<IQQ", header, 4)
+    if version != 1 or count == 0:
+        raise ValueError("unsupported packed expert file")
+    blob = read_exact(dsp_fd, count * ENTRY.size, index_off)
+    return [ENTRY.unpack_from(blob, i * ENTRY.size) for i in range(count)]
+
+
+def verify_against_gguf(gguf_fd: int, dsp_fd: int,
+                        entries: list[tuple[int, ...]]) -> int:
+    """Compare every expert byte between the GGUF and the packed file."""
+    checked = 0
+    for n, (gate_off, up_off, down_off, gate_len, down_len, packed_off) in \
+            enumerate(entries):
+        slices = (
+            (gate_off, packed_off, gate_len),
+            (up_off, packed_off + gate_len, gate_len),
+            (down_off, packed_off + 2 * gate_len, down_len),
+        )
+        for gguf_off, dsp_off, length in slices:
+            a = read_exact(gguf_fd, length, gguf_off)
+            b = read_exact(dsp_fd, length, dsp_off)
+            if a != b:
+                raise ValueError(
+                    f"verification failed at expert {n}, GGUF offset {gguf_off}"
+                )
+            checked += length
+        if (n + 1) % 1024 == 0:
+            print(f"verified {n + 1}/{len(entries)} experts", flush=True)
+    return checked
+
+
+def restore(source: Path, dsp_path: Path) -> int:
+    if not dsp_path.exists():
+        print(f"cannot restore: {dsp_path} does not exist")
+        return 1
+    gguf_fd = os.open(source, os.O_RDWR)
+    dsp_fd = os.open(dsp_path, os.O_RDONLY)
+    try:
+        entries = read_index(dsp_fd)
+        print(f"restoring {len(entries)} experts from {dsp_path.name} "
+              f"into {source.name}")
+        for n, (gate_off, up_off, down_off, gate_len, down_len, packed_off) in \
+                enumerate(entries):
+            slices = (
+                (gate_off, packed_off, gate_len),
+                (up_off, packed_off + gate_len, gate_len),
+                (down_off, packed_off + 2 * gate_len, down_len),
+            )
+            for gguf_off, dsp_off, length in slices:
+                write_exact(gguf_fd, read_exact(dsp_fd, length, dsp_off),
+                            gguf_off)
+            if (n + 1) % 1024 == 0:
+                print(f"restored {n + 1}/{len(entries)} experts", flush=True)
+        os.fsync(gguf_fd)
+        print("verifying...")
+        verify_against_gguf(gguf_fd, dsp_fd, entries)
+    finally:
+        os.close(gguf_fd)
+        os.close(dsp_fd)
+    print(f"done. {source.name} is complete again "
+          f"({disk_usage_gib(source):.1f} GiB on disk). "
+          f"you can delete {dsp_path.name} if you want.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("source", type=Path, help="the GGUF model file")
+    parser.add_argument(
+        "output", type=Path, nargs="?",
+        help="where to write the packed expert file "
+             "(default: <model>.dsp next to the model, which the engine "
+             "finds automatically)",
+    )
+    parser.add_argument(
+        "--layers",
+        help="only pack these layers, e.g. 0-7,20 (default: every layer "
+             "that has expert tensors)",
+    )
+    parser.add_argument(
+        "--keep-gguf-experts", action="store_true",
+        help="keep the expert bytes inside the GGUF too, so the GGUF stays "
+             "usable with other software (costs the disk space twice)",
+    )
+    parser.add_argument(
+        "--restore", action="store_true",
+        help="copy the expert bytes from the .dsp file back into the GGUF, "
+             "undoing the space release",
+    )
+    parser.add_argument("--force", action="store_true", help="replace output")
+    args = parser.parse_args()
+
+    source = args.source.resolve()
+    output = (args.output.resolve() if args.output
+              else source.with_name(source.name + ".dsp"))
+
+    if args.restore:
+        return restore(source, output)
+
+    if output.exists() and not args.force:
+        raise FileExistsError(f"{output} exists (pass --force to replace it)")
+
+    gguf_parser = load_parser(Path(__file__).resolve().parent)
+    info = gguf_parser.parse_gguf(source)
+    by_name = info.tensor_by_name
+
+    layers = (parse_layers(args.layers) if args.layers
+              else discover_layers(by_name))
+    if not layers:
+        raise ValueError("no expert tensors found in this GGUF")
+
+    tensor_sets = []
+    for layer in layers:
+        names = {
+            kind: f"blk.{layer}.ffn_{kind}_exps.weight"
+            for kind in ("gate", "up", "down")
+        }
+        tensors = {kind: by_name.get(name) for kind, name in names.items()}
+        missing = [names[kind] for kind, tensor in tensors.items() if tensor is None]
+        if missing:
+            raise ValueError(f"missing expert tensors: {', '.join(missing)}")
+        sizes = {kind: tensor.n_bytes // N_EXPERT for kind, tensor in tensors.items()}
+        if any(tensor.n_bytes % N_EXPERT for tensor in tensors.values()):
+            raise ValueError(f"layer {layer}: tensor is not divisible by {N_EXPERT}")
+        if sizes["gate"] != sizes["up"]:
+            raise ValueError(f"layer {layer}: gate/up expert sizes differ")
+        tensor_sets.append((layer, tensors, sizes))
+
+    # Refuse to pack a GGUF whose expert bytes were already moved out. Real
+    # expert weights are never all zeros. The sample sits in the aligned
+    # middle of the tensor, because releasing space leaves the unaligned
+    # first and last few bytes of a tensor in place.
+    source_fd = os.open(source, os.O_RDONLY)
+    zero_layers = 0
+    for layer, tensors, sizes in tensor_sets:
+        tensor = tensors["gate"]
+        mid = align_down(tensor.data_offset + tensor.n_bytes // 2, ALIGNMENT)
+        sample = read_exact(source_fd, min(65536, sizes["gate"]), mid)
+        if not any(sample):
+            zero_layers += 1
+    if zero_layers == len(tensor_sets):
+        os.close(source_fd)
+        print("the expert bytes in this GGUF read as all zeros. it looks like")
+        print("they were already moved into a packed expert file. refusing to")
+        print("pack. if you have the .dsp file and want the bytes back in the")
+        print(f"GGUF, run: python3 {sys.argv[0]} --restore {source}")
+        return 1
+    if zero_layers:
+        print(f"warning: {zero_layers} of {len(tensor_sets)} sampled layers "
+              f"read as zeros, this GGUF may be damaged")
+
+    # The packed file is a full second copy of the expert bytes, so make
+    # sure the disk can hold it before writing anything.
+    need = sum(t.n_bytes for _, tensors, _ in tensor_sets
+               for t in tensors.values())
+    vfs = os.statvfs(output.parent if output.parent.exists() else source.parent)
+    free = vfs.f_bavail * vfs.f_frsize
+    if free < need + (2 << 30):
+        os.close(source_fd)
+        print(f"not enough disk space: packing needs "
+              f"{need / (1 << 30):.1f} GiB free and this disk has "
+              f"{free / (1 << 30):.1f} GiB. after packing you can release "
+              f"the same amount inside the GGUF, but during packing both "
+              f"copies exist.")
+        return 1
+
+    count = len(tensor_sets) * N_EXPERT
+    index_offset = HEADER_SIZE
+    data_offset = align_up(index_offset + count * ENTRY.size, ALIGNMENT)
+    temporary = output.with_name(output.name + ".tmp")
+    if temporary.exists():
+        temporary.unlink()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    entries: list[bytes] = []
+    output_fd = os.open(temporary, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o644)
+    try:
+        os.ftruncate(output_fd, data_offset)
+        cursor = data_offset
+        completed = 0
+        for layer, tensors, sizes in tensor_sets:
+            for expert in range(N_EXPERT):
+                gate_off = tensors["gate"].data_offset + expert * sizes["gate"]
+                up_off = tensors["up"].data_offset + expert * sizes["up"]
+                down_off = tensors["down"].data_offset + expert * sizes["down"]
+                packed_off = cursor
+                for offset, length in (
+                    (gate_off, sizes["gate"]),
+                    (up_off, sizes["up"]),
+                    (down_off, sizes["down"]),
+                ):
+                    write_exact(output_fd,
+                                read_exact(source_fd, length, offset), cursor)
+                    cursor += length
+                entries.append(
+                    ENTRY.pack(
+                        gate_off,
+                        up_off,
+                        down_off,
+                        sizes["gate"],
+                        sizes["down"],
+                        packed_off,
+                    )
+                )
+                completed += 1
+                if completed % 1024 == 0:
+                    gib = (cursor - data_offset) / (1 << 30)
+                    print(
+                        f"packed {completed}/{count} experts ({gib:.2f} GiB)",
+                        flush=True,
+                    )
+
+        header = bytearray(HEADER_SIZE)
+        header[:4] = b"DSP1"
+        struct.pack_into("<IQQ", header, 4, 1, index_offset, count)
+        os.pwrite(output_fd, header, 0)
+        index_blob = b"".join(entries)
+        if os.pwrite(output_fd, index_blob, index_offset) != len(index_blob):
+            raise OSError("short index write")
+        os.fsync(output_fd)
+
+        print("verifying every byte...")
+        parsed = [ENTRY.unpack(e) for e in entries]
+        checked = verify_against_gguf(source_fd, output_fd, parsed)
+        print(f"verified: all {checked / (1 << 30):.2f} GiB match the GGUF")
+    except BaseException:
+        os.close(output_fd)
+        output_fd = -1
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+    finally:
+        os.close(source_fd)
+        if output_fd >= 0:
+            os.close(output_fd)
+
+    os.replace(temporary, output)
+    print(f"wrote {output} ({output.stat().st_size / (1 << 30):.2f} GiB)")
+
+    if args.keep_gguf_experts:
+        print("kept the expert bytes inside the GGUF too (--keep-gguf-experts)")
+        return 0
+
+    print("releasing the expert space inside the GGUF...")
+    gguf_rw = os.open(source, os.O_RDWR)
+    try:
+        ok = True
+        for layer, tensors, sizes in tensor_sets:
+            for tensor in tensors.values():
+                if not release_range(gguf_rw, tensor.data_offset, tensor.n_bytes):
+                    ok = False
+                    break
+            if not ok:
+                break
+        os.fsync(gguf_rw)
+    finally:
+        os.close(gguf_rw)
+    if not ok:
+        print("this file system cannot release space inside a file. the GGUF")
+        print("is unchanged, you now simply have both copies.")
+        return 0
+    print(f"done. the GGUF now uses {disk_usage_gib(source):.1f} GiB on disk")
+    print(f"(its reported size stays the same, the expert region reads as")
+    print(f"zeros). the engine finds {output.name} automatically when it sits")
+    print(f"next to the model. to undo this:")
+    print(f"    python3 {sys.argv[0]} --restore {source}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
In GGUF an MoE layer's gate, up and down matrices are three separate multi-gigabyte tensors. That means the three slices belonging to one expert sit about a tensor apart on disk, so a single expert miss during SSD streaming costs three distant reads instead of one.

This adds an optional second file where each expert's three slices are stored next to each other, and makes the engine read from it when it is there:

```
expert 0: gate | up | down
expert 1: gate | up | down
```

The bytes are copied exactly. Nothing is requantized, reordered inside a slice, or transformed, so this only changes where a read lands, never what it returns. Generation output is byte for byte identical.

Related to #840, where I described the whole set of changes I have been measuring on this setup.

## Numbers

Machine: MacBook Pro M4 Max, 36 GB, macOS 25.3, Metal backend. Model: DeepSeek V4 Flash, MXFP4 experts, 145 GB GGUF, streamed from the internal SSD. 1150 cache slots, memory fully locked (`failed=0.00`) on every run, 220 tokens, `--temp 0`. Runs alternate so machine drift hits both arms.

| run | tokens/s | avg expert read (ms) | misses | reads from packed file | output md5 |
|---|---|---|---|---|---|
| without | 3.03 | 3.405 | 22931 | 0 | 9e66c710... |
| with | 3.40 | 3.706 | 22931 | 68793 | 9e66c710... |
| without | 3.03 | 3.358 | 22931 | 0 | 9e66c710... |
| with | 3.16 | 3.841 | 22931 | 68793 | 9e66c710... |
| without | 3.03 | 3.560 | 22931 | 0 | 9e66c710... |
| with | 3.50 | 3.775 | 22931 | 68793 | 9e66c710... |

**+10.7% on generation**, and the two groups do not overlap: the slowest packed run (3.16) still beats the fastest unpacked run (3.03).

Three things in that table are worth pointing at directly.

The miss count is identical in all six runs. It has to be, because the packed file changes only which file a read goes to. Same experts, same order, same cache behaviour. `68793` is exactly `22931 * 3`, so every miss still costs its three slices; they are just adjacent now instead of a tensor apart.

The output md5 is identical in all six runs, which is the point of copying bytes rather than transforming them.

**The average read time goes up, not down, and I want to be upfront about that rather than quietly leave it out.** I do not think it means what it looks like. The three slices of one expert are contiguous in the packed file, so they are serviced as one sequential extent and each individual read's measured wall time includes waiting on its siblings. In the unpacked case the three reads are far apart and complete independently, so each one looks quicker while the expert as a whole takes longer. Total generation time is what actually moved, and it moved the right way in every pair. If you would rather I measure per-expert completion instead of per-read average, tell me which number you trust and I will produce it.

One caveat on my own setup that makes this understate rather than overstate: I restored the expert bytes into the GGUF a couple of hours before these runs, so some of that file was still warm in the page cache. If anything that favours the unpacked arm.

## Using it

```
python3 misc/pack_experts.py model.gguf
```

That writes `model.gguf.dsp` and the engine picks it up automatically because it sits next to the model. `DS4_EXPERT_PACKED_SIDECAR=/path/to.dsp` overrides the location. With no such file present nothing changes.

## The disk space question

A packed file is a second copy of the expert weights, which for DeepSeek V4 Flash is 137 GB. Very few people running a model from SSD have that spare, so by default the tool frees the expert space inside the GGUF once the copy exists. The GGUF stays in place and keeps working with this engine, it just stops occupying that space on disk (145 GB down to 8 GB here).

That only happens after every byte has been read back and compared against the packed file, and it is reversible:

```
python3 misc/pack_experts.py --restore model.gguf
```

which copies the bytes back and verifies them again. I have run the round trip on this model and diffed it.

`--keep-gguf-experts` skips the freeing entirely, for anyone who uses the same GGUF with other software. The tool also refuses to pack a GGUF whose experts have already been moved out, and checks there is enough free space before it writes anything.

If the file system cannot free space inside a file, the tool says so and leaves the GGUF untouched, so you simply end up with both copies.

## Failure mode this had to handle

A GGUF whose expert space has been freed reads as zeros in that region. If someone moves the `.dsp` and runs anyway, the model would quietly generate nonsense from zeroed weights, which looks like a broken model rather than a missing file. So the first sizeable expert read from the GGUF is checked once, and if it comes back entirely zero the engine stops and says what to do. A real expert slice is never all zeros.

## What changed in the engine

- A read task now carries the descriptor it should read from. Unset means the model file, which is what everything gets unless the packed file covers it.
- `ds4_gpu_stream_expert_pread_into` takes that descriptor rather than always using the model.
- One helper resolves an expert's three offsets once, and both the read and its `F_RDADVISE` hint follow it. That collapsed the four places that hinted three ranges each into one call apiece.
- The packed index is a sorted array loaded once, looked up by binary search on the gate offset. A lookup that does not match falls through to the GGUF path, so an incomplete or unrelated `.dsp` cannot corrupt a read.

## Notes

- The three slices stay three reads rather than being fused into one. I measured the fused version and it gained almost nothing (two extra preads are about 10 us against a 244 us gap), while keeping them separate lets compute start as soon as gate and up land. The win is the layout, not the read count.
- This does not touch the GGUF format itself and needs no change to how models are published.
