### PR TITLE
Add pipeline parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ DS4_LINK_LIBS ?= $(CUDA_LDLIBS)
 METAL_LDLIBS := $(LDLIBS)
 endif
 
-.PHONY: all help clean test test-rocm test-metal-session-batch test-mxfp4-cuda test-mxfp4-rocm test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
+.PHONY: all help clean test test-rocm test-metal-session-batch test-mxfp4-cuda test-mxfp4-rocm test-cuda-session-batch test-cuda-mixed-batch test-dist-session-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
 
 ifeq ($(UNAME_S),Darwin)
 .PHONY: metal-decode-schedule-bench metal-prefill-variant-bench check-mxfp4-half-lut
@@ -453,6 +453,18 @@ tests/test_cuda_session_batch: tests/test_cuda_session_batch.o ds4_gpu_args.o ds
 test-cuda-session-batch: tests/test_cuda_session_batch
 	DS4_TEST_MODEL="$(DS4_TEST_MODEL)" ./tests/test_cuda_session_batch
 
+# Distributed decode-batch oracle. Backend-neutral source, so it links through
+# $(DS4_LINK) and builds under the CUDA and ROCm targets alike. Needs a live
+# worker serving the complementary layer slice; see the file header.
+tests/test_dist_session_batch.o: tests/test_dist_session_batch.c ds4.h ds4_distributed.h
+	$(CC) $(CFLAGS) -I. -c -o $@ $<
+
+tests/test_dist_session_batch: tests/test_dist_session_batch.o $(CORE_OBJS)
+	$(DS4_LINK) -o $@ $^ $(DS4_LINK_LIBS)
+
+test-dist-session-batch: tests/test_dist_session_batch
+	DS4_TEST_MODEL="$(DS4_TEST_MODEL)" ./tests/test_dist_session_batch
+
 tests/test_cuda_mixed_batch.o: tests/test_cuda_mixed_batch.c ds4.h ds4_gpu_args.h ds4_gpu_mgpu.h
 	$(CC) $(CFLAGS) -DDS4_TEST_HOOKS -I. -I$(CUDA_HOME)/include -c -o $@ $<
 
@@ -523,4 +535,4 @@ mxfp4-dot-test: tests/test_mxfp4_dot.c
 	./tests/test_mxfp4_dot
 
 clean:
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_rocm tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_rocm tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/test_dist_session_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o

--- a/ds4.c
+++ b/ds4.c
@@ -66340,6 +66340,20 @@ static bool metal_graph_eval_mixed_prefill_decode(
 }
 #endif
 
+/* A distributed coordinator maps only its own --layers slice, but the batch
+ * encoders below build a full local decode graph per session and would walk
+ * layers this process never loaded.  Those sessions take the serialized
+ * fallback instead, which routes each token over the wire.
+ * ds4_sessions_eval_batch_metal_supported() refuses them for the same reason;
+ * the CUDA path, which ROCm also uses, needs the same exclusion. */
+static bool ds4_decode_batch_has_distributed(const ds4_decode_item *items,
+                                             int count) {
+    for (int i = 0; i < count; i++) {
+        if (items[i].session && items[i].session->distributed) return true;
+    }
+    return false;
+}
+
 static int ds4_sessions_eval_batch_cuda(ds4_decode_item *items, int count,
                             char *err, size_t errlen) {
     if (!items || count <= 0) {
@@ -66391,6 +66405,7 @@ static int ds4_sessions_eval_batch_cuda(ds4_decode_item *items, int count,
      * while preserving the exact one-token kernels and per-session KV order. */
     if (e->backend == DS4_BACKEND_CUDA &&
         !ds4_session_is_glm(first) &&
+        !ds4_decode_batch_has_distributed(items, count) &&
         e->support_kind == DS4_SUPPORT_NONE) {
         bool ok = ds4_gpu_begin_commands() != 0;
         for (int i = 0; ok && i < count; i++) {
@@ -66528,6 +66543,8 @@ static int ds4_sessions_eval_batch_with_prefill_cuda(
         native_requested &&
         e->backend == DS4_BACKEND_CUDA &&
         !ds4_session_is_glm(prefill_session) &&
+        !prefill_session->distributed &&
+        !ds4_decode_batch_has_distributed(items, count) &&
         e->support_kind == DS4_SUPPORT_NONE &&
         metal_graph_mixed_prefill_decode_supported(
                 prefill_session, prefill_prompt, start, prefill_rows,

--- a/ds4.c
+++ b/ds4.c
@@ -36894,6 +36894,9 @@ struct ds4_engine {
     bool ssd_streaming_cold;
     bool ssd_streaming_full_layers_set;
     ds4_distributed_options distributed;
+    /* One coordinator endpoint per engine, opened on the first coordinator
+     * session. Sessions borrow it; it outlives all of them. */
+    ds4_dist_coordinator *dist_coordinator;
     ds4_engine_tp_state tp;
     bool metal_ready;
     bool mtp_ready;
@@ -58587,6 +58590,8 @@ bool ds4_engine_is_glm_dsa(ds4_engine *e) {
 
 void ds4_engine_close(ds4_engine *e) {
     if (!e) return;
+    ds4_dist_coordinator_close(e->dist_coordinator);
+    e->dist_coordinator = NULL;
 #if !defined(DS4_NO_GPU) && defined(__APPLE__)
     if (e->tp.active) {
         ds4_gpu_tp_shutdown();
@@ -58760,6 +58765,29 @@ static int ds4_session_tp_register(ds4_session *s) {
     return 1;
 }
 
+/* Attach a coordinator session to the engine's endpoint, opening the endpoint
+ * on first use.  ctx_size comes from the first session; every resident session
+ * on a server shares it. */
+static int ds4_session_attach_distributed(ds4_session *s, ds4_engine *e,
+                                          int ctx_size) {
+    char err[256];
+    if (!e->dist_coordinator &&
+        ds4_dist_coordinator_open(&e->dist_coordinator, e, &e->distributed,
+                                  ctx_size, err, sizeof(err)) != 0) {
+        fprintf(stderr,
+                "ds4: failed to open distributed coordinator endpoint: %s\n",
+                err[0] ? err : "unknown error");
+        return 1;
+    }
+    if (ds4_dist_session_create(&s->distributed, e->dist_coordinator,
+                                err, sizeof(err)) != 0) {
+        fprintf(stderr, "ds4: failed to create distributed coordinator session: %s\n",
+                err[0] ? err : "unknown error");
+        return 1;
+    }
+    return 0;
+}
+
 int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
     if (!out || !e || ctx_size <= 0) return 1;
     if (e->backend == DS4_BACKEND_CPU) {
@@ -58865,26 +58893,15 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
         s->logits = xmalloc((size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
         s->sample_probs =
             xmalloc((size_t)DS4_N_VOCAB * sizeof(s->sample_probs[0]));
-        if (e->distributed.role == DS4_DISTRIBUTED_COORDINATOR) {
-            char err[256];
-            if (ds4_dist_session_create(&s->distributed,
-                                        e,
-                                        &e->distributed,
-                                        s,
-                                        ctx_size,
-                                        err,
-                                        sizeof(err)) != 0) {
-                fprintf(stderr,
-                        "ds4: failed to create distributed coordinator session: %s\n",
-                        err[0] ? err : "unknown error");
-                glm_graph_free(&s->glm_graph);
-                free(s->glm_mtp_hc);
-                free(s->glm_mtp_logits0);
-                free(s->logits);
-                free(s->sample_probs);
-                free(s);
-                return 1;
-            }
+        if (e->distributed.role == DS4_DISTRIBUTED_COORDINATOR &&
+            ds4_session_attach_distributed(s, e, ctx_size) != 0) {
+            glm_graph_free(&s->glm_graph);
+            free(s->glm_mtp_hc);
+            free(s->glm_mtp_logits0);
+            free(s->logits);
+            free(s->sample_probs);
+            free(s);
+            return 1;
         }
         if (!ds4_session_tp_register(s)) {
             ds4_session_free(s);
@@ -59024,28 +59041,17 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
         s->mtp_logits = xmalloc((size_t)DS4_N_VOCAB * sizeof(s->mtp_logits[0]));
         s->mtp_draft_token = -1;
     }
-    if (e->distributed.role == DS4_DISTRIBUTED_COORDINATOR) {
-        char err[256];
-        if (ds4_dist_session_create(&s->distributed,
-                                    e,
-                                    &e->distributed,
-                                    s,
-                                    ctx_size,
-                                    err,
-                                    sizeof(err)) != 0) {
-            fprintf(stderr,
-                    "ds4: failed to create distributed coordinator session: %s\n",
-                    err[0] ? err : "unknown error");
-            metal_graph_free(&s->graph);
-            free(s->logits);
-            free(s->sample_probs);
-            free(s->mtp_logits);
-            free(s->spec_row_logits);
-            free(s->dspark_markov_bias);
-            free(s->dspark_conf_features);
-            free(s);
-            return 1;
-        }
+    if (e->distributed.role == DS4_DISTRIBUTED_COORDINATOR &&
+        ds4_session_attach_distributed(s, e, ctx_size) != 0) {
+        metal_graph_free(&s->graph);
+        free(s->logits);
+        free(s->sample_probs);
+        free(s->mtp_logits);
+        free(s->spec_row_logits);
+        free(s->dspark_markov_bias);
+        free(s->dspark_conf_features);
+        free(s);
+        return 1;
     }
     if (!ds4_session_tp_register(s)) {
         ds4_session_free(s);

--- a/ds4.c
+++ b/ds4.c
@@ -61967,6 +61967,20 @@ int ds4_session_eval(ds4_session *s, int token, char *err, size_t errlen) {
     return ds4_session_eval_probe_tp(s, token, probe_mtp, err, errlen);
 }
 
+/* A distributed coordinator maps only its own --layers slice, but the batch
+ * encoders below build a full local decode graph per session and would walk
+ * layers this process never loaded.  Those sessions take the serialized
+ * fallback instead, which routes each token over the wire.
+ * ds4_sessions_eval_batch_metal_supported() refuses them for the same reason;
+ * the CUDA path, which ROCm also uses, needs the same exclusion. */
+static bool ds4_decode_batch_has_distributed(const ds4_decode_item *items,
+                                             int count) {
+    for (int i = 0; i < count; i++) {
+        if (items[i].session && items[i].session->distributed) return true;
+    }
+    return false;
+}
+
 #ifndef DS4_NO_GPU
 static bool ds4_sessions_eval_batch_metal_supported(
         ds4_decode_item *items,
@@ -62727,6 +62741,50 @@ static int ds4_sessions_eval_batch_with_prefill_cuda(
         char *err,
         size_t errlen);
 
+/* Adapt the engine's decode batch to the distributed one.  A mixed batch, where
+ * only some members are distributed, cannot happen: every session on a
+ * coordinator engine is distributed, and ds4_sessions_eval_batch() has already
+ * rejected members belonging to a different engine. */
+static int ds4_sessions_eval_batch_distributed(ds4_decode_item *items, int count,
+                                               char *err, size_t errlen) {
+    for (int i = 0; i < count; i++) {
+        ds4_session *s = items[i].session;
+        if (!s->distributed) {
+            if (err && errlen) {
+                snprintf(err, errlen,
+                         "decode batch item %d is not a distributed session", i);
+            }
+            return 1;
+        }
+        if (!s->checkpoint_valid) {
+            if (err && errlen) {
+                snprintf(err, errlen,
+                         "distributed decode requires a valid checkpoint");
+            }
+            return 1;
+        }
+    }
+
+    ds4_dist_decode_item *dist_items =
+        xmalloc((size_t)count * sizeof(*dist_items));
+    for (int i = 0; i < count; i++) {
+        ds4_session *s = items[i].session;
+        dist_items[i].dist = s->distributed;
+        dist_items[i].owner = s;
+        dist_items[i].checkpoint = &s->checkpoint;
+        dist_items[i].token = items[i].token;
+        dist_items[i].logits = s->logits;
+    }
+    int rc = ds4_dist_sessions_eval(dist_items, count, err, errlen);
+    free(dist_items);
+    if (rc != 0) {
+        /* Members can be left at different points in the timeline, so rebuild
+         * every one rather than expose a partially committed logical batch. */
+        for (int i = 0; i < count; i++) ds4_session_invalidate(items[i].session);
+    }
+    return rc;
+}
+
 int ds4_sessions_eval_batch(ds4_decode_item *items, int count,
                             char *err, size_t errlen) {
     if (!items || count <= 0) {
@@ -62775,6 +62833,14 @@ int ds4_sessions_eval_batch(ds4_decode_item *items, int count,
             }
             return 1;
         }
+    }
+
+    /* Distributed members spend most of a decode step blocked on a socket, not
+     * on this GPU. Hand them to the distributed batch, which submits every
+     * frame before collecting any result, instead of the serialized fallback
+     * below that pays one full round trip per member. */
+    if (ds4_decode_batch_has_distributed(items, count)) {
+        return ds4_sessions_eval_batch_distributed(items, count, err, errlen);
     }
 
 #ifndef DS4_NO_GPU
@@ -66345,20 +66411,6 @@ static bool metal_graph_eval_mixed_prefill_decode(
     return ok;
 }
 #endif
-
-/* A distributed coordinator maps only its own --layers slice, but the batch
- * encoders below build a full local decode graph per session and would walk
- * layers this process never loaded.  Those sessions take the serialized
- * fallback instead, which routes each token over the wire.
- * ds4_sessions_eval_batch_metal_supported() refuses them for the same reason;
- * the CUDA path, which ROCm also uses, needs the same exclusion. */
-static bool ds4_decode_batch_has_distributed(const ds4_decode_item *items,
-                                             int count) {
-    for (int i = 0; i < count; i++) {
-        if (items[i].session && items[i].session->distributed) return true;
-    }
-    return false;
-}
 
 static int ds4_sessions_eval_batch_cuda(ds4_decode_item *items, int count,
                             char *err, size_t errlen) {

--- a/ds4.h
+++ b/ds4.h
@@ -87,6 +87,11 @@ typedef struct {
     uint32_t prefill_chunk;
     uint32_t prefill_window;
     uint32_t activation_bits;
+    /* Worker only: the largest number of coordinator sessions this worker will
+     * hold at once.  A worker creates one session per session id it is sent and
+     * has no say in how many that is, so without a bound a coordinator with many
+     * resident slots walks it into an OOM kill. */
+    uint32_t max_sessions;
     bool replay_check;
     bool debug;
 } ds4_distributed_options;

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -8384,6 +8384,17 @@ int ds4_dist_prepare_engine_options(
             engine->load_layer_end = opt->layers.has_output ? UINT32_MAX : opt->layers.end;
             engine->load_output = opt->layers.has_output;
         }
+        /* A worker creates one session per coordinator session, on demand, and
+         * runs every eval on a single thread behind its state mutex.  That is
+         * the same serialization the server relies on when it aliases this
+         * workspace across resident sessions, so the worker can alias it too.
+         * Without this each worker session allocates its own prefill workspace
+         * and a coordinator with several sessions OOMs the worker, which has no
+         * say in how many sessions it is asked to hold.
+         */
+        if (opt->role == DS4_DISTRIBUTED_WORKER) {
+            engine->share_session_prefill_workspace = true;
+        }
     }
     return 0;
 }

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -4335,10 +4335,30 @@ static void *dist_coordinator_accept_main(void *arg) {
     return NULL;
 }
 
+/* Workers key their KV timelines by session id, in one table shared by every
+ * connection, so two live sessions that pick the same id silently merge their
+ * KV and corrupt both.  time(), getpid(), a heap address and clock() do not
+ * guarantee a difference between sessions built back to back in one process:
+ * they share the pid, can land in the same second and the same clock tick, and
+ * malloc can hand back an address a freed session just released.
+ *
+ * Reserve the low 16 bits for a per-process counter.  The upper bits still
+ * separate coordinators across hosts and restarts; collisions inside one
+ * coordinator become impossible rather than unlikely.  There are no atomics in
+ * this file and it stays C99, so the counter sits behind a mutex.
+ */
 static uint64_t dist_make_session_id(const void *ptr) {
+    static pthread_mutex_t seq_mu = PTHREAD_MUTEX_INITIALIZER;
+    static uint64_t seq = 0;
+
+    pthread_mutex_lock(&seq_mu);
+    const uint64_t n = ++seq;
+    pthread_mutex_unlock(&seq_mu);
+
     uint64_t id = ((uint64_t)(uint32_t)time(NULL) << 32) ^ (uint64_t)getpid();
     id ^= ((uint64_t)(uintptr_t)ptr << 17) ^ (uint64_t)(uintptr_t)ptr;
     id ^= (uint64_t)clock();
+    id = (id & ~UINT64_C(0xffff)) | (n & UINT64_C(0xffff));
     return id ? id : 1u;
 }
 
@@ -5528,6 +5548,9 @@ int ds4_dist_session_create(
      * WORK results are outstanding.  Keep them out of the WORK request-id stream
      * so progress callbacks cannot perturb the reader's contiguous expectations. */
     d->snapshot_request_id = UINT64_C(1) << 63;
+    DIST_COORD_DEBUG(&coord->state,
+                     "ds4: distributed coordinator API: session id=0x%016llx\n",
+                     (unsigned long long)d->session_id);
     *out = d;
     return 0;
 }

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -2611,6 +2611,81 @@ static int dist_coordinator_send_remote_work_on_fd(
     return 0;
 }
 
+/* Collect one already-submitted WORK result and turn it into logits.
+ *
+ * Split out of dist_coordinator_eval_remote_on_fd() so a batch can submit every
+ * member's frame before waiting on any of them.  A distributed decode is a
+ * local layer slice on this GPU followed by a wait on the socket, and the wait
+ * is the larger half, so collecting in submit order costs the maximum of the
+ * waits rather than their sum.
+ */
+static int dist_coordinator_finish_remote_on_fd(
+        ds4_dist_coordinator_state *state,
+        ds4_session *session,
+        int fd,
+        uint32_t n_tokens,
+        uint64_t request_id,
+        uint64_t expected_result_hash,
+        uint32_t hidden_hc_bytes,
+        float *logits,
+        char *err,
+        size_t errlen) {
+    const bool profile = dist_decode_profile_enabled() && n_tokens == 1;
+    const double recv_t0 = profile ? dist_now_sec() : 0.0;
+    uint32_t kind = 0, payload_bytes = 0;
+    uint64_t result_hash = 0;
+    void *payload = NULL;
+    int rc = dist_recv_result_alloc(fd,
+                                    state,
+                                    request_id,
+                                    &kind,
+                                    &result_hash,
+                                    &payload,
+                                    &payload_bytes,
+                                    err,
+                                    errlen);
+    if (profile) {
+        fprintf(stderr,
+                "ds4: dist decode profile: remote request=%llu wait_result=%.3fms kind=%u payload=%.2fMiB\n",
+                (unsigned long long)request_id,
+                (dist_now_sec() - recv_t0) * 1000.0,
+                kind,
+                (double)payload_bytes / (1024.0 * 1024.0));
+    }
+    if (rc != 0) return rc;
+    if (result_hash != expected_result_hash) {
+        free(payload);
+        if (errlen) snprintf(err, errlen, "distributed result prefix hash mismatch");
+        return 1;
+    }
+
+    const uint32_t logits_bytes =
+        (uint32_t)((uint64_t)ds4_engine_vocab_size(state->engine) * sizeof(float));
+    if (kind == DS4_DIST_RESULT_LOGITS && payload_bytes == logits_bytes) {
+        memcpy(logits, payload, logits_bytes);
+        free(payload);
+        return 0;
+    }
+    if (kind == DS4_DIST_RESULT_HIDDEN_STATE && payload_bytes == hidden_hc_bytes) {
+        int head_rc = ds4_session_eval_output_head_from_hc(session,
+                                                           payload,
+                                                           n_tokens,
+                                                           logits,
+                                                           err,
+                                                           errlen);
+        free(payload);
+        return head_rc;
+    }
+    if (kind == DS4_DIST_RESULT_HIDDEN_STATE) {
+        free(payload);
+        if (errlen) snprintf(err, errlen, "distributed route returned invalid hidden-state size");
+        return 1;
+    }
+    free(payload);
+    if (errlen) snprintf(err, errlen, "distributed route did not return logits or hidden-state");
+    return 1;
+}
+
 static int dist_coordinator_eval_remote_on_fd(
         ds4_dist_coordinator_state *state,
         ds4_session *session,
@@ -2629,9 +2704,6 @@ static int dist_coordinator_eval_remote_on_fd(
         float *logits,
         char *err,
         size_t errlen) {
-    const bool profile = dist_decode_profile_enabled() && n_tokens == 1;
-    const double total_t0 = profile ? dist_now_sec() : 0.0;
-    const double send_t0 = profile ? dist_now_sec() : 0.0;
     int rc = dist_coordinator_send_remote_work_on_fd(state,
                                                      plan,
                                                      fd,
@@ -2648,83 +2720,17 @@ static int dist_coordinator_eval_remote_on_fd(
                                                      hidden_hc_bytes,
                                                      err,
                                                      errlen);
-    const double send_t1 = profile ? dist_now_sec() : 0.0;
-    uint32_t kind = 0, payload_bytes = 0;
-    uint64_t result_hash = 0;
-    void *payload = NULL;
-    if (rc == 0) {
-        const double recv_t0 = profile ? dist_now_sec() : 0.0;
-        rc = dist_recv_result_alloc(fd,
-                                    state,
-                                    request_id,
-                                    &kind,
-                                    &result_hash,
-                                    &payload,
-                                    &payload_bytes,
-                                    err,
-                                    errlen);
-        const double recv_t1 = profile ? dist_now_sec() : 0.0;
-        if (profile) {
-            fprintf(stderr,
-                    "ds4: dist decode profile: remote request=%llu pos=%u send=%.3fms wait_result=%.3fms kind=%u payload=%.2fMiB\n",
-                    (unsigned long long)request_id,
-                    pos0,
-                    (send_t1 - send_t0) * 1000.0,
-                    (recv_t1 - recv_t0) * 1000.0,
-                    kind,
-                    (double)payload_bytes / (1024.0 * 1024.0));
-        }
-    }
     if (rc != 0) return rc;
-    if (result_hash != expected_result_hash) {
-        free(payload);
-        if (errlen) snprintf(err, errlen, "distributed result prefix hash mismatch");
-        return 1;
-    }
-
-    const uint32_t logits_bytes = (uint32_t)((uint64_t)ds4_engine_vocab_size(state->engine) * sizeof(float));
-    if (kind == DS4_DIST_RESULT_LOGITS && payload_bytes == logits_bytes) {
-        const double copy_t0 = profile ? dist_now_sec() : 0.0;
-        memcpy(logits, payload, logits_bytes);
-        free(payload);
-        if (profile) {
-            const double copy_t1 = dist_now_sec();
-            fprintf(stderr,
-                    "ds4: dist decode profile: remote request=%llu copy_logits=%.3fms total=%.3fms\n",
-                    (unsigned long long)request_id,
-                    (copy_t1 - copy_t0) * 1000.0,
-                    (copy_t1 - total_t0) * 1000.0);
-        }
-        return 0;
-    }
-    if (kind == DS4_DIST_RESULT_HIDDEN_STATE && payload_bytes == hidden_hc_bytes) {
-        const double head_t0 = profile ? dist_now_sec() : 0.0;
-        int head_rc = ds4_session_eval_output_head_from_hc(session,
-                                                           payload,
-                                                           n_tokens,
-                                                           logits,
-                                                           err,
-                                                           errlen);
-        free(payload);
-        if (profile) {
-            const double head_t1 = dist_now_sec();
-            fprintf(stderr,
-                    "ds4: dist decode profile: remote request=%llu output_head=%.3fms total=%.3fms rc=%d\n",
-                    (unsigned long long)request_id,
-                    (head_t1 - head_t0) * 1000.0,
-                    (head_t1 - total_t0) * 1000.0,
-                    head_rc);
-        }
-        return head_rc;
-    }
-    if (kind == DS4_DIST_RESULT_HIDDEN_STATE) {
-        free(payload);
-        if (errlen) snprintf(err, errlen, "distributed route returned invalid hidden-state size");
-        return 1;
-    }
-    free(payload);
-    if (errlen) snprintf(err, errlen, "distributed route did not return logits or hidden-state");
-    return 1;
+    return dist_coordinator_finish_remote_on_fd(state,
+                                                session,
+                                                fd,
+                                                n_tokens,
+                                                request_id,
+                                                expected_result_hash,
+                                                hidden_hc_bytes,
+                                                logits,
+                                                err,
+                                                errlen);
 }
 
 static int dist_coordinator_eval_span(
@@ -5762,6 +5768,220 @@ int ds4_dist_session_sync(
             return 1;
         }
         d->plan_ready = true;
+    }
+    return 0;
+}
+
+/* One decode step across several coordinator sessions at once.
+ *
+ * A distributed decode is a local layer slice on this GPU and then a wait on
+ * the socket, and the wait is the larger half: 34 ms local against 44 ms
+ * blocked, measured on the two-node LAN rig at Flash Q4. Evaluating sessions
+ * one at a time therefore leaves both GPUs idle for most of a step, and the
+ * waste grows with the number of stages.
+ *
+ * Every member's WORK frame is submitted before any result is collected, so the
+ * remote waits overlap each other and the remaining local slices. Local slices
+ * stay serialized -- there is one GPU, and each member's slice commits its own
+ * session timeline before the next one starts.
+ *
+ * Ordering that makes this safe: each session owns its connection, so the
+ * frames of one session never interleave with another's, and each session's
+ * prefix hash is read before its own slice commits.
+ */
+/* Per-member state for one batched decode step. */
+typedef struct {
+    uint64_t request_id;
+    uint64_t result_hash;
+    bool submitted;
+    int rc;
+} ds4_dist_batch_member;
+
+/* Submit one member: local layer slice on this GPU, then its WORK frame.
+ *
+ * The prefix hash is read before the slice runs, because the slice commits this
+ * session's timeline (ds4_session_eval_layer_slice -> slice_commit_timeline) and
+ * the hash must describe the state the worker is expected to be in.
+ */
+static int dist_batch_submit_member(
+        ds4_dist_coordinator_state *state,
+        const ds4_dist_decode_item *item,
+        ds4_dist_batch_member *member,
+        float *hidden,
+        uint32_t hidden_bytes,
+        char *err,
+        size_t errlen) {
+    ds4_dist_session *d = item->dist;
+    if (dist_session_ensure_route(d, err, errlen) != 0) return 1;
+
+    const uint32_t pos0 = (uint32_t)item->checkpoint->len;
+    uint64_t prefix_hash = DS4_DIST_TOKEN_HASH_INIT;
+    if (dist_session_token_hash_prefix(item->owner, pos0, &prefix_hash,
+                                       err, errlen) != 0) {
+        return 1;
+    }
+
+    /* A route with no remote hop means the whole model is local: an ordinary
+     * decode, with nothing to overlap. */
+    if (d->plan.count == 0) {
+        return ds4_session_eval_layer_slice(item->owner, &item->token, 1, pos0,
+                                            state->local_start, state->local_end,
+                                            NULL, NULL, true, item->logits,
+                                            err, errlen);
+    }
+
+    member->result_hash = dist_token_hash_update_span(prefix_hash, &item->token, 1);
+    member->request_id = d->request_id++;
+    if (ds4_session_eval_layer_slice(item->owner, &item->token, 1, pos0,
+                                     state->local_start, state->local_end,
+                                     NULL, hidden, false, NULL,
+                                     err, errlen) != 0) {
+        return 1;
+    }
+    if (dist_coordinator_send_remote_work_on_fd(
+            state, &d->plan, d->plan.entry[0].fd, &item->token, 1, pos0,
+            d->session_id, member->request_id, prefix_hash, member->result_hash,
+            false, false, hidden, hidden_bytes, err, errlen) != 0) {
+        return 1;
+    }
+    member->submitted = true;
+    return 0;
+}
+
+/* Rebuild one member that failed, exactly as the single-session path does, so a
+ * transient worker fault stays invisible to the client rather than becoming a
+ * failed request because batching happened to be active.
+ */
+static int dist_batch_recover_member(
+        ds4_dist_coordinator_state *state,
+        const ds4_dist_decode_item *item,
+        int member_rc,
+        char *err,
+        size_t errlen) {
+    ds4_dist_session *d = item->dist;
+    ds4_tokens transcript = {0};
+    ds4_tokens_copy(&transcript, item->checkpoint);
+    ds4_tokens_push(&transcript, item->token);
+    int rc = dist_coordinator_rebuild_from_transcript(
+            state, item->owner, &d->plan, &transcript, d->session_id,
+            &d->request_id, item->logits, &d->plan_generation,
+            member_rc != DS4_DIST_RECV_REMOTE_ERROR, err, errlen);
+    ds4_tokens_free(&transcript);
+    if (rc == 0) {
+        d->plan_ready = true;
+    } else {
+        d->plan_ready = false;
+        d->plan_generation = 0;
+    }
+    return rc;
+}
+
+/* One decode step across several coordinator sessions at once.
+ *
+ * A distributed decode is a local layer slice on this GPU and then a wait on
+ * the socket, and the wait is the larger half: 34 ms local against 44 ms
+ * blocked, measured on the two-node LAN rig at Flash Q4. Evaluating sessions one
+ * at a time therefore leaves both GPUs idle for most of a step, and the waste
+ * grows with the number of stages.
+ *
+ * Every member's frame is submitted before any result is collected, so the
+ * remote waits overlap each other and the remaining local slices. Local slices
+ * stay serialized -- there is one GPU. Each session owns its connection, so the
+ * frames of one never interleave with another's.
+ */
+int ds4_dist_sessions_eval(
+        ds4_dist_decode_item *items,
+        int count,
+        char *err,
+        size_t errlen) {
+    if (!items || count <= 0) {
+        if (errlen) snprintf(err, errlen, "empty distributed decode batch");
+        return 1;
+    }
+    if (count == 1) {
+        return ds4_dist_session_eval(items[0].dist, items[0].owner,
+                                     items[0].checkpoint, items[0].token,
+                                     items[0].logits, err, errlen);
+    }
+
+    ds4_dist_coordinator_state *state = &items[0].dist->coord->state;
+    const uint64_t hidden_bytes64 =
+        ds4_engine_hidden_f32_values(state->engine) * sizeof(float);
+    if (hidden_bytes64 > UINT32_MAX) {
+        if (errlen) snprintf(err, errlen, "distributed coordinator hidden-state chunk is too large");
+        return 1;
+    }
+    const uint32_t hidden_bytes = (uint32_t)hidden_bytes64;
+
+    /* One hidden-state buffer serves the whole batch: a slice writes it and the
+     * following send drains it into the socket before the next slice runs.
+     *
+     * That is safe because a slice is complete when it returns, on every
+     * backend: ds4_session_eval_layer_slice() ends in ds4_gpu_end_commands(),
+     * which waits on the command buffer under Metal and synchronizes the
+     * device or stream under CUDA and ROCm.  If a backend ever made that
+     * asynchronous, this buffer would need to be one per member. */
+    float *hidden = malloc(hidden_bytes);
+    ds4_dist_batch_member *members = calloc((size_t)count, sizeof(members[0]));
+    if (!hidden || !members) {
+        free(hidden);
+        free(members);
+        if (errlen) snprintf(err, errlen, "out of memory preparing distributed decode batch");
+        return 1;
+    }
+
+    char first_err[256];
+    first_err[0] = '\0';
+    int failed = 0;
+
+    for (int i = 0; i < count; i++) {
+        char member_err[256];
+        member_err[0] = '\0';
+        members[i].rc = dist_batch_submit_member(state, &items[i], &members[i],
+                                                 hidden, hidden_bytes,
+                                                 member_err, sizeof(member_err));
+        if (members[i].rc != 0 && !failed++) {
+            snprintf(first_err, sizeof(first_err), "%s", member_err);
+        }
+    }
+
+    /* Collect every submitted member even when a peer has already failed, so no
+     * connection is left holding an unread result. */
+    for (int i = 0; i < count; i++) {
+        if (!members[i].submitted) continue;
+        char member_err[256];
+        member_err[0] = '\0';
+        int rc = dist_coordinator_finish_remote_on_fd(
+                state, items[i].owner, items[i].dist->plan.entry[0].fd, 1,
+                members[i].request_id, members[i].result_hash, hidden_bytes,
+                items[i].logits, member_err, sizeof(member_err));
+        if (rc != 0) {
+            members[i].rc = rc;
+            if (!failed++) snprintf(first_err, sizeof(first_err), "%s", member_err);
+        }
+    }
+
+    for (int i = 0; i < count && failed; i++) {
+        if (members[i].rc == 0) continue;
+        char member_err[256];
+        member_err[0] = '\0';
+        if (dist_batch_recover_member(state, &items[i], members[i].rc,
+                                      member_err, sizeof(member_err)) == 0) {
+            members[i].rc = 0;
+            failed--;
+        } else {
+            snprintf(first_err, sizeof(first_err), "%s", member_err);
+        }
+    }
+
+    free(hidden);
+    free(members);
+    if (failed) {
+        if (errlen) {
+            snprintf(err, errlen, "%s",
+                     first_err[0] ? first_err : "distributed decode batch failed");
+        }
+        return 1;
     }
     return 0;
 }

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -2354,13 +2354,39 @@ static int dist_logits_argmax(const float *logits, int n_vocab) {
     return best;
 }
 
+/* Builds the plan, then gives it its own connection to the first hop.
+ *
+ * The dial sits here and not in dist_coordinator_build_route_plan() because
+ * that runs with the registry mutex held, and a TCP connect must not block
+ * worker registration.  Every caller that produces a usable plan goes through
+ * this function, including the recovery path in
+ * dist_coordinator_rebuild_from_transcript(), so every plan gets a connection.
+ */
 static bool dist_coordinator_ensure_route(
         ds4_dist_coordinator_state *state,
         ds4_dist_route_plan *plan,
         uint64_t *generation,
         char *err,
         size_t errlen) {
-    return dist_coordinator_build_route_plan(state, plan, generation, err, errlen);
+    if (!dist_coordinator_build_route_plan(state, plan, generation, err, errlen)) {
+        return false;
+    }
+    /* count == 0 is a local-only route; fd >= 0 is the one-shot coordinator's
+     * dup() of the control link. */
+    if (plan->count == 0 || plan->entry[0].fd >= 0) return true;
+
+    int fd = dist_connect_endpoint(plan->entry[0].host,
+                                   (int)plan->entry[0].port,
+                                   err,
+                                   errlen);
+    if (fd < 0) {
+        dist_route_plan_free(plan);
+        if (generation) *generation = 0;
+        return false;
+    }
+    dist_set_socket_low_latency(fd);
+    plan->entry[0].fd = fd;
+    return true;
 }
 
 static uint64_t dist_coordinator_generation(ds4_dist_coordinator_state *state) {
@@ -5492,7 +5518,14 @@ int ds4_dist_coordinator_open(
     c->state.local_can_output_head = ds4_engine_has_output_head(engine);
     c->state.replay_check = opt->replay_check;
     c->state.debug = opt->debug;
-    c->state.use_control_for_work = true;
+    /* The control link carries HELLO and liveness for one registry entry, but
+     * WORK is per session: several sessions writing frames onto one stream
+     * would interleave, since a frame is several sequential writes.  Each
+     * session dials the worker's data port instead.  The standalone one-shot
+     * coordinator keeps the control link -- it runs a single session in its own
+     * process, so sharing is safe there and it saves a connect.
+     */
+    c->state.use_control_for_work = false;
     c->state.prefill_chunk = opt->prefill_chunk;
     c->state.prefill_window = opt->prefill_window;
     c->state.activation_bits = dist_activation_bits_or_default(opt->activation_bits);

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -383,12 +383,25 @@ typedef struct {
     uint64_t tensor_bytes;
 } ds4_dist_kv_shard_file;
 
-struct ds4_dist_session {
+/* The listener, the accept loop and the worker registry describe the cluster
+ * this process joined, not any one session, so the engine owns one of these and
+ * every coordinator session borrows it.  Binding them per session used to cap a
+ * coordinator at one resident session: the second bind hit EADDRINUSE.
+ */
+struct ds4_dist_coordinator {
     ds4_dist_coordinator_state state;
     int listen_fd;
     pthread_t accept_tid;
     bool accept_started;
     ds4_dist_accept_ctx accept_ctx;
+};
+
+struct ds4_dist_session {
+    ds4_dist_coordinator *coord;
+    /* The plan stays per session because it owns a dup() of the first hop's
+     * descriptor.  One plan behind several sessions would put several writers
+     * on one stream, and a WORK frame is several sequential writes.
+     */
     ds4_dist_route_plan plan;
     bool plan_ready;
     uint64_t plan_generation;
@@ -4334,10 +4347,10 @@ static int dist_session_ensure_route(ds4_dist_session *d, char *err, size_t errl
         if (errlen) snprintf(err, errlen, "missing distributed session");
         return 1;
     }
-    uint64_t generation = dist_coordinator_generation(&d->state);
+    uint64_t generation = dist_coordinator_generation(&d->coord->state);
     if (d->plan_ready && d->plan_generation == generation) return 0;
     dist_route_plan_free(&d->plan);
-    if (!dist_coordinator_ensure_route(&d->state, &d->plan, &generation, err, errlen)) {
+    if (!dist_coordinator_ensure_route(&d->coord->state, &d->plan, &generation, err, errlen)) {
         d->plan_ready = false;
         d->plan_generation = 0;
         return 1;
@@ -4878,8 +4891,8 @@ static void dist_kv_route_shard(
         const ds4_dist_route_entry **entry) {
     if (entry) *entry = NULL;
     if (shard == 0) {
-        if (layer_start) *layer_start = d->state.local_start;
-        if (layer_end) *layer_end = d->state.local_end;
+        if (layer_start) *layer_start = d->coord->state.local_start;
+        if (layer_end) *layer_end = d->coord->state.local_end;
         return;
     }
     const ds4_dist_route_entry *e = &d->plan.entry[shard - 1u];
@@ -4892,25 +4905,25 @@ static int dist_kv_route_validate(
         const ds4_dist_session *d,
         char *err,
         size_t errlen) {
-    if (!d || d->state.n_layers == 0 ||
-        d->state.local_start != 0 ||
-        d->state.local_end >= d->state.n_layers) {
+    if (!d || d->coord->state.n_layers == 0 ||
+        d->coord->state.local_start != 0 ||
+        d->coord->state.local_end >= d->coord->state.n_layers) {
         if (errlen) snprintf(err, errlen, "distributed KV route does not start at layer 0");
         return 1;
     }
-    uint32_t prev = d->state.local_end;
+    uint32_t prev = d->coord->state.local_end;
     for (uint32_t i = 0; i < d->plan.count; i++) {
         const ds4_dist_route_entry *e = &d->plan.entry[i];
         if (prev == UINT32_MAX ||
             e->layer_start != prev + 1u ||
             e->layer_end < e->layer_start ||
-            e->layer_end >= d->state.n_layers) {
+            e->layer_end >= d->coord->state.n_layers) {
             if (errlen) snprintf(err, errlen, "distributed KV route is not contiguous");
             return 1;
         }
         prev = e->layer_end;
     }
-    if (prev + 1u != d->state.n_layers) {
+    if (prev + 1u != d->coord->state.n_layers) {
         if (errlen) snprintf(err, errlen, "distributed KV route does not cover all layers");
         return 1;
     }
@@ -4940,7 +4953,7 @@ static int dist_save_remote_shard_to_file(
 
     ds4_dist_snapshot_req_fixed req;
     memset(&req, 0, sizeof(req));
-    req.model_id = d->state.model_id;
+    req.model_id = d->coord->state.model_id;
     dist_u64_to_halves(d->session_id, &req.session_hi, &req.session_lo);
     dist_u64_to_halves(request_id, &req.request_hi, &req.request_lo);
     dist_u64_to_halves(token_hash, &req.token_hash_hi, &req.token_hash_lo);
@@ -4972,7 +4985,7 @@ static int dist_save_remote_shard_to_file(
     uint64_t got_session = dist_u64_from_halves(begin.session_hi, begin.session_lo);
     uint64_t got_request = dist_u64_from_halves(begin.request_hi, begin.request_lo);
     uint64_t got_hash = dist_u64_from_halves(begin.token_hash_hi, begin.token_hash_lo);
-    if (begin.model_id != d->state.model_id ||
+    if (begin.model_id != d->coord->state.model_id ||
         got_session != d->session_id ||
         got_request != request_id ||
         got_hash != token_hash ||
@@ -5019,7 +5032,7 @@ static int dist_prepare_shard_from_session_payload(
         goto cleanup;
     for (uint32_t il = layer_start; il <= layer_end; il++) {
         uint64_t layer_bytes = 0;
-        if (!dist_kv_layer_tensor_bytes(d->state.engine, layout, il,
+        if (!dist_kv_layer_tensor_bytes(d->coord->state.engine, layout, il,
                                         n_comp[il], n_index_comp[il],
                                         &layer_bytes)) {
             if (errlen) snprintf(err, errlen, "distributed KV layer byte count overflow");
@@ -5057,7 +5070,7 @@ static int dist_load_remote_shard_from_payload(
 
     ds4_dist_snapshot_begin_fixed begin;
     memset(&begin, 0, sizeof(begin));
-    begin.model_id = d->state.model_id;
+    begin.model_id = d->coord->state.model_id;
     dist_u64_to_halves(d->session_id, &begin.session_hi, &begin.session_lo);
     dist_u64_to_halves(request_id, &begin.request_hi, &begin.request_lo);
     dist_u64_to_halves(token_hash, &begin.token_hash_hi, &begin.token_hash_lo);
@@ -5109,7 +5122,7 @@ int ds4_dist_session_save_payload(
     }
     const uint32_t token_count = (uint32_t)tokens->len;
     const uint64_t token_hash = dist_token_hash_prefix(tokens->v, token_count);
-    const uint32_t vocab = (uint32_t)ds4_engine_vocab_size(d->state.engine);
+    const uint32_t vocab = (uint32_t)ds4_engine_vocab_size(d->coord->state.engine);
     float *logits = malloc((size_t)vocab * sizeof(logits[0]));
     if (!logits) {
         if (errlen) snprintf(err, errlen, "out of memory saving distributed logits");
@@ -5123,8 +5136,8 @@ int ds4_dist_session_save_payload(
 
     const uint32_t shard_count = dist_kv_route_shard_count(d);
     ds4_dist_kv_shard_file *shards = calloc(shard_count, sizeof(shards[0]));
-    uint32_t *n_comp = calloc(d->state.n_layers, sizeof(n_comp[0]));
-    uint32_t *n_index_comp = calloc(d->state.n_layers, sizeof(n_index_comp[0]));
+    uint32_t *n_comp = calloc(d->coord->state.n_layers, sizeof(n_comp[0]));
+    uint32_t *n_index_comp = calloc(d->coord->state.n_layers, sizeof(n_index_comp[0]));
     if (!shards || !n_comp || !n_index_comp) {
         free(logits);
         free(shards);
@@ -5163,7 +5176,7 @@ int ds4_dist_session_save_payload(
             if (errlen) snprintf(err, errlen, "distributed KV shard is empty");
             goto cleanup;
         }
-        if (dist_kv_parse_layer_payload(d->state.engine,
+        if (dist_kv_parse_layer_payload(d->coord->state.engine,
                                         shards[shard].fp,
                                         shards[shard].bytes,
                                         layer_start,
@@ -5178,7 +5191,7 @@ int ds4_dist_session_save_payload(
             goto cleanup;
     }
     if (!layout_set || layout.token_count != token_count ||
-        layout.n_layers != d->state.n_layers ||
+        layout.n_layers != d->coord->state.n_layers ||
         layout.vocab != vocab) {
         if (errlen) snprintf(err, errlen, "distributed KV shard metadata mismatch");
         goto cleanup;
@@ -5260,11 +5273,11 @@ int ds4_dist_session_load_payload(
         .vocab = h[11],
         .raw_live = h[12],
     };
-    if (layout.n_layers != d->state.n_layers ||
+    if (layout.n_layers != d->coord->state.n_layers ||
         layout.ctx > (uint32_t)ds4_session_ctx(owner) ||
         layout.token_count >= (uint32_t)ds4_session_ctx(owner) ||
-        layout.vocab != (uint32_t)ds4_engine_vocab_size(d->state.engine) ||
-        !dist_kv_raw_live_valid(d->state.engine, &layout)) {
+        layout.vocab != (uint32_t)ds4_engine_vocab_size(d->coord->state.engine) ||
+        !dist_kv_raw_live_valid(d->coord->state.engine, &layout)) {
         if (errlen) snprintf(err, errlen, "DS4 KV payload does not match current distributed runtime");
         return 1;
     }
@@ -5292,7 +5305,7 @@ int ds4_dist_session_load_payload(
             return 1;
         }
         if (tok > (uint32_t)INT_MAX ||
-            tok >= (uint32_t)ds4_engine_vocab_size(d->state.engine)) {
+            tok >= (uint32_t)ds4_engine_vocab_size(d->coord->state.engine)) {
             free(tokens);
             free(logits);
             free(n_comp);
@@ -5399,17 +5412,15 @@ cleanup:
  * selects these calls when the owning session has a coordinator attached.
  */
 
-int ds4_dist_session_create(
-        ds4_dist_session **out,
+int ds4_dist_coordinator_open(
+        ds4_dist_coordinator **out,
         ds4_engine *engine,
         const ds4_dist_options *opt,
-        ds4_session *owner,
         int ctx_size,
         char *err,
         size_t errlen) {
-    (void)owner;
     if (!out || !engine || !opt) {
-        if (errlen) snprintf(err, errlen, "missing distributed session parameters");
+        if (errlen) snprintf(err, errlen, "missing distributed coordinator parameters");
         return 1;
     }
     *out = NULL;
@@ -5422,81 +5433,112 @@ int ds4_dist_session_create(
     int listen_fd = dist_open_listener(opt->listen_host, opt->listen_port, err, errlen);
     if (listen_fd < 0) return 1;
 
-    ds4_dist_session *d = calloc(1, sizeof(*d));
-    if (!d) {
+    ds4_dist_coordinator *c = calloc(1, sizeof(*c));
+    if (!c) {
         close(listen_fd);
-        if (errlen) snprintf(err, errlen, "out of memory creating distributed session");
+        if (errlen) snprintf(err, errlen, "out of memory creating distributed coordinator");
         return 1;
     }
 
-    d->listen_fd = listen_fd;
-    d->state.engine = engine;
-    d->state.model_id = (uint32_t)ds4_engine_model_id(engine);
-    d->state.n_layers = (uint32_t)ds4_engine_layer_count(engine);
-    d->state.local_start = opt->layers.start;
-    d->state.local_end = dist_resolved_layer_end(opt, d->state.n_layers);
-    d->state.ctx_size = ctx_size > 0 ? (uint32_t)ctx_size : 0u;
-    d->state.local_has_output = opt->layers.has_output;
-    d->state.local_can_output_head = ds4_engine_has_output_head(engine);
-    d->state.replay_check = opt->replay_check;
-    d->state.debug = opt->debug;
-    d->state.use_control_for_work = true;
-    d->state.prefill_chunk = opt->prefill_chunk;
-    d->state.prefill_window = opt->prefill_window;
-    d->state.activation_bits = dist_activation_bits_or_default(opt->activation_bits);
-    pthread_mutex_init(&d->state.mu, NULL);
+    c->listen_fd = listen_fd;
+    c->state.engine = engine;
+    c->state.model_id = (uint32_t)ds4_engine_model_id(engine);
+    c->state.n_layers = (uint32_t)ds4_engine_layer_count(engine);
+    c->state.local_start = opt->layers.start;
+    c->state.local_end = dist_resolved_layer_end(opt, c->state.n_layers);
+    c->state.ctx_size = ctx_size > 0 ? (uint32_t)ctx_size : 0u;
+    c->state.local_has_output = opt->layers.has_output;
+    c->state.local_can_output_head = ds4_engine_has_output_head(engine);
+    c->state.replay_check = opt->replay_check;
+    c->state.debug = opt->debug;
+    c->state.use_control_for_work = true;
+    c->state.prefill_chunk = opt->prefill_chunk;
+    c->state.prefill_window = opt->prefill_window;
+    c->state.activation_bits = dist_activation_bits_or_default(opt->activation_bits);
+    pthread_mutex_init(&c->state.mu, NULL);
+
+    char local_end[32];
+    if (opt->layers.has_output) snprintf(local_end, sizeof(local_end), "output");
+    else snprintf(local_end, sizeof(local_end), "%u", opt->layers.end);
+    DIST_COORD_DEBUG(&c->state,
+                     "ds4: distributed coordinator API: listening on %s:%d model_id=%u layers=%u local=%u:%s activation_bits=%u\n",
+                     opt->listen_host,
+                     opt->listen_port,
+                     c->state.model_id,
+                     c->state.n_layers,
+                     opt->layers.start,
+                     local_end,
+                     c->state.activation_bits);
+
+    c->accept_ctx.state = &c->state;
+    c->accept_ctx.listen_fd = listen_fd;
+    if (pthread_create(&c->accept_tid, NULL, dist_coordinator_accept_main, &c->accept_ctx) != 0) {
+        close(listen_fd);
+        pthread_mutex_destroy(&c->state.mu);
+        free(c);
+        if (errlen) snprintf(err, errlen, "failed to start distributed coordinator accept loop");
+        return 1;
+    }
+    pthread_detach(c->accept_tid);
+    c->accept_started = true;
+    *out = c;
+    return 0;
+}
+
+void ds4_dist_coordinator_close(ds4_dist_coordinator *c) {
+    if (!c) return;
+    if (c->listen_fd >= 0) {
+        shutdown(c->listen_fd, SHUT_RDWR);
+        close(c->listen_fd);
+        c->listen_fd = -1;
+    }
+    pthread_mutex_lock(&c->state.mu);
+    c->state.shutting_down = true;
+    for (ds4_dist_worker_entry *it = c->state.workers; it; it = it->next) {
+        if (it->fd >= 0) shutdown(it->fd, SHUT_RDWR);
+    }
+    pthread_mutex_unlock(&c->state.mu);
+    /* The accept loop and the per-worker client threads are detached and keep
+     * using this registry and its mutex while they unwind.  Keep the object
+     * itself process-lifetime rather than racing them at shutdown; there is now
+     * exactly one per process instead of one per resident session.
+     */
+}
+
+int ds4_dist_session_create(
+        ds4_dist_session **out,
+        ds4_dist_coordinator *coord,
+        char *err,
+        size_t errlen) {
+    if (!out || !coord) {
+        if (errlen) snprintf(err, errlen, "missing distributed session parameters");
+        return 1;
+    }
+    *out = NULL;
+
+    ds4_dist_session *d = calloc(1, sizeof(*d));
+    if (!d) {
+        if (errlen) snprintf(err, errlen, "out of memory creating distributed session");
+        return 1;
+    }
+    d->coord = coord;
     d->session_id = dist_make_session_id(d);
     d->request_id = 1;
     /* KV snapshots use separate data connections and can run while pipelined
      * WORK results are outstanding.  Keep them out of the WORK request-id stream
      * so progress callbacks cannot perturb the reader's contiguous expectations. */
     d->snapshot_request_id = UINT64_C(1) << 63;
-
-    char local_end[32];
-    if (opt->layers.has_output) snprintf(local_end, sizeof(local_end), "output");
-    else snprintf(local_end, sizeof(local_end), "%u", opt->layers.end);
-    DIST_COORD_DEBUG(&d->state,
-                     "ds4: distributed coordinator API: listening on %s:%d model_id=%u layers=%u local=%u:%s activation_bits=%u\n",
-                     opt->listen_host,
-                     opt->listen_port,
-                     d->state.model_id,
-                     d->state.n_layers,
-                     opt->layers.start,
-                     local_end,
-                     d->state.activation_bits);
-
-    d->accept_ctx.state = &d->state;
-    d->accept_ctx.listen_fd = listen_fd;
-    if (pthread_create(&d->accept_tid, NULL, dist_coordinator_accept_main, &d->accept_ctx) != 0) {
-        close(listen_fd);
-        pthread_mutex_destroy(&d->state.mu);
-        free(d);
-        if (errlen) snprintf(err, errlen, "failed to start distributed coordinator accept loop");
-        return 1;
-    }
-    pthread_detach(d->accept_tid);
-    d->accept_started = true;
     *out = d;
     return 0;
 }
 
 void ds4_dist_session_free(ds4_dist_session *d) {
     if (!d) return;
-    if (d->listen_fd >= 0) {
-        shutdown(d->listen_fd, SHUT_RDWR);
-        close(d->listen_fd);
-        d->listen_fd = -1;
-    }
+    /* Closes this session's dup() of the first hop.  The registry's descriptor
+     * belongs to the accepting client thread and is untouched here.
+     */
     dist_route_plan_free(&d->plan);
-    pthread_mutex_lock(&d->state.mu);
-    d->state.shutting_down = true;
-    for (ds4_dist_worker_entry *it = d->state.workers; it; it = it->next) {
-        if (it->fd >= 0) shutdown(it->fd, SHUT_RDWR);
-    }
-    pthread_mutex_unlock(&d->state.mu);
-    /* Client threads are detached and remove their registry entries after the
-     * socket closes. Keep this small coordinator object process-lifetime to
-     * avoid racing those threads during application shutdown. */
+    free(d);
 }
 
 int ds4_dist_session_route_ready(ds4_dist_session *d, char *err, size_t errlen) {
@@ -5506,7 +5548,7 @@ int ds4_dist_session_route_ready(ds4_dist_session *d, char *err, size_t errlen) 
     }
 
     ds4_dist_route_plan probe = {0};
-    if (!dist_coordinator_build_route_plan(&d->state, &probe, NULL, err, errlen)) {
+    if (!dist_coordinator_build_route_plan(&d->coord->state, &probe, NULL, err, errlen)) {
         return 0;
     }
     dist_route_plan_free(&probe);
@@ -5536,13 +5578,13 @@ int ds4_dist_session_sync(
         if (checkpoint->len == prompt->len) return 0;
 
         uint32_t chunk_cap = 0;
-        if (dist_coordinator_prefill_chunk_cap(&d->state, owner, &chunk_cap, err, errlen) != 0) {
+        if (dist_coordinator_prefill_chunk_cap(&d->coord->state, owner, &chunk_cap, err, errlen) != 0) {
             return 1;
         }
         const uint32_t pos0 = (uint32_t)checkpoint->len;
         const uint32_t suffix = (uint32_t)prompt->len - pos0;
-        if (dist_coordinator_can_pipeline_prefill(&d->state, &d->plan, owner, suffix, chunk_cap)) {
-            int prefill_rc = dist_coordinator_prefill_prompt_pipelined(&d->state,
+        if (dist_coordinator_can_pipeline_prefill(&d->coord->state, &d->plan, owner, suffix, chunk_cap)) {
+            int prefill_rc = dist_coordinator_prefill_prompt_pipelined(&d->coord->state,
                                                                        owner,
                                                                        &d->plan,
                                                                        prompt,
@@ -5556,7 +5598,7 @@ int ds4_dist_session_sync(
                                                                        err,
                                                                        errlen);
             if (prefill_rc != 0) {
-                if (dist_coordinator_rebuild_from_transcript(&d->state,
+                if (dist_coordinator_rebuild_from_transcript(&d->coord->state,
                                                              owner,
                                                              &d->plan,
                                                              prompt,
@@ -5580,7 +5622,7 @@ int ds4_dist_session_sync(
         while (pos < (uint32_t)prompt->len) {
             const uint32_t remaining = (uint32_t)prompt->len - pos;
             const uint32_t chunk = remaining < chunk_cap ? remaining : chunk_cap;
-            int eval_rc = dist_coordinator_eval_span(&d->state,
+            int eval_rc = dist_coordinator_eval_span(&d->coord->state,
                                                      owner,
                                                      &d->plan,
                                                      prompt->v + pos,
@@ -5593,7 +5635,7 @@ int ds4_dist_session_sync(
                                                      err,
                                                      errlen);
             if (eval_rc != 0) {
-                if (dist_coordinator_rebuild_from_transcript(&d->state,
+                if (dist_coordinator_rebuild_from_transcript(&d->coord->state,
                                                              owner,
                                                              &d->plan,
                                                              prompt,
@@ -5617,7 +5659,7 @@ int ds4_dist_session_sync(
         return 0;
     }
 
-    int prefill_rc = dist_coordinator_prefill_prompt(&d->state,
+    int prefill_rc = dist_coordinator_prefill_prompt(&d->coord->state,
                                                      owner,
                                                      &d->plan,
                                                      prompt,
@@ -5627,7 +5669,7 @@ int ds4_dist_session_sync(
                                                      err,
                                                      errlen);
     if (prefill_rc != 0) {
-        if (dist_coordinator_rebuild_from_transcript(&d->state,
+        if (dist_coordinator_rebuild_from_transcript(&d->coord->state,
                                                      owner,
                                                      &d->plan,
                                                      prompt,
@@ -5661,7 +5703,7 @@ int ds4_dist_session_eval(
     }
     if (dist_session_ensure_route(d, err, errlen) != 0) return 1;
 
-    int rc = dist_coordinator_eval_span(&d->state,
+    int rc = dist_coordinator_eval_span(&d->coord->state,
                                         owner,
                                         &d->plan,
                                         &token,
@@ -5677,7 +5719,7 @@ int ds4_dist_session_eval(
         ds4_tokens transcript = {0};
         ds4_tokens_copy(&transcript, checkpoint);
         ds4_tokens_push(&transcript, token);
-        if (dist_coordinator_rebuild_from_transcript(&d->state,
+        if (dist_coordinator_rebuild_from_transcript(&d->coord->state,
                                                      owner,
                                                      &d->plan,
                                                      &transcript,

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -1919,6 +1919,11 @@ static void dist_coordinator_add_worker(
             old->has_output == hello->has_output)
         {
             *link = old->next;
+            /* Same ownership rule as above.  Dropping the entry without
+             * touching the socket left the owning thread parked on a live
+             * connection, so the descriptor survived until the far end
+             * happened to hang up. */
+            if (old->fd >= 0) shutdown(old->fd, SHUT_RDWR);
             DIST_COORD_DEBUG(state,
                              "ds4: distributed coordinator: dropped stale worker %s:%s layers=%u:%u%s\n",
                              old->peer_host,
@@ -2136,7 +2141,13 @@ static void dist_coordinator_forget_route_workers(
                 continue;
             }
             *link = entry->next;
-            close(entry->fd);
+            /* The descriptor belongs to the client thread that accepted it,
+             * which is parked on a blocking read and closes it when that read
+             * returns.  close() here would release the number while that
+             * thread still holds it: an accept() could be handed the same
+             * number and the thread's own close() would land on an unrelated
+             * connection.  shutdown() wakes it and leaves a single owner. */
+            if (entry->fd >= 0) shutdown(entry->fd, SHUT_RDWR);
             DIST_COORD_DEBUG(state,
                              "ds4: distributed coordinator: forgot failed route worker %s:%u layers=%u:%u%s\n",
                              plan->entry[i].host,

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -42,6 +42,14 @@
  * ========================================================================= */
 
 #define DS4_DIST_MAGIC 0x44533444u /* DS4D */
+
+/* Default ceiling on coordinator sessions a worker will hold.  Each one costs
+ * its own KV and context buffers -- 1.03 GiB at ctx 32768 on the Flash Q4
+ * measurement rig, once the prefill workspace is aliased -- against whatever
+ * headroom is left after the resident layer slice.  Eight fits the tested
+ * envelope with room to spare; a coordinator with more resident slots than this
+ * should raise it deliberately, having checked the worker's memory. */
+#define DS4_DIST_WORKER_MAX_SESSIONS_DEFAULT 8u
 #define DS4_DIST_MSG_HELLO 1u
 #define DS4_DIST_MSG_ERROR 2u
 #define DS4_DIST_MSG_WORK 3u
@@ -273,6 +281,8 @@ typedef struct {
     int listen_fd;
     pthread_mutex_t mu;
     ds4_dist_worker_session *sessions;
+    uint32_t session_count;
+    uint32_t max_sessions;
 } ds4_dist_worker_state;
 
 typedef struct ds4_dist_worker_upstream ds4_dist_worker_upstream;
@@ -6869,6 +6879,19 @@ static ds4_dist_worker_session *dist_worker_get_session_locked(
         if (it->session_id == session_id) return it;
     }
 
+    /* Refuse past the cap instead of allocating into an OOM kill.  A worker is
+     * told how many sessions to hold, never asked, so this is the only place it
+     * can say no; the coordinator surfaces the error as a failed request. */
+    if (state->max_sessions != 0 && state->session_count >= state->max_sessions) {
+        if (errlen) {
+            snprintf(err, errlen,
+                     "distributed worker is holding its maximum of %u sessions; "
+                     "raise --max-sessions to accept more",
+                     state->max_sessions);
+        }
+        return NULL;
+    }
+
     ds4_dist_worker_session *entry = calloc(1, sizeof(*entry));
     if (!entry) {
         if (errlen) snprintf(err, errlen, "out of memory creating distributed session");
@@ -6882,6 +6905,7 @@ static ds4_dist_worker_session *dist_worker_get_session_locked(
     entry->session_id = session_id;
     entry->next = state->sessions;
     state->sessions = entry;
+    state->session_count++;
     return entry;
 }
 
@@ -6899,6 +6923,7 @@ static uint32_t dist_worker_clear_sessions(ds4_dist_worker_state *state) {
     pthread_mutex_lock(&state->mu);
     ds4_dist_worker_session *it = state->sessions;
     state->sessions = NULL;
+    state->session_count = 0;
     pthread_mutex_unlock(&state->mu);
 
     while (it) {
@@ -8030,6 +8055,8 @@ static int dist_run_worker(ds4_engine *engine, const ds4_dist_options *opt, int 
     state.has_output = opt->layers.has_output;
     state.ctx_size = ctx_size;
     state.listen_fd = listen_fd;
+    state.max_sessions = opt->max_sessions ? opt->max_sessions
+                                           : DS4_DIST_WORKER_MAX_SESSIONS_DEFAULT;
     pthread_mutex_init(&state.mu, NULL);
 
     pthread_t data_tid;
@@ -8215,6 +8242,9 @@ void ds4_dist_usage(FILE *fp) {
         "      Coordinator TCP listen address. Workers may later use it to force their data listener.\n"
         "  --coordinator HOST PORT\n"
         "      Coordinator TCP address for --role worker.\n"
+        "  --max-sessions N\n"
+        "      Worker cap on concurrent coordinator sessions. Default: 8. Each costs its own\n"
+        "      KV and context buffers, so raise it only against measured worker headroom.\n"
         "  --dist-prefill-chunk N\n"
         "      Coordinator prefill pipeline chunk size. Default: session cap, normally 4096.\n"
         "      Non-default values are experimental and can change logits unless validated.\n"
@@ -8328,6 +8358,21 @@ ds4_dist_cli_parse_result ds4_dist_parse_cli_arg(
         }
         return DS4_DIST_CLI_MATCHED;
     }
+    if (!strcmp(arg, "--max-sessions")) {
+        if (!opt) {
+            if (errlen) snprintf(err, errlen, "missing distributed options");
+            return DS4_DIST_CLI_ERROR;
+        }
+        const char *value = dist_cli_need_arg(index, argc, argv, arg, err, errlen);
+        if (!value) return DS4_DIST_CLI_ERROR;
+        uint32_t n = 0;
+        if (!dist_parse_positive_u32(value, arg, &n, err, errlen)) {
+            return DS4_DIST_CLI_ERROR;
+        }
+        opt->max_sessions = n;
+        return DS4_DIST_CLI_MATCHED;
+    }
+
     if (!strcmp(arg, "--dist-activation-bits")) {
         if (!opt) {
             if (errlen) snprintf(err, errlen, "missing distributed options");
@@ -8439,6 +8484,10 @@ int ds4_dist_prepare_engine_options(
     if (dist_validate_options(opt, err, errlen) != 0) return 1;
     if (opt && opt->replay_check && opt->role != DS4_DISTRIBUTED_COORDINATOR) {
         if (errlen) snprintf(err, errlen, "--dist-replay-check requires --role coordinator");
+        return 1;
+    }
+    if (opt && opt->max_sessions != 0 && opt->role != DS4_DISTRIBUTED_WORKER) {
+        if (errlen) snprintf(err, errlen, "--max-sessions requires --role worker");
         return 1;
     }
     if (engine && opt) {

--- a/ds4_distributed.c
+++ b/ds4_distributed.c
@@ -5789,10 +5789,29 @@ int ds4_dist_session_sync(
  * frames of one session never interleave with another's, and each session's
  * prefix hash is read before its own slice commits.
  */
+/* Build the transcript a failed step must be replayed from.
+ *
+ * The local layer slice commits its token onto the session timeline before the
+ * remote step runs (ds4_session_eval_layer_slice -> slice_commit_timeline), so
+ * once a remote failure is being handled the checkpoint already contains that
+ * token.  Copying the checkpoint and pushing the token again replays it twice
+ * and rebuilds the worker against a timeline that never existed.  Rebuild from
+ * the length the timeline had before the slice instead.
+ */
+static void dist_recovery_transcript(ds4_tokens *out,
+                                     const ds4_tokens *checkpoint,
+                                     uint32_t pos0,
+                                     int token) {
+    ds4_tokens_copy(out, checkpoint);
+    if (out->len > (int)pos0) out->len = (int)pos0;
+    ds4_tokens_push(out, token);
+}
+
 /* Per-member state for one batched decode step. */
 typedef struct {
     uint64_t request_id;
     uint64_t result_hash;
+    uint32_t pos0;          /* timeline length before this member's slice ran */
     bool submitted;
     int rc;
 } ds4_dist_batch_member;
@@ -5815,6 +5834,7 @@ static int dist_batch_submit_member(
     if (dist_session_ensure_route(d, err, errlen) != 0) return 1;
 
     const uint32_t pos0 = (uint32_t)item->checkpoint->len;
+    member->pos0 = pos0;
     uint64_t prefix_hash = DS4_DIST_TOKEN_HASH_INIT;
     if (dist_session_token_hash_prefix(item->owner, pos0, &prefix_hash,
                                        err, errlen) != 0) {
@@ -5855,17 +5875,16 @@ static int dist_batch_submit_member(
 static int dist_batch_recover_member(
         ds4_dist_coordinator_state *state,
         const ds4_dist_decode_item *item,
-        int member_rc,
+        const ds4_dist_batch_member *member,
         char *err,
         size_t errlen) {
     ds4_dist_session *d = item->dist;
     ds4_tokens transcript = {0};
-    ds4_tokens_copy(&transcript, item->checkpoint);
-    ds4_tokens_push(&transcript, item->token);
+    dist_recovery_transcript(&transcript, item->checkpoint, member->pos0, item->token);
     int rc = dist_coordinator_rebuild_from_transcript(
             state, item->owner, &d->plan, &transcript, d->session_id,
             &d->request_id, item->logits, &d->plan_generation,
-            member_rc != DS4_DIST_RECV_REMOTE_ERROR, err, errlen);
+            member->rc != DS4_DIST_RECV_REMOTE_ERROR, err, errlen);
     ds4_tokens_free(&transcript);
     if (rc == 0) {
         d->plan_ready = true;
@@ -5930,8 +5949,11 @@ int ds4_dist_sessions_eval(
         return 1;
     }
 
-    char first_err[256];
-    first_err[0] = '\0';
+    /* One message stands for the batch.  The submit/collect pass keeps the
+     * first failure; a later recovery failure replaces it, because that is the
+     * reason the batch could not be salvaged. */
+    char report_err[256];
+    report_err[0] = '\0';
     int failed = 0;
 
     for (int i = 0; i < count; i++) {
@@ -5941,7 +5963,7 @@ int ds4_dist_sessions_eval(
                                                  hidden, hidden_bytes,
                                                  member_err, sizeof(member_err));
         if (members[i].rc != 0 && !failed++) {
-            snprintf(first_err, sizeof(first_err), "%s", member_err);
+            snprintf(report_err, sizeof(report_err), "%s", member_err);
         }
     }
 
@@ -5957,7 +5979,7 @@ int ds4_dist_sessions_eval(
                 items[i].logits, member_err, sizeof(member_err));
         if (rc != 0) {
             members[i].rc = rc;
-            if (!failed++) snprintf(first_err, sizeof(first_err), "%s", member_err);
+            if (!failed++) snprintf(report_err, sizeof(report_err), "%s", member_err);
         }
     }
 
@@ -5965,12 +5987,12 @@ int ds4_dist_sessions_eval(
         if (members[i].rc == 0) continue;
         char member_err[256];
         member_err[0] = '\0';
-        if (dist_batch_recover_member(state, &items[i], members[i].rc,
+        if (dist_batch_recover_member(state, &items[i], &members[i],
                                       member_err, sizeof(member_err)) == 0) {
             members[i].rc = 0;
             failed--;
         } else {
-            snprintf(first_err, sizeof(first_err), "%s", member_err);
+            snprintf(report_err, sizeof(report_err), "%s", member_err);
         }
     }
 
@@ -5979,7 +6001,7 @@ int ds4_dist_sessions_eval(
     if (failed) {
         if (errlen) {
             snprintf(err, errlen, "%s",
-                     first_err[0] ? first_err : "distributed decode batch failed");
+                     report_err[0] ? report_err : "distributed decode batch failed");
         }
         return 1;
     }
@@ -6000,12 +6022,17 @@ int ds4_dist_session_eval(
     }
     if (dist_session_ensure_route(d, err, errlen) != 0) return 1;
 
+    /* Read before the span, whose local slice commits the token onto the
+     * timeline; the recovery below has to replay from here, not from where the
+     * checkpoint ends up. */
+    const uint32_t pos0 = (uint32_t)checkpoint->len;
+
     int rc = dist_coordinator_eval_span(&d->coord->state,
                                         owner,
                                         &d->plan,
                                         &token,
                                         1,
-                                        (uint32_t)checkpoint->len,
+                                        pos0,
                                         d->session_id,
                                         d->request_id++,
                                         false,
@@ -6014,8 +6041,7 @@ int ds4_dist_session_eval(
                                         errlen);
     if (rc != 0) {
         ds4_tokens transcript = {0};
-        ds4_tokens_copy(&transcript, checkpoint);
-        ds4_tokens_push(&transcript, token);
+        dist_recovery_transcript(&transcript, checkpoint, pos0, token);
         if (dist_coordinator_rebuild_from_transcript(&d->coord->state,
                                                      owner,
                                                      &d->plan,

--- a/ds4_distributed.h
+++ b/ds4_distributed.h
@@ -112,6 +112,24 @@ int ds4_dist_session_eval(
         char *err,
         size_t errlen);
 
+/* Decode one token on each of several coordinator sessions, overlapping their
+ * remote waits. Every member's frame is submitted before any result is
+ * collected, so the batch costs the longest wait rather than their sum.
+ */
+typedef struct {
+    ds4_dist_session *dist;
+    ds4_session *owner;
+    const ds4_tokens *checkpoint;
+    int token;
+    float *logits;
+} ds4_dist_decode_item;
+
+int ds4_dist_sessions_eval(
+        ds4_dist_decode_item *items,
+        int count,
+        char *err,
+        size_t errlen);
+
 /* Save/load use the normal DSV4 payload format. The coordinator gathers or
  * pushes remote layer shards internally so saved files are topology-neutral.
  */

--- a/ds4_distributed.h
+++ b/ds4_distributed.h
@@ -13,6 +13,7 @@
  * ds4_dist_run() directly.
  */
 typedef ds4_distributed_options ds4_dist_options;
+typedef struct ds4_dist_coordinator ds4_dist_coordinator;
 typedef struct ds4_dist_session ds4_dist_session;
 
 /* Options used by standalone `./ds4 --role coordinator -p ...` generation.
@@ -65,12 +66,23 @@ int ds4_dist_prepare_engine_options(
 /* Coordinator session backend used by ds4.c. These mirror the normal session
  * operations; callers outside the engine should not need to call them directly.
  */
-int ds4_dist_session_create(
-        ds4_dist_session **out,
+/* The listener, accept loop and worker registry describe the cluster this
+ * process joined, not any one session, so the engine opens one coordinator and
+ * every coordinator session borrows it. Opening one per session would cap the
+ * process at a single resident session: the second bind hits EADDRINUSE.
+ */
+int ds4_dist_coordinator_open(
+        ds4_dist_coordinator **out,
         ds4_engine *engine,
         const ds4_dist_options *opt,
-        ds4_session *owner,
         int ctx_size,
+        char *err,
+        size_t errlen);
+void ds4_dist_coordinator_close(ds4_dist_coordinator *c);
+
+int ds4_dist_session_create(
+        ds4_dist_session **out,
+        ds4_dist_coordinator *coord,
         char *err,
         size_t errlen);
 void ds4_dist_session_free(ds4_dist_session *d);

--- a/tests/test_dist_session_batch.c
+++ b/tests/test_dist_session_batch.c
@@ -1,0 +1,355 @@
+/* Model-backed oracle for distributed multi-session decode batching.
+ *
+ * Proves that ds4_dist_sessions_eval() -- the path ds4_sessions_eval_batch()
+ * takes when every member is a coordinator session -- produces exactly the
+ * logits the sessions would have produced one at a time.  That matters because
+ * the batch submits every member's WORK frame before collecting any result, so
+ * a member's remote step overlaps its peers' local slices; if that overlap
+ * coupled two sessions' KV or paired a result with the wrong request, the
+ * logits would drift and nothing else in the system would notice.
+ *
+ * Four sessions advance by default, cycling batch sizes 4, 3 and 2 so ragged
+ * counts and the count==1 single-session fallback are both exercised.  Batch
+ * member order is reversed on alternate steps to expose accidental slot
+ * coupling.  Every full-logit frontier is archived, the batched sessions are
+ * freed, and each prompt is then replayed through one isolated control session
+ * whose decodes go one at a time.  Frontiers must match bit for bit.
+ *
+ * This is not part of `make test`: it needs the large model and a live worker.
+ * The coordinator listens and the worker dials in, so the worker must already
+ * be running and serving the complementary layer slice before this starts.
+ *
+ * The worker holds one session per session id it is sent and does not reclaim
+ * one when the coordinator frees its side, so this test needs room for twice
+ * DS4_TEST_SESSION_COUNT: the batched sessions and then the control sessions.
+ * Start the worker with --max-sessions 2N or more.
+ *
+ * Run with, on the coordinator host:
+ *   DS4_TEST_MODEL=/path/to/model.gguf make test-dist-session-batch
+ *
+ * Environment:
+ *   DS4_TEST_MODEL          model path (required)
+ *   DS4_TEST_DIST_LISTEN    coordinator listen host (default 192.168.88.239)
+ *   DS4_TEST_DIST_PORT      coordinator listen port (default 9010)
+ *   DS4_TEST_DIST_LAYERS    coordinator layer slice (default 0:20)
+ *   DS4_TEST_SESSION_COUNT  batched sessions (default 4, max 8)
+ *   DS4_TEST_CONTEXT        context size (default 1024)
+ *   DS4_TEST_ROUTE_TIMEOUT  seconds to wait for the worker (default 120)
+ */
+
+#include "ds4.h"
+#include "ds4_distributed.h"
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#define DEFAULT_SESSION_COUNT 4
+#define MAX_SESSION_COUNT 8
+#define DECODE_STEPS 12
+#define TEST_CTX 1024
+#define DEFAULT_ROUTE_TIMEOUT 120
+
+static const char *prompts[] = {
+    "List the first twenty prime numbers and show no derivation.",
+    "Describe how an LRU cache works using a short worked example.",
+    "Write the first thirty Fibonacci numbers, one per line.",
+    "Compare TCP and UDP using four precise operational examples.",
+    "Explain B-tree insertion with a concrete sequence of ten keys.",
+    "Write a compact C function that validates UTF-8.",
+    "Generate SQL that creates and queries a small issue tracker schema.",
+    "Explain how a CPU branch predictor works, briefly.",
+};
+
+static void fail(const char *what, int session, int step) {
+    fprintf(stderr, "FAIL: %s session=%d step=%d\n", what, session, step);
+    exit(1);
+}
+
+/* A distributed frontier must be bit-identical, not merely close: the batch
+ * and the single-session path run the same kernels on the same slice, so any
+ * difference at all means the batch perturbed state rather than lost accuracy.
+ */
+static void compare_frontier(ds4_session *control, const float *expected,
+                             int expected_argmax, float *actual, int vocab,
+                             int session, int step, int *nonexact) {
+    if (ds4_session_copy_logits(control, actual, vocab) != vocab) {
+        fail("copy control logits", session, step);
+    }
+
+    int different = 0;
+    float max_abs = 0.0f;
+    for (int i = 0; i < vocab; i++) {
+        if (memcmp(&actual[i], &expected[i], sizeof(float)) != 0) different++;
+        float d = fabsf(actual[i] - expected[i]);
+        if (!isfinite(d)) d = INFINITY;
+        if (d > max_abs) max_abs = d;
+    }
+    *nonexact += different;
+
+    const int actual_argmax = ds4_session_argmax(control);
+    if (different != 0 || actual_argmax != expected_argmax) {
+        fprintf(stderr,
+                "FAIL: logits mismatch session=%d step=%d control=%d batch=%d "
+                "max_abs=%g differing=%d\n",
+                session, step, actual_argmax, expected_argmax,
+                max_abs, different);
+        exit(1);
+    }
+}
+
+/* Build the distributed options through the shared CLI parser rather than
+ * filling the struct by hand, so the layer-range grammar this test accepts
+ * cannot drift from the one the binaries accept. */
+static void configure_distributed(ds4_engine_options *opt, const char *layers,
+                                  const char *host, int port) {
+    char port_buf[16];
+    snprintf(port_buf, sizeof(port_buf), "%d", port);
+    char *argv[] = {
+        (char *)"--role",   (char *)"coordinator",
+        (char *)"--layers", (char *)layers,
+        (char *)"--listen", (char *)host, port_buf,
+    };
+    const int argc = (int)(sizeof(argv) / sizeof(argv[0]));
+
+    char err[256] = {0};
+    for (int i = 0; i < argc; i++) {
+        const ds4_dist_cli_parse_result rc =
+            ds4_dist_parse_cli_arg(argv[i], &i, argc, argv, &opt->distributed,
+                                   err, sizeof(err));
+        if (rc != DS4_DIST_CLI_MATCHED) {
+            fprintf(stderr, "FAIL: distributed option '%s': %s\n", argv[i],
+                    err[0] ? err : "not recognised");
+            exit(1);
+        }
+    }
+}
+
+/* The worker dials us, so readiness is "a worker covering the rest of the
+ * model has registered", not "the listener is bound". */
+static void wait_for_route(ds4_session *probe, int timeout_sec) {
+    char err[256] = {0};
+    for (int waited = 0; waited < timeout_sec; waited++) {
+        const int ready = ds4_session_distributed_route_ready(probe, err,
+                                                              sizeof(err));
+        if (ready == 1) return;
+        if (ready < 0) {
+            fprintf(stderr, "FAIL: distributed route: %s\n",
+                    err[0] ? err : "configuration error");
+            exit(1);
+        }
+        if (waited == 0) {
+            fprintf(stderr,
+                    "test_dist_session_batch: waiting for a worker to register"
+                    " (%s)\n", err[0] ? err : "route incomplete");
+        }
+        sleep(1);
+    }
+    fprintf(stderr,
+            "FAIL: no worker registered within %d s. Start one serving the\n"
+            "      layers this coordinator does not, dialling this host, with\n"
+            "      --max-sessions at least twice DS4_TEST_SESSION_COUNT.\n",
+            timeout_sec);
+    exit(1);
+}
+
+static int env_int(const char *name, int fallback) {
+    const char *v = getenv(name);
+    return (v && v[0]) ? atoi(v) : fallback;
+}
+
+int main(void) {
+    const char *model = getenv("DS4_TEST_MODEL");
+    if (!model || !model[0]) {
+        fprintf(stderr, "FAIL: DS4_TEST_MODEL is not set\n");
+        return 1;
+    }
+    const char *listen_host = getenv("DS4_TEST_DIST_LISTEN");
+    if (!listen_host || !listen_host[0]) listen_host = "192.168.88.239";
+    const char *layers = getenv("DS4_TEST_DIST_LAYERS");
+    if (!layers || !layers[0]) layers = "0:20";
+    const int listen_port = env_int("DS4_TEST_DIST_PORT", 9010);
+    const int route_timeout = env_int("DS4_TEST_ROUTE_TIMEOUT",
+                                      DEFAULT_ROUTE_TIMEOUT);
+
+    const int session_count = env_int("DS4_TEST_SESSION_COUNT",
+                                      DEFAULT_SESSION_COUNT);
+    if (session_count < 2 || session_count > MAX_SESSION_COUNT) {
+        fprintf(stderr, "FAIL: DS4_TEST_SESSION_COUNT must be 2..%d\n",
+                MAX_SESSION_COUNT);
+        return 1;
+    }
+    const int test_ctx = env_int("DS4_TEST_CONTEXT", TEST_CTX);
+    if (test_ctx < TEST_CTX || test_ctx > 65536) {
+        fprintf(stderr, "FAIL: DS4_TEST_CONTEXT must be %d..65536\n", TEST_CTX);
+        return 1;
+    }
+
+    ds4_engine_options opt = {
+        .model_path = model,
+        .backend = DS4_BACKEND_CUDA, /* ROCm shares this backend id */
+        .n_threads = 1,
+        .context_size = test_ctx,
+        .placement_ctx_hint = test_ctx,
+        .placement_session_count_hint = session_count,
+        .share_session_prefill_workspace = true,
+    };
+    configure_distributed(&opt, layers, listen_host, listen_port);
+
+    char err[256] = {0};
+    if (ds4_dist_prepare_engine_options(&opt.distributed, &opt,
+                                        err, sizeof(err)) != 0) {
+        fprintf(stderr, "FAIL: %s\n", err);
+        return 1;
+    }
+    ds4_engine *engine = NULL;
+    if (ds4_engine_open(&engine, &opt) != 0) {
+        fprintf(stderr, "FAIL: engine open\n");
+        return 1;
+    }
+
+    ds4_session *batched[MAX_SESSION_COUNT] = {0};
+    ds4_tokens prompt[MAX_SESSION_COUNT] = {0};
+    const int prompt_count = (int)(sizeof(prompts) / sizeof(prompts[0]));
+    for (int i = 0; i < session_count; i++) {
+        if (ds4_session_create(&batched[i], engine, test_ctx) != 0) {
+            fail("session create", i, -1);
+        }
+    }
+    if (!ds4_session_is_distributed(batched[0])) {
+        fprintf(stderr,
+                "FAIL: sessions are not distributed; check --role/--layers\n");
+        return 1;
+    }
+    wait_for_route(batched[0], route_timeout);
+
+    for (int i = 0; i < session_count; i++) {
+        ds4_encode_chat_prompt(engine, NULL, prompts[i % prompt_count],
+                               DS4_THINK_NONE, &prompt[i]);
+        if (ds4_session_sync(batched[i], &prompt[i], err, sizeof(err)) != 0) {
+            fprintf(stderr, "FAIL: prefill session=%d: %s\n", i, err);
+            return 1;
+        }
+    }
+
+    const int vocab = ds4_engine_vocab_size(engine);
+    if (vocab <= 0) fail("engine reports no vocabulary", -1, -1);
+    const size_t frontiers = (size_t)(DECODE_STEPS + 1) * (size_t)session_count;
+    float *expected = malloc(frontiers * (size_t)vocab * sizeof(*expected));
+    int *expected_argmax = malloc(frontiers * sizeof(*expected_argmax));
+    float *actual = malloc((size_t)vocab * sizeof(*actual));
+    if (!expected || !expected_argmax || !actual) fail("logit allocation", -1, -1);
+
+    /* Cycle the group size so a batch is sometimes ragged and sometimes falls
+     * to the count==1 path, which routes through the single-session code the
+     * batch is being checked against. */
+    static const int group_cycle[] = {4, 3, 2};
+    int batched_calls = 0;
+    for (int step = 0; step <= DECODE_STEPS; step++) {
+        int tokens[MAX_SESSION_COUNT];
+        for (int i = 0; i < session_count; i++) {
+            const size_t frontier =
+                (size_t)step * (size_t)session_count + (size_t)i;
+            if (ds4_session_copy_logits(batched[i],
+                                        expected + frontier * (size_t)vocab,
+                                        vocab) != vocab) {
+                fail("archive logits", i, step);
+            }
+            tokens[i] = ds4_session_argmax(batched[i]);
+            expected_argmax[frontier] = tokens[i];
+        }
+        if (step == DECODE_STEPS) break;
+
+        int group = group_cycle[step % 3];
+        if (group > session_count) group = session_count;
+        for (int base = 0; base < session_count; base += group) {
+            ds4_decode_item items[MAX_SESSION_COUNT];
+            const int rows = group < session_count - base
+                ? group : session_count - base;
+            for (int row = 0; row < rows; row++) {
+                const int i = (step & 1) ? base + rows - 1 - row : base + row;
+                items[row].session = batched[i];
+                items[row].token = tokens[i];
+            }
+            if (ds4_sessions_eval_batch(items, rows, err, sizeof(err)) != 0) {
+                fprintf(stderr, "FAIL: batch eval rows=%d base=%d step=%d: %s\n",
+                        rows, base, step, err);
+                return 1;
+            }
+            if (rows > 1) batched_calls++;
+        }
+    }
+
+    for (int i = 0; i < session_count; i++) {
+        ds4_session_free(batched[i]);
+        batched[i] = NULL;
+    }
+
+    /* Guard against a vacuous pass: if every group had collapsed to one row,
+     * the comparison below would be the single-session path against itself. */
+    if (batched_calls == 0) {
+        fprintf(stderr,
+                "FAIL: no multi-row batch ran; the oracle would compare the\n"
+                "      single-session path against itself\n");
+        return 1;
+    }
+
+    /* TODO: two members failing inside one batch is still uncovered.  The
+     * batch collects every submitted member even after a peer has failed and
+     * then recovers each one through dist_coordinator_rebuild_from_transcript,
+     * and that combination cannot be provoked from here: the only faults this
+     * process controls are killing the worker, which fails every member rather
+     * than a chosen two, or closing a route descriptor, which the plan owns.
+     * Covering it needs a diagnostic hook in ds4_distributed.c -- an env-read
+     * bitmask consulted once inside dist_coordinator_finish_remote_on_fd(),
+     * failing the collect for the named members of the next batch only.  That
+     * is a diagnostic switch validating the one release path, not a semantic
+     * variant, so it fits the rules in AGENT.md. */
+
+    int nonexact = 0;
+    for (int i = 0; i < session_count; i++) {
+        ds4_session *control = NULL;
+        if (ds4_session_create(&control, engine, test_ctx) != 0) {
+            fail("control session create", i, -1);
+        }
+        if (ds4_session_sync(control, &prompt[i], err, sizeof(err)) != 0) {
+            fprintf(stderr,
+                    "FAIL: control prefill session=%d: %s\n"
+                    "      If this reports a worker session cap, restart the\n"
+                    "      worker with --max-sessions at least %d.\n",
+                    i, err, 2 * session_count);
+            return 1;
+        }
+        for (int step = 0; step <= DECODE_STEPS; step++) {
+            const size_t frontier =
+                (size_t)step * (size_t)session_count + (size_t)i;
+            compare_frontier(control, expected + frontier * (size_t)vocab,
+                             expected_argmax[frontier], actual, vocab,
+                             i, step, &nonexact);
+            if (step < DECODE_STEPS &&
+                ds4_session_eval(control, expected_argmax[frontier],
+                                 err, sizeof(err)) != 0) {
+                fprintf(stderr, "FAIL: control eval session=%d step=%d: %s\n",
+                        i, step, err);
+                return 1;
+            }
+        }
+        ds4_session_free(control);
+    }
+
+    fprintf(stderr,
+            "test_dist_session_batch PASS sessions=%d steps=%d "
+            "batched_calls=%d nonexact_logits=%d\n",
+            session_count, DECODE_STEPS, batched_calls, nonexact);
+
+    free(actual);
+    free(expected_argmax);
+    free(expected);
+    for (int i = 0; i < session_count; i++) ds4_tokens_free(&prompt[i]);
+    ds4_engine_close(engine);
+    return 0;
+}


### PR DESCRIPTION
Add pipeline parallelism. Increases performance significantly on multi node configurations that can't use tensor parallelism when multiple requests are happening at the same time. When splitting by layers if only a single request is in flight there is only one node actually doing work at a time, while the other nodes are sitting there waiting and doing nothing.

Patches in this PR allows the coordinator to send multiple jobs in flight at the same time so that compute can be more effectively utilized when multiple requests are happening at the same time.

Fixes #784 (prerequisite to this feature)
Fixes #862 

All code written by Claude Opus 5
Tested on a 2-node cluster of Strix Halo 128GB nodes
Tested `make cpu` builds

Limitations:
Could not run `make test` as that requires cuda (I don't have access to such hardware)
I don't have access to a powerful enough metal machine so also can't run those tests.