### PR TITLE
server: native Prometheus GET /metrics endpoint

### DIFF
--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -1,5 +1,11 @@
 #include "ds4_kvstore.h"
 
+static ds4_kvstore_metrics_fn g_kvstore_metrics_fn;
+
+void ds4_kvstore_set_metrics_fn(ds4_kvstore_metrics_fn fn) {
+    g_kvstore_metrics_fn = fn;
+}
+
 /* Shared disk KV checkpoint file support.
  *
  * The low-level file layout and payload helpers are intentionally shared.  The
@@ -1136,6 +1142,13 @@ bool ds4_kvstore_store_live_prefix_text(ds4_kvstore *kc,
         }
         unlink(tmp);
     } else {
+        if (g_kvstore_metrics_fn) {
+            g_kvstore_metrics_fn(
+                store_tokens.len,
+                original_len - store_tokens.len,
+                (double)(DS4_KVSTORE_FIXED_HEADER + 4ull + text_len +
+                         payload_bytes + trailer_bytes) / (1024.0 * 1024.0));
+        }
         kv_logf(kc, DS4_KVSTORE_LOG_KVCACHE,
                 "%s: kv cache stored tokens=%d trimmed=%d reason=%s key=%s size=%.2f MiB save=%.1f ms",
                 kv_log_name(kc),

--- a/ds4_kvstore.h
+++ b/ds4_kvstore.h
@@ -214,4 +214,12 @@ char *ds4_kvstore_path_for_sha(ds4_kvstore *kc, const char sha[41]);
 void ds4_kvstore_le_put32(uint8_t *p, uint32_t v);
 uint32_t ds4_kvstore_le_get32(const uint8_t *p);
 
+/* Optional metrics hook: invoked after a successful cache store with the
+ * stored token count, the tokens trimmed from the original payload, and the
+ * on-disk size in MiB. Used by ds4-server's GET /metrics endpoint; unset by
+ * default, so other kvstore users (agent, tests) are unaffected. */
+typedef void (*ds4_kvstore_metrics_fn)(int stored_tokens, int trimmed_tokens,
+                                       double stored_mib);
+void ds4_kvstore_set_metrics_fn(ds4_kvstore_metrics_fn fn);
+
 #endif

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -8313,6 +8313,106 @@ static double now_sec(void) {
 
 static pthread_mutex_t server_log_mu = PTHREAD_MUTEX_INITIALIZER;
 
+/* ---------------- Prometheus metrics (GET /metrics) ---------------------
+ * Series names match the journald-parsing exporter historically used with
+ * this server, so existing dashboards keep working when the scrape target
+ * moves to this endpoint. Counters cover the process lifetime; throughput
+ * gauges hold the last observed value. Updates happen at the same sites
+ * that emit the corresponding log lines. */
+#define METRICS_REASONS_MAX 12
+typedef struct {
+    char name[24];
+    uint64_t count;
+} metrics_reason;
+
+typedef struct {
+    pthread_mutex_t mu;
+    uint64_t prompt_tokens_total;
+    uint64_t gen_thinking_total, gen_response_total;
+    double prefill_tps_chunk, prefill_tps_avg;
+    double decode_tps_chunk, decode_tps_avg;
+    metrics_reason finish[METRICS_REASONS_MAX];
+    double request_seconds_sum;
+    uint64_t request_seconds_count;
+    double prompt_seconds_sum;
+    uint64_t prompt_seconds_count;
+    uint64_t kv_stored_total, kv_trimmed_tokens_total;
+    double kv_stored_bytes_total;
+    metrics_reason kv_miss[METRICS_REASONS_MAX];
+} server_metrics;
+
+static server_metrics g_server_metrics = { .mu = PTHREAD_MUTEX_INITIALIZER };
+
+static void metrics_reason_add(metrics_reason *arr, const char *name) {
+    if (!name || !name[0]) name = "unknown";
+    for (int i = 0; i < METRICS_REASONS_MAX; i++) {
+        if (arr[i].name[0] == '\0') {
+            snprintf(arr[i].name, sizeof(arr[i].name), "%s", name);
+            arr[i].count = 1;
+            return;
+        }
+        if (!strcmp(arr[i].name, name)) {
+            arr[i].count++;
+            return;
+        }
+    }
+    /* Table full: account under the final bucket rather than dropping. */
+    arr[METRICS_REASONS_MAX - 1].count++;
+}
+
+static void metrics_decode_progress(int tokens, bool thinking,
+                                    double chunk_tps, double avg_tps) {
+    if (tokens < 0) tokens = 0;
+    pthread_mutex_lock(&g_server_metrics.mu);
+    if (thinking) g_server_metrics.gen_thinking_total += (uint64_t)tokens;
+    else g_server_metrics.gen_response_total += (uint64_t)tokens;
+    g_server_metrics.decode_tps_chunk = chunk_tps;
+    g_server_metrics.decode_tps_avg = avg_tps;
+    pthread_mutex_unlock(&g_server_metrics.mu);
+}
+
+static void metrics_prefill_progress(double chunk_tps, double avg_tps) {
+    pthread_mutex_lock(&g_server_metrics.mu);
+    g_server_metrics.prefill_tps_chunk = chunk_tps;
+    g_server_metrics.prefill_tps_avg = avg_tps;
+    pthread_mutex_unlock(&g_server_metrics.mu);
+}
+
+static void metrics_prompt_done(int tokens, double seconds) {
+    if (tokens < 0) tokens = 0;
+    pthread_mutex_lock(&g_server_metrics.mu);
+    g_server_metrics.prompt_tokens_total += (uint64_t)tokens;
+    g_server_metrics.prompt_seconds_sum += seconds;
+    g_server_metrics.prompt_seconds_count++;
+    pthread_mutex_unlock(&g_server_metrics.mu);
+}
+
+static void metrics_request_finish(const char *reason, double seconds) {
+    pthread_mutex_lock(&g_server_metrics.mu);
+    metrics_reason_add(g_server_metrics.finish, reason);
+    g_server_metrics.request_seconds_sum += seconds;
+    g_server_metrics.request_seconds_count++;
+    pthread_mutex_unlock(&g_server_metrics.mu);
+}
+
+static void metrics_kv_miss(const char *reason) {
+    pthread_mutex_lock(&g_server_metrics.mu);
+    metrics_reason_add(g_server_metrics.kv_miss, reason);
+    pthread_mutex_unlock(&g_server_metrics.mu);
+}
+
+/* Registered with ds4_kvstore at server startup. */
+static void metrics_kv_stored_bridge(int stored_tokens, int trimmed_tokens,
+                                     double stored_mib) {
+    (void)stored_tokens;
+    pthread_mutex_lock(&g_server_metrics.mu);
+    g_server_metrics.kv_stored_total++;
+    if (trimmed_tokens > 0)
+        g_server_metrics.kv_trimmed_tokens_total += (uint64_t)trimmed_tokens;
+    g_server_metrics.kv_stored_bytes_total += stored_mib * 1024.0 * 1024.0;
+    pthread_mutex_unlock(&g_server_metrics.mu);
+}
+
 static void server_log(ds4_log_type type, const char *fmt, ...) {
     time_t now = time(NULL);
     struct tm tm;
@@ -10236,6 +10336,7 @@ static void log_decode_progress(req_kind kind, int prompt_tokens, int completion
     const int interval_tokens = completion - *last_completion;
     const double chunk_tps = interval_s > 0.0 ? (double)interval_tokens / interval_s : 0.0;
     const double avg_tps = elapsed > 0.0 ? (double)completion / elapsed : 0.0;
+    metrics_decode_progress(interval_tokens, thinking, chunk_tps, avg_tps);
     char ctx[48];
     request_ctx_span(ctx, sizeof(ctx),
                      prompt_tokens + *last_completion,
@@ -10651,6 +10752,7 @@ static void server_progress_cb(void *ud, const char *event, int current, int tot
     p->last_current = current;
     p->last_t = now;
     p->seen = true;
+    metrics_prefill_progress(chunk_tps, avg_tps);
     char flags[64];
     log_flags(flags, sizeof(flags), p->responses_protocol,
               p->has_tools, false, false, false);
@@ -11305,6 +11407,7 @@ static void generate_job_inner(server *s, server_slot *slot, job *j) {
                    responses_protocol ? " RESPPROTO" : "",
                    old_pos, j->req.prompt.len, common,
                    trace_cache_miss_reason(&cache_diag));
+        metrics_kv_miss(trace_cache_miss_reason(&cache_diag));
     }
     if (cached == 0) slot->continued_last_store_tokens = 0;
     if (s->kv.enabled && cached == 0 && old_pos >= s->kv.opt.min_tokens) {
@@ -11504,6 +11607,7 @@ static void generate_job_inner(server *s, server_slot *slot, job *j) {
     ds4_session_set_progress(slot->session, NULL, NULL);
     ds4_session_set_display_progress(slot->session, NULL, NULL);
     kv_cache_maybe_store_continued(s, slot);
+    metrics_prompt_done(prompt_tokens - cached, now_sec() - t0);
     server_log(DS4_LOG_PREFILL,
                "ds4-server: %s ctx=%s%s%s prompt done %.3fs",
                j->req.kind == REQ_CHAT ? "chat" : "completion",
@@ -12338,6 +12442,7 @@ decode_again:
                        now_sec() - t0);
         }
     }
+    metrics_request_finish(final_finish, now_sec() - t0);
     free(parsed_content);
     free(parsed_reasoning);
     tool_calls_free(&parsed_calls);
@@ -12656,6 +12761,99 @@ static void append_model_json(buf *b, const server *s, const char *id) {
                              s->default_tokens);
 }
 
+/* Render the Prometheus exposition text. `s` may be NULL in unit tests, in
+ * which case the server-state gauges (active requests, per-slot context) are
+ * omitted and only the counter/gauge series above are emitted. Per-slot
+ * context reads are done without the inference lock: a torn read costs at
+ * most one stale gauge sample. */
+static void append_metrics_text(buf *b, server *s) {
+    server_metrics snap;
+    pthread_mutex_lock(&g_server_metrics.mu);
+    snap = g_server_metrics; /* struct copy; snap.mu is never used */
+    pthread_mutex_unlock(&g_server_metrics.mu);
+
+    buf_puts(b, "# HELP ds4_prompt_tokens_total Prompt tokens evaluated by prefill\n"
+                "# TYPE ds4_prompt_tokens_total counter\n");
+    buf_printf(b, "ds4_prompt_tokens_total %llu\n",
+               (unsigned long long)snap.prompt_tokens_total);
+    buf_puts(b, "# HELP ds4_generated_tokens_total Tokens generated, by phase\n"
+                "# TYPE ds4_generated_tokens_total counter\n");
+    buf_printf(b, "ds4_generated_tokens_total{phase=\"thinking\"} %llu\n",
+               (unsigned long long)snap.gen_thinking_total);
+    buf_printf(b, "ds4_generated_tokens_total{phase=\"response\"} %llu\n",
+               (unsigned long long)snap.gen_response_total);
+    buf_puts(b, "# HELP ds4_prefill_tps Prefill tokens/s (last chunk, running avg)\n"
+                "# TYPE ds4_prefill_tps gauge\n");
+    buf_printf(b, "ds4_prefill_tps{window=\"chunk\"} %.2f\n", snap.prefill_tps_chunk);
+    buf_printf(b, "ds4_prefill_tps{window=\"avg\"} %.2f\n", snap.prefill_tps_avg);
+    buf_puts(b, "# HELP ds4_decode_tps Decode tokens/s (last chunk, running avg)\n"
+                "# TYPE ds4_decode_tps gauge\n");
+    buf_printf(b, "ds4_decode_tps{window=\"chunk\"} %.2f\n", snap.decode_tps_chunk);
+    buf_printf(b, "ds4_decode_tps{window=\"avg\"} %.2f\n", snap.decode_tps_avg);
+    buf_puts(b, "# HELP ds4_requests_total Completed requests by finish reason\n"
+                "# TYPE ds4_requests_total counter\n");
+    for (int i = 0; i < METRICS_REASONS_MAX; i++) {
+        if (!snap.finish[i].name[0]) break;
+        buf_printf(b, "ds4_requests_total{finish=\"%s\"} %llu\n",
+                   snap.finish[i].name, (unsigned long long)snap.finish[i].count);
+    }
+    buf_puts(b, "# HELP ds4_request_duration_seconds Wall time per request\n"
+                "# TYPE ds4_request_duration_seconds summary\n");
+    buf_printf(b, "ds4_request_duration_seconds_sum %.3f\n", snap.request_seconds_sum);
+    buf_printf(b, "ds4_request_duration_seconds_count %llu\n",
+               (unsigned long long)snap.request_seconds_count);
+    buf_puts(b, "# HELP ds4_prompt_duration_seconds Wall time per prompt prefill\n"
+                "# TYPE ds4_prompt_duration_seconds summary\n");
+    buf_printf(b, "ds4_prompt_duration_seconds_sum %.3f\n", snap.prompt_seconds_sum);
+    buf_printf(b, "ds4_prompt_duration_seconds_count %llu\n",
+               (unsigned long long)snap.prompt_seconds_count);
+    buf_puts(b, "# HELP ds4_kv_cache_stored_total Successful KV cache stores\n"
+                "# TYPE ds4_kv_cache_stored_total counter\n");
+    buf_printf(b, "ds4_kv_cache_stored_total %llu\n",
+               (unsigned long long)snap.kv_stored_total);
+    buf_puts(b, "# HELP ds4_kv_cache_stored_bytes_total Bytes written by KV cache stores\n"
+                "# TYPE ds4_kv_cache_stored_bytes_total counter\n");
+    buf_printf(b, "ds4_kv_cache_stored_bytes_total %.1f\n", snap.kv_stored_bytes_total);
+    buf_puts(b, "# HELP ds4_kv_cache_trimmed_tokens_total Tokens trimmed before store\n"
+                "# TYPE ds4_kv_cache_trimmed_tokens_total counter\n");
+    buf_printf(b, "ds4_kv_cache_trimmed_tokens_total %llu\n",
+               (unsigned long long)snap.kv_trimmed_tokens_total);
+    buf_puts(b, "# HELP ds4_kv_cache_miss_total Live KV cache misses by reason\n"
+                "# TYPE ds4_kv_cache_miss_total counter\n");
+    for (int i = 0; i < METRICS_REASONS_MAX; i++) {
+        if (!snap.kv_miss[i].name[0]) break;
+        buf_printf(b, "ds4_kv_cache_miss_total{reason=\"%s\"} %llu\n",
+                   snap.kv_miss[i].name, (unsigned long long)snap.kv_miss[i].count);
+    }
+    if (!s) return;
+    int clients;
+    pthread_mutex_lock(&s->mu);
+    clients = s->clients;
+    pthread_mutex_unlock(&s->mu);
+    buf_puts(b, "# HELP ds4_active_requests HTTP requests currently in flight\n"
+                "# TYPE ds4_active_requests gauge\n");
+    buf_printf(b, "ds4_active_requests %d\n", clients);
+    buf_puts(b, "# HELP ds4_context_limit_tokens Configured context size\n"
+                "# TYPE ds4_context_limit_tokens gauge\n");
+    buf_printf(b, "ds4_context_limit_tokens %d\n", s->ctx_size);
+    buf_puts(b, "# HELP ds4_context_tokens Tokens resident per decode slot\n"
+                "# TYPE ds4_context_tokens gauge\n");
+    for (int i = 0; i < s->slot_count; i++) {
+        server_slot *slot = &s->slots[i];
+        int pos = slot->session ? ds4_session_pos(slot->session) : 0;
+        buf_printf(b, "ds4_context_tokens{slot=\"%d\"} %d\n", slot->id, pos);
+    }
+}
+
+static bool send_metrics(server *s, int fd) {
+    buf b = {0};
+    append_metrics_text(&b, s);
+    bool ok = http_response(fd, s->enable_cors, 200,
+                            "text/plain; version=0.0.4", b.ptr);
+    buf_free(&b);
+    return ok;
+}
+
 static bool send_model(server *s, int fd, const char *id) {
     buf b = {0};
     append_model_json(&b, s, id);
@@ -12806,6 +13004,11 @@ static void *client_main(void *arg) {
         goto done;
     }
 
+    if (!strcmp(hr.method, "GET") && !strcmp(hr.path, "/metrics")) {
+        send_metrics(s, fd);
+        http_request_free(&hr);
+        goto done;
+    }
     if (!strcmp(hr.method, "GET") && !strcmp(hr.path, "/v1/models")) {
         send_models(s, fd);
         http_request_free(&hr);
@@ -13384,6 +13587,7 @@ int main(int argc, char **argv) {
     s.disable_exact_dsml_tool_replay = cfg.disable_exact_dsml_tool_replay;
     s.tool_mem.max_entries = cfg.tool_memory_max_ids;
     s.enable_cors = cfg.enable_cors;
+    ds4_kvstore_set_metrics_fn(metrics_kv_stored_bridge);
     s.slots = xmalloc((size_t)slot_count * sizeof(*s.slots));
     memset(s.slots, 0, (size_t)slot_count * sizeof(*s.slots));
     if (s.batched_mode) {
@@ -18309,7 +18513,57 @@ static void test_thinking_canonical_non_thinking_mode_noop(void) {
     chat_msgs_free(&msgs);
 }
 
+static void test_metrics_text(void) {
+    /* Reset the global metrics state, replay a known event sequence, and
+     * check the rendered exposition text. Runs single-threaded. */
+    memset(&g_server_metrics, 0, sizeof(g_server_metrics));
+    pthread_mutex_init(&g_server_metrics.mu, NULL);
+
+    metrics_prompt_done(2739, 60.872);
+    metrics_prefill_progress(31.51, 45.00);
+    metrics_decode_progress(50, true, 5.41, 5.41);
+    metrics_decode_progress(39, false, 5.48, 5.46);
+    metrics_request_finish("stop", 129.107);
+    metrics_request_finish("stop", 10.0);
+    metrics_request_finish("length", 5.0);
+    metrics_kv_miss("token-mismatch");
+    metrics_kv_stored_bridge(1288, 12, 39.79);
+
+    buf b = {0};
+    append_metrics_text(&b, NULL);
+    TEST_ASSERT(b.ptr != NULL);
+    TEST_ASSERT(strstr(b.ptr, "ds4_prompt_tokens_total 2739\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_generated_tokens_total{phase=\"thinking\"} 50\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_generated_tokens_total{phase=\"response\"} 39\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_prefill_tps{window=\"chunk\"} 31.51\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_decode_tps{window=\"chunk\"} 5.48\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_decode_tps{window=\"avg\"} 5.46\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_requests_total{finish=\"stop\"} 2\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_requests_total{finish=\"length\"} 1\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_request_duration_seconds_count 3\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_prompt_duration_seconds_sum 60.872\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_kv_cache_stored_total 1\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_kv_cache_trimmed_tokens_total 12\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_kv_cache_miss_total{reason=\"token-mismatch\"} 1\n"));
+    /* Server-state gauges are omitted when no server is supplied. */
+    TEST_ASSERT(strstr(b.ptr, "ds4_active_requests") == NULL);
+    TEST_ASSERT(strstr(b.ptr, "ds4_context_tokens") == NULL);
+    buf_free(&b);
+
+    /* Reason-table overflow: excess reasons account to the final bucket. */
+    for (int i = 0; i < METRICS_REASONS_MAX + 3; i++) {
+        char r[24];
+        snprintf(r, sizeof(r), "reason-%d", i);
+        metrics_kv_miss(r);
+    }
+    buf b2 = {0};
+    append_metrics_text(&b2, NULL);
+    TEST_ASSERT(strstr(b2.ptr, "reason-10\"} 5\n")); /* 1 own + 4 overflow */
+    buf_free(&b2);
+}
+
 static void ds4_server_unit_tests_run(void) {
+    test_metrics_text();
     test_batched_prefill_round_robin();
     test_mixed_prefill_quantum_option();
     test_batched_live_continuation_slot_binding();

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -8325,19 +8325,31 @@ typedef struct {
     uint64_t count;
 } metrics_reason;
 
+#define METRICS_BUCKETS 9
+/* Upper bounds (seconds) for the prompt/request latency histograms; the
+ * implicit +Inf bucket is the total count. */
+static const double metrics_prompt_bounds[METRICS_BUCKETS] =
+    {0.5, 1, 2, 5, 10, 30, 60, 120, 300};
+static const double metrics_request_bounds[METRICS_BUCKETS] =
+    {1, 2, 5, 10, 30, 60, 120, 300, 600};
+
 typedef struct {
     pthread_mutex_t mu;
     uint64_t prompt_tokens_total;
+    uint64_t reused_tokens_total;
     uint64_t gen_thinking_total, gen_response_total;
     double prefill_tps_chunk, prefill_tps_avg;
     double decode_tps_chunk, decode_tps_avg;
     metrics_reason finish[METRICS_REASONS_MAX];
     double request_seconds_sum;
     uint64_t request_seconds_count;
+    uint64_t request_seconds_bucket[METRICS_BUCKETS];
     double prompt_seconds_sum;
     uint64_t prompt_seconds_count;
+    uint64_t prompt_seconds_bucket[METRICS_BUCKETS];
     uint64_t kv_stored_total, kv_trimmed_tokens_total;
     double kv_stored_bytes_total;
+    metrics_reason kv_hit[METRICS_REASONS_MAX];
     metrics_reason kv_miss[METRICS_REASONS_MAX];
 } server_metrics;
 
@@ -8378,12 +8390,31 @@ static void metrics_prefill_progress(double chunk_tps, double avg_tps) {
     pthread_mutex_unlock(&g_server_metrics.mu);
 }
 
-static void metrics_prompt_done(int tokens, double seconds) {
-    if (tokens < 0) tokens = 0;
+static void metrics_bucket_add(uint64_t *buckets, const double *bounds,
+                               double v) {
+    for (int i = 0; i < METRICS_BUCKETS; i++) {
+        if (v <= bounds[i]) {
+            buckets[i]++;
+            return;
+        }
+    }
+    /* Above the last bound: lands only in the implicit +Inf bucket (the
+     * total count), which render derives from _count. */
+}
+
+static void metrics_prompt_done(int evaluated_tokens, int reused_tokens,
+                                const char *cache_source, double seconds) {
+    if (evaluated_tokens < 0) evaluated_tokens = 0;
+    if (reused_tokens < 0) reused_tokens = 0;
     pthread_mutex_lock(&g_server_metrics.mu);
-    g_server_metrics.prompt_tokens_total += (uint64_t)tokens;
+    g_server_metrics.prompt_tokens_total += (uint64_t)evaluated_tokens;
+    g_server_metrics.reused_tokens_total += (uint64_t)reused_tokens;
+    if (reused_tokens > 0)
+        metrics_reason_add(g_server_metrics.kv_hit, cache_source);
     g_server_metrics.prompt_seconds_sum += seconds;
     g_server_metrics.prompt_seconds_count++;
+    metrics_bucket_add(g_server_metrics.prompt_seconds_bucket,
+                       metrics_prompt_bounds, seconds);
     pthread_mutex_unlock(&g_server_metrics.mu);
 }
 
@@ -8392,6 +8423,8 @@ static void metrics_request_finish(const char *reason, double seconds) {
     metrics_reason_add(g_server_metrics.finish, reason);
     g_server_metrics.request_seconds_sum += seconds;
     g_server_metrics.request_seconds_count++;
+    metrics_bucket_add(g_server_metrics.request_seconds_bucket,
+                       metrics_request_bounds, seconds);
     pthread_mutex_unlock(&g_server_metrics.mu);
 }
 
@@ -11607,7 +11640,8 @@ static void generate_job_inner(server *s, server_slot *slot, job *j) {
     ds4_session_set_progress(slot->session, NULL, NULL);
     ds4_session_set_display_progress(slot->session, NULL, NULL);
     kv_cache_maybe_store_continued(s, slot);
-    metrics_prompt_done(prompt_tokens - cached, now_sec() - t0);
+    metrics_prompt_done(prompt_tokens - cached, cached, cache_source,
+                        now_sec() - t0);
     server_log(DS4_LOG_PREFILL,
                "ds4-server: %s ctx=%s%s%s prompt done %.3fs",
                j->req.kind == REQ_CHAT ? "chat" : "completion",
@@ -12797,13 +12831,40 @@ static void append_metrics_text(buf *b, server *s) {
         buf_printf(b, "ds4_requests_total{finish=\"%s\"} %llu\n",
                    snap.finish[i].name, (unsigned long long)snap.finish[i].count);
     }
+    buf_puts(b, "# HELP ds4_reused_tokens_total Prompt tokens served from KV cache reuse\n"
+                "# TYPE ds4_reused_tokens_total counter\n");
+    buf_printf(b, "ds4_reused_tokens_total %llu\n",
+               (unsigned long long)snap.reused_tokens_total);
+    buf_puts(b, "# HELP ds4_kv_cache_hit_total Prompts that reused cached KV, by source\n"
+                "# TYPE ds4_kv_cache_hit_total counter\n");
+    for (int i = 0; i < METRICS_REASONS_MAX; i++) {
+        if (!snap.kv_hit[i].name[0]) break;
+        buf_printf(b, "ds4_kv_cache_hit_total{source=\"%s\"} %llu\n",
+                   snap.kv_hit[i].name, (unsigned long long)snap.kv_hit[i].count);
+    }
     buf_puts(b, "# HELP ds4_request_duration_seconds Wall time per request\n"
-                "# TYPE ds4_request_duration_seconds summary\n");
+                "# TYPE ds4_request_duration_seconds histogram\n");
+    uint64_t cum = 0;
+    for (int i = 0; i < METRICS_BUCKETS; i++) {
+        cum += snap.request_seconds_bucket[i];
+        buf_printf(b, "ds4_request_duration_seconds_bucket{le=\"%g\"} %llu\n",
+                   metrics_request_bounds[i], (unsigned long long)cum);
+    }
+    buf_printf(b, "ds4_request_duration_seconds_bucket{le=\"+Inf\"} %llu\n",
+               (unsigned long long)snap.request_seconds_count);
     buf_printf(b, "ds4_request_duration_seconds_sum %.3f\n", snap.request_seconds_sum);
     buf_printf(b, "ds4_request_duration_seconds_count %llu\n",
                (unsigned long long)snap.request_seconds_count);
     buf_puts(b, "# HELP ds4_prompt_duration_seconds Wall time per prompt prefill\n"
-                "# TYPE ds4_prompt_duration_seconds summary\n");
+                "# TYPE ds4_prompt_duration_seconds histogram\n");
+    cum = 0;
+    for (int i = 0; i < METRICS_BUCKETS; i++) {
+        cum += snap.prompt_seconds_bucket[i];
+        buf_printf(b, "ds4_prompt_duration_seconds_bucket{le=\"%g\"} %llu\n",
+                   metrics_prompt_bounds[i], (unsigned long long)cum);
+    }
+    buf_printf(b, "ds4_prompt_duration_seconds_bucket{le=\"+Inf\"} %llu\n",
+               (unsigned long long)snap.prompt_seconds_count);
     buf_printf(b, "ds4_prompt_duration_seconds_sum %.3f\n", snap.prompt_seconds_sum);
     buf_printf(b, "ds4_prompt_duration_seconds_count %llu\n",
                (unsigned long long)snap.prompt_seconds_count);
@@ -18519,7 +18580,8 @@ static void test_metrics_text(void) {
     memset(&g_server_metrics, 0, sizeof(g_server_metrics));
     pthread_mutex_init(&g_server_metrics.mu, NULL);
 
-    metrics_prompt_done(2739, 60.872);
+    metrics_prompt_done(2739, 0, "none", 60.872);
+    metrics_prompt_done(100, 1900, "memory-rewind", 0.4);
     metrics_prefill_progress(31.51, 45.00);
     metrics_decode_progress(50, true, 5.41, 5.41);
     metrics_decode_progress(39, false, 5.48, 5.46);
@@ -18532,7 +18594,9 @@ static void test_metrics_text(void) {
     buf b = {0};
     append_metrics_text(&b, NULL);
     TEST_ASSERT(b.ptr != NULL);
-    TEST_ASSERT(strstr(b.ptr, "ds4_prompt_tokens_total 2739\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_prompt_tokens_total 2839\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_reused_tokens_total 1900\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_kv_cache_hit_total{source=\"memory-rewind\"} 1\n"));
     TEST_ASSERT(strstr(b.ptr, "ds4_generated_tokens_total{phase=\"thinking\"} 50\n"));
     TEST_ASSERT(strstr(b.ptr, "ds4_generated_tokens_total{phase=\"response\"} 39\n"));
     TEST_ASSERT(strstr(b.ptr, "ds4_prefill_tps{window=\"chunk\"} 31.51\n"));
@@ -18541,7 +18605,17 @@ static void test_metrics_text(void) {
     TEST_ASSERT(strstr(b.ptr, "ds4_requests_total{finish=\"stop\"} 2\n"));
     TEST_ASSERT(strstr(b.ptr, "ds4_requests_total{finish=\"length\"} 1\n"));
     TEST_ASSERT(strstr(b.ptr, "ds4_request_duration_seconds_count 3\n"));
-    TEST_ASSERT(strstr(b.ptr, "ds4_prompt_duration_seconds_sum 60.872\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_prompt_duration_seconds_sum 61.272\n"));
+    /* Histogram buckets are cumulative: the 0.4 s prompt lands in le=0.5,
+     * the 60.872 s prompt first appears at le=120. */
+    TEST_ASSERT(strstr(b.ptr, "ds4_prompt_duration_seconds_bucket{le=\"0.5\"} 1\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_prompt_duration_seconds_bucket{le=\"60\"} 1\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_prompt_duration_seconds_bucket{le=\"120\"} 2\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_prompt_duration_seconds_bucket{le=\"+Inf\"} 2\n"));
+    /* Request histogram: 129.107 -> le=300, 10.0 -> le=10, 5.0 -> le=5. */
+    TEST_ASSERT(strstr(b.ptr, "ds4_request_duration_seconds_bucket{le=\"5\"} 1\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_request_duration_seconds_bucket{le=\"10\"} 2\n"));
+    TEST_ASSERT(strstr(b.ptr, "ds4_request_duration_seconds_bucket{le=\"300\"} 3\n"));
     TEST_ASSERT(strstr(b.ptr, "ds4_kv_cache_stored_total 1\n"));
     TEST_ASSERT(strstr(b.ptr, "ds4_kv_cache_trimmed_tokens_total 12\n"));
     TEST_ASSERT(strstr(b.ptr, "ds4_kv_cache_miss_total{reason=\"token-mismatch\"} 1\n"));

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -8321,7 +8321,11 @@ static pthread_mutex_t server_log_mu = PTHREAD_MUTEX_INITIALIZER;
  * that emit the corresponding log lines. */
 #define METRICS_REASONS_MAX 12
 typedef struct {
-    char name[24];
+    /* Sized for the longest current reason string,
+     * "incoming-prompt-shorter-than-live-checkpoint" (44 bytes + NUL);
+     * snprintf truncation would otherwise desynchronize the label from
+     * the corresponding log line and could collide two long reasons. */
+    char name[48];
     uint64_t count;
 } metrics_reason;
 

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -8383,8 +8383,16 @@ static void metrics_decode_progress(int tokens, bool thinking,
     pthread_mutex_unlock(&g_server_metrics.mu);
 }
 
-static void metrics_prefill_progress(double chunk_tps, double avg_tps) {
+/* Prompt tokens are accumulated per prefill chunk rather than in one jump
+ * at prompt completion: a whole prompt landing on the counter between two
+ * scrapes renders as an impossible rate() spike (a 27k-token prompt over a
+ * 30 s scrape interval reads as 900 tokens/s). metrics_prompt_done() adds
+ * only the remainder the chunk callbacks have not seen. */
+static void metrics_prefill_progress(int interval_tokens, double chunk_tps,
+                                     double avg_tps) {
+    if (interval_tokens < 0) interval_tokens = 0;
     pthread_mutex_lock(&g_server_metrics.mu);
+    g_server_metrics.prompt_tokens_total += (uint64_t)interval_tokens;
     g_server_metrics.prefill_tps_chunk = chunk_tps;
     g_server_metrics.prefill_tps_avg = avg_tps;
     pthread_mutex_unlock(&g_server_metrics.mu);
@@ -8402,8 +8410,9 @@ static void metrics_bucket_add(uint64_t *buckets, const double *bounds,
      * total count), which render derives from _count. */
 }
 
-static void metrics_prompt_done(int evaluated_tokens, int reused_tokens,
+static void metrics_prompt_done(int remainder_tokens, int reused_tokens,
                                 const char *cache_source, double seconds) {
+    int evaluated_tokens = remainder_tokens;
     if (evaluated_tokens < 0) evaluated_tokens = 0;
     if (reused_tokens < 0) reused_tokens = 0;
     pthread_mutex_lock(&g_server_metrics.mu);
@@ -10320,6 +10329,7 @@ typedef struct {
     double t0;
     double last_t;
     int last_current;
+    int metrics_counted; /* evaluated tokens already added to the metrics counter */
     bool seen;
     /* SSE keepalive during long prefill: send HTTP/SSE headers ahead of
      * generation and emit a `:` comment line every few seconds so HTTP/TCP
@@ -10785,7 +10795,18 @@ static void server_progress_cb(void *ud, const char *event, int current, int tot
     p->last_current = current;
     p->last_t = now;
     p->seen = true;
-    metrics_prefill_progress(chunk_tps, avg_tps);
+    int metrics_add = interval_tokens;
+    {
+        /* Never let display-window resets count cached tokens as evaluated:
+         * cap the per-request total at prompt_tokens - cached_tokens. */
+        const int evaluated_total = p->prompt_tokens - p->cached_tokens;
+        if (evaluated_total <= 0) metrics_add = 0;
+        else if (p->metrics_counted + metrics_add > evaluated_total)
+            metrics_add = evaluated_total - p->metrics_counted;
+        if (metrics_add < 0) metrics_add = 0;
+    }
+    p->metrics_counted += metrics_add;
+    metrics_prefill_progress(metrics_add, chunk_tps, avg_tps);
     char flags[64];
     log_flags(flags, sizeof(flags), p->responses_protocol,
               p->has_tools, false, false, false);
@@ -11640,8 +11661,11 @@ static void generate_job_inner(server *s, server_slot *slot, job *j) {
     ds4_session_set_progress(slot->session, NULL, NULL);
     ds4_session_set_display_progress(slot->session, NULL, NULL);
     kv_cache_maybe_store_continued(s, slot);
-    metrics_prompt_done(prompt_tokens - cached, cached, cache_source,
-                        now_sec() - t0);
+    /* Chunk callbacks already accumulated progress.metrics_counted evaluated
+     * tokens; add only what they have not seen (small prompts may produce no
+     * chunk callbacks at all). */
+    metrics_prompt_done((prompt_tokens - cached) - progress.metrics_counted,
+                        cached, cache_source, now_sec() - t0);
     server_log(DS4_LOG_PREFILL,
                "ds4-server: %s ctx=%s%s%s prompt done %.3fs",
                j->req.kind == REQ_CHAT ? "chat" : "completion",
@@ -18580,9 +18604,11 @@ static void test_metrics_text(void) {
     memset(&g_server_metrics, 0, sizeof(g_server_metrics));
     pthread_mutex_init(&g_server_metrics.mu, NULL);
 
-    metrics_prompt_done(2739, 0, "none", 60.872);
+    /* Chunk-incremental prompt accounting: two chunks then the remainder. */
+    metrics_prefill_progress(2048, 33.60, 33.60);
+    metrics_prefill_progress(600, 31.51, 45.00);
+    metrics_prompt_done(91, 0, "none", 60.872);
     metrics_prompt_done(100, 1900, "memory-rewind", 0.4);
-    metrics_prefill_progress(31.51, 45.00);
     metrics_decode_progress(50, true, 5.41, 5.41);
     metrics_decode_progress(39, false, 5.48, 5.46);
     metrics_request_finish("stop", 129.107);


### PR DESCRIPTION
## Summary

`ds4-server` now answers HTTP `GET /metrics` with Prometheus text exposition format, so a Prometheus server (or any compatible scraper) can collect request, token, and key-value cache statistics directly from the process. Until now the only way to get these series out was to parse the server's log output with a sidecar exporter; a native endpoint removes that moving part and works identically on every platform the server builds on.

The endpoint is read-only, needs no new dependencies, and is entirely opt-in: unless something requests `/metrics`, the only cost is the counter updates on the server's existing accounting paths.

## Exported series

Requests and latency:

- `ds4_requests_total` — completed requests, by endpoint and status.
- `ds4_active_requests` — requests currently being served.
- `ds4_request_duration_seconds` — end-to-end request latency histogram.
- `ds4_prompt_duration_seconds` — prompt-evaluation (prefill) latency histogram.

Tokens and throughput:

- `ds4_prompt_tokens_total` — prompt tokens evaluated, counted per prefill chunk rather than per prompt, so scrape intervals shorter than a long prefill still see accurate rates.
- `ds4_generated_tokens_total` — generated tokens, by phase.
- `ds4_prefill_tps` / `ds4_decode_tps` — instantaneous prefill and decode rates, tokens per second.
- `ds4_context_tokens` / `ds4_context_limit_tokens` — context occupancy and configured limit per session.

Key-value cache (disk store and reuse):

- `ds4_kv_cache_hit_total` / `ds4_kv_cache_miss_total` — cache hits by source (live key-value reuse or the on-disk store) versus misses.
- `ds4_kv_cache_stored_total` / `ds4_kv_cache_stored_bytes_total` — entries and bytes written to the store.
- `ds4_kv_cache_trimmed_tokens_total` — tokens evicted by trimming.
- `ds4_reused_tokens_total` — prompt tokens served from reuse instead of re-evaluation.

Example exposition (truncated):

```
# HELP ds4_prompt_tokens_total Prompt tokens evaluated by prefill
# TYPE ds4_prompt_tokens_total counter
ds4_prompt_tokens_total 86
# HELP ds4_generated_tokens_total Tokens generated, by phase
# TYPE ds4_generated_tokens_total counter
ds4_generated_tokens_total{phase="decode"} 200
```

## Implementation

Three commits:

1. The endpoint itself: text format rendering and routing in `ds4_server.c`.
2. Additional accounting: cache hits split by source, a reused-token counter, and the latency histograms; the key-value store reports hit sources through a small callback (`ds4_kvstore_set_metrics_fn`) so the store code stays free of server types.
3. Prompt-token counting moved from per-prompt to per-chunk accounting, which keeps rate queries correct while a long prefill is still in flight.

No new build flags, no new command-line options, and no changes to any existing behavior when the endpoint is not requested.

## Verification

- Warning-free builds on macOS (Darwin, default `make ds4-server`) and on ROCm (gfx1151, `make strix-halo`).
- The same three commits have been running on our production branch (two-machine ROCm pair, DeepSeek V4 Flash MXFP4) with Prometheus scraping the endpoint; series names above are copied from live output.
