### PR TITLE
Withhold the automatic Metal 4 tensor enable on M5 until accumulate parity

### DIFF
--- a/QA_BEFORE_RELEASES.md
+++ b/QA_BEFORE_RELEASES.md
@@ -292,6 +292,16 @@ Run these gates whenever session scheduling, batched decode, mixed
 prefill/decode, QKV projection, shared or routed experts, tensor parallelism,
 or backend fallback selection changes.
 
+- On M5-class hardware, run the Metal 4 tensor-route gate with a checkpoint
+  whose prompts exercise multi-token prefill:
+  `DS4_TEST_MODEL=gguf/GLM-5.3-Flash-Q2.gguf
+  DS4_TEST_VECTOR_FILE=tests/test-vectors/glm-openrouter/official.vec
+  ./ds4_test --metal-tensor-equivalence`.
+  The `auto` route must pass; the `tensor-optin` report line documents the
+  still-lossy `matmul2d` accumulate that keeps the automatic enable withheld.
+  M5 prefill throughput references in this file predate the withhold and need
+  re-baselining when quoted.
+
 - On a single Metal machine, run the full-vocabulary exact-logit oracle with
   2, 4, 8, and 16 sessions:
   `DS4_TEST_MODEL=/path/to/ds4flash.gguf DS4_TEST_SESSION_COUNT=N make test-metal-session-batch`.

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -2498,17 +2498,36 @@ static void ds4_gpu_detect_metal4_features(void) {
 
             /*
              * Metal 4 TensorOps are portable in source, but on pre-M5 hardware
-             * they can map to ordinary shader fallbacks.  Keep the automatic
-             * fast path restricted to hardware generations where the Neural
+             * they can map to ordinary shader fallbacks.  Keep the fast path
+             * restricted to hardware generations where the Neural
              * Accelerator/TensorOps path is expected to pay off; older Metal
              * machines continue to use the established kernels unless a future
              * device is explicitly added here.
+             *
+             * The automatic enable is currently withheld even on M5-class
+             * devices: measured against the simdgroup reference kernels on an
+             * M5 Max (GLM-5.3-Flash-Q2, macOS 27.0), the hardware matmul2d
+             * accumulate is visibly lossy for both the staged routed-MoE tiles
+             * and the direct-RHS dense prefill tiles.  Prompt logits drift by
+             * whole units, greedy streams diverge, and
+             * ./ds4_test --metal-tensor-equivalence fails on M5 hardware,
+             * while the identical runs with DS4_METAL_DISABLE_METAL4=1 stay
+             * bit-identical to an M3 Ultra.  Operand precision (half or float
+             * staging) and matmul2d_descriptor::relaxed_precision do not move
+             * the error.  Until the driver's accumulation matches the
+             * reference kernels, DS4_METAL_ENABLE_TENSOR=1 opts back in for
+             * performance comparisons.
              */
             if (default_enable) {
                 g_metal4_tensor_api_compile_supported = ds4_gpu_compile_tensor_probe();
-                g_metal4_tensor_api_enabled = g_metal4_tensor_api_compile_supported;
-                if (!g_metal4_tensor_api_enabled) {
+                const int forced = ds4_gpu_env_bool("DS4_METAL_ENABLE_TENSOR") > 0;
+                g_metal4_tensor_api_enabled =
+                    g_metal4_tensor_api_compile_supported && forced;
+                if (!g_metal4_tensor_api_compile_supported) {
                     fprintf(stderr, "ds4: Metal 4 tensor API probe failed; using legacy Metal kernels\n");
+                } else if (!g_metal4_tensor_api_enabled) {
+                    fprintf(stderr, "ds4: Metal 4 tensor API available but not enabled (numerics); "
+                                    "set DS4_METAL_ENABLE_TENSOR=1 to override\n");
                 }
             } else {
                 fprintf(stderr, "ds4: Metal 4 tensor API disabled for pre-M5/pre-A19 devices\n");

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -6056,7 +6056,8 @@ static void test_mpp_summary_print(const test_mpp_eq_summary *summary) {
 
 static void test_run_mpp_candidate(const char *label,
                                    test_mpp_eq_case *cases,
-                                   int ncase) {
+                                   int ncase,
+                                   bool assert_thresholds) {
     fprintf(stderr, "ds4-test: Tensor equivalence candidate route=%s\n", label);
     test_mpp_eq_summary summary;
     test_mpp_summary_init(&summary, label);
@@ -6076,9 +6077,11 @@ static void test_run_mpp_candidate(const char *label,
                     continue;
                 }
                 summary.cases++;
-                test_mpp_eq_result result = test_compare_mpp_logits(tc, cand_logits, true);
+                test_mpp_eq_result result = test_compare_mpp_logits(tc, cand_logits, assert_thresholds);
                 test_mpp_summary_note_logits(&summary, &result);
-                TEST_ASSERT(cand_gen_len == tc->ref_gen_len);
+                if (assert_thresholds) {
+                    TEST_ASSERT(cand_gen_len == tc->ref_gen_len);
+                }
                 if (cand_gen_len != tc->ref_gen_len) summary.greedy_failures++;
                 for (int j = 0; j < tc->ref_gen_len && j < cand_gen_len; j++) {
                     if (cand_gen[j] != tc->ref_gen[j]) {
@@ -6087,7 +6090,9 @@ static void test_run_mpp_candidate(const char *label,
                                 tc->id, j, tc->ref_gen[j], cand_gen[j]);
                         summary.greedy_failures++;
                     }
-                    TEST_ASSERT(cand_gen[j] == tc->ref_gen[j]);
+                    if (assert_thresholds) {
+                        TEST_ASSERT(cand_gen[j] == tc->ref_gen[j]);
+                    }
                 }
             }
             free(cand_logits);
@@ -6126,7 +6131,19 @@ static void test_metal_mpp_equivalence(void) {
     ds4_engine_close(ref_engine);
     test_restore_env("DS4_METAL_DISABLE_METAL4", saved_disable_metal4);
 
-    test_run_mpp_candidate("auto", cases, ncase);
+    test_run_mpp_candidate("auto", cases, ncase, true);
+
+    /*
+     * The automatic Metal 4 tensor enable is withheld on M5-class devices
+     * because the measured matmul2d accumulate drift fails the assertions
+     * above when the route is active.  Keep measuring the explicitly
+     * enabled tensor route in reporting mode so the gap to the reference
+     * stays visible in QA logs without gating the release on it.
+     */
+    char *saved_enable_tensor = test_save_env("DS4_METAL_ENABLE_TENSOR");
+    setenv("DS4_METAL_ENABLE_TENSOR", "1", 1);
+    test_run_mpp_candidate("tensor-optin", cases, ncase, false);
+    test_restore_env("DS4_METAL_ENABLE_TENSOR", saved_enable_tensor);
 
     for (int i = 0; i < ncase; i++) test_mpp_eq_case_free(&cases[i]);
 }


### PR DESCRIPTION
Closes #946.

## What

Stops auto-enabling the Metal 4 TensorOps route (`tensor_matmul`) on M5-class devices, keeping `DS4_METAL_ENABLE_TENSOR=1` as an explicit opt-in. The automatic route was numerically lossy on M5 hardware (issue #946): the `matmul2d` accumulate drifts from the simdgroup reference kernels by whole logit units, independent of operand staging precision and of `matmul2d_descriptor::relaxed_precision`.

## Verification (M5 Max + M3 Ultra, macOS 27.0, GLM-5.3-Flash-Q2, same commit + byte-identical model)

| Check | Before (tensor auto) | After (withheld) |
|---|---|---|
| `ds4_test --metal-tensor-equivalence` | ERR, 28 failures, worst_rms=1.39, worst_max_abs=7.27 | **OK** (auto route all-zero deltas) |
| Greedy logprob dumps vs M3 Ultra (58 / 309 / 3778-token prompts) | 0.8–3.5+ logit drift, argmax flips | **byte-identical** |
| `ds4-eval` case 6 (aime2025-16, 2400 greedy tokens) | M5 picks 24, M3 picks 28, outputs diverge at token 2 | **byte-identical traces** (both pick 28) |
| `--decode-consistency` (3794-token prefix) | max 1.004 / rms 0.203 | 0.300 / 0.064 — same digits as M3 |
| 3778-token prefill wall time (A/B, warm cache) | 15.3–17.7 s | 16.0–17.2 s (no measurable cost) |

`DS4_METAL_ENABLE_TENSOR=1` still re-enables the route and reproduces the old tensor output bit-for-bit (verified).

## Gate change

With the route off by default, `--metal-tensor-equivalence` would have become legacy-vs-legacy and vacuous. The test now:

- asserts parity for the shipped `auto` route (must stay all-zero on every GPU), and
- runs an explicit `tensor-optin` candidate in **reporting mode** so the accumulate gap stays visible in QA logs (`worst_rms=1.386 worst_max_abs=7.27` on M5 today) without gating the release.

Also adds the gate to `QA_BEFORE_RELEASES.md` with a note that M5 prefill throughput references predate the withhold.

## Notes for reviewers

- The routed-MoE MPP kernels, dense NAX kernels, and `DS4_METAL_HAS_TENSOR` shader variants are all unchanged — this only flips the default route selection and can be reverted with one env var once the driver accumulate matches the reference kernels on M5.
- Perf-sensitive paths should re-baseline M5 prefill numbers; the GLM Q2 A/B above showed no regression, but the DS MXFP4 workload that originally motivated the tensor route was not re-measured here.
