### PR TITLE
docs: fix Pi Agent thinkingLevelMap for Flash modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1403,12 +1403,13 @@ For **Pi**, add a provider to `~/.pi/agent/models.json`:
           "name": "DeepSeek V4 Flash (ds4.c local)",
           "reasoning": true,
           "thinkingLevelMap": {
-            "off": null,
-            "minimal": "low",
-            "low": "low",
-            "medium": "medium",
+            "off": "off",
+            "minimal": null,
+            "low": null,
+            "medium": null,
             "high": "high",
-            "xhigh": "xhigh"
+            "xhigh": null,
+            "max": "max"
           },
           "input": ["text"],
           "contextWindow": 100000,


### PR DESCRIPTION
## Summary
- Updates the Pi `thinkingLevelMap` example so it matches DeepSeek V4 Flash's three modes: non-thinking (`off`), thinking (`high`), and Think Max (`max`).
- Hides intermediate Pi levels (`minimal`/`low`/`medium`/`xhigh`) that previously all mapped into normal thinking and masked Think Max.

Fixes #842

## Test plan
- [ ] Diff-check README Pi example against the Thinking Modes section below it
- [ ] Optional: paste into `~/.pi/agent/models.json` and confirm Shift+Tab offers off / high / max only

AI usage disclosure: YES — assisted by Cursor agent; change is docs-only.

Made with [Cursor](https://cursor.com)