### PR TITLE
quality: recognize OrcaRouter as a named collection endpoint

### DIFF
--- a/gguf-tools/quality-testing/README.md
+++ b/gguf-tools/quality-testing/README.md
@@ -67,6 +67,26 @@ python3 gguf-tools/quality-testing/collect_official.py \
   --reasoning-effort none
 ```
 
+For DeepSeek V4 Flash through OrcaRouter:
+
+```sh
+export ORCAROUTER_API_KEY=...
+python3 gguf-tools/quality-testing/collect_official.py \
+  --model deepseek/deepseek-v4-flash \
+  --endpoint https://api.orcarouter.ai/v1/chat/completions \
+  --prompts gguf-tools/quality-testing/prompts.jsonl \
+  --out gguf-tools/quality-testing/data/flash-orcarouter \
+  --count 100 \
+  --max-tokens 24 \
+  --top-logprobs 20 \
+  --thinking disabled \
+  --reasoning-effort omit
+```
+
+When the endpoint contains `orcarouter.ai`, the script reads
+`ORCAROUTER_API_KEY` automatically, mirroring the `OPENROUTER_API_KEY`
+handling for OpenRouter endpoints.
+
 Use one output directory per checkpoint. For PRO 0813 through the official
 DeepSeek API:
 

--- a/gguf-tools/quality-testing/collect_official.py
+++ b/gguf-tools/quality-testing/collect_official.py
@@ -239,7 +239,13 @@ def main() -> int:
         raise SystemExit("--top-logprobs must be between 0 and 20")
 
     openrouter = "openrouter.ai" in args.endpoint
-    api_key_env = args.api_key_env or ("OPENROUTER_API_KEY" if openrouter else "DEEPSEEK_API_KEY")
+    orcarouter = "orcarouter.ai" in args.endpoint
+    if orcarouter:
+        api_key_env = args.api_key_env or "ORCAROUTER_API_KEY"
+    elif openrouter:
+        api_key_env = args.api_key_env or "OPENROUTER_API_KEY"
+    else:
+        api_key_env = args.api_key_env or "DEEPSEEK_API_KEY"
     api_key = os.environ.get(api_key_env)
     if not api_key:
         raise SystemExit(f"{api_key_env} is not set")


### PR DESCRIPTION
`collect_official.py` already treats OpenRouter as a named endpoint: an `openrouter.ai` base URL auto-selects `OPENROUTER_API_KEY`. This adds the same first-class handling for [OrcaRouter](https://www.orcarouter.ai), so DwarfStar's quality-testing flow can pull DeepSeek V4 Flash continuation fixtures through it. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents — like OpenRouter it exposes a provider/model namespace across many models, but also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint, plus gateway-level zero-trust security for AI agents (screening every prompt/response and governing every tool call on a default-deny basis, no app changes). When `--endpoint` contains `orcarouter.ai`, the script reads `ORCAROUTER_API_KEY`.

Verified: `python3 -m py_compile` clean; live run against `https://api.orcarouter.ai/v1/chat/completions` with `--model deepseek/deepseek-v4-flash` collected continuations with output-token logprobs (16 steps, top-5); README example added beside the OpenRouter block.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter — I'm an engineer on the OrcaRouter team.
