### PR TITLE
CUDA: reject prefill mixed shapes wider than the shared scores window (#803)

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -7122,6 +7122,10 @@ __global__ static void attention_prefill_mixed_kernel(
     uint32_t raw_count = t + 1u - raw_start;
     uint32_t visible_comp = (t + 1u) / ratio;
     if (visible_comp > n_comp) visible_comp = n_comp;
+    /* Defense in depth: the launcher rejects shapes wider than the shared
+     * scores window, but never write past it even if a new call site skips
+     * that check (issue #803). */
+    if (raw_count + visible_comp > 512u) return;
     __shared__ float scores[512];
     __shared__ float partial[256];
     __shared__ float max_s;
@@ -18095,6 +18099,21 @@ static int attention_prefill_mixed_launch(
                                                                         n_head,
                                                                         head_dim);
         return cuda_ok(cudaGetLastError(), "attention mixed unpack launch");
+    }
+    /* The scalar fallback kernel accumulates raw + compressed scores in a
+     * fixed __shared__ float scores[512]; refuse shapes whose widest block
+     * would write past it, same bound and log as the ROCm launch (#803). */
+    const uint32_t max_raw = (window != 0u && window < n_tokens) ? window : n_tokens;
+    if ((uint64_t)max_raw + n_comp > 512u) {
+        fprintf(stderr,
+                "ds4: CUDA attention mixed scalar fallback unsupported for %llu scores "
+                "(cap=%u, tokens=%u, comp=%u, window=%u)\n",
+                (unsigned long long)((uint64_t)max_raw + n_comp),
+                512u,
+                n_tokens,
+                n_comp,
+                window);
+        return 0;
     }
     dim3 grid(n_tokens, n_head, 1);
     attention_prefill_mixed_kernel<<<grid, 256>>>((float *)heads->ptr,

--- a/tests/cuda_long_context_smoke.c
+++ b/tests/cuda_long_context_smoke.c
@@ -156,10 +156,77 @@ static int check_decode_attention_overflow_path(void) {
     return rc;
 }
 
+/* Issue #803: the scalar prefill mixed fallback keeps scores in a fixed
+ * __shared__ float[512]. Shapes whose widest block needs more entries must be
+ * rejected by the launcher (so the caller falls back) instead of letting the
+ * kernel write past the array. */
+static int check_prefill_mixed_scores_window(void) {
+    /* head_dim != 512 keeps the launcher off the window/cublas paths and on
+     * the scalar fallback that owns the shared scores window. */
+    const uint32_t n_head = 2;
+    const uint32_t head_dim = 64;
+    const uint32_t ratio = 4;
+    const uint32_t max_tokens = 1024;
+    const uint64_t q_count = (uint64_t)max_tokens * n_head * head_dim;
+    const uint64_t raw_count = (uint64_t)max_tokens * head_dim;
+    const uint32_t max_comp = max_tokens / ratio;
+    const uint64_t comp_count = (uint64_t)max_comp * head_dim;
+    const uint64_t page = 4096;
+
+    float *q_host = (float *)calloc((size_t)q_count, sizeof(float));
+    float *raw_host = (float *)calloc((size_t)raw_count, sizeof(float));
+    float *comp_host = (float *)calloc((size_t)comp_count, sizeof(float));
+    float *model_host = (float *)calloc((size_t)page / sizeof(float), sizeof(float));
+    if (!q_host || !raw_host || !comp_host || !model_host) return 1;
+
+    ds4_gpu_tensor *heads = ds4_gpu_tensor_alloc(q_count * sizeof(float));
+    ds4_gpu_tensor *q = ds4_gpu_tensor_alloc(q_count * sizeof(float));
+    ds4_gpu_tensor *raw = ds4_gpu_tensor_alloc(raw_count * sizeof(float));
+    ds4_gpu_tensor *comp = ds4_gpu_tensor_alloc(comp_count * sizeof(float));
+    int rc = 1;
+    if (heads && q && raw && comp &&
+        ds4_gpu_tensor_write(q, 0, q_host, q_count * sizeof(float)) &&
+        ds4_gpu_tensor_write(raw, 0, raw_host, raw_count * sizeof(float)) &&
+        ds4_gpu_tensor_write(comp, 0, comp_host, comp_count * sizeof(float))) {
+        rc = 0;
+        /* window=0 makes every raw row visible to the last token: 1024 raw
+         * scores never fit in 512, the launcher must refuse the launch. */
+        int wide = ds4_gpu_attention_prefill_static_mixed_heads_tensor(
+            heads, model_host, page, 0, q, raw, comp, 0,
+            max_tokens, max_comp, 0, ratio, n_head, head_dim);
+        if (wide != 0) {
+            fprintf(stderr,
+                    "prefill mixed accepted %u raw + %u comp scores into a 512-wide window\n",
+                    max_tokens, max_comp);
+            rc = 1;
+        }
+        /* A windowed shape that fits (128 raw + 256 comp = 384) must keep
+         * working, and its launch must complete cleanly. */
+        int fits = ds4_gpu_attention_prefill_static_mixed_heads_tensor(
+            heads, model_host, page, 0, q, raw, comp, 0,
+            max_tokens, max_comp, 128, ratio, n_head, head_dim);
+        if (fits == 0 || !ds4_gpu_synchronize()) {
+            fprintf(stderr, "prefill mixed rejected a shape that fits the scores window\n");
+            rc = 1;
+        }
+    }
+
+    ds4_gpu_tensor_free(comp);
+    ds4_gpu_tensor_free(raw);
+    ds4_gpu_tensor_free(q);
+    ds4_gpu_tensor_free(heads);
+    free(model_host);
+    free(comp_host);
+    free(raw_host);
+    free(q_host);
+    return rc;
+}
+
 int main(void) {
     if (!ds4_gpu_init()) return 1;
     int rc = check_large_topk();
     if (check_decode_attention_overflow_path() != 0) rc = 1;
+    if (check_prefill_mixed_scores_window() != 0) rc = 1;
     ds4_gpu_cleanup();
     if (rc == 0) puts("cuda long-context regression: OK");
     return rc;


### PR DESCRIPTION
Fixes #803.

## What

`attention_prefill_mixed_kernel` (the scalar prefill fallback) stores every attention score in a fixed `__shared__ float scores[512]`, and neither the kernel nor the last hop of `attention_prefill_mixed_launch` caps `n_score = raw_count + visible_comp`. Shapes wider than 512 write past the array — silently while the overflow lands in the adjacent `partial[256]`, and as an invalid shared write beyond that (see the analysis in #803).

Following the fix suggested in the issue, and mirroring what the ROCm side already does (`rocm/ds4_rocm_attention_launch.cuh`, `DS4_ROCM_ATTENTION_PREFILL_MIXED_SCORE_CAP`):

- **Host**: `attention_prefill_mixed_launch` computes the worst-case score count (`max_raw = min(window, n_tokens)` or `n_tokens` when `window == 0`, plus `n_comp`) and refuses the launch with the same log line as ROCm when it exceeds 512. Both `ds4_gpu_attention_prefill_static_mixed_heads_tensor` and `ds4_gpu_attention_prefill_masked_mixed_heads_tensor` go through this launch, so both are covered.
- **Kernel**: `if (raw_count + visible_comp > 512u) return;` before any shared write, as defense in depth, matching the ROCm kernel.

## Regression test

New case in `tests/cuda_long_context_smoke.c` (runs under `make cuda-regression`):

- an overflow shape (`n_tokens=1024, window=0, ratio=4` → 1280 scores) must be refused by the launcher;
- a windowed shape that fits (128 raw + 256 comp = 384) must keep working.

`head_dim != 512` keeps the launcher off the token-tile / window / cublas paths so the test deterministically exercises the scalar fallback, without env vars.

## Validation

Environment: RunPod community pods, RTX 3080 and RTX 3090 (sm_86), driver 580.x, CUDA 12.4 toolkit, `make cuda CUDA_ARCH=sm_86`, upstream `c1d4597`. compute-sanitizer from CUDA 13.0 (`cuda-sanitizer-13-0`) — note for other reproducers: the 12.4 sanitizer fails to start at all on 580+ drivers (`Target application terminated before first instrumented API call`).

| | unpatched | patched |
|---|---|---|
| `compute-sanitizer --tool memcheck` on the new test | 40 × `Invalid __shared__ write` at `ds4_cuda.cu:7149` in `attention_prefill_mixed_kernel` (RTX 3090; 100+ on RTX 3080 with a wider run) | 0 invalid writes |
| new regression case | overflow shape accepted | overflow shape refused with the log line, fitting shape passes, `cuda long-context regression: OK` |
| `make test` | — | passes up to the suites that need the real GGUF (not run: no model weights on the pod) |

Two unrelated sanitizer reports remain before and after the patch: `cudaErrorNotSupported` from `cudaHostRegister` in `cuda_model_range_ptr` (`ds4_cuda.cu:747`), reached from the pre-existing decode test. That is the discrete-GPU host-register behavior discussed in #791, not introduced here.

Not done: a before/after `ds4-bench` run, since the pod had no model weights. The guard adds one comparison per launch on the host path only; the kernel guard is two integer adds and a compare per block before any shared traffic.

## Transparency

A commit referencing this issue (`2a2a887f`, by @marcodelpin) appears in #803's timeline, but the fork it lived in is no longer reachable and no PR ever landed. This implementation was done independently against current main.
