### PR TITLE
cuda: fix Ampere token-tile ldmatrix IMA

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -10316,7 +10316,8 @@ __device__ __forceinline__ uint32_t tt_ring_off_bytes(uint32_t row, uint32_t c) 
 
 __device__ __forceinline__ void tt_ldmatrix_x4_addr(uint32_t (&r)[4], unsigned a) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
-    asm volatile("ldmatrix.sync.aligned.m8n8.x4.b16 {%0, %1, %2, %3}, [%4];"
+    /* .shared is required on Ampere; without it sm_80 treats [addr] as generic. */
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];"
                  : "=r"(r[0]), "=r"(r[1]), "=r"(r[2]), "=r"(r[3])
                  : "r"(a));
 #else
@@ -10327,7 +10328,7 @@ __device__ __forceinline__ void tt_ldmatrix_x4_addr(uint32_t (&r)[4], unsigned a
 
 __device__ __forceinline__ void tt_ldmatrix_x2_addr(uint32_t (&r)[2], unsigned a) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
-    asm volatile("ldmatrix.sync.aligned.m8n8.x2.b16 {%0, %1}, [%2];"
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];"
                  : "=r"(r[0]), "=r"(r[1])
                  : "r"(a));
 #else
@@ -10338,7 +10339,7 @@ __device__ __forceinline__ void tt_ldmatrix_x2_addr(uint32_t (&r)[2], unsigned a
 
 __device__ __forceinline__ void tt_ldmatrix_x2_trans_addr(uint32_t (&r)[2], unsigned a) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
-    asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.b16 {%0, %1}, [%2];"
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];"
                  : "=r"(r[0]), "=r"(r[1])
                  : "r"(a));
 #else
@@ -10688,7 +10689,8 @@ __device__ __forceinline__ void tt_issue_record_stage_cp_async(
         uint32_t row0,
         uint32_t nr,
         uint32_t raw_union_count,
-        const int2 * __restrict__ union_records_tile) {
+        const int2 * __restrict__ union_records_tile,
+        uint32_t rec_stride) {
     static_assert(TT_STAGE_ROWS == 32u, "token-tile record issue is fixed at R32");
     const uint32_t raw_rows = tt_stage_raw_rows(row0, nr, raw_union_count);
     const uint32_t lane = tt_lane_id();
@@ -10700,7 +10702,8 @@ __device__ __forceinline__ void tt_issue_record_stage_cp_async(
     if (comp_live && lane16 == 0u) {
         int2 *dst = rec_plane + rr;
         const uint32_t ci = row0 + rr - raw_union_count;
-        tt_cp_async_8B(dst, union_records_tile + ci, true);
+        const bool in_range = ci < rec_stride;
+        tt_cp_async_8B(dst, in_range ? union_records_tile + ci : NULL, in_range);
     }
 }
 
@@ -10715,6 +10718,9 @@ __device__ __forceinline__ void tt_issue_kv_stage_cp_async(
         uint32_t tile_base,
         const half * __restrict__ raw_kv,
         const half * __restrict__ comp_kv,
+        uint32_t n_mirror_rows,
+        uint32_t n_comp,
+        uint32_t rec_stride,
         uint32_t tid) {
     constexpr uint32_t kCp16PerRow = (kTTHeadDim * sizeof(half)) / 16u;
     static_assert(kCp16PerRow == 64u, "expected 64 cp.async chunks per f16 KV row");
@@ -10729,20 +10735,27 @@ __device__ __forceinline__ void tt_issue_kv_stage_cp_async(
 
     if (active && rr < raw_rows) {
         const uint32_t sr = row0 + rr;
-        const half *src = raw_kv + (uint64_t)(tile_base + sr) * kTTHeadDim;
-        tt_issue_cp_async_row(dst, rr, lane16, src, true);
+        const uint32_t raw_idx = tile_base + sr;
+        const bool live = raw_idx < n_mirror_rows;
+        const half *src = live ? raw_kv + (uint64_t)raw_idx * kTTHeadDim : NULL;
+        tt_issue_cp_async_row(dst, rr, lane16, src, live);
     }
 
     if (active && rr >= raw_rows && rr < nr) {
         uint32_t comp_id = 0u;
+        bool have_id = true;
         if (USE_SMEM_RECORDS) {
             comp_id = (uint32_t)rec_plane[rr].x;
         } else {
             const uint32_t ci = row0 + rr - raw_union_count;
-            comp_id = (uint32_t)union_records_tile[ci].x;
+            have_id = ci < rec_stride;
+            if (have_id) {
+                comp_id = (uint32_t)union_records_tile[ci].x;
+            }
         }
-        const half *src = comp_kv + (uint64_t)comp_id * kTTHeadDim;
-        tt_issue_cp_async_row(dst, rr, lane16, src, true);
+        const bool live = have_id && comp_id < n_comp;
+        const half *src = live ? comp_kv + (uint64_t)comp_id * kTTHeadDim : NULL;
+        tt_issue_cp_async_row(dst, rr, lane16, src, live);
     }
 
     if (active && rr >= nr) {
@@ -11038,7 +11051,9 @@ __global__ static void __launch_bounds__(512, 1) attention_tokentile_hmma_kernel
         uint32_t rec_stride,
         uint32_t n_tokens,
         uint32_t n_head,
-        uint32_t raw_row_min) {
+        uint32_t raw_row_min,
+        uint32_t n_mirror_rows,
+        uint32_t n_comp) {
     constexpr uint32_t kKvElems = tt_TokentileLayout<kTTStageRows>::ring_plane_elems;
     constexpr uint32_t kProbStride = tt_TokentileLayout<kTTStageRows>::prob_stride;
     const uint32_t tid = threadIdx.x;
@@ -11113,13 +11128,17 @@ __global__ static void __launch_bounds__(512, 1) attention_tokentile_hmma_kernel
             tile_base,
             raw_kv,
             comp_kv,
+            n_mirror_rows,
+            n_comp,
+            rec_stride,
             tid);
         tt_issue_record_stage_cp_async<kTTStageRows>(
             rec_ring,
             0u,
             nr0,
             raw_union_count,
-            union_records_tile);
+            union_records_tile,
+            rec_stride);
         if (kTTStageRows < n_score) {
             const uint32_t nr1 =
                 n_score - kTTStageRows < kTTStageRows ? n_score - kTTStageRows : kTTStageRows;
@@ -11128,7 +11147,8 @@ __global__ static void __launch_bounds__(512, 1) attention_tokentile_hmma_kernel
                 kTTStageRows,
                 nr1,
                 raw_union_count,
-                union_records_tile);
+                union_records_tile,
+                rec_stride);
         }
         tt_cp_async_commit();
         tt_cp_async_wait_group<0>();
@@ -11166,6 +11186,9 @@ __global__ static void __launch_bounds__(512, 1) attention_tokentile_hmma_kernel
                 tile_base,
                 raw_kv,
                 comp_kv,
+                n_mirror_rows,
+                n_comp,
+                rec_stride,
                 tid);
             const uint32_t prefetch_row0 = next_row0 + kTTStageRows;
             if (prefetch_row0 < n_score) {
@@ -11178,7 +11201,8 @@ __global__ static void __launch_bounds__(512, 1) attention_tokentile_hmma_kernel
                     prefetch_row0,
                     prefetch_nr,
                     raw_union_count,
-                    union_records_tile);
+                    union_records_tile,
+                    rec_stride);
             }
             tt_cp_async_commit();
         }
@@ -11280,6 +11304,8 @@ static int ds4_cuda_attn_tokentile_arch_ok(void) {
         (void)cudaGetLastError();
         return 0;
     }
+    /* ldmatrix/cp.async/HMMA exist from sm_80. The PTX must use .shared;
+     * without it Ampere treats the smem address as generic and IMA's. */
     return prop.major >= 8;
 }
 
@@ -17561,7 +17587,7 @@ static int attention_decode_batch_launch(
                        stream>>>(
                         (float *)heads->ptr, sinks, (const float *)q->ptr,
                         raw_mirror, comp_mirror, records, counts, rec_stride,
-                        n_tokens, n_head, raw_row_min);
+                        n_tokens, n_head, raw_row_min, n_mirror_rows, n_comp);
                 return cuda_ok(cudaGetLastError(),
                                "launch dense token-tile HMMA attention");
             }
@@ -17868,7 +17894,7 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
                        stream>>>(
                         (float *)heads->ptr, sinks, (const float *)q->ptr,
                         raw_mirror, comp_mirror, records, counts, rec_stride,
-                        n_tokens, n_head, raw_row_min);
+                        n_tokens, n_head, raw_row_min, n_mirror_rows, n_comp);
                 return cuda_ok(cudaGetLastError(),
                                "launch token-tile HMMA attention");
             }

--- a/tests/cuda_long_context_smoke.c
+++ b/tests/cuda_long_context_smoke.c
@@ -156,10 +156,93 @@ static int check_decode_attention_overflow_path(void) {
     return rc;
 }
 
+static int check_tokentile_shape_mixed_prefill(void) {
+    /* Flash mixed attention at the token-tile geometry: 128 tokens, 64 heads,
+     * dk=512, SWA 128, ratio 4. This is the dense HMMA path (n_tokens>=128). */
+    const uint32_t n_tokens = 128;
+    const uint32_t n_head = 64;
+    const uint32_t head_dim = 512;
+    const uint32_t window = 128;
+    const uint32_t ratio = 4;
+    const uint32_t n_comp = n_tokens / ratio;
+    const uint64_t q_count = (uint64_t)n_tokens * n_head * head_dim;
+    const uint64_t raw_count = (uint64_t)n_tokens * head_dim;
+    const uint64_t comp_count = (uint64_t)n_comp * head_dim;
+
+    float *sinks = (float *)calloc(n_head, sizeof(float));
+    float *q_host = (float *)calloc((size_t)q_count, sizeof(float));
+    float *raw_host = (float *)calloc((size_t)raw_count, sizeof(float));
+    float *comp_host = (float *)calloc((size_t)comp_count, sizeof(float));
+    float *heads_host = (float *)calloc((size_t)q_count, sizeof(float));
+    if (!sinks || !q_host || !raw_host || !comp_host || !heads_host) {
+        free(heads_host);
+        free(comp_host);
+        free(raw_host);
+        free(q_host);
+        free(sinks);
+        return 1;
+    }
+    for (uint32_t t = 0; t < n_tokens; t++) {
+        for (uint32_t h = 0; h < n_head; h++) {
+            q_host[((uint64_t)t * n_head + h) * head_dim] = 0.01f;
+        }
+        raw_host[(uint64_t)t * head_dim] = 1.0f;
+    }
+    for (uint32_t c = 0; c < n_comp; c++) {
+        comp_host[(uint64_t)c * head_dim] = 1.0f;
+    }
+
+    ds4_gpu_tensor *heads = ds4_gpu_tensor_alloc(q_count * sizeof(float));
+    ds4_gpu_tensor *q = ds4_gpu_tensor_alloc(q_count * sizeof(float));
+    ds4_gpu_tensor *raw = ds4_gpu_tensor_alloc(raw_count * sizeof(float));
+    ds4_gpu_tensor *comp = ds4_gpu_tensor_alloc(comp_count * sizeof(float));
+    int rc = 1;
+    if (heads && q && raw && comp &&
+        ds4_gpu_tensor_write(q, 0, q_host, q_count * sizeof(float)) &&
+        ds4_gpu_tensor_write(raw, 0, raw_host, raw_count * sizeof(float)) &&
+        ds4_gpu_tensor_write(comp, 0, comp_host, comp_count * sizeof(float)) &&
+        ds4_gpu_attention_prefill_static_mixed_heads_tensor(
+            heads, sinks, n_head * sizeof(float), 0, q, raw, comp, 0,
+            n_tokens, n_comp, window, ratio, n_head, head_dim) &&
+        ds4_gpu_synchronize() &&
+        ds4_gpu_tensor_read(heads, 0, heads_host, q_count * sizeof(float))) {
+        rc = 0;
+        for (uint32_t t = 0; t < n_tokens && rc == 0; t++) {
+            for (uint32_t h = 0; h < n_head; h++) {
+                const float v = heads_host[((uint64_t)t * n_head + h) * head_dim];
+                /* Prefill pads pre-window raw rows with zeros, so t=0 is ~0.5. */
+                if (!(v == v) || v < 0.05f || v > 2.0f) {
+                    fprintf(stderr,
+                            "tokentile mixed prefill bad output t=%u h=%u v=%f\n",
+                            t, h, (double)v);
+                    rc = 1;
+                    break;
+                }
+            }
+        }
+    } else {
+        fprintf(stderr,
+                "tokentile-shape mixed prefill failed n_tokens=%u n_comp=%u\n",
+                n_tokens, n_comp);
+    }
+
+    ds4_gpu_tensor_free(comp);
+    ds4_gpu_tensor_free(raw);
+    ds4_gpu_tensor_free(q);
+    ds4_gpu_tensor_free(heads);
+    free(heads_host);
+    free(comp_host);
+    free(raw_host);
+    free(q_host);
+    free(sinks);
+    return rc;
+}
+
 int main(void) {
     if (!ds4_gpu_init()) return 1;
     int rc = check_large_topk();
     if (check_decode_attention_overflow_path() != 0) rc = 1;
+    if (check_tokentile_shape_mixed_prefill() != 0) rc = 1;
     ds4_gpu_cleanup();
     if (rc == 0) puts("cuda long-context regression: OK");
     return rc;


### PR DESCRIPTION
## Summary

The CUDA token-tile HMMA attention path IMA's on Ampere (`sm_80`) as soon as prefill hits `n_tokens >= 128`. Hopper / GB10 already ran this kernel; Ampere did not.

Root cause is the `ldmatrix` PTX, not the architecture gate. The three `ldmatrix.sync.aligned.m8n8.{x4,x2,x2.trans}.b16` helpers omitted `.shared`. On Ampere that makes `[addr]` a generic address, so a shared-memory pointer is decoded as global and the load IMA's. Adding `.shared` is the actual fix; `ds4_cuda_attn_tokentile_arch_ok()` stays `major >= 8`.

## What changed

- Add `.shared` to the three token-tile `ldmatrix` PTX strings.
- Predicate raw/comp/record `cp.async` against the live mirror size so a padded stage cannot issue an unconstrained global load.
- Cover the dense HMMA geometry (128 tokens, 64 heads, dk=512, SWA 128, ratio 4) in `tests/cuda_long_context_smoke.c`.

Metal, ROCm, CPU, and the heads8/cuBLAS fallbacks are untouched.

## Testing

On a CMP 170HX (`sm_80`, 64 GB):

- Isolation (compute-sanitizer cannot attach; GPU debugging is disabled on this card): skip-Q / skip-KV / skip-MMA were clean; IMA was inside `tt_hmma_score_stage` `ldmatrix` even with identity swizzle and without `cp.async`. Adding `.shared` made one-block and full-grid launches pass.
- `make cuda-regression CUDA_ARCH=sm_80` → `cuda long-context regression: OK`
- Hetero ROCm coordinator `0:26` + CUDA worker `27:output`, Q2 GGUF, `--dist-prefill-chunk 4096`:
  - 128-token prefill: 46.60 t/s prefill, 19.05 t/s decode
  - 4096-token prefill: **248.44 t/s** prefill, 16.49 t/s decode (previously IMA; chunk 64 was ~87 t/s)

Not re-run here: GB10 / `sm_121` (the kernel already shipped there), Metal, SSD streaming.

## Notes

Gating Ampere off and keeping HMMA on `sm_90+` / `sm_121` only would also avoid the crash, but that leaves Ampere on the slow heads8 path. The PTX space qualifier is the smaller correct fix.