### PR TITLE
dir-steering: pass --think, not --think-high, to ds4

### DIFF
--- a/dir-steering/tools/build_direction.py
+++ b/dir-steering/tools/build_direction.py
@@ -82,7 +82,7 @@ def run_capture(
     ]
     if system:
         cmd += ["--system", system]
-    cmd.append("--think-high" if think else "--nothink")
+    cmd.append("--think" if think else "--nothink")
     result = subprocess.run(cmd, cwd=ds4.parent, env=env, check=False,
                             stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
     if result.returncode != 0:


### PR DESCRIPTION
`build_direction.py --think` aborts before capturing anything:

```
ds4: unknown option: --think-high
```

`ds4` accepts `--think`, `--think-max` and `--nothink`. `--think-high` is not one of them, so every thinking-mode capture fails on the first pair. The default (non-thinking) path is unaffected, which is why the documented example still works.

One character in `run_capture()`:

```diff
-    cmd.append("--think-high" if think else "--nothink")
+    cmd.append("--think" if think else "--nothink")
```

Verified on an M3 Max 128 GB, GLM 5.3 Flash Q2, `--profile glm-5.3-flash`:

- before: fails at pair 1/100
- after: completes 100/100 and writes a 45 x 4096 direction

Worth having because the two capture points are not interchangeable. Building the same 100 matched pairs both ways, the per-layer cosine between the direct-answer direction and the post-`<think>` direction averages **0.19**, diverging most in layers 3 to 12. So `--think` selects a genuinely different behavioural axis rather than a variant of the same one — and until now it was unreachable.