### PR TITLE
agent: accept --rocm in ROCm builds

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -526,7 +526,11 @@ static float parse_float_range(const char *s, const char *opt, float min, float 
 
 static ds4_backend parse_backend(const char *s) {
     if (!strcmp(s, "metal")) return DS4_BACKEND_METAL;
+#ifdef DS4_ROCM_BUILD
+    if (!strcmp(s, "rocm")) return DS4_BACKEND_CUDA;
+#else
     if (!strcmp(s, "cuda")) return DS4_BACKEND_CUDA;
+#endif
     if (!strcmp(s, "cpu")) return DS4_BACKEND_CPU;
     fprintf(stderr, "ds4-agent: invalid backend: %s\n", s);
     exit(2);
@@ -668,8 +672,13 @@ static agent_config parse_options(int argc, char **argv) {
             c.engine.backend = parse_backend(need_arg(&i, argc, argv, arg));
         } else if (!strcmp(arg, "--metal")) {
             c.engine.backend = DS4_BACKEND_METAL;
+#ifdef DS4_ROCM_BUILD
+        } else if (!strcmp(arg, "--rocm")) {
+            c.engine.backend = DS4_BACKEND_CUDA;
+#else
         } else if (!strcmp(arg, "--cuda")) {
             c.engine.backend = DS4_BACKEND_CUDA;
+#endif
         } else if (!strcmp(arg, "--gpu-vram")) {
             c.gpu_vram_arg = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--gpu-devices")) {


### PR DESCRIPTION
On a ROCm build `ds4-agent` disagrees with itself. The help, which it shares with the other tools, offers `--metal | --rocm | --cpu` and `Backend name: metal, rocm, or cpu`. The parser then refuses both:

```
$ ./ds4-agent --rocm --help
ds4-agent: unknown option: --rocm
$ ./ds4-agent --backend rocm --help
ds4-agent: invalid backend: rocm
```

`ds4_agent.c` has no `DS4_ROCM_BUILD` handling at all, while `ds4_cli.c:217` and `ds4_cli.c:1941` have carried it since the ROCm target landed. I copied that idiom instead of inventing a second one.

**This changes behaviour: a ROCm build now rejects `--cuda`.** ds4, ds4-server, ds4-bench and ds4-eval have always rejected it, so this makes ds4-agent consistent, but it breaks anyone who scripted `ds4-agent --cuda` on a ROCm box. If you would rather not break that, I can keep `--cuda` working as an undocumented alias instead.

```
GPU     AMD Radeon 780M (gfx1103), Ryzen 7 8845HS, 58 GiB usable RAM
OS      CachyOS, kernel 7.2.0-1-cachyos
ROCm    7.2.4
ds4     c1d4597 plus this commit
build   make rocm ROCM_ARCH=gfx1103 HIPCC="hipcc --rocm-path=/opt/rocm"
```

Both flags are accepted after the change, `--cuda` is rejected. I also built the default Metal target on an M4 Pro, 0 errors and 0 warnings, to check the non-ROCm side is untouched. No CUDA host here, so that path is compile-checked only.
