### PR TITLE
engine: clearer refusal when --ssd-streaming meets a single-GPU --gpu-vram budget (#880)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -57746,8 +57746,20 @@ static int ds4_engine_open_internal(ds4_engine **out,
         return 1;
     }
     if (e->ssd_streaming && e->multi_tier) {
-        fprintf(stderr,
-                "ds4: --ssd-streaming is not compatible with multi-GPU placement\n");
+        /* An explicit --gpu-vram budget smaller than the model classifies
+         * the remaining layers as CPU spill, which makes even a single-GPU
+         * placement multi-tier: on that path the old "multi-GPU" wording
+         * sent people hunting for a second device (issue #880). */
+        if (gpu_cfg && gpu_cfg->n_gpus == 1) {
+            fprintf(stderr,
+                    "ds4: --ssd-streaming does not support tiered placement: "
+                    "the explicit --gpu-vram budget is smaller than the model, "
+                    "so layers would spill to CPU. Drop --gpu-vram and let "
+                    "streaming manage VRAM itself.\n");
+        } else {
+            fprintf(stderr,
+                    "ds4: --ssd-streaming is not compatible with multi-GPU placement\n");
+        }
         ds4_engine_close(e);
         *out = NULL;
         return 1;


### PR DESCRIPTION
Fixes #880.

With one CUDA device, an explicit `--gpu-vram` budget smaller than the model classifies the remaining layers as CPU spill, the placement becomes multi-tier, and the streaming guard refuses with *"not compatible with multi-GPU placement"* — on a machine with a single GPU. That message sent us hunting for a phantom second device (repro in #880: two commands, one flag apart).

Message-only change, per the issue's first suggested fix: when `gpu_cfg->n_gpus == 1` the refusal now names the real condition and the way out (drop `--gpu-vram\`, streaming manages VRAM itself). Actual multi-GPU placements keep the existing wording. No behavior change — the guard still refuses exactly the same configurations.

Validation: `make cpu` builds warning-free on commit `c1d4597`; the touched code is a refusal path with no inference surface. Verified the exact refusal text on an RTX 3090 pod while working #836 (that is how the issue was found).