### PR TITLE
server: reject NaN float arguments

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -12972,7 +12972,7 @@ static int parse_nonneg_int_arg(const char *s, const char *opt) {
 static float parse_float_arg(const char *s, const char *opt, float minv, float maxv) {
     char *end = NULL;
     float v = strtof(s, &end);
-    if (!s[0] || *end || v < minv || v > maxv) {
+    if (!s[0] || *end || !isfinite(v) || v < minv || v > maxv) {
         server_log(DS4_LOG_DEFAULT, "ds4-server: invalid value for %s: %s", opt, s);
         exit(2);
     }


### PR DESCRIPTION
`parse_float_arg()` validates with a range comparison:

```c
if (!s[0] || *end || v < minv || v > maxv) {
```

Every comparison against NaN is false, so `nan` passes **both** bounds checks and is accepted. `inf` and `-inf` are already rejected, since `inf > maxv` and `-inf < minv` hold — NaN is the only value that slips through.

Reproduced against current `main`:

| argument | before | after |
|---|---|---|
| `--mtp-margin nan` | **accepted**, `engine.mtp_margin = NaN` | rejected |
| `--mtp-margin inf` | rejected | rejected |
| `--mtp-margin -inf` | rejected | rejected |
| `--mtp-margin 0.5` | accepted | accepted |
| `--mtp-margin 2000` | rejected | rejected |

The NaN reaches the engine rather than failing at the boundary, where it propagates silently through whatever arithmetic consumes it.

Affected flags: `--mtp-margin`, `--glm-mtp`, `--directional-steering-ffn`, `--directional-steering-attn`.

The fix adds `!isfinite(v)`, which rejects NaN at parse time and leaves every other case unchanged. `math.h` is already included, so there is no new dependency.

Builds clean with no new warnings on macOS/Metal (`make ds4-server`).