### PR TITLE
readme: --ssd-streaming and --mtp cannot be combined

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,10 @@ GGUF of about 5.6 GiB. It is not a standalone model. Download it once:
 The support file can be used with the 0731 Flash `ds4f-q2`, `ds4f-q2-q4`, and
 `ds4f-q4` models listed above. It is checkpoint-specific
 and must not be paired with an older Flash model. For now **DeepSeek V4 PRO**
-is not supported. On Metal, the main model may be resident or use
-`--ssd-streaming`; the support model still adds its own weights and runtime
+is not supported. In a single-process run the main model must be resident:
+`--ssd-streaming` together with `--mtp` is rejected, and `--dspark` requires
+`--mtp`. In a distributed run `--mtp` is ignored instead, so DSpark is
+unavailable there too. The support model adds its own weights and runtime
 state to the memory requirement. DSpark replaces the legacy one-stage MTP
 support model for that run rather than stacking with it.
 


### PR DESCRIPTION
The DSpark section says the main model may be resident or use `--ssd-streaming` on Metal. The code refuses that combination everywhere:

```
ds4.c:57822   --ssd-streaming is not compatible with --mtp yet
ds4.c:57454   --dspark requires --mtp FILE
```

Since `--dspark` needs `--mtp`, and `--mtp` is refused alongside streaming, DSpark never runs with a streamed main model on any backend.

There is a second case the old wording missed. The guard sits inside a `distributed.role == DS4_DISTRIBUTED_NONE` branch, and so does the `model_open` for the support model, so a distributed run takes neither path and drops `--mtp` without saying anything. The new text covers both.

Docs only, no code touched.
