### PR TITLE
agent: accept the ROCm backend options the help advertises

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -526,9 +526,19 @@ static float parse_float_range(const char *s, const char *opt, float min, float 
 
 static ds4_backend parse_backend(const char *s) {
     if (!strcmp(s, "metal")) return DS4_BACKEND_METAL;
+#ifdef DS4_ROCM_BUILD
+    /* ROCm reuses the CUDA backend enum; accept the spelling the shared help
+     * advertises. "cuda" stays accepted so existing scripts keep working. */
+    if (!strcmp(s, "rocm")) return DS4_BACKEND_CUDA;
+#endif
     if (!strcmp(s, "cuda")) return DS4_BACKEND_CUDA;
     if (!strcmp(s, "cpu")) return DS4_BACKEND_CPU;
     fprintf(stderr, "ds4-agent: invalid backend: %s\n", s);
+#ifdef DS4_ROCM_BUILD
+    fprintf(stderr, "ds4-agent: valid backends are: metal, rocm, cpu\n");
+#else
+    fprintf(stderr, "ds4-agent: valid backends are: metal, cuda, cpu\n");
+#endif
     exit(2);
 }
 
@@ -668,6 +678,10 @@ static agent_config parse_options(int argc, char **argv) {
             c.engine.backend = parse_backend(need_arg(&i, argc, argv, arg));
         } else if (!strcmp(arg, "--metal")) {
             c.engine.backend = DS4_BACKEND_METAL;
+#ifdef DS4_ROCM_BUILD
+        } else if (!strcmp(arg, "--rocm")) {
+            c.engine.backend = DS4_BACKEND_CUDA;
+#endif
         } else if (!strcmp(arg, "--cuda")) {
             c.engine.backend = DS4_BACKEND_CUDA;
         } else if (!strcmp(arg, "--gpu-vram")) {


### PR DESCRIPTION
On a ROCm build `ds4-agent --help` advertises `--rocm` and `--backend rocm`, but the agent's own parser handled only `metal`/`cuda`/`cpu`, so both advertised spellings exit 2:

```
$ ./ds4-agent --rocm --help
ds4-agent: unknown option: --rocm
$ ./ds4-agent --backend rocm --help
ds4-agent: invalid backend: rocm
```

`QA_BEFORE_RELEASES.md` §2 treats a binary that advertises a flag but answers `unknown option` as a release blocker.

The help text is generated centrally by `ds4_help.c` (`print_model_runtime`, gated on `DS4_ROCM_BUILD`), but backend parsing is duplicated across the frontends — and the agent's copy is the only one without the ROCm conditional:

```
$ grep -c DS4_ROCM_BUILD ds4_cli.c ds4_server.c ds4_bench.c ds4_eval.c ds4_help.c ds4_agent.c
ds4_cli.c:6  ds4_server.c:3  ds4_bench.c:3  ds4_eval.c:3  ds4_help.c:1  ds4_agent.c:0
```

## The change

Mirrors the existing `ds4_cli.c` handling — `--rocm` and `--backend rocm` map to the `DS4_BACKEND_CUDA` enum that ROCm already reuses, plus the build-appropriate valid-backends diagnostic the other frontends print. +14 lines, one file, no deletions.

## One deliberate choice

`--cuda` and `--backend cuda` **stay accepted** on ROCm builds. `ds4_cli.c` rejects them there, so this is not full parity. The reasoning: the agent has accepted `--cuda` as the only working spelling for as long as its ROCm help has advertised `--rocm`, so anyone driving `ds4-agent` on ROCm today is relying on it. Removing it is a deliberate break and felt like a separate decision for you to make rather than something to fold in here. Happy to align it if you'd prefer.

## Verification

Framework Desktop, Ryzen AI Max+ 395, Radeon 8060S (`gfx1151`), Fedora 44, ROCm 7.1.1, `make strix-halo`:

| | before | after |
|---|---|---|
| `--rocm --help` | exit 2, `unknown option` | **exit 0** |
| `--backend rocm --help` | exit 2, `invalid backend` | **exit 0** |
| `--cuda --help` | exit 0 | exit 0 (unchanged) |
| `--backend bogus` | exit 2, no hint | exit 2 + `valid backends are: metal, rocm, cpu` |

Build clean, no new warnings. `tests/test_gpu_args_cli.sh` unchanged at `PASS=41 FAIL=12`.

## Note on those 12 failures

They are pre-existing and unrelated to this change: the suite asserts `--gpu-vram`, `--gpu-devices` and `--cuda-tensor-parallel` appear in every binary's help, while `ds4_help.c` deliberately omits all three under `DS4_ROCM_BUILD`. So `make test` cannot be green on Strix Halo, which is plausibly why this drift went unnoticed — the suite's output isn't read on this platform.

Making it build-aware, adding an assertion that an *advertised* backend option is actually *accepted*, and covering `ds4-eval` (currently absent from `BINS`, despite having its own `parse_backend`) would suit a follow-up. Glad to do that separately if useful.
