### PR TITLE
cli: name only the backends the build actually has

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -57531,7 +57531,15 @@ static int ds4_engine_open_internal(ds4_engine **out,
         return 1;
     }
     if (e->ssd_streaming && !ds4_backend_supports_ssd_streaming(e->backend)) {
-        fprintf(stderr, "ds4: --ssd-streaming is currently supported only with --metal/--cuda/--rocm\n");
+#if defined(DS4_ROCM_BUILD)
+        fprintf(stderr, "ds4: --ssd-streaming is currently supported only with --rocm\n");
+#elif defined(DS4_NO_GPU)
+        fprintf(stderr, "ds4: --ssd-streaming requires a GPU build; this binary is CPU-only\n");
+#elif defined(__APPLE__)
+        fprintf(stderr, "ds4: --ssd-streaming is currently supported only with --metal\n");
+#else
+        fprintf(stderr, "ds4: --ssd-streaming is currently supported only with --cuda\n");
+#endif
         ds4_engine_close(e);
         *out = NULL;
         return 1;

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -167,7 +167,7 @@ static void print_model_runtime(FILE *fp, const help_colors *c,
     }
     opt(fp, c, "-t, --threads N", "CPU helper threads for host-side/reference work.");
     opt(fp, c, "--power N", "GPU duty-cycle target, 1..100. Default: 100");
-    opt(fp, c, "--ssd-streaming", "Metal/CUDA/ROCm: opt in to SSD-backed model streaming instead of full residency.");
+    opt(fp, c, "--ssd-streaming", "GPU backends only: opt in to SSD-backed model streaming instead of full residency.");
     opt(fp, c, "--ssd-streaming-cold", "SSD streaming: skip default popularity-based expert-cache preload.");
     opt(fp, c, "--ssd-streaming-cache-experts N|NGB", "SSD streaming: N is an exact dynamic expert count; NGB is a routed memory budget that also reserves two full prefill layers. Auto: 80% working set minus non-routed weights; GLM Metal caps lower.");
     opt(fp, c, "--ssd-streaming-full-layers N", "GLM Metal streaming: keep the first N routed layers fully resident. Default: auto from NGB expert budget; use 0 to disable.");


### PR DESCRIPTION
The message names three flags, but no build accepts all three.

`ds4_backend_supports_ssd_streaming` at `ds4.c:399` has four outcomes rather than two: ROCm, Linux CUDA, Apple, and `DS4_NO_GPU`. One message could not match all four, so it always named at least one flag the running binary rejects.

The clearest case is the default macOS build, where the predicate excludes CUDA through its `__APPLE__` arm. `ds4 --cuda --ssd-streaming` gets refused by a message that then suggests `--cuda`. On Linux the same line suggests `--metal`, which passes this check and dies 360 lines later at `ds4.c:57893` with "Metal backend requested but this build is linked with CUDA".

I should say I found this by reading the code, not by hitting it in a run. What I did check is what each build actually prints, by reading the strings back out of the binaries:

```
make       (M4 Pro, macOS)             ... only with --metal
make rocm  (Radeon 780M, ROCm 7.2.4)   ... only with --rocm
make cpu   (same Linux host)           requires a GPU build; this binary is CPU-only
```

Each arm now names one flag that works in that build, keyed off the same macros as the predicate. The `--ssd-streaming` help line had the same problem, listing Metal/CUDA/ROCm unconditionally three lines below an `#ifdef` that gets it right.

0 errors on all three builds. The ROCm one has a warning at `ds4_server.c:11329` that is there without my change. No CUDA host here, so that arm is compile-checked only.
