### PR TITLE
kvstore: reject disk KV checkpoints written under different model weights (#805)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -36856,6 +36856,8 @@ typedef struct {
 struct ds4_engine {
     ds4_model model;
     ds4_model mtp_model;
+    /* Lazily computed by ds4_engine_weights_fp24(); 0 = not computed yet. */
+    uint32_t weights_fp24;
     ds4_vocab vocab;
     ds4_weights weights;
     ds4_mtp_weights mtp_weights;
@@ -58427,6 +58429,84 @@ bool ds4_engine_glm_layer_payload_bytes(ds4_engine *e,
 int ds4_engine_model_id(ds4_engine *e) {
     (void)e;
     return (int)DS4_MODEL_VARIANT;
+}
+
+static uint32_t weights_fp24_step(uint32_t h, const uint8_t *p, size_t n) {
+    for (size_t i = 0; i < n; i++) h = (h ^ p[i]) * 16777619u;
+    return h;
+}
+
+/* FNV-1a over the file size plus 64 evenly spaced 64-byte windows of the
+ * tensor data region.  Reads via pread when a descriptor is available, else
+ * from the mapping — under SSD streaming the mapping is partial on purpose,
+ * so the descriptor path is the safe default.  Cost is a few dozen page
+ * reads once per engine, off the hot path. */
+static uint32_t weights_fp24_compute(int fd, const uint8_t *map,
+                                     uint64_t data_start, uint64_t file_size) {
+    enum { FP_WINDOWS = 64, FP_WINDOW_BYTES = 64 };
+    uint32_t h = 2166136261u;
+    uint8_t size_le[8];
+    for (int i = 0; i < 8; i++) size_le[i] = (uint8_t)(file_size >> (i * 8));
+    h = weights_fp24_step(h, size_le, sizeof(size_le));
+    if ((fd >= 0 || map) && file_size > data_start) {
+        const uint64_t span = file_size - data_start;
+        uint8_t buf[FP_WINDOW_BYTES];
+        for (uint32_t w = 0; w < FP_WINDOWS; w++) {
+            uint64_t off = data_start + (span / FP_WINDOWS) * w;
+            if (off >= file_size) break;
+            size_t want = FP_WINDOW_BYTES;
+            if (off + want > file_size) want = (size_t)(file_size - off);
+            if (fd >= 0) {
+                ssize_t got = pread(fd, buf, want, (off_t)off);
+                if (got > 0) h = weights_fp24_step(h, buf, (size_t)got);
+            } else {
+                h = weights_fp24_step(h, map + off, want);
+            }
+        }
+    }
+    uint32_t fp = (h ^ (h >> 24)) & 0xffffffu;
+    return fp ? fp : 1u; /* 0 is reserved for "header predates fingerprints" */
+}
+
+uint32_t ds4_weights_fp24_of_fd(int fd, uint64_t data_start, uint64_t file_size) {
+    return weights_fp24_compute(fd, NULL, data_start, file_size);
+}
+
+uint32_t ds4_engine_weights_fp24(ds4_engine *e) {
+    /* Benign race under concurrent first calls: both compute the same
+     * value from the same file and store it, so no synchronization. */
+    if (e->weights_fp24 != 0) return e->weights_fp24;
+    const ds4_model *m = &e->model;
+    if (m->tensors && m->n_tensors > 0 && (m->fd >= 0 || m->map)) {
+        /* Sample the head of EVERY tensor, so no single-tensor edit can
+         * slip between windows.  ~1000 reads of 64 bytes, once. */
+        uint32_t h = 2166136261u;
+        uint8_t meta[16];
+        for (int i = 0; i < 8; i++) meta[i] = (uint8_t)(m->size >> (i * 8));
+        for (int i = 0; i < 8; i++) meta[8 + i] = (uint8_t)(m->n_tensors >> (i * 8));
+        h = weights_fp24_step(h, meta, sizeof(meta));
+        for (uint64_t t = 0; t < m->n_tensors; t++) {
+            const ds4_tensor *ten = &m->tensors[t];
+            uint64_t off = ten->abs_offset;
+            if (off >= m->size) continue;
+            size_t want = 64;
+            if (want > ten->bytes) want = (size_t)ten->bytes;
+            if (off + want > m->size) want = (size_t)(m->size - off);
+            if (m->fd >= 0) {
+                uint8_t buf[64];
+                ssize_t got = pread(m->fd, buf, want, (off_t)off);
+                if (got > 0) h = weights_fp24_step(h, buf, (size_t)got);
+            } else {
+                h = weights_fp24_step(h, m->map + off, want);
+            }
+        }
+        uint32_t fp = (h ^ (h >> 24)) & 0xffffffu;
+        e->weights_fp24 = fp ? fp : 1u;
+    } else {
+        e->weights_fp24 = weights_fp24_compute(m->fd, m->map,
+                                               m->tensor_data_pos, m->size);
+    }
+    return e->weights_fp24;
 }
 
 /* Decode gate firing schedule for the TP transport (see ds4_tp_identity):

--- a/ds4.h
+++ b/ds4.h
@@ -249,6 +249,14 @@ bool ds4_engine_glm_layer_payload_bytes(ds4_engine *e,
  * KV files with the previously-zero reserved byte remain Flash-compatible;
  * Pro and later shapes must use nonzero ids. */
 int ds4_engine_model_id(ds4_engine *e);
+/* 24-bit fingerprint of the weights actually loaded, from samples of the
+ * GGUF tensor data.  model_id only identifies the model *shape*, so two
+ * GGUFs with different weights (a fine-tune, a requant) share it; the
+ * fingerprint is what tells them apart in the disk KV cache header
+ * (issue #805).  Never returns 0: that value is reserved for headers
+ * written before the fingerprint existed. */
+uint32_t ds4_engine_weights_fp24(ds4_engine *e);
+uint32_t ds4_weights_fp24_of_fd(int fd, uint64_t data_start, uint64_t file_size);
 bool ds4_engine_is_glm_dsa(ds4_engine *e);
 const char *ds4_backend_name(ds4_backend backend);
 bool ds4_think_mode_enabled(ds4_think_mode mode);

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -4245,6 +4245,7 @@ static bool agent_kv_load_path(agent_worker *w, const char *path,
         ok = false;
     }
     if (ok && hdr.payload_bytes != 0 && hdr.weights_fp24 != 0 &&
+        hdr.quant_bits == (uint8_t)ds4_engine_routed_quant_bits(w->engine) &&
         hdr.weights_fp24 != ds4_engine_weights_fp24(w->engine))
     {
         snprintf(err, err_len, "KV checkpoint was written for different model weights");

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -4244,6 +4244,12 @@ static bool agent_kv_load_path(agent_worker *w, const char *path,
         snprintf(err, err_len, "KV checkpoint was written for a different model");
         ok = false;
     }
+    if (ok && hdr.payload_bytes != 0 && hdr.weights_fp24 != 0 &&
+        hdr.weights_fp24 != ds4_engine_weights_fp24(w->engine))
+    {
+        snprintf(err, err_len, "KV checkpoint was written for different model weights");
+        ok = false;
+    }
     if (ok && hdr.payload_bytes != 0 &&
         hdr.quant_bits != (uint8_t)ds4_engine_routed_quant_bits(w->engine))
     {
@@ -4392,7 +4398,9 @@ static bool agent_kv_save_path(agent_worker *w, const char *path,
     }
 
     uint8_t h[DS4_KVSTORE_FIXED_HEADER];
-    ds4_kvstore_fill_header(h, (uint8_t)model_id, (uint8_t)quant_bits,
+    ds4_kvstore_fill_header(h, (uint8_t)model_id,
+                            ds4_engine_weights_fp24(w->engine),
+                            (uint8_t)quant_bits,
                             ds4_kvstore_reason_code(reason),
                             session_identity ? DS4_KVSTORE_EXT_SESSION_TITLE : 0,
                             (uint32_t)tokens->len, 0,
@@ -5783,7 +5791,8 @@ static bool agent_worker_strip_session(agent_worker *w, const char *prefix,
 
     uint8_t h[DS4_KVSTORE_FIXED_HEADER];
     uint64_t now = (uint64_t)time(NULL);
-    ds4_kvstore_fill_header(h, hdr.model_id, hdr.quant_bits, hdr.reason, hdr.ext_flags,
+    ds4_kvstore_fill_header(h, hdr.model_id, hdr.weights_fp24,
+                            hdr.quant_bits, hdr.reason, hdr.ext_flags,
                             stripped_token_count, hdr.hits, hdr.ctx_size,
                             hdr.created_at, now, 0);
     uint8_t tb[4];

--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -517,6 +517,7 @@ static bool kv_cache_incoming_supersedes_continued(
     if ((size_t)e->text_bytes >= incoming->text_len) return false;
     if (e->model_id != incoming->model_id) return false;
     if (e->weights_fp24 != 0 && incoming->weights_fp24 != 0 &&
+        e->quant_bits == incoming->quant_bits &&
         e->weights_fp24 != incoming->weights_fp24) return false;
     if (incoming->reject_different_quant &&
         e->quant_bits != incoming->quant_bits)
@@ -1212,7 +1213,11 @@ int ds4_kvstore_find_text_prefix(ds4_kvstore *kc, const char *prompt_text,
         if (e->text_bytes > prompt_bytes || e->text_bytes > SIZE_MAX) continue;
         if ((int)e->tokens < kc->opt.min_tokens) continue;
         if (e->model_id != (uint8_t)model_id) continue;
+        /* Same quantization, different weights: never reusable.  Across
+         * quantizations the fingerprints differ by construction, so the
+         * existing reject_different_quant policy stays the only gate. */
         if (weights_fp24 != 0 && e->weights_fp24 != 0 &&
+            e->quant_bits == (uint8_t)quant_bits &&
             e->weights_fp24 != weights_fp24) continue;
         if ((uint32_t)ctx_size < e->ctx_size) continue;
         if (kc->reject_different_quant && e->quant_bits != (uint8_t)quant_bits) continue;
@@ -1266,7 +1271,9 @@ int ds4_kvstore_try_load_text(ds4_kvstore *kc,
         if (hdr.model_id != (uint8_t)model_id) {
             header_ok = false;
             fail_reason = "cached checkpoint was written for a different model";
-        } else if (hdr.weights_fp24 != 0 && hdr.weights_fp24 != weights_fp24) {
+        } else if (hdr.weights_fp24 != 0 &&
+                   hdr.quant_bits == (uint8_t)quant_bits &&
+                   hdr.weights_fp24 != weights_fp24) {
             header_ok = false;
             fail_reason = "cached checkpoint was written for different model weights";
         } else if ((uint64_t)text_bytes > prompt_bytes) {

--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -391,7 +391,8 @@ static void kv_cache_push(ds4_kvstore *kc, ds4_kvstore_entry e) {
 }
 
 void ds4_kvstore_fill_header(uint8_t h[DS4_KVSTORE_FIXED_HEADER],
-                             uint8_t model_id, uint8_t quant_bits,
+                             uint8_t model_id, uint32_t weights_fp24,
+                             uint8_t quant_bits,
                              uint8_t reason, uint8_t ext_flags,
                              uint32_t tokens, uint32_t hits, uint32_t ctx_size,
                              uint64_t created_at, uint64_t last_used,
@@ -409,6 +410,9 @@ void ds4_kvstore_fill_header(uint8_t h[DS4_KVSTORE_FIXED_HEADER],
     ds4_kvstore_le_put32(h + 12, hits);
     ds4_kvstore_le_put32(h + 16, ctx_size);
     h[20] = KV_CACHE_PAYLOAD_ABI;
+    h[21] = (uint8_t)(weights_fp24 & 0xff);
+    h[22] = (uint8_t)((weights_fp24 >> 8) & 0xff);
+    h[23] = (uint8_t)((weights_fp24 >> 16) & 0xff);
     kv_le_put64(h + 24, created_at);
     kv_le_put64(h + 32, last_used);
     kv_le_put64(h + 40, payload_bytes);
@@ -426,6 +430,8 @@ bool ds4_kvstore_read_header(FILE *fp, ds4_kvstore_entry *e,
                 DS4_KVSTORE_REASON_UNKNOWN;
     e->ext_flags = h[6];
     e->model_id = h[7];
+    e->weights_fp24 = (uint32_t)h[21] | ((uint32_t)h[22] << 8) |
+                      ((uint32_t)h[23] << 16);
     e->tokens = ds4_kvstore_le_get32(h + 8);
     e->hits = ds4_kvstore_le_get32(h + 12);
     e->ctx_size = ds4_kvstore_le_get32(h + 16);
@@ -491,7 +497,8 @@ bool ds4_kvstore_touch_file(const char *path, uint32_t hits) {
     if (ok) {
         uint8_t h[DS4_KVSTORE_FIXED_HEADER];
         uint64_t now = (uint64_t)time(NULL);
-        ds4_kvstore_fill_header(h, e.model_id, e.quant_bits, e.reason, e.ext_flags,
+        ds4_kvstore_fill_header(h, e.model_id, e.weights_fp24,
+                                e.quant_bits, e.reason, e.ext_flags,
                                 e.tokens, hits, e.ctx_size,
                                 e.created_at, now, e.payload_bytes);
         ok = fseek(fp, 0, SEEK_SET) == 0 &&
@@ -509,6 +516,8 @@ static bool kv_cache_incoming_supersedes_continued(
     if (e->text_bytes == 0 || e->text_bytes > SIZE_MAX) return false;
     if ((size_t)e->text_bytes >= incoming->text_len) return false;
     if (e->model_id != incoming->model_id) return false;
+    if (e->weights_fp24 != 0 && incoming->weights_fp24 != 0 &&
+        e->weights_fp24 != incoming->weights_fp24) return false;
     if (incoming->reject_different_quant &&
         e->quant_bits != incoming->quant_bits)
         return false;
@@ -906,7 +915,8 @@ static void kv_cache_rewrite_trailer(ds4_kvstore *kc, const char *path,
         if (ok && ignored > 0) {
             uint8_t h[DS4_KVSTORE_FIXED_HEADER];
             uint64_t now = (uint64_t)time(NULL);
-            ds4_kvstore_fill_header(h, hdr.model_id, hdr.quant_bits, hdr.reason,
+            ds4_kvstore_fill_header(h, hdr.model_id, hdr.weights_fp24,
+                                    hdr.quant_bits, hdr.reason,
                                     (uint8_t)(hdr.ext_flags | hooks->ext_flag),
                                     hdr.tokens, hdr.hits, hdr.ctx_size,
                                     hdr.created_at, now, hdr.payload_bytes);
@@ -1045,6 +1055,7 @@ bool ds4_kvstore_store_live_prefix_text(ds4_kvstore *kc,
         .text = text,
         .text_len = text_len,
         .model_id = (uint8_t)model_id,
+        .weights_fp24 = ds4_engine_weights_fp24(engine),
         .quant_bits = (uint8_t)quant_bits,
         .ctx_size = (uint32_t)ds4_session_ctx(session),
         .reject_different_quant = kc->reject_different_quant,
@@ -1073,7 +1084,9 @@ bool ds4_kvstore_store_live_prefix_text(ds4_kvstore *kc,
     uint8_t h[DS4_KVSTORE_FIXED_HEADER];
     uint8_t ext_flags = trailer_est_bytes > 0 && hooks ? hooks->ext_flag : 0;
     if (text_override) ext_flags |= cache_text_ext;
-    ds4_kvstore_fill_header(h, (uint8_t)model_id, (uint8_t)quant_bits,
+    ds4_kvstore_fill_header(h, (uint8_t)model_id,
+                            ds4_engine_weights_fp24(engine),
+                            (uint8_t)quant_bits,
                             reason_code, ext_flags,
                             (uint32_t)store_tokens.len, 0,
                             (uint32_t)ds4_session_ctx(session),
@@ -1188,7 +1201,8 @@ bool ds4_kvstore_maybe_store_continued(ds4_kvstore *kc,
 }
 
 int ds4_kvstore_find_text_prefix(ds4_kvstore *kc, const char *prompt_text,
-                                 int model_id, int quant_bits, int ctx_size) {
+                                 int model_id, uint32_t weights_fp24,
+                                 int quant_bits, int ctx_size) {
     if (!prompt_text) return -1;
     const size_t prompt_bytes = strlen(prompt_text);
     kv_cache_refresh(kc);
@@ -1198,6 +1212,8 @@ int ds4_kvstore_find_text_prefix(ds4_kvstore *kc, const char *prompt_text,
         if (e->text_bytes > prompt_bytes || e->text_bytes > SIZE_MAX) continue;
         if ((int)e->tokens < kc->opt.min_tokens) continue;
         if (e->model_id != (uint8_t)model_id) continue;
+        if (weights_fp24 != 0 && e->weights_fp24 != 0 &&
+            e->weights_fp24 != weights_fp24) continue;
         if ((uint32_t)ctx_size < e->ctx_size) continue;
         if (kc->reject_different_quant && e->quant_bits != (uint8_t)quant_bits) continue;
         if (best >= 0) {
@@ -1227,7 +1243,9 @@ int ds4_kvstore_try_load_text(ds4_kvstore *kc,
     if (quant_bits != 2 && quant_bits != 4) return 0;
     const int model_id = ds4_engine_model_id(engine);
     const size_t prompt_bytes = strlen(prompt_text);
-    int idx = ds4_kvstore_find_text_prefix(kc, prompt_text, model_id, quant_bits,
+    const uint32_t weights_fp24 = ds4_engine_weights_fp24(engine);
+    int idx = ds4_kvstore_find_text_prefix(kc, prompt_text, model_id,
+                                           weights_fp24, quant_bits,
                                            ds4_session_ctx(session));
     if (idx < 0) return 0;
 
@@ -1248,6 +1266,9 @@ int ds4_kvstore_try_load_text(ds4_kvstore *kc,
         if (hdr.model_id != (uint8_t)model_id) {
             header_ok = false;
             fail_reason = "cached checkpoint was written for a different model";
+        } else if (hdr.weights_fp24 != 0 && hdr.weights_fp24 != weights_fp24) {
+            header_ok = false;
+            fail_reason = "cached checkpoint was written for different model weights";
         } else if ((uint64_t)text_bytes > prompt_bytes) {
             header_ok = false;
             fail_reason = "cached text is longer than prompt";

--- a/ds4_kvstore.h
+++ b/ds4_kvstore.h
@@ -44,6 +44,11 @@ typedef struct {
     /* Stored in header byte 7.  Flash is 0 for backward compatibility with
      * older cache files where this reserved byte was always written as zero. */
     uint8_t model_id;
+    /* Stored in header bytes 21..23.  model_id identifies the model shape;
+     * this identifies the weights (see ds4_engine_weights_fp24).  0 means
+     * the header predates fingerprints: such entries are accepted for
+     * backward compatibility, like model_id 0 above (issue #805). */
+    uint32_t weights_fp24;
     uint8_t reason;
     uint32_t tokens;
     uint32_t hits;
@@ -83,6 +88,7 @@ typedef struct {
     const char *text;
     size_t text_len;
     uint8_t model_id;
+    uint32_t weights_fp24;
     uint8_t quant_bits;
     uint32_t ctx_size;
     bool reject_different_quant;
@@ -157,7 +163,8 @@ void ds4_kvstore_evict(ds4_kvstore *kc, const ds4_tokens *live,
                        uint64_t extra_bytes,
                        const ds4_kvstore_eviction_context *incoming);
 int ds4_kvstore_find_text_prefix(ds4_kvstore *kc, const char *prompt_text,
-                                 int model_id, int quant_bits, int ctx_size);
+                                 int model_id, uint32_t weights_fp24,
+                                 int quant_bits, int ctx_size);
 
 bool ds4_kvstore_store_live_prefix_text(ds4_kvstore *kc,
                                         ds4_engine *engine,
@@ -201,7 +208,8 @@ bool ds4_kvstore_read_header(FILE *fp, ds4_kvstore_entry *e,
 bool ds4_kvstore_read_entry_file(const char *path, const char sha[41],
                                  ds4_kvstore_entry *out);
 void ds4_kvstore_fill_header(uint8_t h[DS4_KVSTORE_FIXED_HEADER],
-                             uint8_t model_id, uint8_t quant_bits,
+                             uint8_t model_id, uint32_t weights_fp24,
+                             uint8_t quant_bits,
                              uint8_t reason, uint8_t ext_flags,
                              uint32_t tokens, uint32_t hits, uint32_t ctx_size,
                              uint64_t created_at, uint64_t last_used,

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -9360,6 +9360,8 @@ static void kv_cache_restore_tool_memory_for_messages(server *s, const chat_msgs
         uint64_t skip = (uint64_t)text_bytes + hdr.payload_bytes;
         if (ok && hdr.model_id == model_id &&
             (hdr.weights_fp24 == 0 || !s->engine ||
+             hdr.quant_bits !=
+                 (uint8_t)ds4_engine_routed_quant_bits(s->engine) ||
              hdr.weights_fp24 == ds4_engine_weights_fp24(s->engine)) &&
             (hdr.ext_flags & KV_EXT_TOOL_MAP) &&
             skip <= (uint64_t)INT64_MAX &&
@@ -17447,6 +17449,7 @@ static void test_kv_stub_file(const char *dir, const char *sha,
 static void test_kv_text_stub_file_model(const char *dir, const char *text,
                                          uint8_t model_id,
                                          uint32_t weights_fp24,
+                                         uint8_t quant_bits,
                                          uint8_t reason,
                                          uint32_t tokens,
                                          uint64_t payload_bytes) {
@@ -17463,8 +17466,8 @@ static void test_kv_text_stub_file_model(const char *dir, const char *text,
     }
 
     uint8_t h[KV_CACHE_FIXED_HEADER];
-    ds4_kvstore_fill_header(h, model_id, weights_fp24, 2, reason, 0, tokens, 0,
-                            32768, 100, 100, payload_bytes);
+    ds4_kvstore_fill_header(h, model_id, weights_fp24, quant_bits, reason, 0,
+                            tokens, 0, 32768, 100, 100, payload_bytes);
     uint8_t text_len[4];
     le_put32(text_len, (uint32_t)strlen(text));
     TEST_ASSERT(fwrite(h, 1, sizeof(h), fp) == sizeof(h));
@@ -17480,7 +17483,7 @@ static void test_kv_text_stub_file_model(const char *dir, const char *text,
 static void test_kv_text_stub_file(const char *dir, const char *text,
                                    uint8_t reason,
                                    uint32_t tokens, uint64_t payload_bytes) {
-    test_kv_text_stub_file_model(dir, text, 0, 0, reason, tokens, payload_bytes);
+    test_kv_text_stub_file_model(dir, text, 0, 0, 2, reason, tokens, payload_bytes);
 }
 
 static void test_kv_cache_lookup_uses_longest_text_prefix(void) {
@@ -17530,7 +17533,7 @@ static void test_kv_cache_lookup_rejects_wrong_model(void) {
     if (!dir) return;
 
     const char *text = "shared rendered prefix";
-    test_kv_text_stub_file_model(dir, text, 1, 0, KV_REASON_COLD, 512, 0);
+    test_kv_text_stub_file_model(dir, text, 1, 0, 2, KV_REASON_COLD, 512, 0);
 
     kv_disk_cache kc = {0};
     kc.enabled = true;
@@ -17566,9 +17569,15 @@ static void test_kv_cache_lookup_rejects_wrong_weights(void) {
     const char *text_a = "prompt cached under weights A";
     const char *text_b = "prompt cached under weights B";
     const char *text_legacy = "prompt cached before fingerprints";
-    test_kv_text_stub_file_model(dir, text_a, 0, 0x00A11CEu, KV_REASON_COLD, 512, 0);
-    test_kv_text_stub_file_model(dir, text_b, 0, 0x00B0BB0u, KV_REASON_COLD, 512, 0);
-    test_kv_text_stub_file_model(dir, text_legacy, 0, 0, KV_REASON_COLD, 512, 0);
+    test_kv_text_stub_file_model(dir, text_a, 0, 0x00A11CEu, 2, KV_REASON_COLD, 512, 0);
+    test_kv_text_stub_file_model(dir, text_b, 0, 0x00B0BB0u, 2, KV_REASON_COLD, 512, 0);
+    test_kv_text_stub_file_model(dir, text_legacy, 0, 0, 2, KV_REASON_COLD, 512, 0);
+    /* A q4 checkpoint of the SAME logical model: fingerprints necessarily
+     * differ across quants, so the fingerprint must not veto it — the
+     * existing reject_different_quant policy stays the only cross-quant
+     * gate. */
+    const char *text_q4 = "prompt cached under the q4 requant";
+    test_kv_text_stub_file_model(dir, text_q4, 0, 0x00C4C4Cu, 4, KV_REASON_COLD, 512, 0);
 
     kv_disk_cache kc = {0};
     kc.enabled = true;
@@ -17585,9 +17594,13 @@ static void test_kv_cache_lookup_rejects_wrong_weights(void) {
      * model_id 0 does for old cache files. */
     idx = ds4_kvstore_find_text_prefix(&kc, text_legacy, 0, 0x00A11CEu, 2, 32768);
     TEST_ASSERT(idx >= 0 && kc.entry[idx].weights_fp24 == 0);
+    /* ...and the cross-quant checkpoint stays reusable despite the
+     * different fingerprint (reject_different_quant is false here). */
+    idx = ds4_kvstore_find_text_prefix(&kc, text_q4, 0, 0x00A11CEu, 2, 32768);
+    TEST_ASSERT(idx >= 0 && kc.entry[idx].quant_bits == 4);
 
     kv_cache_close(&kc);
-    const char *texts[] = {text_a, text_b, text_legacy};
+    const char *texts[] = {text_a, text_b, text_legacy, text_q4};
     for (size_t i = 0; i < sizeof(texts) / sizeof(texts[0]); i++) {
         char sha[41], name[44];
         sha1_bytes_hex(texts[i], strlen(texts[i]), sha);

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -9316,8 +9316,9 @@ static void kv_fill_header(uint8_t h[KV_CACHE_FIXED_HEADER], uint8_t quant_bits,
                            uint32_t tokens, uint32_t hits, uint32_t ctx_size,
                            uint64_t created_at, uint64_t last_used,
                            uint64_t payload_bytes) {
-    ds4_kvstore_fill_header(h, 0, quant_bits, reason, ext_flags, tokens, hits,
-                            ctx_size, created_at, last_used, payload_bytes);
+    ds4_kvstore_fill_header(h, 0, 0, quant_bits, reason, ext_flags, tokens,
+                            hits, ctx_size, created_at, last_used,
+                            payload_bytes);
 }
 #endif
 
@@ -9357,7 +9358,10 @@ static void kv_cache_restore_tool_memory_for_messages(server *s, const chat_msgs
         uint32_t text_bytes = 0;
         bool ok = kv_read_header(fp, &hdr, &text_bytes);
         uint64_t skip = (uint64_t)text_bytes + hdr.payload_bytes;
-        if (ok && hdr.model_id == model_id && (hdr.ext_flags & KV_EXT_TOOL_MAP) &&
+        if (ok && hdr.model_id == model_id &&
+            (hdr.weights_fp24 == 0 || !s->engine ||
+             hdr.weights_fp24 == ds4_engine_weights_fp24(s->engine)) &&
+            (hdr.ext_flags & KV_EXT_TOOL_MAP) &&
             skip <= (uint64_t)INT64_MAX &&
             fseeko(fp, (off_t)skip, SEEK_CUR) == 0)
         {
@@ -9644,7 +9648,8 @@ static void kv_cache_maybe_store_continued(server *s, server_slot *slot) {
 #ifdef DS4_SERVER_TEST
 static int kv_cache_find_text_prefix(kv_disk_cache *kc, const char *prompt_text,
                                      int quant_bits, int ctx_size) {
-    return ds4_kvstore_find_text_prefix(kc, prompt_text, 0, quant_bits, ctx_size);
+    return ds4_kvstore_find_text_prefix(kc, prompt_text, 0, 0, quant_bits,
+                                        ctx_size);
 }
 #endif
 
@@ -17440,7 +17445,9 @@ static void test_kv_stub_file(const char *dir, const char *sha,
 }
 
 static void test_kv_text_stub_file_model(const char *dir, const char *text,
-                                         uint8_t model_id, uint8_t reason,
+                                         uint8_t model_id,
+                                         uint32_t weights_fp24,
+                                         uint8_t reason,
                                          uint32_t tokens,
                                          uint64_t payload_bytes) {
     char sha[41];
@@ -17456,7 +17463,7 @@ static void test_kv_text_stub_file_model(const char *dir, const char *text,
     }
 
     uint8_t h[KV_CACHE_FIXED_HEADER];
-    ds4_kvstore_fill_header(h, model_id, 2, reason, 0, tokens, 0,
+    ds4_kvstore_fill_header(h, model_id, weights_fp24, 2, reason, 0, tokens, 0,
                             32768, 100, 100, payload_bytes);
     uint8_t text_len[4];
     le_put32(text_len, (uint32_t)strlen(text));
@@ -17473,7 +17480,7 @@ static void test_kv_text_stub_file_model(const char *dir, const char *text,
 static void test_kv_text_stub_file(const char *dir, const char *text,
                                    uint8_t reason,
                                    uint32_t tokens, uint64_t payload_bytes) {
-    test_kv_text_stub_file_model(dir, text, 0, reason, tokens, payload_bytes);
+    test_kv_text_stub_file_model(dir, text, 0, 0, reason, tokens, payload_bytes);
 }
 
 static void test_kv_cache_lookup_uses_longest_text_prefix(void) {
@@ -17523,7 +17530,7 @@ static void test_kv_cache_lookup_rejects_wrong_model(void) {
     if (!dir) return;
 
     const char *text = "shared rendered prefix";
-    test_kv_text_stub_file_model(dir, text, 1, KV_REASON_COLD, 512, 0);
+    test_kv_text_stub_file_model(dir, text, 1, 0, KV_REASON_COLD, 512, 0);
 
     kv_disk_cache kc = {0};
     kc.enabled = true;
@@ -17531,9 +17538,9 @@ static void test_kv_cache_lookup_rejects_wrong_model(void) {
     kc.opt = kv_cache_default_options();
 
     TEST_ASSERT(ds4_kvstore_find_text_prefix(&kc, "shared rendered prefix and tail",
-                                             0, 2, 32768) < 0);
+                                             0, 0, 2, 32768) < 0);
     int idx = ds4_kvstore_find_text_prefix(&kc, "shared rendered prefix and tail",
-                                           1, 2, 32768);
+                                           1, 0, 2, 32768);
     TEST_ASSERT(idx >= 0);
     TEST_ASSERT(idx >= 0 && kc.entry[idx].model_id == 1);
 
@@ -17546,6 +17553,83 @@ static void test_kv_cache_lookup_rejects_wrong_model(void) {
     unlink(path);
     free(path);
     rmdir(dir);
+}
+
+static void test_kv_cache_lookup_rejects_wrong_weights(void) {
+    char tmpl[] = "/tmp/ds4-kv-weights-fp-test.XXXXXX";
+    char *dir = mkdtemp(tmpl);
+    TEST_ASSERT(dir != NULL);
+    if (!dir) return;
+
+    /* Same model shape, three headers: fingerprinted with A, fingerprinted
+     * with B, and a legacy header without a fingerprint (issue #805). */
+    const char *text_a = "prompt cached under weights A";
+    const char *text_b = "prompt cached under weights B";
+    const char *text_legacy = "prompt cached before fingerprints";
+    test_kv_text_stub_file_model(dir, text_a, 0, 0x00A11CEu, KV_REASON_COLD, 512, 0);
+    test_kv_text_stub_file_model(dir, text_b, 0, 0x00B0BB0u, KV_REASON_COLD, 512, 0);
+    test_kv_text_stub_file_model(dir, text_legacy, 0, 0, KV_REASON_COLD, 512, 0);
+
+    kv_disk_cache kc = {0};
+    kc.enabled = true;
+    kc.dir = xstrdup(dir);
+    kc.opt = kv_cache_default_options();
+
+    /* An engine with weights A must not pick up the checkpoint of B... */
+    int idx = ds4_kvstore_find_text_prefix(&kc, text_b, 0, 0x00A11CEu, 2, 32768);
+    TEST_ASSERT(idx < 0);
+    /* ...must still pick up its own... */
+    idx = ds4_kvstore_find_text_prefix(&kc, text_a, 0, 0x00A11CEu, 2, 32768);
+    TEST_ASSERT(idx >= 0 && kc.entry[idx].weights_fp24 == 0x00A11CEu);
+    /* ...and legacy entries without a fingerprint stay loadable, like
+     * model_id 0 does for old cache files. */
+    idx = ds4_kvstore_find_text_prefix(&kc, text_legacy, 0, 0x00A11CEu, 2, 32768);
+    TEST_ASSERT(idx >= 0 && kc.entry[idx].weights_fp24 == 0);
+
+    kv_cache_close(&kc);
+    const char *texts[] = {text_a, text_b, text_legacy};
+    for (size_t i = 0; i < sizeof(texts) / sizeof(texts[0]); i++) {
+        char sha[41], name[44];
+        sha1_bytes_hex(texts[i], strlen(texts[i]), sha);
+        snprintf(name, sizeof(name), "%.40s.kv", sha);
+        char *path = path_join(dir, name);
+        unlink(path);
+        free(path);
+    }
+    rmdir(dir);
+}
+
+static void test_weights_fp24_of_fd_tells_weights_apart(void) {
+    char tmpl_a[] = "/tmp/ds4-fp24-a.XXXXXX";
+    char tmpl_b[] = "/tmp/ds4-fp24-b.XXXXXX";
+    int fd_a = mkstemp(tmpl_a);
+    int fd_b = mkstemp(tmpl_b);
+    TEST_ASSERT(fd_a >= 0 && fd_b >= 0);
+    if (fd_a < 0 || fd_b < 0) return;
+
+    /* Two files with identical size and header region, one byte of tensor
+     * data apart — the scenario of #805 in miniature. */
+    enum { FILE_BYTES = 1 << 16, DATA_START = 512 };
+    uint8_t *buf = xmalloc(FILE_BYTES);
+    for (int i = 0; i < FILE_BYTES; i++) buf[i] = (uint8_t)(i * 31u);
+    TEST_ASSERT(write(fd_a, buf, FILE_BYTES) == FILE_BYTES);
+    /* Flip a byte the sampler is guaranteed to read: the first window
+     * always starts exactly at data_start. */
+    buf[DATA_START] ^= 0xff;
+    TEST_ASSERT(write(fd_b, buf, FILE_BYTES) == FILE_BYTES);
+    free(buf);
+
+    uint32_t fp_a = ds4_weights_fp24_of_fd(fd_a, DATA_START, FILE_BYTES);
+    uint32_t fp_b = ds4_weights_fp24_of_fd(fd_b, DATA_START, FILE_BYTES);
+    TEST_ASSERT(fp_a != 0 && fp_b != 0);
+    TEST_ASSERT(fp_a != fp_b);
+    /* Same bytes, same fingerprint. */
+    TEST_ASSERT(ds4_weights_fp24_of_fd(fd_a, DATA_START, FILE_BYTES) == fp_a);
+
+    close(fd_a);
+    close(fd_b);
+    unlink(tmpl_a);
+    unlink(tmpl_b);
 }
 
 static void test_kv_cache_lookup_rejects_stale_payload_abi(void) {
@@ -17581,7 +17665,7 @@ static void test_kv_cache_lookup_rejects_stale_payload_abi(void) {
     kc.opt = kv_cache_default_options();
 
     TEST_ASSERT(ds4_kvstore_find_text_prefix(&kc, "stale rendered prefix and tail",
-                                             0, 2, 32768) < 0);
+                                             0, 0, 2, 32768) < 0);
 
     kv_cache_close(&kc);
     unlink(path);
@@ -18424,6 +18508,8 @@ static void ds4_server_unit_tests_run(void) {
     test_sha1_bytes_hex_matches_known_vector();
     test_kv_cache_lookup_uses_longest_text_prefix();
     test_kv_cache_lookup_rejects_wrong_model();
+    test_kv_cache_lookup_rejects_wrong_weights();
+    test_weights_fp24_of_fd_tells_weights_apart();
     test_kv_cache_lookup_rejects_stale_payload_abi();
     test_kv_cache_eviction_values_fresh_snapshots();
     test_kv_cache_eviction_prefers_anchor_reason();


### PR DESCRIPTION
Fixes #805.

## What

`ds4_engine_model_id()` returns the compile-time model variant, so the 1-byte `model_id` in the disk KV cache header identifies the model *shape*, not the weights: two GGUFs with the same structure — the issue's official-vs-Huihui case, or any requant — share it, and a checkpoint written under one set of weights is silently restored under another.

Following the header's own compatibility pattern:

- **`ds4_engine_weights_fp24()`** — a 24-bit FNV-1a fingerprint of the loaded weights: file size, tensor count, and the head of *every* tensor (so no single-tensor edit slips between samples). A few hundred 64-byte `pread`s, once per engine, off the hot path; reads via the descriptor so it also works under SSD streaming where the mapping is partial on purpose.
- Stored in the **free header bytes 21..23** (no version bump, no layout change).
- Every restore path rejects on mismatch with a clear reason (`cached checkpoint was written for different model weights`): `ds4_kvstore_try_load_text`, the agent checkpoint restore, the server tool-map scan, prefix lookup, and the continued-supersede check.
- **Headers written before the fingerprint carry 0 there and stay accepted**, mirroring the `model_id` 0 rule documented in `ds4_kvstore.h` — existing caches keep working, protection applies to checkpoints written from now on.

## Limits (stated, not hidden)

- 24 bits: a 1-in-16M chance that two different weight sets collide, versus the current 100%. If a full-width fingerprint is preferred, it needs a `KV_CACHE_VERSION` bump and a wider field — happy to do that variant instead if you'd rather.
- Legacy (fingerprint-0) checkpoints remain loadable by design; a stricter mode could refuse them, but that would invalidate every existing cache on upgrade.

## Validation (per CONTRIBUTING.md)

- Machine: Linux x86_64, CPU build (`make cpu`, `-DDS4_NO_GPU`), commit `c1d4597`. This change touches no inference path — header bytes, lookup filters and one sampling pass at engine init — so no backend regression surface; `make cpu` builds warning-free.
- New regression tests in the server unit group (`./ds4_test --server`, all green):
  - `test_weights_fp24_of_fd_tells_weights_apart`: two files identical except one tensor byte → different fingerprints; same bytes → same fingerprint (the issue's scenario in miniature);
  - `test_kv_cache_lookup_rejects_wrong_weights`: lookup skips a checkpoint fingerprinted under other weights, still returns its own, still accepts a legacy 0-fingerprint entry.
- Mutation check: breaking the header parse on purpose turns the new test red.
- Not run here: `--logprob-vectors` / `--long-context` (need the model GGUF; no weights on this machine). The change does not touch tokenization, attention or logits.
