### PR TITLE
metal: scale default prefill chunk with prompt length

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -12156,6 +12156,60 @@ static uint32_t ds4_effective_prefill_chunk(bool cuda_tensor_parallel,
     return cuda_tensor_parallel ? DS4_CUDA_TP_DEFAULT_PREFILL_CHUNK : 0;
 }
 
+/* Default prefill chunking shrinks as the prompt grows.
+ *
+ * A chunk's GPU cost scales with the context it attends against, so a chunk that
+ * is comfortable at 128k blows the macOS command-buffer watchdog at 271k.  Under
+ * tensor parallelism that kill is not survivable: it aborts the in-flight bulk
+ * RDMA gate and the client sees "tp: worker sync send failed".  A fixed ceiling
+ * only moves the context at which that happens, so the bound itself must scale.
+ *
+ * Chunk size is the right lever because it scales both halves of the wait that
+ * actually gets killed.  Serving submits prefill per LAYER, not per chunk
+ * (metal_graph_prefill_layer_major() splits whenever a progress callback is
+ * installed), and under TP a layer's buffer carries a wait on the gate event the
+ * peer signals, so it stays resident for the peer's work plus the round trip.
+ *
+ * The budget is an empirical envelope over measured pass/fail whole
+ * configurations, NOT a cost model: wall time is not monotone in the product
+ * (4096 ran 11.4 s/chunk at 80k but 7.0 s/chunk at 154k).  Re-measure before
+ * retuning, and do not extrapolate into untested regimes (notably 512 at 1M).
+ *   allow  4096 *  80333 = 3.29e8   (passed)
+ *   allow  4096 * 154390 = 6.32e8   (passed)
+ *   allow  2048 * 232306 = 4.76e8   (passed, zero faults over 782 s)
+ *   reject 4096 * 271180 = 1.11e9   (killed on its first chunk)
+ * 5<<27 = 6.71e8 sits just above the largest pass and 1.65x below the failure.
+ * An earlier 1<<29 rejected the proven 4096/154k point and cost ~45% of prefill
+ * throughput in the band where this workload sits, so do not tighten it without
+ * a hardware measurement.  Sizes round DOWN to a power of two, keeping the KV
+ * boundary aligned and the reachable set to chunks the graph paths already run:
+ *
+ *   prompt <=  163840 -> 4096      prompt <=  655360 -> 1024
+ *   prompt <=  327680 -> 2048      prompt <= 1310720 ->  512
+ *
+ * TP CONSTRAINT: both ranks must chunk identically or the per-layer gates stop
+ * pairing.  prompt_len is rank-identical by construction (ds4_session_sync()
+ * mirrors the exact token array to the worker) and the variant comes from the
+ * shared model shape.  Never derive this from anything rank-local (wall clock,
+ * load, free memory, measured throughput), and never from the allocated
+ * ctx_size: a 1M allocation would pin every prompt to the floor. */
+#define DS4_PREFILL_CHUNK_WORK_BUDGET (5ull << 27)
+#define DS4_PREFILL_CHUNK_MIN         512u
+
+/* Largest chunk that keeps one command buffer clear of the GPU watchdog for a
+ * prompt of `prompt_len` tokens.  RUNTIME ONLY -- never use this to size the
+ * prefill workspace (see ds4_prefill_cap_for_prompt).  Rounds down to a power of
+ * two so the only reachable sizes are ones the graph paths already run and the
+ * 2048-token KV boundary alignment still divides evenly. */
+static uint32_t ds4_prefill_watchdog_chunk(uint32_t prompt_len) {
+    const uint32_t base = DS4_MODEL_VARIANT == DS4_VARIANT_PRO ? 8192u : 4096u;
+    if (prompt_len == 0) return base;
+    const uint64_t budget = DS4_PREFILL_CHUNK_WORK_BUDGET / prompt_len;
+    uint32_t chunk = DS4_PREFILL_CHUNK_MIN;
+    while (chunk < base && (uint64_t)chunk * 2u <= budget) chunk *= 2u;
+    return chunk;
+}
+
 static uint32_t ds4_prefill_cap_for_prompt(int prompt_len,
                                            uint32_t requested_chunk) {
     if (prompt_len <= 0) return 1;
@@ -12173,6 +12227,16 @@ static uint32_t ds4_prefill_cap_for_prompt(int prompt_len,
                 cap = (uint32_t)v;
             }
         } else if (prompt_len > 4096) {
+            /* ALLOCATION sizing only: always the base ceiling, never the
+             * watchdog ladder.  Callers reach this with ctx_size (session and
+             * planner paths, e.g. ds4.c metal_graph_prefill_cap_for_prompt at
+             * session create), so applying the ladder here would evaluate it at
+             * the full 1M allocation and pin every prompt to the floor -- a
+             * measured ~25% prefill loss even on a 10k prompt that was never at
+             * watchdog risk.  The workspace is therefore sized for the largest
+             * chunk that can ever run, and the ladder is applied at RUNTIME
+             * against the real prompt length by
+             * metal_graph_prefill_watchdog_chunk(). */
             cap = DS4_MODEL_VARIANT == DS4_VARIANT_PRO ? 8192u : 4096u;
         }
     }
@@ -35223,6 +35287,22 @@ static bool metal_graph_prefill_chunked_range(
 
     uint32_t chunk_cap = g->prefill_cap;
     if (start != 0 && chunk_cap > g->raw_cap) chunk_cap = g->raw_cap;
+    /* Keep one command buffer clear of the GPU watchdog.  The workspace is
+     * sized for the base chunk, so this is where the ladder is actually
+     * applied, against the real prompt length rather than the allocated
+     * context.  Both TP ranks mirror the identical token array through
+     * ds4_session_sync(), so prompt->len is rank-identical and the two sides
+     * derive the same schedule -- required, or the per-layer gates stop
+     * pairing up.  An explicit --prefill-chunk / DS4_METAL_PREFILL_CHUNK has
+     * already been folded into g->prefill_cap, and clamping only ever
+     * shrinks, so an operator override still wins as an upper bound. */
+    if (prompt->len > 0) {
+        const uint32_t watchdog_cap =
+            ds4_prefill_watchdog_chunk((uint32_t)prompt->len);
+        if (watchdog_cap != 0 && watchdog_cap < chunk_cap) {
+            chunk_cap = watchdog_cap;
+        }
+    }
     if (chunk_cap == 0) return false;
 
     const bool profile =
@@ -35880,7 +35960,8 @@ static uint32_t metal_graph_raw_cap_for_context(int ctx_size, uint32_t prefill_c
 }
 
 /* Choose the prefill ubatch size. Whole-batch is fastest for normal prompts.
- * Long Flash prompts default to 4096-token chunks; PRO defaults to 8192. */
+ * Long prompts fall back to ds4_default_prefill_chunk(), which shrinks the
+ * chunk as the context grows to stay clear of the GPU watchdog. */
 static uint32_t metal_graph_prefill_cap_for_prompt(int prompt_len,
                                                    uint32_t prefill_chunk) {
     return ds4_prefill_cap_for_prompt(prompt_len, prefill_chunk);
@@ -57020,6 +57101,10 @@ uint32_t ds4_test_effective_prefill_chunk(bool cuda_tensor_parallel,
 uint32_t ds4_test_planner_prefill_cap(int prompt_len,
                                       uint32_t prefill_chunk) {
     return engine_planner_prefill_cap(prompt_len, prefill_chunk);
+}
+
+uint32_t ds4_test_prefill_watchdog_chunk(uint32_t prompt_len) {
+    return ds4_prefill_watchdog_chunk(prompt_len);
 }
 
 uint32_t ds4_test_planner_raw_cap(int ctx_size, uint32_t prefill_cap) {

--- a/tests/test_engine_mgpu_placement.c
+++ b/tests/test_engine_mgpu_placement.c
@@ -75,6 +75,7 @@ uint32_t ds4_test_effective_prefill_chunk(bool cuda_tensor_parallel,
                                           uint32_t requested_chunk);
 uint32_t ds4_test_planner_prefill_cap(int prompt_len,
                                       uint32_t prefill_chunk);
+uint32_t ds4_test_prefill_watchdog_chunk(uint32_t prompt_len);
 uint32_t ds4_test_planner_raw_cap(int ctx_size, uint32_t prefill_cap);
 size_t ds4_test_glm_per_layer_kv_bytes(uint32_t layer, int ctx_size);
 size_t ds4_test_compute_glm_entry_bytes_sum_with_sessions(
@@ -666,6 +667,95 @@ static void test_cuda_tp_output_head_moves_to_lower_half(void) {
     restore_env_value("DS4_METAL_PREFILL_CHUNK", old_chunk);
 }
 
+/* The prefill chunk has TWO distinct bounds and conflating them is a shipped
+ * regression, not a hypothetical:
+ *
+ *  - ds4_test_planner_prefill_cap() sizes the prefill WORKSPACE.  Its callers
+ *    pass ctx_size, so it must stay at the variant ceiling.  A revision that
+ *    applied the watchdog ladder here evaluated it at the full 1M allocation and
+ *    pinned every request to the 512 floor, measured at ~411 t/s on a 10,816
+ *    token prompt that was never at watchdog risk (versus 547-573 at 4096).
+ *  - ds4_test_prefill_watchdog_chunk() is the RUNTIME bound, keyed on the real
+ *    prompt length, and is the one that must shrink.
+ *
+ * Pin both, so neither can absorb the other's job again. */
+static void test_prefill_watchdog_bound(void) {
+    fprintf(stderr, "RUN: test_prefill_watchdog_bound\n");
+
+    char *old_chunk = save_env_value("DS4_METAL_PREFILL_CHUNK");
+    unsetenv("DS4_METAL_PREFILL_CHUNK");
+
+    /* cap(8192) is the variant's long-prompt ceiling (4096, or 8192 for PRO). */
+    const uint32_t ceiling = ds4_test_planner_prefill_cap(8192, 0);
+
+    static const int ladder[] = {
+        8192, 65536, 131072, 154390, 163840, 232306, 262144, 327680,
+        393216, 524288, 655360, 1000000,
+    };
+    const int n_ladder = (int)(sizeof(ladder) / sizeof(ladder[0]));
+
+    /* ALLOCATION must NOT track the ladder: it is called with ctx_size. */
+    bool alloc_flat = true;
+    for (int i = 0; i < n_ladder; i++) {
+        if (ds4_test_planner_prefill_cap(ladder[i], 0) != ceiling) {
+            alloc_flat = false;
+        }
+    }
+    CHECK(alloc_flat,
+          "workspace sizing stays at the variant ceiling for every context");
+
+    /* RUNTIME bound must shrink, monotonically, powers of two, floored. */
+    bool monotone = true, bounded = true, floored = true, pow2 = true;
+    uint32_t prev = ceiling;
+    for (int i = 0; i < n_ladder; i++) {
+        const uint32_t c = ds4_test_prefill_watchdog_chunk((uint32_t)ladder[i]);
+        if (c > prev) monotone = false;
+        if (c > ceiling) bounded = false;
+        if (c < 512u) floored = false;
+        if ((c & (c - 1u)) != 0u) pow2 = false;
+        prev = c;
+    }
+    CHECK(monotone, "runtime bound never grows as the prompt grows");
+    CHECK(bounded, "runtime bound never exceeds the variant ceiling");
+    CHECK(floored, "runtime bound keeps its 512-token floor");
+    CHECK(pow2, "runtime bound only selects power-of-two chunks");
+    CHECK(prev < ceiling, "runtime bound has actually shrunk by 1M tokens");
+
+    /* The two configurations proven on hardware must both remain reachable.
+     * 4096 completed a 154,390-token prefill at ~7.0 s/chunk; 2048 completed a
+     * 232,306-token prefill with zero faults on either rank (782.9 s, 296.74
+     * t/s).  Recompute from DS4_PREFILL_CHUNK_WORK_BUDGET if it is retuned. */
+    CHECK(ds4_test_prefill_watchdog_chunk(154390) == 4096,
+          "runtime bound keeps the hardware-proven 4096 at 154k tokens");
+    CHECK(ds4_test_prefill_watchdog_chunk(232306) == 2048,
+          "runtime bound reproduces the hardware-proven 2048 at 232k tokens");
+
+    /* And the configuration proven FATAL must be rejected: 4096 at ~271k was
+     * killed on its first chunk by the Metal command-buffer watchdog. */
+    CHECK(ds4_test_prefill_watchdog_chunk(271180) < 4096,
+          "runtime bound rejects the 4096 chunk that was killed at 271k");
+
+    /* Short prompts are untouched, and the clamp to prompt_len still holds. */
+    CHECK(ds4_test_planner_prefill_cap(4096, 0) == 4096,
+          "prompts at the whole-batch threshold are not chunked");
+    CHECK(ds4_test_planner_prefill_cap(1000, 0) == 1000,
+          "short prompts are capped by prompt length");
+    CHECK(ds4_test_planner_prefill_cap(1000000, 1u << 30) == 1000000,
+          "an oversized explicit chunk still clamps to prompt length");
+
+    /* Precedence: an operator override must still win outright. */
+    CHECK(ds4_test_planner_prefill_cap(1000000, 2048) == 2048,
+          "an explicit prefill chunk wins over the default");
+    setenv("DS4_METAL_PREFILL_CHUNK", "2048", 1);
+    CHECK(ds4_test_planner_prefill_cap(1000000, 0) == 2048,
+          "DS4_METAL_PREFILL_CHUNK wins over the default");
+    CHECK(ds4_test_planner_prefill_cap(1000000, 4096) == 4096,
+          "an explicit prefill chunk wins over DS4_METAL_PREFILL_CHUNK");
+    unsetenv("DS4_METAL_PREFILL_CHUNK");
+
+    restore_env_value("DS4_METAL_PREFILL_CHUNK", old_chunk);
+}
+
 int main(void) {
     test_tensor_to_entry();
     test_null_config();
@@ -678,6 +768,7 @@ int main(void) {
     test_glm_per_layer_cache_accounting();
     test_glm_session_count_accounting();
     test_cuda_tp_prefill_default_accounting();
+    test_prefill_watchdog_bound();
     test_cuda_tp_output_head_moves_to_lower_half();
 
     fprintf(stderr, "\ntest_engine_mgpu_placement: %d/%d checks passed (%d failed)\n",


### PR DESCRIPTION
## Problem

The default prefill chunk is fixed (4096 for Flash). A chunk's GPU cost grows with the context it attends against, so a chunk size that is comfortable at 128k blows the macOS command-buffer watchdog on long prompts: at ~271k ctx the first chunk dies with `Metal command batch failed: Caused GPU Timeout Error (00000002:kIOGPUCommandBufferCallbackErrorTimeout)`.

Under `--tensor-parallel` that kill is fatal rather than transient: the killed buffer carries the in-flight bulk RDMA gate, the peer reports `peer disconnected during bulk RDMA gate`, and the client gets HTTP 500 `tp: worker sync send failed`. One long prompt takes down the pair.

The per-layer submission is what makes chunk size the right lever: serving always splits prefill per layer (`metal_graph_prefill_layer_major`, progress callback installed by the server), and under TP a layer's buffer also waits on the gate event the peer signals, so its residency includes the peer's half plus the round trip. Chunk size scales both halves of that wait.

## Fix

Scale the default chunk down as the prompt grows, bounded by a work budget (chunk x prompt_len) calibrated on measured whole-configuration pass/fail from a two-Mac M5 Max (128GB) TP/DSPark pair over Thunderbolt 5 RDMA:

| config | result |
|---|---|
| 4096 x 80,333 = 3.29e8 | pass (11.4 s/chunk) |
| 4096 x 154,390 = 6.32e8 | pass (7.0 s/chunk) |
| 2048 x 232,306 = 4.76e8 | pass, zero faults over 782 s |
| 4096 x 271,180 = 1.11e9 | killed on first chunk |

Budget 5<<27 = 6.71e8 sits just above the largest pass, 1.65x below the failure. Chunks round down to powers of two (keeps the 2048-token KV boundary alignment and only reaches sizes the graph paths already run). Explicit `--prefill-chunk` / `DS4_METAL_PREFILL_CHUNK` still win over the bound.

Note the budget is an empirical envelope, not a wall-time model - chunk wall time is not monotone in the product (11.4 s at 80k vs 7.0 s at 154k, both pass), consistent with the killed resource being one layer's buffer + gate wait rather than whole-chunk compute.

Two properties the implementation is careful about:

- **Runtime only.** Workspace allocation keeps using the variant ceiling. Keying allocation off ctx_size would pin every prompt of a `--ctx 1000000` server to the 512 floor (measured ~25% prefill loss on short prompts when I got this wrong in an earlier revision).
- **TP rank identity.** Both ranks must run identical chunk schedules or the per-layer gates stop pairing. The chunk derives only from prompt_len (rank-identical: the leader mirrors the exact token array via `ds4_tp_send_sync`) and the model variant (verified equal by the hello exchange). Nothing rank-local.

## Validation

- `tests/test_engine_mgpu_placement`: 116/116, including a new test pinning the ladder invariants (monotone/bounded/floored/power-of-two), the measured pass/fail points, precedence of explicit chunks, and - separately - that the allocation path stays flat across contexts (the regression I shipped and reverted while developing this).
- Live on the TP pair: 232,306-token prefill completed with `finish=stop`, zero coordinator/worker faults, no launchd restarts; 80,333-token prefill at 419 t/s avg; short-prompt throughput unchanged (allocation cap stays 4096).
- Single-machine behavior below ~164k prompts is unchanged (still 4096).