### PR TITLE
server: separate resident sessions from active requests

### DIFF
--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -60,6 +60,17 @@ preallocates independent KV states and queues requests when all slots are busy.
 Choose context and slot count together: a context that fits once may not fit
 four times. Idle slots can be cached before reuse; active requests are not evicted.
 
+`--max-active-requests N` separates resident KV capacity from compute
+concurrency. It requires `--batched-session`, may not exceed the resident
+session count, and defaults to that count so existing behavior is unchanged.
+For example, `--batched-session 10 --max-active-requests 1` allocates ten
+resident session slots while processing complete requests one at a time;
+additional requests wait in the server queue instead of occupying another
+active slot. This avoids mixed prefill/decode contention without reducing
+resident KV capacity. Request-to-slot selection is unchanged: this option
+controls admission concurrency, not which checkpoint the existing router
+chooses for a request.
+
 | Backend/model | Decode execution |
 | --- | --- |
 | Metal, resident Flash | Native shared-expert/QKV batching where supported |

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -345,6 +345,7 @@ static void print_server_api(FILE *fp, const help_colors *c) {
     opt(fp, c, "--cors", "Add Access-Control-Allow-* headers for browser JS clients.");
     opt(fp, c, "--trace FILE", "Write prompts, cache decisions, output, and tool calls.");
     opt(fp, c, "--batched-session N", "Keep N resident sessions and batch decode-ready requests.");
+    opt(fp, c, "--max-active-requests N", "Limit concurrently assigned requests without reducing resident slot count.");
     opt(fp, c, "--mixed-prefill-quantum N", "Prefill chunk while generations are active. Default: 128; GLM-5.3 minimum: 1024");
     para(fp, c, "Endpoints: /v1/chat/completions, /v1/responses, /v1/completions, and /v1/messages.");
     para(fp, c, "Model endpoint aliases include deepseek-v4-flash and deepseek-v4-pro; both serve the loaded GGUF.");

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -9131,6 +9131,10 @@ struct server {
     ds4_tp *tp_leader;
     server_slot *slots;
     int slot_count;
+    /* Resident slot allocation and compute concurrency are intentionally
+     * independent. busy covers both assigned and running jobs, so this cap
+     * serializes complete requests. Slot selection is unchanged. */
+    int max_active_requests;
     int ctx_size;
     bool batched_mode;
     pthread_t *slot_threads;
@@ -13362,9 +13366,28 @@ static int job_slot_score(server *s, server_slot *slot, const job *j,
     return common;
 }
 
+/* Requires s->mu. A busy slot owns an assigned or running request for its
+ * whole lifetime, including prefill, decode, streaming, and cancellation. */
+static int active_request_count_locked(const server *s) {
+    if (!s) return 0;
+    int active = 0;
+    for (int i = 0; i < s->slot_count; i++) {
+        if (s->slots[i].busy) active++;
+    }
+    return active;
+}
+
+static int active_request_limit(const server *s) {
+    if (!s || s->slot_count <= 0) return 0;
+    return s->max_active_requests > 0
+           ? s->max_active_requests : s->slot_count;
+}
+
 static void dispatch_jobs_locked(server *s) {
     if (!s || !s->batched_mode) return;
-    for (;;) {
+    int active = active_request_count_locked(s);
+    const int active_limit = active_request_limit(s);
+    while (active < active_limit) {
         job *chosen = NULL;
         job *chosen_prev = NULL;
         server_slot *chosen_slot = NULL;
@@ -13401,6 +13424,7 @@ static void dispatch_jobs_locked(server *s) {
         chosen->next = NULL;
         chosen_slot->assigned = chosen;
         chosen_slot->busy = true;
+        active++;
         pthread_cond_broadcast(&s->cv);
     }
 }
@@ -13903,6 +13927,7 @@ typedef struct {
     int tool_memory_max_ids;
     bool enable_cors;
     int batched_sessions;
+    int max_active_requests;
     int mixed_prefill_quantum;
 } server_config;
 
@@ -14137,6 +14162,9 @@ static server_config parse_options(int argc, char **argv) {
             c.trace_path = need_arg(&i, argc, argv, arg);
         } else if (!strcmp(arg, "--batched-session")) {
             c.batched_sessions = parse_int_arg(need_arg(&i, argc, argv, arg), arg);
+        } else if (!strcmp(arg, "--max-active-requests")) {
+            c.max_active_requests =
+                parse_int_arg(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--mixed-prefill-quantum")) {
             c.mixed_prefill_quantum =
                 parse_int_arg(need_arg(&i, argc, argv, arg), arg);
@@ -14250,6 +14278,16 @@ static server_config parse_options(int argc, char **argv) {
     {
         server_log(DS4_LOG_DEFAULT,
                    "ds4-server: --kv-cache-cold-max-tokens must be 0 or >= --kv-cache-min-tokens");
+        exit(2);
+    }
+    if (c.max_active_requests > 0 && c.batched_sessions <= 0) {
+        server_log(DS4_LOG_DEFAULT,
+                   "ds4-server: --max-active-requests requires --batched-session");
+        exit(2);
+    }
+    if (c.max_active_requests > c.batched_sessions) {
+        server_log(DS4_LOG_DEFAULT,
+                   "ds4-server: --max-active-requests cannot exceed --batched-session");
         exit(2);
     }
     if (c.engine.directional_steering_file && !directional_steering_scale_set) {
@@ -14403,6 +14441,8 @@ int main(int argc, char **argv) {
     s.tp_leader = tp_leader;
     s.ctx_size = cfg.ctx_size;
     s.slot_count = slot_count;
+    s.max_active_requests = cfg.max_active_requests > 0
+                            ? cfg.max_active_requests : slot_count;
     s.batched_mode = cfg.batched_sessions > 0;
     s.mixed_prefill_quantum = cfg.mixed_prefill_quantum;
     s.last_prefill_slot = slot_count - 1;
@@ -14454,8 +14494,9 @@ int main(int argc, char **argv) {
     }
     if (s.batched_mode) {
         server_log(DS4_LOG_DEFAULT,
-                   "ds4-server: batched mode enabled resident_sessions=%d prefill_quantum=%d mixed_prefill_quantum=%d decode_coalesce_us=%ld",
+                   "ds4-server: batched mode enabled resident_sessions=%d max_active_requests=%d prefill_quantum=%d mixed_prefill_quantum=%d decode_coalesce_us=%ld",
                    s.slot_count,
+                   s.max_active_requests,
                    server_prefill_quantum_for(&s, false),
                    server_prefill_quantum_for(&s, true),
                    server_decode_coalesce_us());
@@ -14649,6 +14690,100 @@ static void test_mixed_prefill_quantum_option(void) {
     TEST_ASSERT(server_prefill_quantum_for(&s, true) == 2048);
     s.mixed_prefill_quantum = defaults.mixed_prefill_quantum;
     TEST_ASSERT(server_prefill_quantum_for(&s, true) == 128);
+}
+
+static void test_max_active_requests_option(void) {
+    char *default_argv[] = {"ds4-server"};
+    server_config defaults = parse_options(1, default_argv);
+    TEST_ASSERT(defaults.batched_sessions == 0);
+    TEST_ASSERT(defaults.max_active_requests == 0);
+
+    char *custom_argv[] = {
+        "ds4-server", "--batched-session", "10",
+        "--max-active-requests", "1"
+    };
+    server_config custom = parse_options(5, custom_argv);
+    TEST_ASSERT(custom.batched_sessions == 10);
+    TEST_ASSERT(custom.max_active_requests == 1);
+}
+
+static void test_dispatch_respects_active_request_limit(void) {
+    server s = {0};
+    pthread_mutex_init(&s.mu, NULL);
+    pthread_mutex_init(&s.tool_mu, NULL);
+    pthread_cond_init(&s.cv, NULL);
+    s.batched_mode = true;
+    server_slot slots[3] = {0};
+    s.slots = slots;
+    s.slot_count = 3;
+    TEST_ASSERT(active_request_limit(&s) == 3);
+    s.max_active_requests = 1;
+
+    job first = {0}, second = {0}, third = {0};
+    job *jobs[3] = {&first, &second, &third};
+    const char *call_ids[3] = {"call-0", "call-1", "call-2"};
+    for (int i = 0; i < 3; i++) {
+        slots[i].id = i;
+        slots[i].responses_live.valid = true;
+        id_list_push_unique(&slots[i].responses_live.call_ids, call_ids[i]);
+        jobs[i]->req.responses_requires_live_tool_state = true;
+        id_list_push_unique(&jobs[i]->req.responses_live_call_ids,
+                            call_ids[i]);
+    }
+    first.next = &second;
+    second.next = &third;
+    s.head = &first;
+    s.tail = &third;
+
+    pthread_mutex_lock(&s.mu);
+    dispatch_jobs_locked(&s);
+    TEST_ASSERT(slots[0].assigned == &first);
+    TEST_ASSERT(slots[0].busy);
+    TEST_ASSERT(slots[1].assigned == NULL);
+    TEST_ASSERT(slots[2].assigned == NULL);
+    TEST_ASSERT(s.head == &second);
+    TEST_ASSERT(s.tail == &third);
+    TEST_ASSERT(active_request_count_locked(&s) == 1);
+
+    /* A worker clears assigned before running the job, but busy must retain
+     * ownership and keep queued requests from entering other slots. */
+    slots[0].assigned = NULL;
+    dispatch_jobs_locked(&s);
+    TEST_ASSERT(slots[1].assigned == NULL);
+    TEST_ASSERT(slots[2].assigned == NULL);
+    TEST_ASSERT(s.head == &second);
+
+    /* Completing the first request opens exactly one queue position. */
+    slots[0].busy = false;
+    dispatch_jobs_locked(&s);
+    TEST_ASSERT(slots[1].assigned == &second);
+    TEST_ASSERT(slots[1].busy);
+    TEST_ASSERT(s.head == &third);
+    TEST_ASSERT(s.tail == &third);
+    TEST_ASSERT(active_request_count_locked(&s) == 1);
+
+    /* Raising the cap to two admits exactly one more job while the second
+     * worker owns its claimed request. */
+    slots[1].assigned = NULL;
+    s.max_active_requests = 2;
+    dispatch_jobs_locked(&s);
+    TEST_ASSERT(slots[2].assigned == &third);
+    TEST_ASSERT(slots[2].busy);
+    TEST_ASSERT(s.head == NULL);
+    TEST_ASSERT(s.tail == NULL);
+    TEST_ASSERT(active_request_count_locked(&s) == 2);
+
+    slots[1].busy = false;
+    slots[2].assigned = NULL;
+    slots[2].busy = false;
+    pthread_mutex_unlock(&s.mu);
+    for (int i = 0; i < 3; i++) {
+        live_tool_state_free(&slots[i].responses_live);
+        request_free(&jobs[i]->req);
+    }
+    pthread_mutex_destroy(&s.mu);
+    pthread_mutex_destroy(&s.tool_mu);
+    pthread_cond_destroy(&s.cv);
 }
 
 static void test_multimodal_prefill_resume_frontier(void) {
@@ -18464,20 +18599,34 @@ static void test_cancel_unlinks_queued_jobs(void) {
 static void test_cancel_detaches_assigned_job(void) {
     server s;
     server_slot slot = {0};
-    job j;
+    job j, queued;
     test_cancel_server_init(&s);
     test_cancel_job_init(&j);
+    test_cancel_job_init(&queued);
     s.batched_mode = true;
+    s.max_active_requests = 1;
     test_server_bind_slot(&s, &slot);
+    slot.responses_live.valid = true;
+    id_list_push_unique(&slot.responses_live.call_ids, "call-next");
+    queued.req.responses_requires_live_tool_state = true;
+    id_list_push_unique(&queued.req.responses_live_call_ids, "call-next");
     slot.assigned = &j;
     slot.busy = true;
+    s.head = s.tail = &queued;
 
     server_cancel_job(&s, &j);
     TEST_ASSERT(job_cancelled(&j));
     TEST_ASSERT(j.done);
-    TEST_ASSERT(slot.assigned == NULL);
-    TEST_ASSERT(!slot.busy);
+    TEST_ASSERT(slot.assigned == &queued);
+    TEST_ASSERT(slot.busy);
+    TEST_ASSERT(s.head == NULL);
+    TEST_ASSERT(s.tail == NULL);
 
+    slot.assigned = NULL;
+    slot.busy = false;
+    live_tool_state_free(&slot.responses_live);
+    request_free(&queued.req);
+    test_cancel_job_destroy(&queued);
     test_cancel_job_destroy(&j);
     test_cancel_server_destroy(&s);
 }
@@ -19744,6 +19893,8 @@ static void test_responses_inline_image_content(void) {
 static void ds4_server_unit_tests_run(void) {
     test_batched_prefill_round_robin();
     test_mixed_prefill_quantum_option();
+    test_max_active_requests_option();
+    test_dispatch_respects_active_request_limit();
     test_multimodal_prefill_resume_frontier();
     test_batched_live_continuation_slot_binding();
     test_request_defaults_use_min_p_filtering();


### PR DESCRIPTION
## Summary

Add `--max-active-requests N` so resident KV capacity and inference concurrency
can be configured independently.

## Why

`--batched-session` currently controls both how many KV sessions stay resident
and how many requests may occupy inference slots. A deployment may want several
warm conversations but only one active request to avoid mixed prefill/decode
contention.

For example:

```sh
./ds4-server --batched-session 10 --max-active-requests 1 ...
```

This allocates ten resident slots while admitting one assigned or running
request. Additional requests remain queued until that request completes or is
cancelled. `busy` already spans assignment, worker claim and execution, so the
new limit reuses the existing ownership state rather than adding another
scheduler.

This is admission control only. It does not change which slot the existing
router selects. As discussed in #765, reuse-aware slot selection is
complementary; this option alone does not guarantee that ten unrelated
sequential conversations all remain warm.

## Compatibility

Omitting the option preserves current behavior by setting the active limit to
the resident-session count. The option requires batched mode, must be positive
and cannot exceed the resident count. Model execution, cache formats, sampling
and existing routing are unchanged.

## Practical impact

This adds control over contention: a deployment can retain several warm sessions while admitting fewer simultaneous inference requests. It is not an unconditional throughput increase; reducing active requests can improve an individual request's latency while reducing parallel service capacity. The default is unchanged. The tests establish admission behavior, not an optimal setting or a measured speedup over `f62ca29`.

## Combined runtime context

A [stock/full-stack engine comparison](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/README.md) measures pristine `f62ca29` against the complete integrated runtime on GB10 CUDA and M3 Ultra Metal, including full 262,144-token capacity. The original full sweeps used one process pair per machine and include additional changes beyond these 13 PRs. A [targeted M3 follow-up](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/m3-attribution/README.md) did not reproduce the original short-decode slowdown, using a reversed-order pair, same-process controls and an exact original-executable replay. These results do not isolate this PR’s marginal gain, establish universal speed or quality, or newly benchmark its server/cache workflows. See the [per-PR assessment](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/PR-ASSESSMENT.md) for its supported benefit and limits.

## Validation

The build and runtime checks below ran before upstream’s README-only update. The full PR diff and every other tracked file are byte-identical at this head; `git diff --check` passed again. The documentation-only rebase was not rebuilt.

One standalone commit, `29e6104e792a`, directly on upstream `f62ca29a3087` (2026-09-07). Tests cover the unchanged default, one and two active requests, queuing, assignment, worker claim, completion and cancellation. Invalid CLI combinations are rejected before serving.

Checks on the preceding `b6af0ad` base passed on Apple M3 Ultra / Darwin 27.0 / Apple clang 21: clean default Metal build, `make test-frontends`, session-state, TP-command and vision-image tests, `make cpu`, and `git diff --check`. Fully instrumented host C/Objective-C ASan+UBSan tests also passed (`-O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all`, leak detection off). CPU portability is compile/link coverage; the sanitizer runs are host tests, not GPU instrumentation.

Before the Metal-only upstream update, the same patch passed checks on NVIDIA DGX Spark / Ubuntu / Linux 6.17.0-1032-nvidia, GCC 13.3 and CUDA 13.0.88: clean `make -j4 cuda-spark` (`sm_121a`), `make CUDA_ARCH=sm_121a test-frontends`, session-state, TP-command and vision-image tests, and a clean `make -j4 cpu` build. CPU ASan+UBSan server/session/TP/vision tests passed with leak detection on; agent tests passed with leak detection off for the unchanged upstream fixture leak. These are host tests and compile/link coverage; CUDA execution is recorded separately. The later upstream updates are a five-line GLM SSD change inside a Metal-only guard and a README edit. CUDA source and the PR patch are unchanged; native Linux preprocessing of `ds4.c` was byte-identical for CUDA, CPU and sanitizer builds.

No full aggregate model-suite or untested-backend result is claimed.
