### PR TITLE
server: accept inline images on tool/function role messages (fixes #933)

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -2028,7 +2028,8 @@ static bool parse_messages(const char **p, chat_msgs *msgs) {
         (*p)++;
         if (!msg.role) msg.role = xstrdup("user");
         if (!msg.content) msg.content = xstrdup("");
-        if (msg.images.len && strcmp(msg.role, "user")) goto fail;
+        if (msg.images.len && strcmp(msg.role, "user") &&
+            strcmp(msg.role, "tool") && strcmp(msg.role, "function")) goto fail;
         chat_msgs_push(msgs, msg);
         memset(&msg, 0, sizeof(msg));
         json_ws(p);
@@ -19351,6 +19352,46 @@ static void test_openai_inline_image_content(void) {
     buf_free(&json);
 }
 
+static void test_openai_tool_role_image_content(void) {
+    /* #933: a tool-result message carrying an inline image (the normal shape
+     * for coding agents attaching a screenshot as a tool result) must parse,
+     * matching the OpenAI wire format DeepSeek's own template already wraps
+     * in a user turn. Assistant/system images stay rejected. */
+    const char *accepted_roles[] = {"tool", "function", "user"};
+    for (size_t i = 0; i < sizeof(accepted_roles) / sizeof(accepted_roles[0]); i++) {
+        buf json = {0};
+        buf_puts(&json, "[{\"role\":\"");
+        buf_puts(&json, accepted_roles[i]);
+        buf_puts(&json, "\",\"content\":[{\"type\":\"text\",\"text\":\"result: \"},"
+            "{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,");
+        buf_puts(&json, test_inline_png_base64);
+        buf_puts(&json, "\"}}]}]");
+        const char *p = json.ptr;
+        chat_msgs msgs = {0};
+        TEST_ASSERT(parse_messages(&p, &msgs));
+        TEST_ASSERT(msgs.len == 1);
+        TEST_ASSERT(msgs.v[0].images.len == 1);
+        chat_msgs_free(&msgs);
+        buf_free(&json);
+    }
+
+    const char *rejected_roles[] = {"assistant", "system"};
+    for (size_t i = 0; i < sizeof(rejected_roles) / sizeof(rejected_roles[0]); i++) {
+        buf json = {0};
+        buf_puts(&json, "[{\"role\":\"");
+        buf_puts(&json, rejected_roles[i]);
+        buf_puts(&json, "\",\"content\":[{\"type\":\"image_url\","
+            "\"image_url\":{\"url\":\"data:image/png;base64,");
+        buf_puts(&json, test_inline_png_base64);
+        buf_puts(&json, "\"}}]}]");
+        const char *p = json.ptr;
+        chat_msgs msgs = {0};
+        TEST_ASSERT(!parse_messages(&p, &msgs));
+        chat_msgs_free(&msgs);
+        buf_free(&json);
+    }
+}
+
 static void test_http_image_paths_and_urls_are_rejected(void) {
     const char *cases[] = {
         "[{\"role\":\"user\",\"content\":[{\"type\":\"image_url\","
@@ -19488,6 +19529,7 @@ static void ds4_server_unit_tests_run(void) {
     test_thinking_canonical_with_tools_preserves_reasoning();
     test_thinking_canonical_non_thinking_mode_noop();
     test_openai_inline_image_content();
+    test_openai_tool_role_image_content();
     test_http_image_paths_and_urls_are_rejected();
     test_anthropic_inline_image_content();
     test_responses_inline_image_content();


### PR DESCRIPTION
Fixes #933. Credit to @aj-img for the precise diagnosis and suggested fix there — this PR implements exactly what was proposed.

## Problem

`parse_messages` rejected any OpenAI Chat Completions message carrying an inline image whose `role` wasn't exactly `"user"`, always with a generic `400 "invalid JSON request"`. That breaks the normal shape for coding agents that attach a tool-result screenshot as an `image_url` content part on a `role: "tool"` (or `role: "function"`) message — the same data URI on `role: "user"` was accepted.

## Fix

As diagnosed in #933: the user-only restriction was meant to keep image tokens landing on a user-shaped turn, but DS4's own chat template already renders tool results inside a user turn (`<|User|><tool_result>...`), so the API-level role tag doesn't need to match that internal shape. One line in `parse_messages`: allow `user`/`tool`/`function`, keep rejecting `assistant`/`system`, file paths, and `https` URLs exactly as before (`parse_anthropic_messages`'s identical-looking check is untouched — Anthropic's wire format has no separate tool role; `tool_result` blocks always nest inside a `user`-role message already, so it isn't exposed to this bug).

## Testing

- Added `test_openai_tool_role_image_content`, mirroring the existing `test_openai_inline_image_content` / `test_http_image_paths_and_urls_are_rejected` pair: asserts `user`/`tool`/`function` all parse and capture the image, and that `assistant`/`system` still fail.
- Verified it's a real regression test, not a happy-path-only check: reverted the fix locally, confirmed the new test fails at the exact new assertions, restored it, confirmed green.
- Verified end-to-end past the parser: built `ds4-server` with the fix, sent the exact three-message shape from the issue (`user` text → `assistant` with `tool_calls` → `tool` message with a real screenshot as `image_url`) over HTTP — `200`, and the model's answer correctly described the screenshot's actual on-screen content (not a hallucination). Confirmed the two negative cases still `400`: an image on `role: assistant`, and an `https://` URL on `role: tool`.
- Full `make test` green throughout, on `main` @ current head.

## Scope

The issue's "prefer a specific error string for remaining schema failures" suggestion is explicitly marked optional there and left out, to keep this to the one behavioral fix.