### PR TITLE
tokenizer: fix bpe_emit_piece's O(n^2) merge loop (#853)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -37187,14 +37187,123 @@ static int bpe_rank(const ds4_vocab *vocab, const owned_str *a, const owned_str 
     return rank;
 }
 
-/* Apply byte-level BPE to one regex-like pre-tokenized piece and emit token ids. */
+/* Doubly-linked BPE symbol used by bpe_emit_piece's merge heap (see below):
+ * `prev`/`next` are indices into the backing array, -1 meaning "no neighbor". */
+typedef struct {
+    char *ptr;
+    uint64_t len;
+    int prev, next;
+    bool deleted;
+} bpe_sym;
+
+/* One candidate adjacent-pair merge, keyed by BPE rank (lower merges first).
+ * left_len/right_len snapshot sym[left]/sym[right]'s lengths at push time;
+ * since a merge only ever *grows* the left symbol (see bpe_merge below), a
+ * length mismatch at pop time cheaply proves the pair changed since this
+ * candidate was queued, without needing a separate version counter. */
+typedef struct {
+    int left, right;
+    int rank;
+    uint64_t left_len, right_len;
+} bpe_bigram;
+
+/* True if `a` must sink below `b` in the min-heap: higher rank loses, and
+ * among equal ranks the rightmost (larger `left` index) loses, so pop order
+ * matches the original left-to-right full rescan's tie-break exactly. */
+static bool bpe_bigram_gt(bpe_bigram a, bpe_bigram b) {
+    if (a.rank != b.rank) return a.rank > b.rank;
+    return a.left > b.left;
+}
+
+static void bpe_heap_sift_up(bpe_bigram *heap, uint32_t idx) {
+    while (idx > 0) {
+        const uint32_t parent = (idx - 1u) / 2u;
+        if (!bpe_bigram_gt(heap[parent], heap[idx])) break;
+        bpe_bigram tmp = heap[parent];
+        heap[parent] = heap[idx];
+        heap[idx] = tmp;
+        idx = parent;
+    }
+}
+
+static void bpe_heap_sift_down(bpe_bigram *heap, uint32_t n, uint32_t idx) {
+    for (;;) {
+        const uint32_t left = idx * 2u + 1u;
+        const uint32_t right = left + 1u;
+        uint32_t smallest = idx;
+        if (left < n && bpe_bigram_gt(heap[smallest], heap[left])) smallest = left;
+        if (right < n && bpe_bigram_gt(heap[smallest], heap[right])) smallest = right;
+        if (smallest == idx) break;
+        bpe_bigram tmp = heap[idx];
+        heap[idx] = heap[smallest];
+        heap[smallest] = tmp;
+        idx = smallest;
+    }
+}
+
+static void bpe_heap_push(bpe_bigram **heap, uint32_t *n, uint32_t *cap, bpe_bigram e) {
+    if (*n == *cap) {
+        *cap = (*cap == 0) ? 16 : (*cap * 2);
+        *heap = xrealloc(*heap, (size_t)(*cap) * sizeof(**heap));
+    }
+    (*heap)[*n] = e;
+    bpe_heap_sift_up(*heap, *n);
+    (*n)++;
+}
+
+static bpe_bigram bpe_heap_pop(bpe_bigram *heap, uint32_t *n) {
+    bpe_bigram top = heap[0];
+    (*n)--;
+    heap[0] = heap[*n];
+    bpe_heap_sift_down(heap, *n, 0);
+    return top;
+}
+
+/* Look up the rank for (sym[left], sym[left].next) and, if a merge exists
+ * for that pair, push it as a new candidate. */
+static void bpe_push_candidate(const ds4_vocab *vocab, bpe_sym *sym,
+                                bpe_bigram **heap, uint32_t *heap_n, uint32_t *heap_cap,
+                                int left) {
+    int right = sym[left].next;
+    if (right < 0) return;
+    int rank = bpe_rank(vocab, &(owned_str){ sym[left].ptr, sym[left].len },
+                                &(owned_str){ sym[right].ptr, sym[right].len });
+    if (rank < 0) return;
+    bpe_heap_push(heap, heap_n, heap_cap, (bpe_bigram){
+        .left = left, .right = right, .rank = rank,
+        .left_len = sym[left].len, .right_len = sym[right].len });
+}
+
+/* Merge sym[left]'s right neighbor into sym[left] and splice it out of the list. */
+static void bpe_merge(bpe_sym *sym, int left) {
+    int right = sym[left].next;
+    uint64_t new_len = sym[left].len + sym[right].len;
+    sym[left].ptr = xrealloc(sym[left].ptr, (size_t)new_len);
+    memcpy(sym[left].ptr + sym[left].len, sym[right].ptr, (size_t)sym[right].len);
+    sym[left].len = new_len;
+
+    free(sym[right].ptr);
+    sym[right].ptr = NULL;
+    sym[right].deleted = true;
+
+    sym[left].next = sym[right].next;
+    if (sym[right].next >= 0) sym[sym[right].next].prev = left;
+}
+
+/* Apply byte-level BPE to one regex-like pre-tokenized piece and emit token ids.
+ *
+ * Merges are found via a min-heap of candidate adjacent pairs over a doubly-
+ * linked symbol list, instead of rescanning every pair on every merge: O(n log n)
+ * instead of O(n^2), fixing large CJK/no-space prompts taking minutes to
+ * tokenize (github.com/antirez/ds4 issue #853). Tie-breaking (leftmost pair
+ * wins when ranks are equal) and the final token sequence are unchanged. */
 static void bpe_emit_piece(const ds4_vocab *vocab, ds4_str raw_piece, token_vec *out) {
     uint64_t encoded_len = 0;
     char *encoded = byte_encode(raw_piece, &encoded_len);
 
     int n_sym = 0;
     int cap_sym = 32;
-    owned_str *sym = xcalloc((size_t)cap_sym, sizeof(sym[0]));
+    bpe_sym *sym = xcalloc((size_t)cap_sym, sizeof(sym[0]));
 
     for (uint64_t off = 0; off < encoded_len;) {
         int n = utf8_len_from_first_byte((uint8_t)encoded[off]);
@@ -37203,41 +37312,42 @@ static void bpe_emit_piece(const ds4_vocab *vocab, ds4_str raw_piece, token_vec 
             cap_sym *= 2;
             sym = xrealloc(sym, (size_t)cap_sym * sizeof(sym[0]));
         }
-        sym[n_sym++] = owned_copy(encoded + off, (uint64_t)n);
+        owned_str piece = owned_copy(encoded + off, (uint64_t)n);
+        sym[n_sym] = (bpe_sym){ .ptr = piece.ptr, .len = piece.len,
+                                 .prev = n_sym - 1, .next = -1, .deleted = false };
+        if (n_sym > 0) sym[n_sym - 1].next = n_sym;
+        n_sym++;
         off += (uint64_t)n;
     }
 
-    for (;;) {
-        int best_i = -1;
-        int best_rank = INT32_MAX;
+    bpe_bigram *heap = NULL;
+    uint32_t heap_n = 0, heap_cap = 0;
 
-        for (int i = 0; i + 1 < n_sym; i++) {
-            int rank = bpe_rank(vocab, &sym[i], &sym[i + 1]);
-            if (rank >= 0 && rank < best_rank) {
-                best_rank = rank;
-                best_i = i;
-            }
-        }
-
-        if (best_i < 0) break;
-
-        owned_str merged;
-        merged.len = sym[best_i].len + sym[best_i + 1].len;
-        merged.ptr = xmalloc((size_t)merged.len);
-        memcpy(merged.ptr, sym[best_i].ptr, (size_t)sym[best_i].len);
-        memcpy(merged.ptr + sym[best_i].len, sym[best_i + 1].ptr, (size_t)sym[best_i + 1].len);
-
-        free(sym[best_i].ptr);
-        free(sym[best_i + 1].ptr);
-        sym[best_i] = merged;
-
-        for (int j = best_i + 1; j + 1 < n_sym; j++) {
-            sym[j] = sym[j + 1];
-        }
-        n_sym--;
+    for (int i = 0; i + 1 < n_sym; i++) {
+        bpe_push_candidate(vocab, sym, &heap, &heap_n, &heap_cap, i);
     }
 
-    for (int i = 0; i < n_sym; i++) {
+    while (heap_n > 0) {
+        bpe_bigram top = bpe_heap_pop(heap, &heap_n);
+        int left = top.left, right = top.right;
+
+        if (sym[left].deleted || sym[right].deleted) continue;
+        if (sym[left].next != right) continue;
+        if (sym[left].len != top.left_len || sym[right].len != top.right_len) continue;
+
+        bpe_merge(sym, left);
+
+        if (sym[left].prev >= 0) {
+            bpe_push_candidate(vocab, sym, &heap, &heap_n, &heap_cap, sym[left].prev);
+        }
+        bpe_push_candidate(vocab, sym, &heap, &heap_n, &heap_cap, left);
+    }
+    free(heap);
+
+    /* sym[0] can never be deleted (a merge only ever deletes its right side,
+     * and sym[0] has no left neighbor to be absorbed by), so it's always the
+     * surviving list's head. */
+    for (int i = 0; n_sym > 0 && i >= 0; i = sym[i].next) {
         int token = -1;
         if (table_get(&vocab->token_to_id, sym[i].ptr, sym[i].len, &token)) {
             token_vec_push(out, token);
@@ -37248,9 +37358,9 @@ static void bpe_emit_piece(const ds4_vocab *vocab, ds4_str raw_piece, token_vec 
                 }
             }
         }
-        free(sym[i].ptr);
     }
 
+    for (int i = 0; i < n_sym; i++) free(sym[i].ptr);
     free(sym);
     free(encoded);
 }


### PR DESCRIPTION
Fixes #853.

## Root cause

`bpe_emit_piece`'s merge loop rescanned every adjacent symbol pair on every
merge iteration (`ds4.c`, previously around line 37174). Real CJK/no-space
prompts pre-tokenize into a single very long piece, so `n` stays large across
the whole merge process and the rescan-per-merge makes it O(n²).

## Fix

Replaces the flat-array rescan with a min-heap of candidate adjacent merges
over a doubly-linked symbol list (same shape as llama.cpp's own BPE tokenizer
and the classic HF-tokenizers approach): each merge only pushes the (at most
two) newly-adjacent pairs it created, instead of rescanning everything.
O(n log n) instead of O(n²).

- Tie-breaking is unchanged: the heap orders by `(rank asc, left-position
  asc)`, which reproduces the original scan's "leftmost pair wins on equal
  rank" behavior exactly.
- Staleness of a popped heap entry is detected by snapshotting both symbols'
  lengths at push time and comparing against their current length at pop
  time — cheap and sufficient, since a symbol's length only ever grows (by
  absorbing its right neighbor), so any change since the candidate was queued
  shows up as a length mismatch.

## Verification

Built both the pre-fix and post-fix binary and diffed `--dump-tokens` output
(byte-for-byte identical token id sequences in all cases):

- Small ASCII with punctuation/whitespace/newlines
- A tie-break-heavy repeated-bigram case (`"ab"` × 800)
- Empty prompt, single character
- Large English prose (~46 KB)
- A large CJK repetition stress case (~72 KB, no whitespace boundaries —
  reproduces the reported worst case): **18.03s → 0.23s (~79x)**, output
  identical
- Both of the repo's own long-context fixtures,
  `tests/long_context_story_prompt.txt` (~140 KB, 30475 tokens) and
  `tests/long_context_security_prompt.txt` (~149 KB, 36667 tokens) — already
  fast pre-fix (normal English word-boundaries keep pieces small), confirming
  no regression on the common case, byte-identical output

Also checked for leaks with `leaks --atExit` on the large-prose case: 0
leaks. Builds clean with `-Wall -Wextra -std=c99`, no new warnings.

Model used for all of the above: the repo owner's own deployed
DeepSeek-V4-Flash 0731 quant (Q4K/IQ2XXS mixed), via
`ds4 --dump-tokens --prompt-file` — this path only loads tokenizer vocab/
merge-rank metadata, not model weights, so none of this required loading the
full model.