### PR TITLE
dspark: fix indexer sparse-threshold mismatch + skip batched verify for a bare draft_n==1 accept

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ DS4_LINK_LIBS ?= $(CUDA_LDLIBS)
 METAL_LDLIBS := $(LDLIBS)
 endif
 
-.PHONY: all help clean test test-rocm test-glm53-kda-rocm test-metal-session-batch test-mxfp4-cuda test-mxfp4-rocm test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
+.PHONY: all help clean test test-rocm test-glm53-kda-rocm test-metal-session-batch test-mxfp4-cuda test-mxfp4-rocm test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth dspark-indexer-threshold-boundary mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
 
 ifeq ($(UNAME_S),Darwin)
 .PHONY: metal-decode-schedule-bench metal-prefill-variant-bench check-mxfp4-half-lut
@@ -84,6 +84,7 @@ help:
 	@echo "  make check-mxfp4-half-lut  Verify the checked-in MXFP4 half LUT matches the generator"
 	@echo "  make test-mxfp4-metal  Check the MXFP4 half LUT, then run Metal MXFP4 exactness tests"
 	@echo "  make dspark-verify-depth  Run DSpark speculative verification smoke if support GGUF is present"
+	@echo "  make dspark-indexer-threshold-boundary  Check DSpark verify's indexer sparse threshold matches decode at n_comp in (512,1024]"
 	@echo "  make mtp-verify-depth  Run legacy MTP speculative verification smoke if MTP GGUF is present"
 	@echo "  make clean        Remove build outputs"
 
@@ -166,6 +167,7 @@ help:
 	@echo "  make cpu                 Build CPU-only ./ds4, ./ds4-server, ./ds4-bench, ./ds4-eval, and ./ds4-agent"
 	@echo "  make test                Build and run tests"
 	@echo "  make dspark-verify-depth Run DSpark speculative verification smoke if support GGUF is present"
+	@echo "  make dspark-indexer-threshold-boundary  Check DSpark verify's indexer sparse threshold matches decode at n_comp in (512,1024]"
 	@echo "  make mtp-verify-depth    Run legacy MTP speculative verification smoke if MTP GGUF is present"
 	@echo "  make clean               Remove build outputs"
 
@@ -572,6 +574,16 @@ dspark-verify-depth: ds4_test
 		echo "dspark-verify-depth: run ./download_model.sh ds4f-dspark or set DS4_DSPARK_SUPPORT=FILE"; \
 	else \
 		DS4_TEST_MODEL="$(DS4_TEST_MODEL)" DS4_TEST_DSPARK="$(DS4_DSPARK_SUPPORT)" ./ds4_test --dspark-verify-depth; \
+	fi
+
+dspark-indexer-threshold-boundary: ds4_test
+	@if [ ! -f "$(DS4_TEST_MODEL)" ]; then \
+		echo "dspark-indexer-threshold-boundary: skipped, missing model $(DS4_TEST_MODEL)"; \
+	elif [ ! -f "$(DS4_DSPARK_SUPPORT)" ]; then \
+		echo "dspark-indexer-threshold-boundary: skipped, missing DSpark support $(DS4_DSPARK_SUPPORT)"; \
+		echo "dspark-indexer-threshold-boundary: run ./download_model.sh ds4f-dspark or set DS4_DSPARK_SUPPORT=FILE"; \
+	else \
+		DS4_TEST_MODEL="$(DS4_TEST_MODEL)" DS4_TEST_DSPARK="$(DS4_DSPARK_SUPPORT)" ./ds4_test --dspark-indexer-threshold-boundary; \
 	fi
 
 mtp-verify-depth: ds4_test

--- a/ds4.c
+++ b/ds4.c
@@ -69615,6 +69615,29 @@ static int ds4_session_eval_dspark_speculative_stochastic(
         DS4_DSPARK_STOCH_FINISH();
         return n_accept;
     }
+    if (draft_n == 1) {
+        /* Position 0 just got accepted above and it's the entire draft, so
+         * there is nothing left for the batched verifier to check -- the
+         * only remaining work is committing drafts[0] and obtaining next-
+         * token logits, which a plain decode step gives at a fraction of
+         * the cost of a full multi-layer batch dispatch at n_tokens == 1
+         * (mirrors the position-0-rejection cheap path just above). */
+        if (ds4_session_eval_probe_tp(s, drafts[0], false, err, errlen) != 0) {
+            DS4_DSPARK_STOCH_FINISH();
+            return -1;
+        }
+        accepted[n_accept++] = drafts[0];
+        if (stats_enabled) {
+            s->dspark_stats.full_accepts++;
+            s->dspark_stats.direct_full_commits++;
+            s->dspark_stats.accepted_draft_tokens += 1;
+            ds4_dspark_stats_note_len(s->dspark_stats.accepted_len_hist, 1);
+        }
+        ds4_session_dspark_scheduler_note(
+            s, 1, false, DS4_DSPARK_STOCH_EXTRA_MS());
+        DS4_DSPARK_STOCH_FINISH();
+        return n_accept;
+    }
     ds4_engine *e = s->engine;
     ds4_spec_frontier frontier;
     memset(&frontier, 0, sizeof(frontier));

--- a/ds4.c
+++ b/ds4.c
@@ -29874,6 +29874,18 @@ static bool metal_graph_encode_layer_attention_batch(
             uint32_t use_comp_mask = 0;
             bool use_indexed_comp = false;
             double index_stage_t0 = 0.0;
+            /* Verify-shaped batches (DSpark/MTP suffix re-verification, never
+             * more than a few draft tokens) must pick the same dense-vs-indexed
+             * branch that single-token decode would for the same n_comp, or the
+             * verifier attends over a different candidate set than the decode
+             * path it's supposed to be reproducing.  Real multi-thousand-token
+             * prefill chunks keep the original DS4_N_INDEXER_TOP_K cutover --
+             * decode's amortization argument for going sparse earlier hasn't
+             * been separately validated at that scale. */
+            const bool verify_shaped_batch = n_tokens <= 8;
+            const uint32_t indexer_dense_threshold = verify_shaped_batch
+                ? metal_graph_decode_indexer_sparse_threshold(g)
+                : DS4_N_INDEXER_TOP_K;
 
             ok = ds4_gpu_store_raw_kv_batch_tensor(g->layer_raw_cache[il],
                                                      metal_graph_batch_kv(g),
@@ -29881,7 +29893,7 @@ static bool metal_graph_encode_layer_attention_batch(
                                                      pos0,
                                                      n_tokens,
                                                      DS4_N_HEAD_DIM) != 0;
-            if (ok && ratio == 4 && n_comp > DS4_N_INDEXER_TOP_K) {
+            if (ok && ratio == 4 && n_comp > indexer_dense_threshold) {
                 const float index_scale = 1.0f / sqrtf((float)(DS4_N_INDEXER_HEAD_DIM * DS4_N_INDEXER_HEAD));
                 if (index_stage_profile) {
                     ok = metal_graph_indexer_stage_profile_boundary(NULL,

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -6778,6 +6778,102 @@ static void test_dspark_verify_depth(void) {
     ds4_engine_close(engine);
     test_restore_env("DS4_DSPARK_SCHEDULER", saved_scheduler);
 }
+
+/* Regression for the indexer sparse-threshold mismatch between decode
+ * (metal_graph_decode_indexer_sparse_threshold(), 1024) and the batched
+ * verify path (previously a bare DS4_N_INDEXER_TOP_K, 512): a ratio-4 layer
+ * with n_comp in (512,1024] used to attend densely in decode but sparsely
+ * (indexer top-k) in DSpark's verify batch -- a different candidate set for
+ * what's supposed to be the same computation.  Sizes the prompt so ratio-4
+ * layers land n_comp in that exact window, then reuses the verify-depth
+ * oracle: every committed speculative token must replay as a (near-)argmax
+ * under plain decode. */
+static void test_dspark_indexer_threshold_boundary(void) {
+    const char *support = getenv("DS4_TEST_DSPARK");
+    if (!support || !support[0]) {
+        fprintf(stderr, "ds4-test: dspark-indexer-threshold-boundary skipped (set DS4_TEST_DSPARK to a DSpark support GGUF)\n");
+        return;
+    }
+
+    char *saved_scheduler = test_save_env("DS4_DSPARK_SCHEDULER");
+    setenv("DS4_DSPARK_SCHEDULER", "0", 1);
+
+    char *full_text = test_read_file("tests/long_context_story_prompt.txt");
+    TEST_ASSERT(full_text != NULL);
+
+    ds4_engine *engine = test_open_dspark_engine(support);
+    ds4_tokens prompt = {0};
+    int *spec = NULL;
+
+    if (engine && full_text) {
+        const int draft_depth = ds4_engine_mtp_draft_tokens(engine);
+        TEST_ASSERT(draft_depth > 2);
+
+        /* ~13000 bytes of this story (English prose, ~5.8 bytes/word here)
+         * tokenizes to roughly 2600-2900 tokens -- n_comp ~650-725 for
+         * ratio-4 layers after prefill, comfortably inside (512,1024] with
+         * headroom for the ~128 generated tokens (+~32 rows) to stay under
+         * the 1024 ceiling too. */
+        const size_t slice_bytes = 13000;
+        size_t full_len = strlen(full_text);
+        size_t use_len = slice_bytes < full_len ? slice_bytes : full_len;
+        char *slice = malloc(use_len + 1);
+        TEST_ASSERT(slice != NULL);
+        if (slice) {
+            memcpy(slice, full_text, use_len);
+            slice[use_len] = '\0';
+
+            ds4_chat_begin(engine, &prompt);
+            ds4_chat_append_message(engine, &prompt, "user", slice);
+            ds4_chat_append_assistant_prefix(engine, &prompt, DS4_THINK_NONE);
+            TEST_ASSERT(prompt.len > 0);
+            free(slice);
+
+            fprintf(stderr,
+                    "ds4-test: dspark-indexer-threshold-boundary prompt.len=%d n_comp~%d\n",
+                    prompt.len, prompt.len / 4);
+            TEST_ASSERT(prompt.len / 4 > 512 && prompt.len / 4 <= 1024);
+
+            const int maxgen = 128;
+            spec = malloc((size_t)maxgen * sizeof(*spec));
+            TEST_ASSERT(spec != NULL);
+            if (draft_depth > 2 && spec && prompt.len > 0) {
+                int nspec = 0, max_chunk = 0;
+                const bool ok_spec = test_mtp_capture_speculative(engine, &prompt,
+                                                                  maxgen,
+                                                                  spec, &nspec,
+                                                                  &max_chunk);
+                TEST_ASSERT(ok_spec);
+                TEST_ASSERT(nspec > 32);
+
+                float worst_gap = 0.0f;
+                int worst_at = -1;
+                const bool ok_check = test_mtp_worst_argmax_gap(engine, &prompt,
+                                                                spec, nspec,
+                                                                &worst_gap,
+                                                                &worst_at);
+                TEST_ASSERT(ok_check);
+                fprintf(stderr,
+                        "ds4-test: dspark-indexer-threshold-boundary nspec=%d max_chunk=%d worst_argmax_gap=%.3f at=%d\n",
+                        nspec, max_chunk, worst_gap, worst_at);
+                /* Tighter than the other verify-depth tests' 2.0f tolerance:
+                 * attending over the wrong candidate set (indexed top-512
+                 * instead of dense-1024) measured ~0.9 on this model/prompt,
+                 * while the correct dense path measures exactly 0.0 (same
+                 * computation as decode, not just numerically close to it).
+                 * 0.05f still absorbs ordinary batched-vs-single-token
+                 * floating-point reduction-order noise. */
+                TEST_ASSERT(worst_gap <= 0.05f);
+            }
+        }
+    }
+
+    free(spec);
+    free(full_text);
+    ds4_tokens_free(&prompt);
+    ds4_engine_close(engine);
+    test_restore_env("DS4_DSPARK_SCHEDULER", saved_scheduler);
+}
 #endif
 
 static void test_server_unit_group(void) {
@@ -6809,6 +6905,7 @@ static const ds4_test_entry test_entries[] = {
     {"--streaming-decode-prefill-correctness", "streaming-decode-prefill-correctness", "streaming decode-style cold prefill drift and repeatability", test_streaming_decode_prefill_correctness},
     {"--mtp-verify-depth", "mtp-verify-depth", "MTP speculative verify commits autoregressive-identical tokens at draft depth > 2", test_mtp_verify_depth},
     {"--dspark-verify-depth", "dspark-verify-depth", "DSpark speculative verify commits autoregressive-identical tokens at draft depth > 2", test_dspark_verify_depth},
+    {"--dspark-indexer-threshold-boundary", "dspark-indexer-threshold-boundary", "DSpark batched verify matches decode's indexer sparse-threshold for n_comp in (512,1024]", test_dspark_indexer_threshold_boundary},
 #endif
     {"--server", "server", "server parser/rendering/cache unit tests", test_server_unit_group},
 };
@@ -6845,7 +6942,7 @@ static void test_print_help(const char *prog) {
     puts("  DS4_TEST_LOCAL_GOLDEN_FILE=FILE  Local fixture. Default: flash-0731/local-golden.vec.");
     puts("  DS4_TEST_MPP_EQ_CASE=NAME  Run only Tensor equivalence cases whose id contains NAME.");
     puts("  DS4_TEST_MTP=FILE         Legacy MTP support GGUF for --mtp-verify-depth.");
-    puts("  DS4_TEST_DSPARK=FILE      DSpark support GGUF for --dspark-verify-depth.");
+    puts("  DS4_TEST_DSPARK=FILE      DSpark support GGUF for --dspark-verify-depth and --dspark-indexer-threshold-boundary.");
     puts("  DS4_TEST_CONTINUED_PREFILL_TOKENS=N  Large suffix size for --glm53-continued-prefill.");
     puts("  DS4_TEST_CONTINUED_PREFILL_STEPS=N   Number of consecutive large suffixes to test.");
     puts("  DS4_TEST_CONTINUED_PREFILL_ALLOW_COARSE=1  Permit coarse short-suffix progress for baseline timing.");


### PR DESCRIPTION
Two small, independently-verified follow-ups from #913, against current `main`.

## 1. Indexer sparse-threshold mismatch between decode and batched verify

`metal_graph_encode_layer_attention_batch`'s `!zero_prefix` branch (used by both DSpark and MTP suffix re-verification) picks the indexed-vs-dense attention path purely on `n_comp > DS4_N_INDEXER_TOP_K` (512), while single-token decode gates the same choice on the higher `metal_graph_decode_indexer_sparse_threshold()` (1024). For a ratio-4 layer with `n_comp` in (512,1024], decode attends densely over all compressed rows but the verifier attends over only the indexed top-512 -- a different candidate set for what's supposed to be a faithful re-check of decode's own output.

Fixed by matching decode's threshold for verify-shaped batches (`n_tokens <= 8`); real multi-thousand-token prefill keeps the original cutover, since decode's amortization argument for going sparse earlier hasn't been validated at that scale.

New test `--dspark-indexer-threshold-boundary` sizes a real prompt so a ratio-4 layer's `n_comp` lands in the affected window, then reuses the existing verify-depth oracle (replay committed speculative tokens through plain decode, require near-argmax match). Confirmed the test actually discriminates the bug: `worst_argmax_gap` measures 0.939 without this fix and exactly 0.000 with it, on real weights (DeepSeek-V4-Flash, M5 Max, Metal).

## 2. Skip the batched verifier for a bare draft_n==1 accept

`ds4_session_eval_dspark_speculative_stochastic` already routes a position-0 *rejection* through a plain decode step instead of the full `metal_graph_verify_suffix_tops` batched verifier (nothing left to check once the replacement is sampled). A position-0 *acceptance* with `draft_n==1` -- reachable when the proposed draft gets clamped to a single token near the end of generation, near the context/output-buffer limit, or by an EOS at position 0 -- fell through to that same full batched verifier unconditionally, paying for a 43-layer batch dispatch at `n_tokens==1` to obtain logits a plain decode call gives at a fraction of the cost.

Mirrors the existing rejection path: commits `drafts[0]` and gets the next logits via `ds4_session_eval_probe_tp` instead. This changes nothing about the accept/reject decision or RNG consumption -- `draft_n==1` means there's nothing left to verify, so the fast path and the batched path compute the same result through different kernels.

Verified bit-identical output (same seed, `--mtp-exact-sampling`, temp 0.6) across 5 prompts with the fast path enabled vs disabled. The underlying claim that batched-verify dispatch overhead dominates over plain decode at small `n_tokens` is visible directly in this machine's own DSpark stats (~23ms/token plain decode vs ~48ms/call batched verify for `n_tokens` 2-5, DeepSeek-V4-Flash, M5 Max, Metal).

TP-safe: the leader now sends a `DS4_TP_FRAME_EVAL` instead of `DS4_TP_FRAME_VERIFY` for this case, which the worker's message-driven dispatch loop (`ds4_tp.c`) already handles -- the same alternate frame type the existing rejection path already relies on.

No dedicated automated regression test for this one: the trigger (draft length clamped to exactly 1 by generation-tail/context/buffer limits) isn't reliably reproducible through the CLI without scaffolding disproportionate to the fix's narrow scope. Verified manually instead (see above); happy to add one if there's a cleaner way to force it.

## Testing

- `make test`: all green (`test_layer_pack` 97/97, `test_engine_mgpu_placement` 101/101, `test_gpu_args_cli` 53/53, `test_sampling` OK).
- `make dspark-verify-depth` and the new `make dspark-indexer-threshold-boundary`: both pass with `worst_argmax_gap=0.000` on real weights (M5 Max, Metal, DeepSeek-V4-Flash + DSpark support GGUF).
- `tests/dspark_acceptance_fixture.sh` (both greedy and `--mtp-exact-sampling` modes): no new mismatches or errors vs current `main`'s baseline behavior.

Closes the two remaining open items from #913; the fusion-kernel lead from that report is unrelated and still unresolved/not pursued here.