### PR TITLE
kvstore: save continued checkpoints after crossed interval frontiers

### DIFF
--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -111,6 +111,11 @@ workloads, the controls are `--kv-cache-min-tokens`,
 `--kv-cache-boundary-trim-tokens`, and `--kv-cache-boundary-align-tokens`.
 Check `./ds4-server --help` for their defaults.
 
+Continued-save intervals are rounded up to the cold-boundary alignment. The
+cache writes the first valid live checkpoint at or beyond each absolute
+frontier. Restored unaligned checkpoints can therefore leave restart points
+even when fixed-size prefill chunks step over every exact interval boundary.
+
 Quantization variants may share compatible prefixes. Add
 `--kv-cache-reject-different-quant` for same-quant reuse only.
 Cache files contain prompt text and model state: treat the directory as

--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -12,6 +12,7 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
+#include <limits.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -732,8 +733,12 @@ static int kv_cache_continued_step(const ds4_kvstore *kc) {
     int step = kc->opt.continued_interval_tokens;
     const int align = kc->opt.boundary_align_tokens;
     if (align > 0) {
-        step = ((step + align - 1) / align) * align;
-        if (step <= 0) step = align;
+        const int64_t rounded =
+            (((int64_t)step + align - 1) / align) * align;
+        /* live_tokens is an int, so a rounded frontier above INT_MAX can
+         * never be reached.  Avoid signed overflow and disable that schedule. */
+        if (rounded > INT_MAX) return 0;
+        step = (int)rounded;
     }
     return step;
 }
@@ -742,8 +747,20 @@ int ds4_kvstore_continued_store_target(const ds4_kvstore *kc, int live_tokens) {
     const int step = kv_cache_continued_step(kc);
     if (step <= 0) return 0;
     if (live_tokens < kc->opt.min_tokens) return 0;
-    if (live_tokens % step != 0) return 0;
     if (live_tokens <= kc->continued_last_store_tokens) return 0;
+
+    /* A restored cold/text checkpoint is not guaranteed to land on an exact
+     * multiple of step.  Prefill normally advances in fixed-size chunks from
+     * that restored position, so requiring live_tokens % step == 0 can make
+     * the progression miss every absolute frontier forever.  Save the first
+     * real live checkpoint at or beyond the next frontier instead.  Session
+     * payloads already support arbitrary positions (evict/shutdown snapshots
+     * routinely use them), and returning live_tokens keeps the saved graph
+     * state and token vector at the same exact frontier. */
+    int64_t last = kc->continued_last_store_tokens;
+    if (last < 0) last = 0;
+    const int64_t next = (last / step + 1) * (int64_t)step;
+    if ((int64_t)live_tokens < next) return 0;
     return live_tokens;
 }
 

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -10292,6 +10292,12 @@ static void kv_cache_slot_note_store(server_slot *slot, int tokens) {
     }
 }
 
+static void kv_cache_slot_note_load(server_slot *slot, int tokens) {
+    /* A restore or rebuild may move a slot forward, backward, or to zero.
+     * Continued scheduling must restart from that exact frontier. */
+    if (slot && tokens >= 0) slot->continued_last_store_tokens = tokens;
+}
+
 static int kv_cache_slot_suppress_continued(server *s, server_slot *slot,
                                              int tokens) {
     if (kv_cache_slot_continued_target(s, slot, tokens) != tokens) return -1;
@@ -10374,6 +10380,7 @@ static int kv_cache_try_load_text(server *s, server_slot *slot,
     pthread_mutex_unlock(&s->kv_mu);
     pthread_mutex_unlock(&s->inference_mu);
     if (loaded > 0) {
+        kv_cache_slot_note_load(slot, loaded);
         if (loaded_path_out && lr.path) *loaded_path_out = xstrdup(lr.path);
         if (loaded_ext_flags_out) *loaded_ext_flags_out = lr.ext_flags;
     }
@@ -11711,6 +11718,7 @@ static void canonicalize_tool_checkpoint(server *s, server_slot *slot,
             pthread_mutex_lock(&s->inference_mu);
             ds4_session_invalidate(slot->session);
             pthread_mutex_unlock(&s->inference_mu);
+            kv_cache_slot_note_load(slot, 0);
         }
 
         char sync_err[160] = {0};
@@ -18712,7 +18720,7 @@ static void test_kv_cache_chat_anchor_ignores_multiturn_tail(void) {
     ds4_tokens_free(&prompt);
 }
 
-static void test_kv_cache_continued_uses_aligned_frontiers(void) {
+static void test_kv_cache_continued_crosses_interval_frontiers(void) {
     kv_disk_cache kc = {0};
     kc.enabled = true;
     kc.opt = kv_cache_default_options();
@@ -18734,6 +18742,53 @@ static void test_kv_cache_continued_uses_aligned_frontiers(void) {
     kc.continued_last_store_tokens = 20480;
     TEST_ASSERT(kv_cache_continued_store_target(&kc, 29999) == 0);
     TEST_ASSERT(kv_cache_continued_store_target(&kc, 30000) == 30000);
+
+    /* Regression for a real Pi miss: loading a 9703-token cold anchor and
+     * advancing in 2048-token GLM prefill chunks never lands on an exact
+     * 16384-token multiple.  The first live point past each absolute frontier
+     * must still become a continued checkpoint. */
+    kc.opt.continued_interval_tokens = 16384;
+    kc.opt.boundary_align_tokens = 2048;
+    kc.continued_last_store_tokens = 9703;
+    TEST_ASSERT(kv_cache_continued_store_target(&kc, 15847) == 0);
+    TEST_ASSERT(kv_cache_continued_store_target(&kc, 17895) == 17895);
+    kc.continued_last_store_tokens = 17895;
+    TEST_ASSERT(kv_cache_continued_store_target(&kc, 32231) == 0);
+    TEST_ASSERT(kv_cache_continued_store_target(&kc, 34279) == 34279);
+    kc.continued_last_store_tokens = 34279;
+    TEST_ASSERT(kv_cache_continued_store_target(&kc, 34279) == 0);
+
+    /* A large prefill step may cross several frontiers.  Persist the exact
+     * live state once; the following interval is then based on that state. */
+    kc.continued_last_store_tokens = 9703;
+    TEST_ASSERT(kv_cache_continued_store_target(&kc, 65536) == 65536);
+    kc.continued_last_store_tokens = 65536;
+    TEST_ASSERT(kv_cache_continued_store_target(&kc, 81919) == 0);
+    TEST_ASSERT(kv_cache_continued_store_target(&kc, 81920) == 81920);
+
+    /* CLI values are int-sized.  Rounding near INT_MAX must not overflow. */
+    kc.opt.continued_interval_tokens = INT_MAX;
+    kc.opt.boundary_align_tokens = 2;
+    kc.continued_last_store_tokens = 0;
+    TEST_ASSERT(kv_cache_continued_store_target(&kc, INT_MAX) == 0);
+    kc.opt.boundary_align_tokens = 1;
+    TEST_ASSERT(kv_cache_continued_store_target(&kc, INT_MAX) == INT_MAX);
+}
+
+static void test_kv_cache_disk_load_resets_slot_frontier(void) {
+    server_slot slot = {0};
+    slot.continued_last_store_tokens = 0;
+    kv_cache_slot_note_load(&slot, 65536);
+    TEST_ASSERT(slot.continued_last_store_tokens == 65536);
+
+    /* Restoring an older checkpoint must move the schedule backward too. */
+    slot.continued_last_store_tokens = 100000;
+    kv_cache_slot_note_load(&slot, 65536);
+    TEST_ASSERT(slot.continued_last_store_tokens == 65536);
+
+    /* A full rebuild starts scheduling again from token zero. */
+    kv_cache_slot_note_load(&slot, 0);
+    TEST_ASSERT(slot.continued_last_store_tokens == 0);
 }
 
 static void test_kv_cache_cold_store_suppresses_duplicate_continued_boundary(void) {
@@ -19368,7 +19423,7 @@ static void test_kv_cache_eviction_decayed_hits_tie_break_by_age(void) {
     rmdir(dir);
 }
 
-static void test_kv_cache_eviction_keeps_aligned_continued_frontiers(void) {
+static void test_kv_cache_eviction_keeps_continued_frontiers(void) {
     char tmpl[] = "/tmp/ds4-kv-live-prefix-test.XXXXXX";
     char *dir = mkdtemp(tmpl);
     TEST_ASSERT(dir != NULL);
@@ -19863,7 +19918,8 @@ static void ds4_server_unit_tests_run(void) {
     test_kv_cache_store_len_uses_configured_boundary();
     test_kv_cache_chat_anchor_uses_last_user_before_assistant();
     test_kv_cache_chat_anchor_ignores_multiturn_tail();
-    test_kv_cache_continued_uses_aligned_frontiers();
+    test_kv_cache_continued_crosses_interval_frontiers();
+    test_kv_cache_disk_load_resets_slot_frontier();
     test_kv_cache_cold_store_suppresses_duplicate_continued_boundary();
     test_kv_cache_file_size_must_fit_budget();
     test_sha1_bytes_hex_matches_known_vector();
@@ -19878,7 +19934,7 @@ static void ds4_server_unit_tests_run(void) {
     test_kv_cache_eviction_keeps_smaller_context_prefix();
     test_kv_cache_eviction_score_decays_stale_hits();
     test_kv_cache_eviction_decayed_hits_tie_break_by_age();
-    test_kv_cache_eviction_keeps_aligned_continued_frontiers();
+    test_kv_cache_eviction_keeps_continued_frontiers();
 }
 
 #ifndef DS4_SERVER_TEST_NO_MAIN


### PR DESCRIPTION
## Summary

Save a continued KV checkpoint at the first valid live position that reaches or
passes each configured interval frontier.

## Why

The old condition required `live_tokens % step == 0`. After restoring an
unaligned checkpoint, fixed-size prefill chunks can cross every interval without
ever landing on an exact multiple. For example, `9703 + n * 2048` never equals a
multiple of 16,384, so a long continuation could produce no continued
checkpoints at all.

This change treats the per-slot value as a scheduling frontier: a save becomes
eligible when the live position crosses the next interval, and a load or rebuild
resets the frontier to the position actually restored. The saved token vector and
graph payload still come from the same exact live position. Interval rounding is
performed in `int64_t` before checking the `int` range.

## Compatibility

The cache format, cache keys, payload, defaults and model execution are
unchanged. This only changes when an already-enabled continued checkpoint is
scheduled.

## Practical impact

The benefit is avoiding repeated prefill after a restart or eviction: configured continued checkpoints become available even after an unaligned restore. This does not accelerate token generation. Its contribution over the rebased upstream is the corrected checkpoint-scheduling condition; the regression tests below exercise that failure directly. No per-PR latency or throughput uplift against `f62ca29` has been measured.

## Combined runtime context

A [stock/full-stack engine comparison](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/README.md) measures pristine `f62ca29` against the complete integrated runtime on GB10 CUDA and M3 Ultra Metal, including full 262,144-token capacity. The original full sweeps used one process pair per machine and include additional changes beyond these 13 PRs. A [targeted M3 follow-up](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/m3-attribution/README.md) did not reproduce the original short-decode slowdown, using a reversed-order pair, same-process controls and an exact original-executable replay. These results do not isolate this PR’s marginal gain, establish universal speed or quality, or newly benchmark its server/cache workflows. See the [per-PR assessment](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/PR-ASSESSMENT.md) for its supported benefit and limits.

## Validation

The build and runtime checks below ran before upstream’s README-only update. The full PR diff and every other tracked file are byte-identical at this head; `git diff --check` passed again. The documentation-only rebase was not rebuilt.

One standalone commit, `fd7eda0f51d8`, directly on upstream `f62ca29a3087` (2026-09-07). Regression coverage includes unaligned 9,703-token restores, crossed intervals, large jumps, forward/backward/zero restores, duplicate suppression and `INT_MAX` rounding.

Checks on the preceding `b6af0ad` base passed on Apple M3 Ultra / Darwin 27.0 / Apple clang 21: clean default Metal build, `make test-frontends`, session-state, TP-command and vision-image tests, `make cpu`, and `git diff --check`. Fully instrumented host C/Objective-C ASan+UBSan tests also passed (`-O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all`, leak detection off). CPU portability is compile/link coverage; the sanitizer runs are host tests, not GPU instrumentation.

Before the Metal-only upstream update, the same patch passed checks on NVIDIA DGX Spark / Ubuntu / Linux 6.17.0-1032-nvidia, GCC 13.3 and CUDA 13.0.88: clean `make -j4 cuda-spark` (`sm_121a`), `make CUDA_ARCH=sm_121a test-frontends`, session-state, TP-command and vision-image tests, and a clean `make -j4 cpu` build. CPU ASan+UBSan server/session/TP/vision tests passed with leak detection on; agent tests passed with leak detection off for the unchanged upstream fixture leak. These are host tests and compile/link coverage; CUDA execution is recorded separately. The later upstream updates are a five-line GLM SSD change inside a Metal-only guard and a README edit. CUDA source and the PR patch are unchanged; native Linux preprocessing of `ds4.c` was byte-identical for CUDA, CPU and sanitizer builds.

No full aggregate model-suite or untested-backend result is claimed.
