### PR TITLE
STRIXHALO.md: amd_iommu=off and amdgpu.gttsize are not required (and amd_iommu=off disables the NPU)

### DIFF
--- a/STRIXHALO.md
+++ b/STRIXHALO.md
@@ -65,8 +65,19 @@ buffers.
 Use these kernel parameters:
 
 ```text
-amd_iommu=off amdgpu.gttsize=126976 ttm.pages_limit=32505856 ttm.page_pool_size=32505856
+ttm.pages_limit=32505856 ttm.page_pool_size=32505856
 ```
+
+`ttm.pages_limit` alone sets the GTT ceiling: `mem_info_gtt_total` comes out at exactly
+`pages_limit * 4096`. `amdgpu.gttsize` is not needed, and ROCm issue #5595 advises against
+setting it together with `ttm.pages_limit`.
+
+> **On `amd_iommu=off`.** Earlier revisions of this document recommended it. It may buy a
+> small memory-read speedup, but it is **not required** — DS4 has been run with the full
+> 80.76 GiB model on a 128 GB Ryzen AI MAX+ 395 host with IOMMU translation active
+> (`iommu.passthrough=0`). If your machine has an **XDNA2 NPU**, do not use it: the
+> `amdxdna` driver needs an IOMMU present for PASID, so `amd_iommu=off` disables the NPU
+> entirely.
 
 On Ubuntu with GRUB:
 
@@ -78,7 +89,7 @@ sudoedit /etc/default/grub
 Set:
 
 ```text
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash amd_iommu=off amdgpu.gttsize=126976 ttm.pages_limit=32505856 ttm.page_pool_size=32505856"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash ttm.pages_limit=32505856 ttm.page_pool_size=32505856"
 ```
 
 Then:
@@ -92,16 +103,14 @@ After reboot, verify:
 
 ```sh
 cat /proc/cmdline
-sudo dmesg | grep -Ei 'GTT|gttsize|TTM|VRAM'
+cat /sys/class/drm/card*/device/mem_info_gtt_total
+sudo dmesg | grep -Ei 'GTT|TTM|VRAM'
 rocminfo | grep -A80 'Name:                    gfx1151'
 ```
 
-Expected signs:
-
-```text
-amdgpu:  126976M of GTT memory ready
-rocminfo gfx1151 pool: 130023424 KB
-```
+Expected signs: `mem_info_gtt_total` should equal `pages_limit * 4096` — with
+`ttm.pages_limit=32505856` that is `133143986176` bytes (124 GiB), and rocminfo should
+report a matching gfx1151 pool.
 
 ## 4. Build DS4
 


### PR DESCRIPTION
I ran DS4 on a Strix Halo host without two of the four kernel parameters in §3, and it worked. Since one of those two silently disables the machine's NPU, I think the document is worth softening.

**Host:** ASUS ROG Flow Z13 (GZ302EA), Ryzen AI MAX+ 395, 128 GB, NixOS 26.11, kernel 7.1.0 (mainline).
**Model:** a community `DeepSeek-V4-Flash-…-Q2` GGUF, 80.76 GiB — same size class as the one §5 recommends, same `iq2_xxs` / `q2_k` / `q8_0` quant family.

Kernel command line, in full — note what's *absent*:

```
… iommu.passthrough=0 amd_pstate=active amdgpu.dcdebugmask=0x600 ttm.pages_limit=25165824 ttm.page_pool_size=25165824
```

No `amd_iommu=off`. No `amdgpu.gttsize`. `iommu.passthrough=0` means IOMMU translation is *active*, which is the demanding case rather than a soft-disable. Result:

```
ds4: ROCm backend initialized on AMD Radeon 8060S Graphics (sm_115)
ds4: ROCm startup model preparation covered 80.76 GiB of tensor spans in 57.063s
ds4: prefill: 21.99 t/s, generation: 13.70 t/s
```

Coherent output, no errors.

**On `amdgpu.gttsize`:** `ttm.pages_limit` alone sets the ceiling, exactly. `ttm.pages_limit=25165824` × 4096 = 103079215104 bytes, and `mem_info_gtt_total` reads 103079215104 — a 1:1 map with `gttsize` never set. Separately, ROCm issue #5595 advises against setting `amdgpu.gttsize` and `ttm.pages_limit` together, so recommending both invites the conflict it warns about.

**On `amd_iommu=off`:** the same package that has the iGPU also has an **XDNA2 NPU**, and its `amdxdna` driver requires an IOMMU to be present for PASID. With `amd_iommu=off` there is no IOMMU at all and the NPU stops working — so following §3 as written costs Halo users their NPU. This isn't my finding; it's documented by the NixOS [`nix-amd-ai`](https://github.com/noamsto/nix-amd-ai) flake, which has a section titled "`amd_iommu=off` would kill the NPU". On this host the NPU (FastFlowLM, `flm validate` → 8 columns, firmware 1.1.2.65) and DS4 coexist fine, because the IOMMU is left on.

I haven't measured whether `amd_iommu=off` buys anything — the Strix Halo wiki claims a small memory-read speedup. My claim is narrower: it isn't a prerequisite for running DS4, and it has a cost the document doesn't mention. If you'd rather keep it as an optional performance note with an NPU warning attached, that works too and I'll rework the diff.

One knock-on the diff also fixes: the "verify" block a few lines down greps for `gttsize` and expects `amdgpu: 126976M of GTT memory ready`, which only appears when `gttsize` is set — so following the new parameter list would have made the documented expected signs fail. It now checks `mem_info_gtt_total` against `pages_limit * 4096` instead.

Caveat for the record: one host, one model, one configuration. I'm claiming "not required here", not "wrong".