### PR TITLE
ROCm: accelerate GLM 5.3 Flash prefill on gfx1151

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,15 @@ ROCM_LDLIBS ?= -lm -pthread -lhipblas -lhipblaslt -lrocblas
 ROCM_MMQ_Y ?= 64
 ROCM_MMQ_FLAGS := $(ROCM_CFLAGS) -std=c++17 -DGGML_USE_HIP -DDS4_HIP_MMQ_Y=$(ROCM_MMQ_Y) $(MMQ_INCLUDES)
 ROCM_MMQ_OBJS := cuda/mmq/ds4_ggml_stubs.rocm.o cuda/mmq/ds4_mmq.rocm.o cuda/mmq/quantize.rocm.o cuda/mmq/mmid.rocm.o cuda/mmq/mmvq.rocm.o cuda/mmq/d2r_stubs.rocm.o
+ROCM_GLM_KERNEL_OBJS := rocm/ds4_rocm_glm_selected_multihead.o
+ROCM_QUALITY_SCORE := gguf-tools/quality-testing/score_official_rocm
+ROCM_QUALITY_OBJS := ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o rax.o ds4_gpu_args.o $(ROCM_GLM_KERNEL_OBJS) $(ROCM_MMQ_OBJS)
 DS4_LINK ?= $(NVCC) $(NVCCFLAGS)
 DS4_LINK_LIBS ?= $(CUDA_LDLIBS)
 METAL_LDLIBS := $(LDLIBS)
 endif
 
-.PHONY: all help clean test test-rocm test-glm53-kda-rocm test-metal-session-batch test-mxfp4-cuda test-mxfp4-rocm test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
+.PHONY: all help clean test test-rocm test-glm53-kda-rocm test-glm53-iq2-mmq-rocm quality-score-rocm test-metal-session-batch test-mxfp4-cuda test-mxfp4-rocm test-cuda-session-batch test-cuda-mixed-batch dspark-acceptance dspark-verify-depth mtp-verify-depth cpu cuda cuda-spark cuda-generic cuda-regression strix-halo rocm
 
 ifeq ($(UNAME_S),Darwin)
 .PHONY: metal-decode-schedule-bench metal-prefill-variant-bench check-mxfp4-half-lut
@@ -163,6 +166,7 @@ help:
 	@echo "  make rocm                Alias for make strix-halo"
 	@echo "  make test-mxfp4-rocm     Build and run the synthetic ROCm MXFP4 MoE test"
 	@echo "  make test-rocm           Core regression suite on ROCm-only hosts"
+	@echo "  make quality-score-rocm  Build the official scorer against the exact ROCm objects"
 	@echo "  make cpu                 Build CPU-only ./ds4, ./ds4-server, ./ds4-bench, ./ds4-eval, and ./ds4-agent"
 	@echo "  make test                Build and run tests"
 	@echo "  make dspark-verify-depth Run DSpark speculative verification smoke if support GGUF is present"
@@ -185,12 +189,24 @@ cuda:
 
 strix-halo:
 	$(MAKE) -B ds4 ds4-server ds4-bench ds4-eval ds4-agent \
-		CORE_OBJS="ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o $(ROCM_MMQ_OBJS)" \
+		CORE_OBJS="ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o $(ROCM_GLM_KERNEL_OBJS) $(ROCM_MMQ_OBJS)" \
 		CFLAGS="$(CFLAGS) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD" \
 		DS4_LINK="$(HIPCC) $(ROCM_CFLAGS)" \
 		DS4_LINK_LIBS="$(ROCM_LDLIBS)"
 
 rocm: strix-halo
+
+ifneq ($(UNAME_S),Darwin)
+quality-score-rocm:
+	$(MAKE) -B $(ROCM_QUALITY_SCORE) \
+		CFLAGS="$(CFLAGS) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD"
+
+gguf-tools/quality-testing/score_official.rocm.o: gguf-tools/quality-testing/score_official.c ds4.h ds4_distributed.h ds4_gpu_args.h ds4_ssd.h ds4_tp.h
+	$(CC) $(filter-out -ffast-math,$(CFLAGS)) -I. -c -o $@ $<
+
+$(ROCM_QUALITY_SCORE): gguf-tools/quality-testing/score_official.rocm.o $(ROCM_QUALITY_OBJS)
+	$(HIPCC) $(ROCM_CFLAGS) -o $@ $^ $(ROCM_LDLIBS)
+endif
 
 # Core regression suite for ROCm-only hosts: the CUDA-specific binaries
 # (tests/test_sampling, the CUDA session/mixed-batch oracles) are not part
@@ -200,7 +216,7 @@ test-rocm:
 	$(MAKE) -B ds4_test ds4_agent_test ds4-eval q4k-dot-test mxfp4-dot-test \
 		tests/test_layer_pack tests/test_engine_mgpu_placement tests/test_gpu_args \
 		ds4 ds4-server ds4-bench ds4-agent \
-		CORE_OBJS="ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o $(ROCM_MMQ_OBJS)" \
+		CORE_OBJS="ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o $(ROCM_GLM_KERNEL_OBJS) $(ROCM_MMQ_OBJS)" \
 		CFLAGS="$(CFLAGS) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD" \
 		DS4_LINK="$(HIPCC) $(ROCM_CFLAGS)" \
 		DS4_LINK_LIBS="$(ROCM_LDLIBS)"
@@ -375,7 +391,7 @@ test-glm53-kda: $(GLM53_KDA_TEST)
 tests/test_glm53_kda_rocm.o: tests/test_glm53_kda.c ds4_gpu.h
 	$(CC) $(filter-out -ffast-math,$(CFLAGS)) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD -I. -c -o $@ $<
 
-$(GLM53_KDA_ROCM_TEST): tests/test_glm53_kda_rocm.o ds4_rocm.o
+$(GLM53_KDA_ROCM_TEST): tests/test_glm53_kda_rocm.o ds4_rocm.o ds4_image.o $(ROCM_GLM_KERNEL_OBJS) $(ROCM_MMQ_OBJS)
 	$(HIPCC) $(ROCM_CFLAGS) -o $@ $^ $(ROCM_LDLIBS)
 
 test-glm53-kda-rocm: $(GLM53_KDA_ROCM_TEST)
@@ -411,6 +427,9 @@ cuda/mmq/ds4_repack.o: cuda/mmq/ds4_repack.cu cuda/mmq/ds4_repack.h
 ds4_rocm.o: ds4_rocm.cu ds4_gpu.h ds4_glm53_vision_gpu.cuh ds4_deepseek4_vision_gpu.cuh ds4_image.h ds4_iq2_tables_cuda.inc $(ROCM_SRCS)
 	$(HIPCC) $(ROCM_CFLAGS) -c -o $@ ds4_rocm.cu
 
+rocm/ds4_rocm_glm_selected_multihead.o: rocm/ds4_rocm_glm_selected_multihead.cu
+	$(HIPCC) $(ROCM_CFLAGS) -std=c++17 -c -o $@ $<
+
 cuda/mmq/ds4_ggml_stubs.rocm.o: cuda/mmq/ds4_ggml_stubs.cu cuda/mmq/ds4_ggml_stubs.h cuda/mmq/common.cuh cuda/mmq/vendors/hip.h
 	$(HIPCC) $(ROCM_MMQ_FLAGS) -c -o $@ $<
 
@@ -428,6 +447,17 @@ cuda/mmq/mmvq.rocm.o: cuda/mmq/mmvq.cu cuda/mmq/mmvq.cuh cuda/mmq/common.cuh cud
 
 cuda/mmq/d2r_stubs.rocm.o: cuda/mmq/test/d2r_stubs.cu cuda/mmq/ds4_mmq_d2r.cuh cuda/mmq/vendors/hip.h
 	$(HIPCC) $(ROCM_MMQ_FLAGS) -c -o $@ $<
+
+cuda/mmq/test/test_mmq_parity.rocm.o: cuda/mmq/test/test_mmq_parity.cu cuda/mmq/test/iq2_host_tables.h cuda/mmq/ds4_mmq.h cuda/mmq/ggml-common.h
+	$(HIPCC) $(ROCM_MMQ_FLAGS) -Wno-unused-value -c -o $@ $<
+
+cuda/mmq/test/test_mmq_parity_rocm: cuda/mmq/test/test_mmq_parity.rocm.o $(ROCM_MMQ_OBJS)
+	$(HIPCC) $(ROCM_CFLAGS) -o $@ $^ -lm -pthread
+
+test-glm53-iq2-mmq-rocm: cuda/mmq/test/test_mmq_parity_rocm
+	@set -e; for n in 127 128 511 512 513; do \
+		./cuda/mmq/test/test_mmq_parity_rocm --glm53-iq2-pair $$n; \
+	done
 
 tests/test_mxfp4_rocm.o: tests/test_mxfp4_rocm.c ds4_gpu.h
 	$(CC) $(filter-out -ffast-math,$(CFLAGS)) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD -I. -c -o $@ $<
@@ -600,4 +630,4 @@ mxfp4-dot-test: tests/test_mxfp4_dot.c
 	./tests/test_mxfp4_dot
 
 clean:
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_rocm tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_glm53_kda tests/test_glm53_kda_rocm tests/test_glm53_vision_engine tests/test_glm53_vision_prompt tests/test_deepseek4_vision_image tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o gguf-tools/quality-testing/score_official_rocm gguf-tools/quality-testing/score_official.rocm.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_rocm tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_glm53_kda tests/test_glm53_kda_rocm tests/test_glm53_vision_engine tests/test_glm53_vision_prompt tests/test_deepseek4_vision_image tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o cuda/mmq/test/test_mmq_parity_rocm cuda/mmq/test/test_mmq_parity.rocm.o

--- a/README.md
+++ b/README.md
@@ -1238,6 +1238,8 @@ not select a different model.
 Tool schemas are rendered into DeepSeek's DSML tool format, and generated DSML
 tool calls are mapped back to OpenAI tool calls.
 
+`/v1/completions` performs raw prefix completion without applying a chat template. `prompt` accepts either one string or one non-empty flat array of integer token IDs; batches, nested arrays, string arrays, mixed arrays, and out-of-range IDs are rejected. String prompts receive the model-family start sequence and recognize explicitly spelled special tokens, while token arrays are used exactly as supplied. The compatibility fields `thinking`, `think`, and `reasoning_effort` are validated but ignored because they cannot alter a raw Completion prompt.
+
 `/v1/responses` accepts OpenAI Responses-style `input`, `instructions`,
 `tools`, `tool_choice`, `max_output_tokens`, `temperature`, `top_p`, `stream`,
 and `reasoning`. It is the preferred endpoint for Codex CLI. The server keeps

--- a/README.md
+++ b/README.md
@@ -334,13 +334,10 @@ OpenAI or base64 image source for Anthropic. File paths and remote URLs are
 rejected. A request may contain up to 16 images and the HTTP body is limited to
 64 MiB.
 
-Vision runs on Metal, single-GPU CUDA, and ROCm. On a DGX Spark, use the CUDA
-command above and add `--vision FILE`. On the 128 GB Strix Halo reference host,
-Q2 needs the same SSD-streaming options as text inference:
+Vision runs on Metal, single-GPU CUDA, and ROCm. On a DGX Spark, use the CUDA command above and add `--vision FILE`. On the 128 GB Strix Halo reference host, Q2 runs fully resident by default:
 
 ```sh
-./ds4 --rocm --ssd-streaming --ssd-streaming-cache-experts 32GB \
-  -m gguf/GLM-5.3-Flash-Q2.gguf \
+./ds4 --rocm -m gguf/GLM-5.3-Flash-Q2.gguf \
   --vision gguf/GLM-5.3-Flash-Vision-Encoder.gguf
 ```
 

--- a/cuda/mmq/ds4_mmq.cu
+++ b/cuda/mmq/ds4_mmq.cu
@@ -57,6 +57,38 @@ static bool ds4_mmq_gfx1151_flag(const char *name, int cc) {
     return env ? env[0] != '0' : cc == GGML_CUDA_CC_OFFSET_AMD + 0x1151;
 }
 
+#if defined(GGML_USE_HIP)
+static int ds4_mmq_positive_int_env(const char *name) {
+    const char *env = getenv(name);
+    if (!env || !env[0]) return 0;
+    char *end = nullptr;
+    const long value = strtol(env, &end, 10);
+    return end != env && value > 0 && value <= INT_MAX ? (int)value : 0;
+}
+#endif
+
+static int ds4_mmq_glm_iq2_x_max(
+        ggml_type type, int cc, int n_tokens,
+        int n_experts, int n_expert_used) {
+#if defined(GGML_USE_HIP)
+    const char *env = getenv("DS4_ROCM_GLM_IQ2_X_MAX");
+    if (env) return ds4_mmq_positive_int_env("DS4_ROCM_GLM_IQ2_X_MAX");
+    if (type == GGML_TYPE_IQ2_XXS &&
+        cc == GGML_CUDA_CC_OFFSET_AMD + 0x1151 &&
+        n_experts == 288 && n_expert_used == 8 &&
+        n_tokens >= 128 && n_tokens <= 512) {
+        return 24;
+    }
+#else
+    (void)type;
+    (void)cc;
+    (void)n_tokens;
+    (void)n_experts;
+    (void)n_expert_used;
+#endif
+    return 0;
+}
+
 static uint64_t ds4_mmq_nvtx_payload(uint32_t first, uint32_t second) {
     return ((uint64_t)first << 32) | second;
 }
@@ -1720,6 +1752,8 @@ int ds4_mmq_moe_pair_impl(
         /*ncols_max=*/routed_ncols_max,
         /*x_soa=*/xa_soa,
         /*soa_blocks=*/soa_blocks,
+        /*mmq_x_max=*/ds4_mmq_glm_iq2_x_max(
+            type, cc, n_tokens, n_experts, n_expert_used),
     };
 
     {

--- a/cuda/mmq/mmq.cuh
+++ b/cuda/mmq/mmq.cuh
@@ -3692,14 +3692,21 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 
     constexpr int ITER_K          = get_iter_k(type);
     constexpr int blocks_per_iter = ITER_K / qk;
-    // Invalid columns must be zero before the matrix instruction. Masking
-    // only write-back is too late: stale or NaN tail blocks can contaminate
-    // other values in the same hardware matrix fragment.
+    // Keep complete tiles on the direct load path. For a partial tile, zero its invalid suffix once and refresh only the valid prefix below so no stale or NaN tail value can enter a hardware matrix fragment.
+    const bool full_y_tile = tile_y_max_j >= mmq_x - 1;
     const int valid_y_words = min(mmq_x, tile_y_max_j + 1) * MMQ_TILE_Y_K;
+    const int linear_tid = threadIdx.y*warp_size + threadIdx.x;
+    constexpr int nthreads = nwarps * warp_size;
 
     float sum[mmq_x*mmq_y / (nwarps*warp_size)] = {0.0f};
 
     constexpr int sz = sizeof(block_q8_1_mmq) / sizeof(int);
+
+    if (!full_y_tile) {
+        for (int l = valid_y_words + linear_tid; l < mmq_x * MMQ_TILE_Y_K; l += nthreads) {
+            tile_y[l] = 0;
+        }
+    }
 
     for (int kb0 = kb0_start; kb0 < kb0_stop; kb0 += blocks_per_iter) {
         // ds4 (P4 Inc3): when the caller supplies an aligned-SoA weight
@@ -3725,11 +3732,17 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
         }
         {
             const int * by0 = y + ncols_y * (kb0 * qk / ne_block) * sz;
+            if (full_y_tile) {
 #pragma unroll
-            for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
-                int l = l0 + threadIdx.y*warp_size + threadIdx.x;
-
-                tile_y[l] = l < valid_y_words ? by0[l] : 0;
+                for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
+                    const int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+                    tile_y[l] = by0[l];
+                }
+            } else {
+#pragma unroll
+                for (int l = linear_tid; l < valid_y_words; l += nthreads) {
+                    tile_y[l] = by0[l];
+                }
             }
         }
 
@@ -3741,11 +3754,17 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 
         {
             const int * by0 = y + ncols_y * ((kb0 * qk / ne_block) * sz + sz);
+            if (full_y_tile) {
 #pragma unroll
-            for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
-                int l = l0 + threadIdx.y*warp_size + threadIdx.x;
-
-                tile_y[l] = l < valid_y_words ? by0[l] : 0;
+                for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
+                    const int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+                    tile_y[l] = by0[l];
+                }
+            } else {
+#pragma unroll
+                for (int l = linear_tid; l < valid_y_words; l += nthreads) {
+                    tile_y[l] = by0[l];
+                }
             }
         }
 

--- a/cuda/mmq/mmq.cuh
+++ b/cuda/mmq/mmq.cuh
@@ -4187,6 +4187,10 @@ struct mmq_args {
     // ignored; soa_blocks = pair count (Q2_K) or block count (IQ2_XXS).
     // Trailing fields so existing aggregate initializers value-init them.
     const char * x_soa; int64_t soa_blocks;
+    // Optional per-call cap for the output-column tile. Zero preserves the
+    // backend-wide selector. This lets a measured routed short-prefill shape
+    // avoid changing unrelated dense MMQ calls in the same process.
+    int mmq_x_max;
 };
 
 template<ggml_type type>
@@ -4323,7 +4327,10 @@ void mul_mat_q_case(ggml_backend_cuda_context & ctx, const mmq_args & args, cuda
     const int warp_size = ggml_cuda_info().devices[id].warp_size;
     const int nwarps    = mmq_get_nwarps_host(cc, warp_size);
 
-    const int mmq_x_max = get_mmq_x_max_host(cc);
+    const int hardware_mmq_x_max = get_mmq_x_max_host(cc);
+    const int mmq_x_max = args.mmq_x_max > 0
+        ? std::min(args.mmq_x_max, hardware_mmq_x_max)
+        : hardware_mmq_x_max;
     const int mmq_y = get_mmq_y_host(cc);
 
     int mmq_x_best  = 0;

--- a/cuda/mmq/test/test_mmq_parity.cu
+++ b/cuda/mmq/test/test_mmq_parity.cu
@@ -843,6 +843,179 @@ bool run_moe_pair_generic(
     return ok;
 }
 
+// GLM-5.3-Flash production-topology verifier for the IQ2_XXS paired MMQ
+// prefill path.  The generic verifier above deliberately keeps its expert
+// population small because it also constructs a full dequantized CPU
+// reference.  Here the reference is the two single-W MMQ entries, so we can
+// exercise the real 288-expert/top-8 address arithmetic without allocating a
+// pointless ~9 GiB F32 copy of the weights.  Guard regions catch output
+// under/overwrites and every candidate stage is synchronized immediately.
+bool run_glm53_iq2_pair_shape(int n_tokens, uint32_t seed) {
+    constexpr int M = 2048;
+    constexpr int K = 4096;
+    constexpr int n_experts = 288;
+    constexpr int n_expert_used = 8;
+    constexpr size_t guard_count = 256;
+    constexpr uint32_t guard_bits = 0x4b7fffffu;
+
+    fprintf(stderr,
+            "=== IQ2_XXS/GLM53_PAIR M=%d K=%d ntok=%d nexp=%d nused=%d seed=%u ===\n",
+            M, K, n_tokens, n_experts, n_expert_used, seed);
+    if (n_tokens < 1 || n_tokens > 2048) {
+        fprintf(stderr, "invalid GLM53 token count: %d\n", n_tokens);
+        return false;
+    }
+
+    std::mt19937 rng(seed);
+    std::normal_distribution<float> nd(0.0f, 1.0f);
+    const int blocks_per_row = K / QK_K_LOCAL;
+    const size_t blocks_per_expert = (size_t)M * blocks_per_row;
+    const size_t weight_blocks = (size_t)n_experts * blocks_per_expert;
+
+    // A moderately varied block pool makes generation fast enough for a
+    // production-size test while keeping every fp16 scale finite.
+    std::vector<block_iq2_xxs> pool_a(4096), pool_b(4096);
+    for (auto & block : pool_a) generate_random_block_iq2_xxs(&block, rng);
+    for (auto & block : pool_b) generate_random_block_iq2_xxs(&block, rng);
+    std::vector<block_iq2_xxs> W_a(weight_blocks), W_b(weight_blocks);
+    for (size_t i = 0; i < weight_blocks; i++) {
+        W_a[i] = pool_a[i % pool_a.size()];
+        W_b[i] = pool_b[(i * 17u + 3u) % pool_b.size()];
+    }
+
+    std::vector<int32_t> ids((size_t)n_tokens * n_expert_used);
+    for (int t = 0; t < n_tokens; t++) {
+        for (int s = 0; s < n_expert_used; s++) {
+            ids[(size_t)t * n_expert_used + s] = (t * 13 + s * 31) % n_experts;
+        }
+    }
+    std::vector<float> X((size_t)n_tokens * K);
+    for (auto & value : X) value = nd(rng);
+
+    const size_t out_count = (size_t)M * n_tokens * n_expert_used;
+    const size_t guarded_count = out_count + 2 * guard_count;
+    float guard_value;
+    std::memcpy(&guard_value, &guard_bits, sizeof(guard_value));
+    std::vector<float> initialized(guarded_count, guard_value);
+    std::vector<float> ya_single(guarded_count), yb_single(guarded_count);
+    std::vector<float> ya_pair(guarded_count), yb_pair(guarded_count);
+
+    cudaStream_t stream = nullptr;
+    void * dWa = nullptr;
+    void * dWb = nullptr;
+    float * dX = nullptr;
+    int32_t * dIds = nullptr;
+    float * dYa_single_base = nullptr;
+    float * dYb_single_base = nullptr;
+    float * dYa_pair_base = nullptr;
+    float * dYb_pair_base = nullptr;
+    bool ok = true;
+
+#define GLM53_CUDA(call) do {                                                   \
+        const cudaError_t err_ = (call);                                        \
+        if (err_ != cudaSuccess) {                                              \
+            fprintf(stderr, "%s failed: %s\n", #call, cudaGetErrorString(err_)); \
+            ok = false;                                                         \
+            goto cleanup;                                                       \
+        }                                                                       \
+    } while (0)
+
+    GLM53_CUDA(cudaStreamCreate(&stream));
+    GLM53_CUDA(cudaMalloc(&dWa, W_a.size() * sizeof(block_iq2_xxs)));
+    GLM53_CUDA(cudaMalloc(&dWb, W_b.size() * sizeof(block_iq2_xxs)));
+    GLM53_CUDA(cudaMalloc(&dX, X.size() * sizeof(float)));
+    GLM53_CUDA(cudaMalloc(&dIds, ids.size() * sizeof(int32_t)));
+    GLM53_CUDA(cudaMalloc(&dYa_single_base, guarded_count * sizeof(float)));
+    GLM53_CUDA(cudaMalloc(&dYb_single_base, guarded_count * sizeof(float)));
+    GLM53_CUDA(cudaMalloc(&dYa_pair_base, guarded_count * sizeof(float)));
+    GLM53_CUDA(cudaMalloc(&dYb_pair_base, guarded_count * sizeof(float)));
+    GLM53_CUDA(cudaMemcpyAsync(dWa, W_a.data(), W_a.size() * sizeof(block_iq2_xxs), cudaMemcpyHostToDevice, stream));
+    GLM53_CUDA(cudaMemcpyAsync(dWb, W_b.data(), W_b.size() * sizeof(block_iq2_xxs), cudaMemcpyHostToDevice, stream));
+    GLM53_CUDA(cudaMemcpyAsync(dX, X.data(), X.size() * sizeof(float), cudaMemcpyHostToDevice, stream));
+    GLM53_CUDA(cudaMemcpyAsync(dIds, ids.data(), ids.size() * sizeof(int32_t), cudaMemcpyHostToDevice, stream));
+    GLM53_CUDA(cudaMemcpyAsync(dYa_single_base, initialized.data(), guarded_count * sizeof(float), cudaMemcpyHostToDevice, stream));
+    GLM53_CUDA(cudaMemcpyAsync(dYb_single_base, initialized.data(), guarded_count * sizeof(float), cudaMemcpyHostToDevice, stream));
+    GLM53_CUDA(cudaMemcpyAsync(dYa_pair_base, initialized.data(), guarded_count * sizeof(float), cudaMemcpyHostToDevice, stream));
+    GLM53_CUDA(cudaMemcpyAsync(dYb_pair_base, initialized.data(), guarded_count * sizeof(float), cudaMemcpyHostToDevice, stream));
+
+    {
+        float * dYa_single = dYa_single_base + guard_count;
+        float * dYb_single = dYb_single_base + guard_count;
+        float * dYa_pair = dYa_pair_base + guard_count;
+        float * dYb_pair = dYb_pair_base + guard_count;
+        GLM53_CUDA(cudaMemsetAsync(dYa_single, 0, out_count * sizeof(float), stream));
+        GLM53_CUDA(cudaMemsetAsync(dYb_single, 0, out_count * sizeof(float), stream));
+        GLM53_CUDA(cudaMemsetAsync(dYa_pair, 0, out_count * sizeof(float), stream));
+        GLM53_CUDA(cudaMemsetAsync(dYb_pair, 0, out_count * sizeof(float), stream));
+
+        const int rc_sa = ds4_mmq_iq2_xxs_moe(dWa, dX, dIds, dYa_single,
+                                               M, K, n_tokens, n_experts,
+                                               n_expert_used, stream);
+        GLM53_CUDA(cudaStreamSynchronize(stream));
+        const int rc_sb = ds4_mmq_iq2_xxs_moe(dWb, dX, dIds, dYb_single,
+                                               M, K, n_tokens, n_experts,
+                                               n_expert_used, stream);
+        GLM53_CUDA(cudaStreamSynchronize(stream));
+        const int rc_pair = ds4_mmq_iq2_xxs_moe_pair(
+            dWa, dWb, dX, dIds, dYa_pair, dYb_pair, M, K, n_tokens,
+            n_experts, n_expert_used, stream);
+        GLM53_CUDA(cudaStreamSynchronize(stream));
+        if (rc_sa != 0 || rc_sb != 0 || rc_pair != 0) {
+            fprintf(stderr, "GLM53 entries returned single_a=%d single_b=%d pair=%d\n",
+                    rc_sa, rc_sb, rc_pair);
+            ok = false;
+            goto cleanup;
+        }
+    }
+
+    GLM53_CUDA(cudaMemcpyAsync(ya_single.data(), dYa_single_base, guarded_count * sizeof(float), cudaMemcpyDeviceToHost, stream));
+    GLM53_CUDA(cudaMemcpyAsync(yb_single.data(), dYb_single_base, guarded_count * sizeof(float), cudaMemcpyDeviceToHost, stream));
+    GLM53_CUDA(cudaMemcpyAsync(ya_pair.data(), dYa_pair_base, guarded_count * sizeof(float), cudaMemcpyDeviceToHost, stream));
+    GLM53_CUDA(cudaMemcpyAsync(yb_pair.data(), dYb_pair_base, guarded_count * sizeof(float), cudaMemcpyDeviceToHost, stream));
+    GLM53_CUDA(cudaStreamSynchronize(stream));
+
+    for (const auto * guarded : {&ya_single, &yb_single, &ya_pair, &yb_pair}) {
+        for (size_t i = 0; i < guard_count; i++) {
+            if ((*guarded)[i] != guard_value ||
+                (*guarded)[guard_count + out_count + i] != guard_value) {
+                fprintf(stderr, "GLM53 output canary corrupted at guard index %zu\n", i);
+                ok = false;
+                break;
+            }
+        }
+    }
+    if (ok) {
+        std::vector<float> ya_single_out(ya_single.begin() + guard_count,
+                                         ya_single.begin() + guard_count + out_count);
+        std::vector<float> yb_single_out(yb_single.begin() + guard_count,
+                                         yb_single.begin() + guard_count + out_count);
+        std::vector<float> ya_pair_out(ya_pair.begin() + guard_count,
+                                       ya_pair.begin() + guard_count + out_count);
+        std::vector<float> yb_pair_out(yb_pair.begin() + guard_count,
+                                       yb_pair.begin() + guard_count + out_count);
+        // The production x16 tile may change the final F32 reduction order
+        // between a standalone and paired launch.  The observed envelope is
+        // sub-millifloat, so require a tight 1e-3 absolute / 1e-5 relative
+        // bound over the complete output instead of bit identity.
+        ok = check_close(ya_pair_out, ya_single_out, 1.0e-3f, 1.0e-5f) &&
+             check_close(yb_pair_out, yb_single_out, 1.0e-3f, 1.0e-5f);
+    }
+
+cleanup:
+    if (dWa) cudaFree(dWa);
+    if (dWb) cudaFree(dWb);
+    if (dX) cudaFree(dX);
+    if (dIds) cudaFree(dIds);
+    if (dYa_single_base) cudaFree(dYa_single_base);
+    if (dYb_single_base) cudaFree(dYb_single_base);
+    if (dYa_pair_base) cudaFree(dYa_pair_base);
+    if (dYb_pair_base) cudaFree(dYb_pair_base);
+    if (stream) cudaStreamDestroy(stream);
+#undef GLM53_CUDA
+    fprintf(stderr, "%s\n\n", ok ? "PASS" : "FAIL");
+    return ok;
+}
+
 bool run_q4_K_moe(int M, int K, int nt, int ne, int nu, uint32_t seed) {
     auto fn = [](block_q4_K * blk, float * out,
                  int n_experts, int M, int K, int blocks_per_expert,
@@ -1145,9 +1318,12 @@ bool run_q8_0_dense_vec(int M, int N, int K, uint32_t seed) {
 } // namespace
 
 int main(int argc, char ** argv) {
-    (void)argc; (void)argv;
     int rc = ds4_mmq_init(0);
     if (rc != 0) { fprintf(stderr, "ds4_mmq_init failed: %d\n", rc); return 1; }
+
+    if (argc == 3 && std::strcmp(argv[1], "--glm53-iq2-pair") == 0) {
+        return run_glm53_iq2_pair_shape(std::atoi(argv[2]), 0x53F1A500) ? 0 : 1;
+    }
 
     bool all_ok = true;
 

--- a/ds4.c
+++ b/ds4.c
@@ -45280,6 +45280,9 @@ static DS4_MAYBE_UNUSED bool glm_graph_use_dense_compact_attention_prefill(
     /* The CUDA GEMM setup crosses over the scalar online kernel near 256
      * tokens on GB10. Keep short prompts on the lower-latency path. */
     return g_n_gpus == 1 && n_tokens >= 256u;
+#elif defined(DS4_ROCM_BUILD)
+    /* The grouped hipBLAS path has the same setup/throughput crossover. */
+    return n_tokens >= 256u;
 #else
     return true;
 #endif
@@ -50024,7 +50027,7 @@ static bool glm_graph_forward_indexed_tokens(
                 }
                 if (n_tokens <= 8u && (glm_decode_ablate_mask() & DS4_GLM_ABLATE_ATTN_CORE)) { /* ablate */ } else if (ok && use_split_value_proj) {
                     int rc = 0;
-#if defined(__APPLE__) || (!defined(DS4_ROCM_BUILD) && !defined(DS4_NO_GPU))
+#if !defined(DS4_NO_GPU)
                     if (slice_causal &&
                         glm_graph_use_dense_compact_attention_prefill(slice) &&
                         !tp_attn_head_split) {

--- a/ds4.c
+++ b/ds4.c
@@ -40640,7 +40640,7 @@ static double glm_graph_bytes_to_gib(uint64_t bytes) {
     return (double)bytes / (1024.0 * 1024.0 * 1024.0);
 }
 
-#ifdef DS4_ROCM_BUILD
+#if defined(DS4_ROCM_BUILD) && !defined(DS4_NO_GPU)
 static uint64_t g_glm_rocm_guard_available_baseline;
 #endif
 
@@ -62390,7 +62390,7 @@ static int ds4_engine_open_internal(ds4_engine **out,
                                      const ds4_engine_options *opt,
                                      const ds4_gpu_config *gpu_cfg) {
     ds4_engine *e = xcalloc(1, sizeof(*e));
-#ifdef DS4_ROCM_BUILD
+#if defined(DS4_ROCM_BUILD) && !defined(DS4_NO_GPU)
     g_glm_rocm_guard_available_baseline =
         glm_graph_host_available_memory_bytes();
 #endif

--- a/ds4.c
+++ b/ds4.c
@@ -40640,7 +40640,7 @@ static double glm_graph_bytes_to_gib(uint64_t bytes) {
     return (double)bytes / (1024.0 * 1024.0 * 1024.0);
 }
 
-#ifdef DS4_ROCM_BUILD
+#if defined(DS4_ROCM_BUILD) && !defined(DS4_NO_GPU)
 static uint64_t g_glm_rocm_guard_available_baseline;
 #endif
 
@@ -62387,7 +62387,7 @@ static int ds4_engine_open_internal(ds4_engine **out,
                                      const ds4_engine_options *opt,
                                      const ds4_gpu_config *gpu_cfg) {
     ds4_engine *e = xcalloc(1, sizeof(*e));
-#ifdef DS4_ROCM_BUILD
+#if defined(DS4_ROCM_BUILD) && !defined(DS4_NO_GPU)
     g_glm_rocm_guard_available_baseline =
         glm_graph_host_available_memory_bytes();
 #endif

--- a/ds4_rocm.cu
+++ b/ds4_rocm.cu
@@ -57,6 +57,9 @@ extern "C" int ds4_mmq_iq2_xxs_moe_pair(
 extern "C" int ds4_mmq_q8_0_dense_vec(
     const void *W, const float *X_f32, float *out_f32,
     int M, int N, int K, cudaStream_t stream);
+extern "C" int ds4_mmq_q4_K_dense(
+    const void *W, const float *X_f32, float *out_f32,
+    int M, int N, int K, cudaStream_t stream);
 extern "C" int ds4_mmq_q2_K_moe_down_sum6_vec(
     const void *W, const float *X, const int32_t *ids, float *out,
     int M, int K, int n_tokens, int n_experts, int n_expert_used,

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -4954,45 +4954,147 @@ bad:
     return false;
 }
 
-static bool parse_prompt(const char **p, char **out) {
+typedef enum {
+    COMPLETION_PROMPT_NONE = 0,
+    COMPLETION_PROMPT_TEXT,
+    COMPLETION_PROMPT_TOKENS,
+} completion_prompt_kind;
+
+typedef struct {
+    completion_prompt_kind kind;
+    char *text;
+    ds4_tokens tokens;
+} completion_prompt;
+
+static void completion_prompt_free(completion_prompt *prompt) {
+    if (!prompt) return;
+    free(prompt->text);
+    ds4_tokens_free(&prompt->tokens);
+    memset(prompt, 0, sizeof(*prompt));
+}
+
+static bool parse_completion_token_id(const char **p, int *out) {
     json_ws(p);
-    if (**p == '"') return json_string(p, out);
-    if (**p != '[') {
-        if (!json_skip_value(p)) return false;
-        *out = xstrdup("");
-        return true;
+    const char *start = *p;
+    if (*start < '0' || *start > '9') return false;
+    uint64_t value = 0;
+    if (*start == '0' && start[1] >= '0' && start[1] <= '9') return false;
+    while (**p >= '0' && **p <= '9') {
+        const uint32_t digit = (uint32_t)(**p - '0');
+        if (value > ((uint64_t)INT_MAX - digit) / 10u) return false;
+        value = value * 10u + digit;
+        (*p)++;
     }
-    (*p)++;
-    json_ws(p);
-    if (**p == '"') {
-        if (!json_string(p, out)) return false;
-    } else {
-        *out = xstrdup("");
-        if (**p && **p != ']' && !json_skip_value(p)) return false;
-    }
-    while (**p && **p != ']') {
-        json_ws(p);
-        if (**p == ',') {
-            (*p)++;
-            if (!json_skip_value(p)) return false;
-        } else {
-            break;
-        }
-    }
-    if (**p != ']') return false;
-    (*p)++;
+    *out = (int)value;
     return true;
 }
 
-static bool parse_completion_request(ds4_engine *e, const char *body, int def_tokens,
-                                     int ctx_size, request *r, char *err, size_t errlen) {
+static bool parse_completion_prompt(const char **p, completion_prompt *out,
+                                    char *err, size_t errlen) {
+    completion_prompt parsed = {0};
+    json_ws(p);
+    if (**p == '"') {
+        if (!json_string(p, &parsed.text)) {
+            snprintf(err, errlen, "prompt must be a valid JSON string or a flat array of integer token IDs");
+            return false;
+        }
+        parsed.kind = COMPLETION_PROMPT_TEXT;
+        *out = parsed;
+        return true;
+    }
+    if (**p != '[') {
+        snprintf(err, errlen, "prompt must be a string or a flat array of integer token IDs");
+        return false;
+    }
+    (*p)++;
+    json_ws(p);
+    if (**p == ']') {
+        (*p)++;
+        parsed.kind = COMPLETION_PROMPT_TOKENS;
+        *out = parsed;
+        return true;
+    }
+    while (**p) {
+        int token = 0;
+        if (!parse_completion_token_id(p, &token)) {
+            snprintf(err, errlen, "prompt token array must contain only non-negative integer token IDs");
+            completion_prompt_free(&parsed);
+            return false;
+        }
+        ds4_tokens_push(&parsed.tokens, token);
+        json_ws(p);
+        if (**p == ']') {
+            (*p)++;
+            parsed.kind = COMPLETION_PROMPT_TOKENS;
+            *out = parsed;
+            return true;
+        }
+        if (**p != ',') {
+            snprintf(err, errlen, "prompt token array must be a flat array of integer token IDs");
+            completion_prompt_free(&parsed);
+            return false;
+        }
+        (*p)++;
+        json_ws(p);
+        if (**p == ']') {
+            snprintf(err, errlen, "prompt token array must not contain a trailing comma");
+            completion_prompt_free(&parsed);
+            return false;
+        }
+    }
+    snprintf(err, errlen, "unterminated prompt token array");
+    completion_prompt_free(&parsed);
+    return false;
+}
+
+static bool completion_prompt_build(ds4_engine *e, int vocab_size,
+                                    completion_prompt *prompt, request *r,
+                                    char *err, size_t errlen) {
+    if (prompt->kind == COMPLETION_PROMPT_TEXT) {
+        if (!e) {
+            snprintf(err, errlen, "completion text tokenization requires a loaded model");
+            return false;
+        }
+        r->prompt_text = prompt->text;
+        prompt->text = NULL;
+        ds4_chat_begin(e, &r->prompt);
+        ds4_tokenize_rendered_chat(e, r->prompt_text, &r->prompt);
+        return true;
+    }
+    if (prompt->kind != COMPLETION_PROMPT_TOKENS) {
+        snprintf(err, errlen, "missing prompt");
+        return false;
+    }
+    if (prompt->tokens.len == 0) {
+        snprintf(err, errlen, "prompt token array must not be empty");
+        return false;
+    }
+    if (vocab_size <= 0) {
+        snprintf(err, errlen, "completion token validation requires a loaded model");
+        return false;
+    }
+    for (int i = 0; i < prompt->tokens.len; i++) {
+        if (prompt->tokens.v[i] < 0 || prompt->tokens.v[i] >= vocab_size) {
+            snprintf(err, errlen, "prompt token ID %d is outside the model vocabulary [0, %d)",
+                     prompt->tokens.v[i], vocab_size);
+            return false;
+        }
+    }
+    r->prompt = prompt->tokens;
+    memset(&prompt->tokens, 0, sizeof(prompt->tokens));
+    return true;
+}
+
+static bool parse_completion_request_with_vocab(ds4_engine *e, int vocab_size,
+                                                const char *body, int def_tokens,
+                                                int ctx_size, request *r,
+                                                char *err, size_t errlen) {
     request_init(r, REQ_COMPLETION, def_tokens);
     r->model_syntax = server_model_syntax_for_engine(e);
     const char *p = body;
-    char *prompt = NULL;
-    bool got_thinking = false;
-    bool thinking_enabled = true;
-    ds4_think_mode reasoning_effort = DS4_THINK_HIGH;
+    completion_prompt prompt = {0};
+    bool got_prompt = false;
+    (void)ctx_size;
 
     json_ws(&p);
     if (*p != '{') goto bad;
@@ -5008,14 +5110,16 @@ static bool parse_completion_request(ds4_engine *e, const char *body, int def_to
         }
         p++;
         if (!strcmp(key, "prompt")) {
-            char *tmp = NULL;
-            if (!parse_prompt(&p, &tmp)) {
-                free(tmp);
+            completion_prompt tmp = {0};
+            if (!parse_completion_prompt(&p, &tmp, err, errlen)) {
                 free(key);
-                goto bad;
+                completion_prompt_free(&prompt);
+                request_free(r);
+                return false;
             }
-            free(prompt);
+            completion_prompt_free(&prompt);
             prompt = tmp;
+            got_prompt = true;
         } else if (!strcmp(key, "model")) {
             if (!json_string_replace(&p, &r->model)) {
                 free(key);
@@ -5075,22 +5179,23 @@ static bool parse_completion_request(ds4_engine *e, const char *body, int def_to
                 goto bad;
             }
         } else if (!strcmp(key, "thinking")) {
-            if (!parse_thinking_control_value(&p, &thinking_enabled)) {
+            bool ignored = false;
+            if (!parse_thinking_control_value(&p, &ignored)) {
                 free(key);
                 goto bad;
             }
-            got_thinking = true;
         } else if (!strcmp(key, "reasoning_effort")) {
-            if (!parse_reasoning_effort_value(&p, &reasoning_effort)) {
+            ds4_think_mode ignored = DS4_THINK_NONE;
+            if (!parse_reasoning_effort_value(&p, &ignored)) {
                 free(key);
                 goto bad;
             }
         } else if (!strcmp(key, "think")) {
-            if (!json_bool(&p, &thinking_enabled)) {
+            bool ignored = false;
+            if (!json_bool(&p, &ignored)) {
                 free(key);
                 goto bad;
             }
-            got_thinking = true;
         } else if (!strcmp(key, "stop")) {
             if (!parse_stop(&p, &r->stops)) {
                 free(key);
@@ -5106,36 +5211,32 @@ static bool parse_completion_request(ds4_engine *e, const char *body, int def_to
         json_ws(&p);
     }
     if (*p != '}') goto bad;
-    if (!prompt) {
+    if (!got_prompt) {
         snprintf(err, errlen, "missing prompt");
+        completion_prompt_free(&prompt);
         request_free(r);
         return false;
     }
-    if (!got_thinking && model_alias_disables_thinking(r->model)) thinking_enabled = false;
-    if (!got_thinking && model_alias_enables_thinking(r->model)) thinking_enabled = true;
-    r->think_mode = ds4_think_mode_for_context(
-        think_mode_from_enabled(thinking_enabled, reasoning_effort), ctx_size);
-    chat_msgs msgs = {0};
-    chat_msg sys = {0};
-    sys.role = xstrdup("system");
-    sys.content = xstrdup("You are a helpful assistant");
-    chat_msgs_push(&msgs, sys);
-    chat_msg user_msg = {0};
-    user_msg.role = xstrdup("user");
-    user_msg.content = prompt;
-    prompt = NULL;
-    chat_msgs_push(&msgs, user_msg);
-    r->prompt_text = render_chat_prompt_text_for_syntax(
-        r->model_syntax, &msgs, NULL, NULL, r->think_mode);
-    ds4_tokenize_rendered_chat(e, r->prompt_text, &r->prompt);
-    chat_msgs_free(&msgs);
-    free(prompt);
+    r->think_mode = DS4_THINK_NONE;
+    if (!completion_prompt_build(e, vocab_size, &prompt, r,
+                                 err, errlen)) {
+        completion_prompt_free(&prompt);
+        request_free(r);
+        return false;
+    }
+    completion_prompt_free(&prompt);
     return true;
 bad:
-    free(prompt);
+    completion_prompt_free(&prompt);
     snprintf(err, errlen, "invalid JSON request");
     request_free(r);
     return false;
+}
+
+static bool parse_completion_request(ds4_engine *e, const char *body, int def_tokens,
+                                     int ctx_size, request *r, char *err, size_t errlen) {
+    return parse_completion_request_with_vocab(
+        e, ds4_engine_vocab_size(e), body, def_tokens, ctx_size, r, err, errlen);
 }
 
 static long long wall_ms(void) {
@@ -10369,9 +10470,23 @@ static int live_text_prefix_prompt(server *s, server_slot *slot,
 
     size_t live_text_len = 0;
     char *live_text = render_tokens_text(s->engine, live_tokens, &live_text_len);
+    size_t live_text_start = 0;
+    if (req->kind == REQ_COMPLETION) {
+        ds4_tokens start = {0};
+        ds4_chat_begin(s->engine, &start);
+        size_t start_text_len = 0;
+        char *start_text = render_tokens_text(s->engine, &start, &start_text_len);
+        if (byte_prefix_match(live_text, live_text_len,
+                              start_text, start_text_len)) {
+            live_text_start = start_text_len;
+        }
+        free(start_text);
+        ds4_tokens_free(&start);
+    }
     const size_t prompt_text_len = strlen(req->prompt_text);
     if (!byte_prefix_match(req->prompt_text, prompt_text_len,
-                           live_text, live_text_len))
+                           live_text + live_text_start,
+                           live_text_len - live_text_start))
     {
         free(live_text);
         return 0;
@@ -10382,7 +10497,8 @@ static int live_text_prefix_prompt(server *s, server_slot *slot,
      * come after it.  Reusing req->prompt's token suffix would be wrong: full
      * prompt BPE may have merged across this byte boundary. */
     build_prompt_from_exact_prefix_and_text_suffix(
-        s->engine, live_tokens, req->prompt_text + live_text_len,
+        s->engine, live_tokens,
+        req->prompt_text + live_text_len - live_text_start,
         effective_prompt);
     free(live_text);
     return live_tokens->len;
@@ -17670,6 +17786,82 @@ static void test_json_skip_has_nesting_limit(void) {
     free(bad);
 }
 
+static void test_completion_prompt_shapes(void) {
+    char err[160] = {0};
+    completion_prompt prompt = {0};
+    const char *p = "\"raw <think> text\"";
+    TEST_ASSERT(parse_completion_prompt(&p, &prompt, err, sizeof(err)));
+    TEST_ASSERT(prompt.kind == COMPLETION_PROMPT_TEXT);
+    TEST_ASSERT(prompt.text && !strcmp(prompt.text, "raw <think> text"));
+    TEST_ASSERT(*p == '\0');
+    completion_prompt_free(&prompt);
+
+    p = "[11, 22, 33]";
+    TEST_ASSERT(parse_completion_prompt(&p, &prompt, err, sizeof(err)));
+    TEST_ASSERT(prompt.kind == COMPLETION_PROMPT_TOKENS);
+    TEST_ASSERT(prompt.tokens.len == 3);
+    TEST_ASSERT(prompt.tokens.len == 3 && prompt.tokens.v[0] == 11);
+    TEST_ASSERT(prompt.tokens.len == 3 && prompt.tokens.v[1] == 22);
+    TEST_ASSERT(prompt.tokens.len == 3 && prompt.tokens.v[2] == 33);
+    TEST_ASSERT(*p == '\0');
+    completion_prompt_free(&prompt);
+
+    const char *invalid[] = {
+        "null", "7", "true", "[\"a\"]", "[11,\"a\"]", "[[11,22]]",
+        "[11.0]", "[1e2]", "[-1]", "[01]", "[2147483648]", "[11,]",
+        "[11", "{\"tokens\":[11]}"
+    };
+    for (size_t i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+        memset(&prompt, 0, sizeof(prompt));
+        memset(err, 0, sizeof(err));
+        p = invalid[i];
+        TEST_ASSERT(!parse_completion_prompt(&p, &prompt, err, sizeof(err)));
+        TEST_ASSERT(err[0] != '\0');
+        completion_prompt_free(&prompt);
+    }
+}
+
+static void test_completion_token_requests_are_exact(void) {
+    char err[160] = {0};
+    request r;
+    bool ok = parse_completion_request_with_vocab(
+        NULL, 1000,
+        "{\"prompt\":[11,22,33],\"max_tokens\":0,\"thinking\":true,\"think\":false,\"reasoning_effort\":\"max\",\"stream\":true}",
+        128, 4096, &r, err, sizeof(err));
+    TEST_ASSERT(ok);
+    if (ok) {
+        TEST_ASSERT(r.prompt.len == 3);
+        TEST_ASSERT(r.prompt.len == 3 && r.prompt.v[0] == 11);
+        TEST_ASSERT(r.prompt.len == 3 && r.prompt.v[1] == 22);
+        TEST_ASSERT(r.prompt.len == 3 && r.prompt.v[2] == 33);
+        TEST_ASSERT(r.prompt_text == NULL);
+        TEST_ASSERT(r.max_tokens == 0);
+        TEST_ASSERT(r.stream);
+        TEST_ASSERT(r.think_mode == DS4_THINK_NONE);
+        request_free(&r);
+    }
+
+    ok = parse_completion_request_with_vocab(
+        NULL, 100, "{\"prompt\":[99],\"max_tokens\":0}",
+        128, 4096, &r, err, sizeof(err));
+    TEST_ASSERT(ok);
+    if (ok) request_free(&r);
+
+    const char *invalid[] = {
+        "{}", "{\"prompt\":[]}", "{\"prompt\":[100]}",
+        "{\"prompt\":[11,\"a\"]}", "{\"prompt\":[[11]]}",
+        "{\"prompt\":null}"
+    };
+    for (size_t i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+        memset(err, 0, sizeof(err));
+        ok = parse_completion_request_with_vocab(
+            NULL, 100, invalid[i], 128, 4096, &r, err, sizeof(err));
+        TEST_ASSERT(!ok);
+        TEST_ASSERT(err[0] != '\0');
+        if (ok) request_free(&r);
+    }
+}
+
 static void test_request_parsers_reject_malformed_duplicate_owned_fields(void) {
     const char *p =
         "{\"name\":\"ok\",\"name\":\"bad\\q\",\"arguments\":\"{}\"}";
@@ -19496,6 +19688,8 @@ static void ds4_server_unit_tests_run(void) {
     test_stop_list_parses_all_sequences();
     test_stop_list_streaming_holds_and_trims_stop_text();
     test_json_skip_has_nesting_limit();
+    test_completion_prompt_shapes();
+    test_completion_token_requests_are_exact();
     test_request_parsers_reject_malformed_duplicate_owned_fields();
     test_json_parser_handles_tool_heavy_requests();
     test_json_string_handles_surrogates();

--- a/rocm/ds4_rocm_glm.cuh
+++ b/rocm/ds4_rocm_glm.cuh
@@ -400,7 +400,19 @@ extern "C" int ds4_gpu_glm53_matmul_bf16(
         &beta,
         out->ptr, CUDA_R_32F, (int)out_dim,
         CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
-    return cublas_ok(status, "GLM-5.3 BF16 matmul");
+    if (!cublas_ok(status, "GLM-5.3 BF16 matmul")) return 0;
+    /* The 16384 -> 24 mHC projection consumes the single reusable BF16
+     * activation scratch above.  On ROCm 10/gfx1151, returning while that
+     * consumer is still live lets a following graph stage recycle the scratch
+     * and can corrupt the next layer.  Fence the 2048-row production prefill
+     * chunk that exposes the reuse race; short prefill and one-token decode
+     * stay on their existing asynchronous paths. */
+    if (in_dim == 16384u && out_dim == 24u && n_rows >= 2048u &&
+        !cuda_ok(cudaDeviceSynchronize(),
+                 "GLM-5.3 mHC BF16 scratch lifetime fence")) {
+        return 0;
+    }
+    return 1;
 }
 
 __global__ static void glm53_rocm_matmul_q4_K_q8_K_kernel(
@@ -457,6 +469,25 @@ extern "C" int ds4_gpu_matmul_q4_K_tensor(
     const char *weight = cuda_model_range_ptr(
         model_map, weight_offset, weight_bytes, "GLM-5.3 Q4_K matrix");
     if (!weight) return 0;
+    const char *mmq_env = getenv("DS4_ROCM_GLM_Q4_MMQ");
+    const bool use_mmq = mmq_env ? mmq_env[0] != '0'
+                                 : ds4_gpu_dspark_gfx1151_fast_path() != 0;
+    if (n_rows > 8u && use_mmq) {
+        static int logged = 0;
+        if (!logged) {
+            logged = 1;
+            fprintf(stderr,
+                    "ds4: ROCm GLM Q4_K prefill using tiled MMQ\n");
+        }
+        const int rc = ds4_mmq_q4_K_dense(
+            weight, (const float *)x->ptr, (float *)out->ptr,
+            (int)out_dim, (int)n_rows, (int)in_dim, (cudaStream_t)0);
+        if (rc != 0) {
+            fprintf(stderr, "ds4: ROCm GLM Q4_K MMQ failed (%d)\n", rc);
+            return 0;
+        }
+        return 1;
+    }
     cuda_block_q8_K *xq = (cuda_block_q8_K *)cuda_tmp_alloc(
         xq_bytes,
         "GLM-5.3 Q4_K activations");
@@ -4331,6 +4362,19 @@ static int glm_attention_indexed_lora_selected_gemm(
     return 1;
 }
 
+extern "C" int ds4_rocm_glm_selected_multihead_launch(
+        float *lora_out,
+        const float *qk_low,
+        const char *kv_lora_cache,
+        const int32_t *selected,
+        uint32_t n_tokens,
+        uint32_t n_selected,
+        uint32_t cache_cap,
+        bool cache_f16,
+        uint32_t n_head,
+        uint32_t kv_lora_dim,
+        uint32_t qk_nope);
+
 static int glm_attention_indexed_lora_launch(
         ds4_gpu_tensor *lora_out,
         const ds4_gpu_tensor *q,
@@ -4386,6 +4430,35 @@ static int glm_attention_indexed_lora_launch(
         (qk_rope != 0u &&
          !glm_rocm_tensor_has_cache2(k_rope_cache, cache_cap, qk_rope, elem))) {
         return 0;
+    }
+    const char *selected_attn_multihead_env =
+        getenv("DS4_ROCM_GLM_SELECTED_ATTN_MULTIHEAD");
+    if (!causal_range && has_selected && qk_rope == 0u &&
+        (selected_attn_multihead_env == NULL ||
+         cuda_env_present(selected_attn_multihead_env))) {
+        if (!ds4_rocm_glm_selected_multihead_launch(
+                (float *)lora_out->ptr,
+                (const float *)qk_low->ptr,
+                (const char *)kv_lora_cache->ptr,
+                (const int32_t *)selected->ptr,
+                n_tokens,
+                n_selected,
+                cache_cap,
+                cache_f16,
+                n_head,
+                kv_lora_dim,
+                qk_nope)) {
+            return 0;
+        }
+        static int notice_printed = 0;
+        if (!notice_printed) {
+            fprintf(stderr,
+                    DS4_GPU_LOG_PREFIX
+                    "GLM selected indexed prefill using arithmetic-preserving "
+                    "4-head attention tiles\n");
+            notice_printed = 1;
+        }
+        return 1;
     }
     /* Once the visible context exceeds the indexer's top-k, each token carries
      * its own selected row list.  Gather those rows into per-token FP16
@@ -4535,6 +4608,203 @@ extern "C" int ds4_gpu_glm_attention_indexed_batch_lora_tensor(
                                              n_ctx_orig, false, true, freq_base,
                                              freq_scale, ext_factor, attn_factor,
                                              beta_fast, beta_slow);
+}
+
+__global__ static void glm_dense_compact_pack_q_f16_kernel(
+        __half *packed,
+        const float *q,
+        uint32_t n_q,
+        uint32_t n_head,
+        uint32_t head0,
+        uint32_t group_heads,
+        uint32_t dim) {
+    const uint64_t i = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    const uint64_t count = (uint64_t)group_heads * n_q * dim;
+    if (i >= count) return;
+    const uint32_t d = (uint32_t)(i % dim);
+    const uint64_t row = i / dim;
+    const uint32_t token = (uint32_t)(row % n_q);
+    const uint32_t head = head0 + (uint32_t)(row / n_q);
+    packed[i] = __float2half(q[((uint64_t)token * n_head + head) * dim + d]);
+}
+
+__global__ static void glm_dense_compact_causal_softmax_f16_kernel(
+        __half *prob,
+        const float *scores,
+        uint32_t n_q,
+        uint32_t n_kv,
+        uint32_t q_row0,
+        float scale) {
+    const uint32_t token = blockIdx.x;
+    const uint32_t group_head = blockIdx.y;
+    if (token >= n_q) return;
+    const uint32_t visible = min(n_kv, q_row0 + token + 1u);
+    const uint64_t row = ((uint64_t)group_head * n_q + token) * n_kv;
+
+    float local_max = -FLT_MAX;
+    for (uint32_t col = threadIdx.x; col < visible; col += blockDim.x) {
+        local_max = fmaxf(local_max, scores[row + col] * scale);
+    }
+    __shared__ float reduce[256];
+    reduce[threadIdx.x] = local_max;
+    __syncthreads();
+    for (uint32_t stride = blockDim.x >> 1u; stride > 0u; stride >>= 1u) {
+        if (threadIdx.x < stride) {
+            reduce[threadIdx.x] = fmaxf(reduce[threadIdx.x],
+                                         reduce[threadIdx.x + stride]);
+        }
+        __syncthreads();
+    }
+    const float max_score = reduce[0];
+
+    float local_sum = 0.0f;
+    for (uint32_t col = threadIdx.x; col < visible; col += blockDim.x) {
+        local_sum += expf(scores[row + col] * scale - max_score);
+    }
+    reduce[threadIdx.x] = local_sum;
+    __syncthreads();
+    for (uint32_t stride = blockDim.x >> 1u; stride > 0u; stride >>= 1u) {
+        if (threadIdx.x < stride) {
+            reduce[threadIdx.x] += reduce[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+    const float inv_sum = reduce[0] > 0.0f ? 1.0f / reduce[0] : 0.0f;
+    for (uint32_t col = threadIdx.x; col < n_kv; col += blockDim.x) {
+        const float p = col < visible
+            ? expf(scores[row + col] * scale - max_score) * inv_sum : 0.0f;
+        prob[row + col] = __float2half(p);
+    }
+}
+
+__global__ static void glm_dense_compact_unpack_f32_kernel(
+        float *out,
+        const float *packed,
+        uint32_t n_q,
+        uint32_t n_head,
+        uint32_t head0,
+        uint32_t group_heads,
+        uint32_t dim) {
+    const uint64_t i = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    const uint64_t count = (uint64_t)group_heads * n_q * dim;
+    if (i >= count) return;
+    const uint32_t d = (uint32_t)(i % dim);
+    const uint64_t row = i / dim;
+    const uint32_t token = (uint32_t)(row % n_q);
+    const uint32_t head = head0 + (uint32_t)(row / n_q);
+    out[((uint64_t)token * n_head + head) * dim + d] = packed[i];
+}
+
+extern "C" int ds4_gpu_glm_attention_dense_compact_lora_causal_tensor(
+        ds4_gpu_tensor       *lora_out,
+        const ds4_gpu_tensor *qk_low,
+        const ds4_gpu_tensor *kv_lora_cache,
+        uint32_t              q_row0,
+        uint32_t              n_q,
+        uint32_t              n_kv,
+        uint32_t              cache_cap,
+        bool                  cache_f16,
+        uint32_t              n_head,
+        uint32_t              kv_lora_dim,
+        uint32_t              qk_dim) {
+    if (!lora_out || !qk_low || !kv_lora_cache || !g_cublas_ready ||
+        n_q == 0u || n_kv == 0u || n_kv > cache_cap ||
+        q_row0 >= n_kv || n_q > n_kv - q_row0 || !cache_f16 ||
+        n_q > INT_MAX || n_kv > INT_MAX || n_head == 0u ||
+        kv_lora_dim != 512u || qk_dim == 0u ||
+        qk_low->bytes < (uint64_t)n_q * n_head * kv_lora_dim * sizeof(float) ||
+        kv_lora_cache->bytes < (uint64_t)cache_cap * kv_lora_dim * sizeof(__half) ||
+        lora_out->bytes < (uint64_t)n_q * n_head * kv_lora_dim * sizeof(float)) {
+        return 0;
+    }
+
+    const uint32_t visible_kv = min(n_kv, q_row0 + n_q);
+    const uint32_t max_group_heads = min(n_head, 8u);
+    if ((uint64_t)n_q > UINT64_MAX / max_group_heads / visible_kv) return 0;
+    const uint64_t q_count =
+        (uint64_t)max_group_heads * n_q * kv_lora_dim;
+    const uint64_t score_count =
+        (uint64_t)max_group_heads * n_q * visible_kv;
+    const uint64_t q_bytes = q_count * sizeof(__half);
+    const uint64_t score_off = (q_bytes + 255u) & ~255ull;
+    const uint64_t score_bytes = score_count * sizeof(float);
+    const uint64_t prob_off = (score_off + score_bytes + 255u) & ~255ull;
+    const uint64_t prob_bytes = score_count * sizeof(__half);
+    const uint64_t out_off = (prob_off + prob_bytes + 255u) & ~255ull;
+    const uint64_t out_bytes = q_count * sizeof(float);
+    if (score_off < q_bytes || prob_off < score_off || out_off < prob_off ||
+        out_off > UINT64_MAX - out_bytes) return 0;
+
+    unsigned char *scratch = (unsigned char *)cuda_tmp_alloc(
+        out_off + out_bytes, "GLM dense compact attention");
+    if (!scratch) return 0;
+    __half *q_half = (__half *)scratch;
+    float *scores = (float *)(scratch + score_off);
+    __half *prob = (__half *)(scratch + prob_off);
+    float *packed_out = (float *)(scratch + out_off);
+    const __half *kv = (const __half *)kv_lora_cache->ptr;
+    const float attn_scale = 1.0f / sqrtf((float)qk_dim);
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+
+    for (uint32_t head0 = 0; head0 < n_head; head0 += max_group_heads) {
+        const uint32_t group_heads = min(max_group_heads, n_head - head0);
+        const uint64_t group_q_count =
+            (uint64_t)group_heads * n_q * kv_lora_dim;
+        glm_dense_compact_pack_q_f16_kernel<<<
+            (group_q_count + 255u) / 256u, 256>>>(
+                q_half, (const float *)qk_low->ptr, n_q, n_head, head0,
+                group_heads, kv_lora_dim);
+        if (!cuda_ok(cudaGetLastError(),
+                     "GLM dense attention Q pack launch")) return 0;
+
+        cublasStatus_t st = cublasGemmStridedBatchedEx(
+            g_cublas,
+            CUBLAS_OP_T, CUBLAS_OP_N,
+            (int)visible_kv, (int)n_q, (int)kv_lora_dim,
+            &alpha,
+            kv, CUDA_R_16F, (int)kv_lora_dim, 0,
+            q_half, CUDA_R_16F, (int)kv_lora_dim,
+            (long long)n_q * kv_lora_dim,
+            &beta,
+            scores, CUDA_R_32F, (int)visible_kv,
+            (long long)n_q * visible_kv,
+            (int)group_heads,
+            CUBLAS_COMPUTE_32F,
+            CUBLAS_GEMM_DEFAULT);
+        if (!cublas_ok(st, "GLM dense attention score GEMM")) return 0;
+
+        const dim3 softmax_grid(n_q, group_heads, 1u);
+        glm_dense_compact_causal_softmax_f16_kernel<<<
+            softmax_grid, 256>>>(
+                prob, scores, n_q, visible_kv, q_row0, attn_scale);
+        if (!cuda_ok(cudaGetLastError(),
+                     "GLM dense attention softmax launch")) return 0;
+
+        st = cublasGemmStridedBatchedEx(
+            g_cublas,
+            CUBLAS_OP_N, CUBLAS_OP_N,
+            (int)kv_lora_dim, (int)n_q, (int)visible_kv,
+            &alpha,
+            kv, CUDA_R_16F, (int)kv_lora_dim, 0,
+            prob, CUDA_R_16F, (int)visible_kv,
+            (long long)n_q * visible_kv,
+            &beta,
+            packed_out, CUDA_R_32F, (int)kv_lora_dim,
+            (long long)n_q * kv_lora_dim,
+            (int)group_heads,
+            CUBLAS_COMPUTE_32F,
+            CUBLAS_GEMM_DEFAULT);
+        if (!cublas_ok(st, "GLM dense attention value GEMM")) return 0;
+
+        glm_dense_compact_unpack_f32_kernel<<<
+            (group_q_count + 255u) / 256u, 256>>>(
+                (float *)lora_out->ptr, packed_out, n_q, n_head, head0,
+                group_heads, kv_lora_dim);
+        if (!cuda_ok(cudaGetLastError(),
+                     "GLM dense attention output unpack launch")) return 0;
+    }
+    return 1;
 }
 
 extern "C" int ds4_gpu_glm_attention_indexed_batch_lora_causal_tensor(

--- a/rocm/ds4_rocm_glm_selected_multihead.cu
+++ b/rocm/ds4_rocm_glm_selected_multihead.cu
@@ -1,0 +1,234 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+namespace {
+
+constexpr uint32_t kHeadTile = 4u;
+
+__device__ __forceinline__ float cache_load(
+        const char *cache,
+        uint64_t index,
+        bool cache_f16) {
+    return cache_f16 ?
+        __half2float(reinterpret_cast<const __half *>(cache)[index]) :
+        reinterpret_cast<const float *>(cache)[index];
+}
+
+__global__ void glm_selected_multihead_kernel(
+        float *lora_out,
+        const float *qk_low,
+        const char *kv_lora_cache,
+        const int32_t *selected,
+        uint32_t n_tokens,
+        uint32_t n_selected,
+        uint32_t cache_cap,
+        bool cache_f16,
+        uint32_t n_head,
+        uint32_t kv_lora_dim,
+        uint32_t qk_nope) {
+    const uint32_t token = blockIdx.y;
+    const uint32_t head0 = blockIdx.x * kHeadTile;
+    if (token >= n_tokens || head0 >= n_head || n_selected == 0u) return;
+    const uint32_t remaining = n_head - head0;
+    const uint32_t head_count = remaining < kHeadTile ? remaining : kHeadTile;
+    const float scale = rsqrtf(static_cast<float>(qk_nope));
+    const int32_t *selected_row =
+        selected + static_cast<uint64_t>(token) * n_selected;
+    extern __shared__ float shared[];
+    float *scores = shared;
+    float *reduce = scores + static_cast<uint64_t>(kHeadTile) * n_selected;
+    float local_max[kHeadTile];
+#pragma unroll
+    for (uint32_t h = 0; h < kHeadTile; h++) local_max[h] = -INFINITY;
+
+    for (uint32_t s = threadIdx.x; s < n_selected; s += blockDim.x) {
+        const int32_t row_i = selected_row[s];
+        const bool valid = row_i >= 0 && static_cast<uint32_t>(row_i) < cache_cap;
+        float dot[kHeadTile];
+#pragma unroll
+        for (uint32_t h = 0; h < kHeadTile; h++) dot[h] = 0.0f;
+        if (valid) {
+            const uint64_t cache_base =
+                static_cast<uint64_t>(static_cast<uint32_t>(row_i)) *
+                kv_lora_dim;
+            const float *low = qk_low +
+                (static_cast<uint64_t>(token) * n_head + head0) *
+                kv_lora_dim;
+            for (uint32_t j = 0; j < kv_lora_dim; j++) {
+                const float kv = cache_load(
+                    kv_lora_cache, cache_base + j, cache_f16);
+#pragma unroll
+                for (uint32_t h = 0; h < kHeadTile; h++) {
+                    if (h < head_count) {
+                        dot[h] += low[static_cast<uint64_t>(h) *
+                                      kv_lora_dim + j] * kv;
+                    }
+                }
+            }
+        }
+#pragma unroll
+        for (uint32_t h = 0; h < kHeadTile; h++) {
+            if (h < head_count) {
+                const float score = valid ? dot[h] * scale : -INFINITY;
+                scores[static_cast<uint64_t>(h) * n_selected + s] = score;
+                local_max[h] = fmaxf(local_max[h], score);
+            }
+        }
+    }
+
+#pragma unroll
+    for (uint32_t h = 0; h < kHeadTile; h++) {
+        reduce[static_cast<uint64_t>(h) * blockDim.x + threadIdx.x] =
+            local_max[h];
+    }
+    __syncthreads();
+    for (uint32_t stride = blockDim.x >> 1u; stride > 0u; stride >>= 1u) {
+        if (threadIdx.x < stride) {
+#pragma unroll
+            for (uint32_t h = 0; h < kHeadTile; h++) {
+                float *head_reduce =
+                    reduce + static_cast<uint64_t>(h) * blockDim.x;
+                head_reduce[threadIdx.x] =
+                    fmaxf(head_reduce[threadIdx.x],
+                          head_reduce[threadIdx.x + stride]);
+            }
+        }
+        __syncthreads();
+    }
+    if (!isfinite(reduce[0])) {
+        for (uint32_t j = threadIdx.x; j < kv_lora_dim; j += blockDim.x) {
+#pragma unroll
+            for (uint32_t h = 0; h < kHeadTile; h++) {
+                if (h < head_count) {
+                    lora_out[((static_cast<uint64_t>(token) * n_head +
+                               head0 + h) * kv_lora_dim) + j] = 0.0f;
+                }
+            }
+        }
+        return;
+    }
+
+    float local_sum[kHeadTile];
+#pragma unroll
+    for (uint32_t h = 0; h < kHeadTile; h++) local_sum[h] = 0.0f;
+    for (uint32_t s = threadIdx.x; s < n_selected; s += blockDim.x) {
+#pragma unroll
+        for (uint32_t h = 0; h < kHeadTile; h++) {
+            if (h < head_count) {
+                float *head_scores =
+                    scores + static_cast<uint64_t>(h) * n_selected;
+                const float weight = expf(
+                    head_scores[s] -
+                    reduce[static_cast<uint64_t>(h) * blockDim.x]);
+                head_scores[s] = weight;
+                local_sum[h] += weight;
+            }
+        }
+    }
+#pragma unroll
+    for (uint32_t h = 0; h < kHeadTile; h++) {
+        reduce[static_cast<uint64_t>(h) * blockDim.x + threadIdx.x] =
+            local_sum[h];
+    }
+    __syncthreads();
+    for (uint32_t stride = blockDim.x >> 1u; stride > 0u; stride >>= 1u) {
+        if (threadIdx.x < stride) {
+#pragma unroll
+            for (uint32_t h = 0; h < kHeadTile; h++) {
+                float *head_reduce =
+                    reduce + static_cast<uint64_t>(h) * blockDim.x;
+                head_reduce[threadIdx.x] += head_reduce[threadIdx.x + stride];
+            }
+        }
+        __syncthreads();
+    }
+
+    for (uint32_t j = threadIdx.x; j < kv_lora_dim; j += blockDim.x) {
+        float acc[kHeadTile];
+#pragma unroll
+        for (uint32_t h = 0; h < kHeadTile; h++) acc[h] = 0.0f;
+        for (uint32_t s = 0; s < n_selected; s++) {
+            const int32_t row_i = selected_row[s];
+            const bool valid =
+                row_i >= 0 && static_cast<uint32_t>(row_i) < cache_cap;
+            if (valid) {
+                const float kv = cache_load(
+                    kv_lora_cache,
+                    static_cast<uint64_t>(static_cast<uint32_t>(row_i)) *
+                        kv_lora_dim + j,
+                    cache_f16);
+#pragma unroll
+                for (uint32_t h = 0; h < kHeadTile; h++) {
+                    if (h < head_count) {
+                        acc[h] += scores[static_cast<uint64_t>(h) *
+                                         n_selected + s] * kv;
+                    }
+                }
+            }
+        }
+#pragma unroll
+        for (uint32_t h = 0; h < kHeadTile; h++) {
+            if (h < head_count) {
+                const float denom = fmaxf(
+                    reduce[static_cast<uint64_t>(h) * blockDim.x],
+                    1.0e-20f);
+                lora_out[((static_cast<uint64_t>(token) * n_head +
+                           head0 + h) * kv_lora_dim) + j] = acc[h] / denom;
+            }
+        }
+    }
+}
+
+}  // namespace
+
+extern "C" int ds4_rocm_glm_selected_multihead_launch(
+        float *lora_out,
+        const float *qk_low,
+        const char *kv_lora_cache,
+        const int32_t *selected,
+        uint32_t n_tokens,
+        uint32_t n_selected,
+        uint32_t cache_cap,
+        bool cache_f16,
+        uint32_t n_head,
+        uint32_t kv_lora_dim,
+        uint32_t qk_nope) {
+    if (!lora_out || !qk_low || !kv_lora_cache || !selected ||
+        n_tokens == 0u || n_selected == 0u || cache_cap == 0u ||
+        n_head == 0u || kv_lora_dim == 0u || qk_nope == 0u) {
+        return 0;
+    }
+    const dim3 grid((n_head + kHeadTile - 1u) / kHeadTile,
+                    n_tokens,
+                    1u);
+    const size_t shared_bytes =
+        static_cast<size_t>(kHeadTile) * (n_selected + 256u) * sizeof(float);
+    hipLaunchKernelGGL(glm_selected_multihead_kernel,
+                       grid,
+                       dim3(256u),
+                       shared_bytes,
+                       0,
+                       lora_out,
+                       qk_low,
+                       kv_lora_cache,
+                       selected,
+                       n_tokens,
+                       n_selected,
+                       cache_cap,
+                       cache_f16,
+                       n_head,
+                       kv_lora_dim,
+                       qk_nope);
+    const hipError_t error = hipGetLastError();
+    if (error != hipSuccess) {
+        std::fprintf(stderr,
+                     "ds4: ROCm GLM selected multihead launch failed: %s\n",
+                     hipGetErrorString(error));
+        return 0;
+    }
+    return 1;
+}

--- a/rocm/ds4_rocm_moe_launch.cuh
+++ b/rocm/ds4_rocm_moe_launch.cuh
@@ -813,9 +813,20 @@ static int routed_moe_launch(
             mxfp4_path && use_expert_tiles && !use_mxfp4_tile32 && !use_mxfp4_ldsB &&
             !use_mxfp4_tile4 && n_tokens >= 8u &&
             getenv("DS4_ROCM_ENABLE_MXFP4_ROW64") != NULL;
+        const char *glm53_iq2_mmq_288_env =
+            getenv("DS4_ROCM_GLM53_IQ2_MMQ_288");
+        const uint32_t use_glm53_iq2_mmq_288 =
+            g_glm_model &&
+            n_total_expert == DS4_ROCM_GLM53_N_EXPERT &&
+            n_expert == DS4_ROCM_N_EXPERT_USED &&
+            expert_in_dim == 4096u &&
+            expert_mid_dim == 2048u &&
+            out_dim == 4096u &&
+            (glm53_iq2_mmq_288_env == NULL ||
+             cuda_env_present(glm53_iq2_mmq_288_env));
         const uint32_t use_rocm_mmq_gateup =
             ok && iq2_path && n_tokens >= 128u && !g_quality_mode &&
-            n_total_expert <= 256u &&
+            (n_total_expert <= 256u || use_glm53_iq2_mmq_288) &&
             !batch_stream_selected && !batch_stream_split_selected &&
             !split_selected && !compact_selected && gate_w && up_w &&
             (stream_full_layer || full_table_cached) &&

--- a/rocm/ds4_rocm_runtime.cuh
+++ b/rocm/ds4_rocm_runtime.cuh
@@ -5554,7 +5554,8 @@ static uint64_t cuda_model_arena_chunk_bytes(uint64_t need) {
      *
      * Keep GLM on its existing allocation policy.
      */
-    if (!g_glm_model && need > default_bytes / 2u) return need;
+    if (g_glm_model) return need;
+    if (need > default_bytes / 2u) return need;
 
     uint64_t bytes = default_bytes;
     if (bytes < need) {
@@ -6418,11 +6419,18 @@ extern "C" void ds4_gpu_print_memory_report(const char *label) {
         return;
     }
     const uint64_t used_b = (uint64_t)total_b - (uint64_t)free_b;
+    uint64_t arena_allocated_bytes = 0;
+    uint64_t arena_used_bytes = 0;
+    for (const cuda_model_arena &arena : g_model_arenas) {
+        arena_allocated_bytes += arena.bytes;
+        arena_used_bytes += arena.used;
+    }
     const char *placement = cuda_model_image_bytes() ? "device_copy" : "mapped/range_cache";
     fprintf(stderr,
             DS4_GPU_LOG_PREFIX "memory %s: used=%.2f GiB free=%.2f GiB total=%.2f GiB "
             "placement=%s model_image=%.2f GiB range_cache=%.2f GiB "
-            "q8_f16_cache=%.2f GiB scratch=%.2f GiB",
+            "model_arenas=%zu arena_allocated=%.2f GiB arena_used=%.2f GiB "
+            "arena_stranded=%.2f GiB q8_f16_cache=%.2f GiB scratch=%.2f GiB",
             label ? label : "",
             (double)used_b / 1073741824.0,
             (double)free_b / 1073741824.0,
@@ -6430,6 +6438,10 @@ extern "C" void ds4_gpu_print_memory_report(const char *label) {
             placement,
             (double)cuda_model_image_bytes() / 1073741824.0,
             (double)g_model_range_bytes / 1073741824.0,
+            g_model_arenas.size(),
+            (double)arena_allocated_bytes / 1073741824.0,
+            (double)arena_used_bytes / 1073741824.0,
+            (double)(arena_allocated_bytes - arena_used_bytes) / 1073741824.0,
             (double)g_q8_f16_bytes / 1073741824.0,
             (double)g_cuda_tmp_bytes / 1073741824.0);
     fprintf(stderr, "\n");

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -145,6 +145,70 @@ static void test_close_engine(bool quality) {
     *slot = NULL;
 }
 
+static bool test_tokens_match(const ds4_tokens *a, const ds4_tokens *b) {
+    if (!a || !b || a->len != b->len) return false;
+    for (int i = 0; i < a->len; i++) {
+        if (a->v[i] != b->v[i]) return false;
+    }
+    return true;
+}
+
+static void test_raw_completion_prompt_tokenization(void) {
+    ds4_engine *engine = test_get_engine(false);
+    if (!engine) return;
+
+    const char *raw = "Raw completion text <think> remains direct.";
+    request r;
+    char err[160] = {0};
+    bool ok = parse_completion_request(
+        engine,
+        "{\"prompt\":\"Raw completion text <think> remains direct.\",\"max_tokens\":0,\"thinking\":true,\"think\":true,\"reasoning_effort\":\"max\"}",
+        128, 4096, &r, err, sizeof(err));
+    TEST_ASSERT(ok);
+    if (ok) {
+        ds4_tokens expected = {0};
+        ds4_chat_begin(engine, &expected);
+        ds4_tokenize_rendered_chat(engine, raw, &expected);
+        TEST_ASSERT(r.prompt_text && !strcmp(r.prompt_text, raw));
+        TEST_ASSERT(test_tokens_match(&r.prompt, &expected));
+        TEST_ASSERT(r.max_tokens == 0);
+        TEST_ASSERT(r.think_mode == DS4_THINK_NONE);
+        ds4_tokens_free(&expected);
+        request_free(&r);
+    }
+
+    ok = parse_completion_request(
+        engine, "{\"prompt\":\"<think>\",\"max_tokens\":0}",
+        128, 4096, &r, err, sizeof(err));
+    TEST_ASSERT(ok);
+    if (ok) {
+        ds4_tokens start = {0};
+        ds4_chat_begin(engine, &start);
+        TEST_ASSERT(r.prompt.len == start.len + 1);
+        ds4_tokens_free(&start);
+        request_free(&r);
+    }
+
+    const int vocab_size = ds4_engine_vocab_size(engine);
+    char body[128];
+    snprintf(body, sizeof(body), "{\"prompt\":[%d],\"max_tokens\":0}",
+             vocab_size - 1);
+    ok = parse_completion_request(
+        engine, body, 128, 4096, &r, err, sizeof(err));
+    TEST_ASSERT(ok);
+    if (ok) {
+        TEST_ASSERT(r.prompt.len == 1 && r.prompt.v[0] == vocab_size - 1);
+        request_free(&r);
+    }
+
+    snprintf(body, sizeof(body), "{\"prompt\":[%d],\"max_tokens\":0}",
+             vocab_size);
+    ok = parse_completion_request(
+        engine, body, 128, 4096, &r, err, sizeof(err));
+    TEST_ASSERT(!ok);
+    if (ok) request_free(&r);
+}
+
 static void test_session_snapshot_roundtrip(void) {
     ds4_engine *engine = test_get_engine(false);
     if (!engine) return;
@@ -1000,10 +1064,14 @@ static void test_metal_q8_0_decode_pair_exact_case(
 }
 
 static void test_metal_q8_0_decode_pair_exact(void) {
+#if defined(DS4_ROCM_BUILD)
+    fprintf(stderr, "ds4-test: Metal paired Q8_0 exactness skipped on ROCm\n");
+#else
     /* Cover both possible one-bank tail directions. Distinct seeds ensure a
      * mistaken A-for-B weight binding cannot compare equal by construction. */
     test_metal_q8_0_decode_pair_exact_case(77, 19, 11, 97);
     test_metal_q8_0_decode_pair_exact_case(19, 77, 23, 131);
+#endif
 }
 
 #if defined(__APPLE__)
@@ -6795,6 +6863,7 @@ typedef struct {
 
 static const ds4_test_entry test_entries[] = {
 #ifndef DS4_NO_GPU
+    {"--raw-completions", "raw-completions", "raw Completion string, special-token, and token-ID prompt construction", test_raw_completion_prompt_tokenization},
     {"--session-snapshot", "session-snapshot", "session snapshot and recurrent-state round trip", test_session_snapshot_roundtrip},
     {"--long-context", "long-context", "long-context story fact-recall regression", test_long_story_fact_recall},
     {"--tool-call-quality", "tool-call-quality", "model tool call and post-result stop regression", test_tool_call_quality},

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -1000,10 +1000,14 @@ static void test_metal_q8_0_decode_pair_exact_case(
 }
 
 static void test_metal_q8_0_decode_pair_exact(void) {
+#if defined(DS4_ROCM_BUILD)
+    fprintf(stderr, "ds4-test: Metal paired Q8_0 exactness skipped on ROCm\n");
+#else
     /* Cover both possible one-bank tail directions. Distinct seeds ensure a
      * mistaken A-for-B weight binding cannot compare equal by construction. */
     test_metal_q8_0_decode_pair_exact_case(77, 19, 11, 97);
     test_metal_q8_0_decode_pair_exact_case(19, 77, 23, 131);
+#endif
 }
 
 #if defined(__APPLE__)

--- a/tests/test_glm53_vision_prompt.c
+++ b/tests/test_glm53_vision_prompt.c
@@ -44,8 +44,10 @@ int main(int argc, char **argv) {
     options.context_size = 4096;
     options.quality = true;
 #ifdef DS4_ROCM_BUILD
-    options.ssd_streaming = true;
-    options.ssd_streaming_cache_bytes = UINT64_C(32) << 30;
+    if (getenv("DS4_TEST_SSD_STREAMING") != NULL) {
+        options.ssd_streaming = true;
+        options.ssd_streaming_cache_bytes = UINT64_C(32) << 30;
+    }
 #endif
 
     ds4_engine *engine = NULL;


### PR DESCRIPTION
## Summary

This PR improves fully resident GLM-5.3-Flash-Q2 prefill and memory use on ROCm/gfx1151:

- 512-token prefill: **83.83 -> 179.70 tok/s** (`+114.4%`)
- 4096-token prefill: **82.24 -> 191.28 tok/s** (`+132.6%`)
- 8192-token prefill: **33.82 -> 111.98 tok/s** (`+231.1%`)
- stranded model-arena capacity: **13.38 -> 0.00 GiB**

The model remains fully resident. SSD streaming is not used.

## Performance

The matched baseline is main at [`3da2da96`](https://github.com/antirez/ds4/commit/3da2da96b250bc8a7564cf3342c34149b6cde429); the PR is rebased onto [`b0982a1b`](https://github.com/antirez/ds4/commit/b0982a1b4ee9d0f157e600bfd102fbeac951a829). Measurements used the same `GLM-5.3-Flash-Q2.gguf`, prompt, context allocation, and `ds4-bench` settings on AMD Radeon 8060S Graphics (`gfx1151`) with 128 GB unified memory and ROCm 10.0 / HIP 7.15.

| Fixed prefill | Matched main | This PR | Change |
|---:|---:|---:|---:|
| 512 tokens | 83.83 tok/s median | 179.70 tok/s median (179.65-179.81) | +114.4% |
| 4096 tokens | 82.24 tok/s | 191.28 tok/s median (191.18-191.37) | +132.6% |
| 8192 tokens | 33.82 tok/s | 111.98 tok/s median (111.89-112.02) | +231.1% |

An 8192-token prefill followed by 64 ordinary decode tokens completes at 112.20 prefill tok/s and 10.83 decode tok/s.

## Memory

| Metric | Matched main | This PR | Change |
|---|---:|---:|---:|
| Model data | 89.87 GiB | 89.87 GiB | unchanged |
| Stranded model-arena capacity | 13.38 GiB | 0.00 GiB | -13.38 GiB |

The fully resident memory plans are 90.72 GiB at 512 tokens, 92.84 GiB at 4096, and 92.89 GiB at 8192.

## Main changes

- GLM Q4_K projections use tiled MMQ for prefill-sized work while decode-sized rows retain the low-overhead direct path; fixed-512 Q4_K projection time falls from 919.1 ms to 110.8 ms.
- Compact causal LoRA attention batches score and value operations through hipBLAS.
- The tuned paired-IQ2 gate/up path admits only GLM-5.3-Flash's exact 288-expert, top-8, 4096x2048x4096 topology while retaining the conservative guard for unknown models.
- Long-context selected attention uses arithmetic-preserving four-head tiles beyond the dense-attention window.
- GLM model ranges use their merged sizes instead of fixed-size arenas, eliminating 13.38 GiB of stranded capacity.
- Partial MMQ tiles zero the invalid suffix once before the K loop and refresh only the valid prefix at each stage, retaining upstream's zero-before-WMMA correction while recovering register pressure, occupancy, and prefill throughput.

## DeepSeek V4 Vision rebase

During development this PR was rebased onto upstream main after [`fc8bf3c3`](https://github.com/antirez/ds4/commit/fc8bf3c39c51892c41f439a4ce17b90643dd1984) added DeepSeek V4 Flash vision, [`e976a543`](https://github.com/antirez/ds4/commit/e976a543314b0c190a6d6ef6c1b278cc68ccae13) added the ROCm Vision-Exp path, and [`f9c459ce`](https://github.com/antirez/ds4/commit/f9c459ce2f662cf2782de77bae1afc738f1f5625) corrected shared ROCm MMQ scratch lifetime and partial-tile reads.

The shared MMQ tail correction initially reduced DeepSeek prefill by 5.9-7.4%. This PR retains its safety properties while restructuring partial-tile loading: HIP scratch remains stream-local and live until safe destruction, invalid columns remain zero before every matrix operation, complete tiles use direct loads, and partial tiles zero their invalid suffix once and refresh only the valid prefix. Matched DeepSeek prefill reaches 234.70/298.89/294.37/290.42 tok/s at the 2K/4K/6K/8K frontiers, improving post-vision main by 5.6-7.0% and finishing within 1% of the pre-vision curve.

Because these kernels are shared by GLM and DeepSeek, validation includes the DeepSeek official scorer, MMQ production shapes, five real Vision-Exp image fixtures, and the repository vision-prompt test with a fully resident DeepSeek model and encoder. This verifies that the GLM performance work composes with the upstream DeepSeek V4 Vision changes rather than testing GLM in isolation.

## Validation

| Check | Result |
|---|---|
| GLM official scorer | 100 cases, 11,559 target tokens, NLL `0.460424520`, 88/100 first-token matches, LCP `6.980`; unchanged |
| DeepSeek official scorer | 100 cases, 2,313 target tokens, NLL `0.401858465`, first-token matches 55/100, LCP `5.100`; unchanged |
| IQ2 production shape | 288 experts, top-8, M=2048, K=4096; token counts 127/128/511/512/513 pass; canaries intact; maximum absolute difference `0.000854` |
| Long context | 8192+64 completes at 112.20 prefill and 10.83 decode tok/s |
| Vision prompt | Fully resident DeepSeek Vision-Exp model and encoder pass image identity reuse, invalidation, changed-image logits, restored-image exactness, and generation with an 81.18 GiB plan |
| ROCm tests | Full `test-rocm`, GLM KDA, IQ2 MMQ, and DeepSeek vision preprocessing suites pass |
| Build | Five production binaries and ROCm test/scorer targets build with zero compiler or linker warnings |
| Source | `git diff --check` passes |

## Backend scope

The GLM attention, MoE admission, and allocation changes are ROCm-specific. The MMQ tail-load restructuring is shared HIP/CUDA code and preserves the existing zero-before-matrix semantics; Metal implementation files are unchanged. The vision-prompt test now defaults to fully resident execution on every backend and enables ROCm SSD streaming only when `DS4_TEST_SSD_STREAMING=1` is explicitly set.
