### PR TITLE
server: persist vision KV with exact conditioning provenance

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -54417,6 +54417,8 @@ typedef struct {
     uint32_t token_start;
     uint32_t token_count;
     uint8_t fingerprint[32];
+    uint8_t state_fingerprint[32];
+    bool state_fingerprint_valid;
 } ds4_vision_identity;
 
 struct ds4_session {
@@ -64444,6 +64446,9 @@ static int ds4_prompt_append_deepseek4_vision(
     free(embedding->data);
     embedding->data = block;
     embedding->token_count = layout.token_count;
+    memset(embedding->state_fingerprint, 0,
+           sizeof(embedding->state_fingerprint));
+    embedding->state_fingerprint_valid = false;
     embedding->layout = 0;
     embedding->grid_width = 0;
     embedding->grid_height = 0;
@@ -66664,7 +66669,33 @@ static void ds4_session_note_prefill_progress(void *ud, const char *event, int c
  *
  * A non-matching prompt discards the checkpoint and prefills from token zero.
  */
-static int ds4_session_sync_internal(ds4_session *s, const ds4_tokens *prompt, char *err, size_t errlen);
+static int ds4_session_sync_internal(ds4_session *s, const ds4_tokens *prompt,
+                                     char *err, size_t errlen,
+                                     int *retained_tokens);
+
+static int ds4_session_sync_preflight(ds4_session *s,
+                                      const ds4_tokens *prompt,
+                                      char *err, size_t errlen) {
+    if (!s || !prompt) {
+        snprintf(err, errlen, "missing session or prompt");
+        return 1;
+    }
+    if (prompt->len <= 0) {
+        snprintf(err, errlen, "empty prompt");
+        return 1;
+    }
+    if (prompt->len >= s->ctx_size) {
+        snprintf(err, errlen,
+                 "prompt length %d exceeds context %d (one token of generation room is required)",
+                 prompt->len, s->ctx_size);
+        return 1;
+    }
+    if (ds4_session_cancelled(s)) {
+        snprintf(err, errlen, "interrupted");
+        return DS4_SESSION_SYNC_INTERRUPTED;
+    }
+    return 0;
+}
 
 static bool ds4_session_vision_prefix_matches(
         const ds4_session     *s,
@@ -66701,6 +66732,60 @@ bool ds4_session_has_vision_state(const ds4_session *s) {
     return s && (s->checkpoint_image_count != 0 || s->sync_image_count != 0);
 }
 
+size_t ds4_session_vision_identity_count(const ds4_session *s) {
+    return s ? s->checkpoint_image_count : 0;
+}
+
+bool ds4_session_vision_identity(const ds4_session *s, size_t index,
+                                 uint32_t *token_start,
+                                 uint32_t *token_count,
+                                 uint8_t state_fingerprint[32]) {
+    if (!s || index >= s->checkpoint_image_count) return false;
+    const ds4_vision_identity *image = &s->checkpoint_images[index];
+    if (!image->state_fingerprint_valid) return false;
+    if (token_start) *token_start = image->token_start;
+    if (token_count) *token_count = image->token_count;
+    if (state_fingerprint)
+        memcpy(state_fingerprint, image->state_fingerprint, 32);
+    return true;
+}
+
+bool ds4_session_restore_vision_identities(ds4_session *s,
+                                           const ds4_vision_span *images,
+                                           size_t image_count) {
+    if (!s || !s->checkpoint_valid || image_count == 0 || !images) return false;
+    if (image_count > SIZE_MAX / sizeof(s->checkpoint_images[0])) return false;
+
+    uint64_t previous_end = 0;
+    for (size_t i = 0; i < image_count; i++) {
+        const uint64_t start = images[i].token_start;
+        const uint64_t count = images[i].embedding.token_count;
+        const uint64_t end = start + count;
+        if (!images[i].embedding.state_fingerprint_valid || count == 0 ||
+            start < previous_end || end > (uint64_t)s->checkpoint.len)
+            return false;
+        previous_end = end;
+    }
+
+    ds4_vision_identity *copy = calloc(image_count, sizeof(copy[0]));
+    if (!copy) return false;
+    for (size_t i = 0; i < image_count; i++) {
+        copy[i].token_start = images[i].token_start;
+        copy[i].token_count = images[i].embedding.token_count;
+        memcpy(copy[i].fingerprint, images[i].embedding.fingerprint,
+               sizeof(copy[i].fingerprint));
+        memcpy(copy[i].state_fingerprint,
+               images[i].embedding.state_fingerprint,
+               sizeof(copy[i].state_fingerprint));
+        copy[i].state_fingerprint_valid =
+            images[i].embedding.state_fingerprint_valid;
+    }
+    free(s->checkpoint_images);
+    s->checkpoint_images = copy;
+    s->checkpoint_image_count = image_count;
+    return true;
+}
+
 static bool ds4_session_vision_range_overlaps(
         const ds4_session *s,
         uint32_t           token_start,
@@ -66716,18 +66801,49 @@ static bool ds4_session_vision_range_overlaps(
     return false;
 }
 
-static bool ds4_session_store_vision_identities(ds4_session *s) {
+/* retained_tokens describes the prefix the backend actually kept, not merely
+ * a token match observed before sync. -1 means that sync cannot attest its
+ * image-state provenance (for example, a distributed recovery). */
+static bool ds4_session_store_vision_identities(ds4_session *s,
+                                                int retained_tokens) {
     ds4_vision_identity *copy = NULL;
     if (s->sync_image_count != 0) {
         if (s->sync_image_count > SIZE_MAX / sizeof(copy[0])) return false;
         copy = calloc(s->sync_image_count, sizeof(copy[0]));
         if (!copy) return false;
         for (size_t i = 0; i < s->sync_image_count; i++) {
-            copy[i].token_start = s->sync_images[i].token_start;
-            copy[i].token_count = s->sync_images[i].embedding.token_count;
+            const ds4_vision_span *current = &s->sync_images[i];
+            copy[i].token_start = current->token_start;
+            copy[i].token_count = current->embedding.token_count;
             memcpy(copy[i].fingerprint,
-                   s->sync_images[i].embedding.fingerprint,
+                   current->embedding.fingerprint,
                    sizeof(copy[i].fingerprint));
+            const uint64_t end = (uint64_t)copy[i].token_start +
+                                 copy[i].token_count;
+            if (retained_tokens >= 0 && end <= (uint64_t)retained_tokens &&
+                i < s->checkpoint_image_count) {
+                /* Retained KV still belongs to the old conditioning vectors,
+                 * even if this request carries newly encoded vectors/hash. */
+                const ds4_vision_identity *previous =
+                    &s->checkpoint_images[i];
+                if (previous->token_start == copy[i].token_start &&
+                    previous->token_count == copy[i].token_count &&
+                    previous->state_fingerprint_valid &&
+                    memcmp(previous->fingerprint, copy[i].fingerprint,
+                           sizeof(copy[i].fingerprint)) == 0) {
+                    memcpy(copy[i].state_fingerprint,
+                           previous->state_fingerprint,
+                           sizeof(copy[i].state_fingerprint));
+                    copy[i].state_fingerprint_valid = true;
+                }
+            } else if (retained_tokens >= 0 &&
+                       copy[i].token_start >= (uint32_t)retained_tokens &&
+                       current->embedding.state_fingerprint_valid) {
+                memcpy(copy[i].state_fingerprint,
+                       current->embedding.state_fingerprint,
+                       sizeof(copy[i].state_fingerprint));
+                copy[i].state_fingerprint_valid = true;
+            }
         }
     }
     free(s->checkpoint_images);
@@ -66741,11 +66857,17 @@ static bool ds4_session_store_vision_identities(ds4_session *s) {
  * graph sequence and the per-layer gates pair up.  The worker acks a sync
  * once its matching prefill completes, surfacing worker-side failures
  * here instead of as a gate timeout mid-decode. */
-int ds4_session_sync(ds4_session *s, const ds4_tokens *prompt, char *err, size_t errlen) {
+static int ds4_session_sync_impl(ds4_session *s, const ds4_tokens *prompt,
+                                 char *err, size_t errlen,
+                                 bool *backend_started) {
+    if (backend_started) *backend_started = false;
+    int preflight = ds4_session_sync_preflight(s, prompt, err, errlen);
+    if (preflight != 0) return preflight;
     if (s && !ds4_session_vision_prefix_matches(
                      s, s->sync_images, s->sync_image_count)) {
         ds4_session_invalidate(s);
     }
+    if (backend_started) *backend_started = true;
 #ifndef DS4_NO_GPU
     ds4_session_dspark_scheduler_begin_request(s);
 #endif
@@ -66767,7 +66889,9 @@ int ds4_session_sync(ds4_session *s, const ds4_tokens *prompt, char *err, size_t
             return 1;
         }
     }
-    int rc = ds4_session_sync_internal(s, prompt, err, errlen);
+    int retained_tokens = 0;
+    int rc = ds4_session_sync_internal(s, prompt, err, errlen,
+                                       &retained_tokens);
 #ifndef DS4_NO_GPU
     if (rc == 0) glm_debug_dump_prefill_logits(s->logits);
     if (rc == 0) {
@@ -66813,13 +66937,244 @@ int ds4_session_sync(ds4_session *s, const ds4_tokens *prompt, char *err, size_t
             return rc != 0 ? rc : 1;
         }
     }
-    if (rc == 0 && !ds4_session_store_vision_identities(s)) {
+    if (rc == 0 && !ds4_session_store_vision_identities(s, retained_tokens)) {
         ds4_session_invalidate(s);
         snprintf(err, errlen, "unable to retain image prompt identity");
         return 1;
     }
     return rc;
 }
+
+int ds4_session_sync(ds4_session *s, const ds4_tokens *prompt,
+                     char *err, size_t errlen) {
+    return ds4_session_sync_impl(s, prompt, err, errlen, NULL);
+}
+
+static int ds4_session_finish_multimodal_sync(ds4_session *s, int rc,
+                                              bool backend_started) {
+    /* A failed image sync may have advanced the token checkpoint at a safe
+     * prefill boundary, but ds4_session_sync() publishes image identities only
+     * after the whole sync succeeds.  Do not leave that image-conditioned KV
+     * frontier available for later eviction or reuse without an exact key. */
+    if (rc != 0 && backend_started && s &&
+        (s->checkpoint_valid || s->checkpoint_image_count != 0)) {
+        ds4_session_invalidate(s);
+    }
+    if (s) {
+        s->sync_images = NULL;
+        s->sync_image_count = 0;
+    }
+    return rc;
+}
+
+#ifndef DS4_NO_GPU
+static bool ds4_test_cancel_always(void *ud) {
+    (void)ud;
+    return true;
+}
+
+bool ds4_test_multimodal_sync_finish_policy(void) {
+    ds4_engine engine = {0};
+    engine.backend = DS4_BACKEND_CPU;
+
+    for (size_t retained = 0; retained <= 1; retained++) {
+        ds4_session session = {0};
+        ds4_vision_span images[2] = {0};
+        session.engine = &engine;
+        session.checkpoint_valid = true;
+        token_vec_push(&session.checkpoint, 7);
+        if (retained != 0) {
+            session.checkpoint_images = calloc(1, sizeof(session.checkpoint_images[0]));
+            if (!session.checkpoint_images) {
+                token_vec_free(&session.checkpoint);
+                return false;
+            }
+            session.checkpoint_image_count = 1;
+        }
+        session.sync_images = images;
+        session.sync_image_count = retained + 1;
+
+        int rc = ds4_session_finish_multimodal_sync(
+            &session, DS4_SESSION_SYNC_INTERRUPTED, true);
+        bool invalidated = rc == DS4_SESSION_SYNC_INTERRUPTED &&
+                           !session.checkpoint_valid &&
+                           session.checkpoint.len == 0 &&
+                           !session.checkpoint_images &&
+                           session.checkpoint_image_count == 0 &&
+                           !session.sync_images &&
+                           session.sync_image_count == 0;
+        token_vec_free(&session.checkpoint);
+        free(session.checkpoint_images);
+        if (!invalidated) return false;
+    }
+
+    ds4_session completed = {0};
+    ds4_vision_span image = {0};
+    completed.engine = &engine;
+    completed.checkpoint_valid = true;
+    token_vec_push(&completed.checkpoint, 11);
+    completed.checkpoint_images = calloc(1, sizeof(completed.checkpoint_images[0]));
+    if (!completed.checkpoint_images) {
+        token_vec_free(&completed.checkpoint);
+        return false;
+    }
+    completed.checkpoint_image_count = 1;
+    completed.sync_images = &image;
+    completed.sync_image_count = 1;
+    int rc = ds4_session_finish_multimodal_sync(&completed, 0, true);
+    bool preserved = rc == 0 && completed.checkpoint_valid &&
+                     completed.checkpoint.len == 1 &&
+                     completed.checkpoint_image_count == 1 &&
+                     !completed.sync_images &&
+                     completed.sync_image_count == 0;
+    token_vec_free(&completed.checkpoint);
+    free(completed.checkpoint_images);
+    if (!preserved) return false;
+
+    ds4_session rejected = {0};
+    ds4_vision_span rejected_image = {0};
+    int rejected_token = 42;
+    ds4_tokens rejected_prompt = {
+        .v = &rejected_token,
+        .len = 1,
+        .cap = 1,
+    };
+    engine.vision_ready = true;
+    engine.vision_image_token = rejected_token;
+    rejected.engine = &engine;
+    rejected.ctx_size = 1;
+    rejected.checkpoint_valid = true;
+    token_vec_push(&rejected.checkpoint, 17);
+    rejected.checkpoint_images = calloc(1, sizeof(rejected.checkpoint_images[0]));
+    if (!rejected.checkpoint_images) {
+        token_vec_free(&rejected.checkpoint);
+        return false;
+    }
+    rejected.checkpoint_image_count = 1;
+    rejected_image.embedding.data = (float *)&rejected_token;
+    rejected_image.embedding.token_count = 1;
+    char err[80] = {0};
+    rc = ds4_session_sync_multimodal(&rejected, &rejected_prompt,
+                                     &rejected_image, 1,
+                                     err, sizeof(err));
+    preserved = rc != 0 && rejected.checkpoint_valid &&
+                rejected.checkpoint.len == 1 &&
+                rejected.checkpoint_image_count == 1;
+    if (preserved) {
+        rejected.ctx_size = 2;
+        rejected.cancel = ds4_test_cancel_always;
+        rc = ds4_session_sync_multimodal(&rejected, &rejected_prompt,
+                                         &rejected_image, 1,
+                                         err, sizeof(err));
+        preserved = rc == DS4_SESSION_SYNC_INTERRUPTED &&
+                    rejected.checkpoint_valid &&
+                    rejected.checkpoint.len == 1 &&
+                    rejected.checkpoint_image_count == 1;
+    }
+    token_vec_free(&rejected.checkpoint);
+    free(rejected.checkpoint_images);
+    return preserved;
+}
+
+bool ds4_test_vision_identity_carries_exact_state_fingerprint(void) {
+    ds4_session session = {0};
+    ds4_vision_span current = {0};
+    session.checkpoint_images = calloc(1, sizeof(session.checkpoint_images[0]));
+    if (!session.checkpoint_images) return false;
+    session.checkpoint_image_count = 1;
+    session.checkpoint_images[0].token_start = 64;
+    session.checkpoint_images[0].token_count = 8;
+    memset(session.checkpoint_images[0].fingerprint, 0x31,
+           sizeof(session.checkpoint_images[0].fingerprint));
+    memset(session.checkpoint_images[0].state_fingerprint, 0xa7,
+           sizeof(session.checkpoint_images[0].state_fingerprint));
+    session.checkpoint_images[0].state_fingerprint_valid = true;
+
+    current.token_start = 64;
+    current.embedding.token_count = 8;
+    memset(current.embedding.fingerprint, 0x31,
+           sizeof(current.embedding.fingerprint));
+    current.embedding.state_fingerprint_valid = false;
+    session.sync_images = &current;
+    session.sync_image_count = 1;
+    if (!ds4_session_store_vision_identities(&session, 72)) {
+        free(session.checkpoint_images);
+        return false;
+    }
+    bool preserved = session.checkpoint_image_count == 1 &&
+                     session.checkpoint_images[0].state_fingerprint_valid;
+    for (size_t i = 0; preserved &&
+                       i < sizeof(session.checkpoint_images[0].state_fingerprint);
+         i++) {
+        preserved = session.checkpoint_images[0].state_fingerprint[i] == 0xa7;
+    }
+
+    /* A changed image must never inherit the old conditioning hash. */
+    current.embedding.fingerprint[0] ^= 0xff;
+    current.embedding.state_fingerprint_valid = false;
+    if (!ds4_session_store_vision_identities(&session, 72)) preserved = false;
+    const bool changed_rejected = session.checkpoint_image_count == 1 &&
+        !session.checkpoint_images[0].state_fingerprint_valid;
+    free(session.checkpoint_images);
+    return preserved && changed_rejected;
+}
+
+bool ds4_test_vision_identity_keeps_retained_hash(void) {
+    const struct {
+        int retained;
+        bool previous_valid, current_valid, changed_source, expected_valid;
+        uint8_t expected_hash;
+    } cases[] = {
+        {80, true,  true,  false, true,  0xa7}, /* new hash must not relabel old KV */
+        {72, true,  false, false, true,  0xa7}, /* exact image-end boundary */
+        { 0, true,  true,  false, true,  0xb8}, /* full rebuild uses new vectors */
+        { 0, true,  false, false, false, 0},    /* rebuild cannot inherit old hash */
+        {64, true,  true,  false, true,  0xb8}, /* image starts at recompute boundary */
+        {68, true,  true,  false, false, 0},    /* mixed old/new image rows */
+        {-1, true,  true,  false, false, 0},    /* backend cannot attest provenance */
+        {80, false, true,  false, false, 0},    /* unknown old vectors stay unknown */
+        {80, true,  true,  true,  false, 0},    /* no matching retained identity */
+    };
+    for (size_t n = 0; n < sizeof(cases) / sizeof(cases[0]); n++) {
+        ds4_session session = {0};
+        ds4_vision_span current[2] = {0};
+        session.checkpoint_images = calloc(1, sizeof(session.checkpoint_images[0]));
+        if (!session.checkpoint_images) return false;
+        session.checkpoint_image_count = 1;
+        session.checkpoint_images[0].token_start = 64;
+        session.checkpoint_images[0].token_count = 8;
+        memset(session.checkpoint_images[0].fingerprint, 0x31, 32);
+        memset(session.checkpoint_images[0].state_fingerprint, 0xa7, 32);
+        session.checkpoint_images[0].state_fingerprint_valid = cases[n].previous_valid;
+        current[0].token_start = 64;
+        current[0].embedding.token_count = 8;
+        memset(current[0].embedding.fingerprint,
+               cases[n].changed_source ? 0x32 : 0x31, 32);
+        memset(current[0].embedding.state_fingerprint, 0xb8, 32);
+        current[0].embedding.state_fingerprint_valid = cases[n].current_valid;
+        /* An appended image is newly computed, independently of the old one. */
+        current[1].token_start = 96;
+        current[1].embedding.token_count = 8;
+        memset(current[1].embedding.state_fingerprint, 0xc9, 32);
+        current[1].embedding.state_fingerprint_valid = true;
+        session.sync_images = current;
+        session.sync_image_count = 2;
+        bool ok = ds4_session_store_vision_identities(&session, cases[n].retained);
+        ok = ok && session.checkpoint_image_count == 2 &&
+             session.checkpoint_images[0].state_fingerprint_valid == cases[n].expected_valid &&
+             session.checkpoint_images[1].state_fingerprint_valid == (cases[n].retained >= 0);
+        for (size_t i = 0; ok && i < 32; i++) {
+            if (cases[n].expected_valid)
+                ok = session.checkpoint_images[0].state_fingerprint[i] == cases[n].expected_hash;
+            if (cases[n].retained >= 0)
+                ok = ok && session.checkpoint_images[1].state_fingerprint[i] == 0xc9;
+        }
+        free(session.checkpoint_images);
+        if (!ok) return false;
+    }
+    return true;
+}
+#endif
 
 int ds4_session_sync_multimodal(
         ds4_session *s,
@@ -66875,36 +67230,24 @@ int ds4_session_sync_multimodal(
     s->graph.prefill_vision_spans = images;
     s->graph.prefill_vision_span_count = image_count;
 #endif
-    const int rc = ds4_session_sync(s, prompt, err, errlen);
+    bool backend_started = false;
+    const int rc = ds4_session_sync_impl(s, prompt, err, errlen,
+                                         &backend_started);
 #ifndef DS4_NO_GPU
     s->graph.prefill_vision_spans = NULL;
     s->graph.prefill_vision_span_count = 0;
 #endif
-    s->sync_images = NULL;
-    s->sync_image_count = 0;
-    return rc;
+    return ds4_session_finish_multimodal_sync(s, rc, backend_started);
 }
 
-static int ds4_session_sync_internal(ds4_session *s, const ds4_tokens *prompt, char *err, size_t errlen) {
-    if (!s || !prompt) {
-        snprintf(err, errlen, "missing session or prompt");
-        return 1;
-    }
-    if (prompt->len <= 0) {
-        snprintf(err, errlen, "empty prompt");
-        return 1;
-    }
-    if (prompt->len >= s->ctx_size) {
-        snprintf(err, errlen,
-                 "prompt length %d exceeds context %d (one token of generation room is required)",
-                 prompt->len, s->ctx_size);
-        return 1;
-    }
-    if (ds4_session_cancelled(s)) {
-        snprintf(err, errlen, "interrupted");
-        return DS4_SESSION_SYNC_INTERRUPTED;
-    }
+static int ds4_session_sync_internal(ds4_session *s, const ds4_tokens *prompt,
+                                     char *err, size_t errlen,
+                                     int *retained_tokens) {
+    *retained_tokens = 0;
     if (s->distributed) {
+        /* The coordinator may recover by replaying after a suffix failure;
+         * its current interface does not report which image rows survived. */
+        *retained_tokens = -1;
         const ds4_tokens *checkpoint = s->checkpoint_valid ? &s->checkpoint : NULL;
         return ds4_dist_session_sync(s->distributed,
                                      s,
@@ -66920,6 +67263,7 @@ static int ds4_session_sync_internal(ds4_session *s, const ds4_tokens *prompt, c
             prompt->len >= s->checkpoint.len &&
             ds4_tokens_starts_with(prompt, &s->checkpoint))
         {
+            *retained_tokens = s->checkpoint.len;
             s->mtp_draft_valid = false;
             for (int i = s->checkpoint.len; i < prompt->len; i++) {
                 if (ds4_session_cancelled(s)) {
@@ -67008,6 +67352,7 @@ static int ds4_session_sync_internal(ds4_session *s, const ds4_tokens *prompt, c
             ds4_tokens_starts_with(prompt, &s->checkpoint))
         {
             start = s->checkpoint.len;
+            *retained_tokens = start;
             resumed_checkpoint = true;
             s->mtp_draft_valid = false;
         } else {
@@ -67242,6 +67587,9 @@ static int ds4_session_sync_internal(ds4_session *s, const ds4_tokens *prompt, c
             s->glm_graph.full_kv_cache &&
             s->glm_dense_cache_len < s->glm_graph.ctx_cap)
         {
+            /* This repairs only a dense window alongside retained compact
+             * state. A single retained-prefix boundary cannot describe it. */
+            *retained_tokens = -1;
             const uint32_t dense_end =
                 (uint32_t)prompt->len < s->glm_graph.ctx_cap ?
                     (uint32_t)prompt->len :
@@ -67346,6 +67694,11 @@ static int ds4_session_sync_internal(ds4_session *s, const ds4_tokens *prompt, c
             (uint32_t)suffix >= resume_min &&
             indexed_batch_available)
         {
+            /* A dense-cache gap is not a lost compact prefix. Indexed prefill
+             * reads layer_kv_lora_cache/layer_k_rope_cache and writes only from
+             * start onward. The decode-resume branch below uses the same
+             * compact caches when dense KV lags. Both retain the old image
+             * conditioning; only the dense bridge above reports unknown. */
             for (int i = start; i < prompt->len; ) {
                 if (ds4_session_cancelled(s)) {
                     snprintf(err, errlen, "interrupted");
@@ -67713,6 +68066,7 @@ static int ds4_session_sync_internal(ds4_session *s, const ds4_tokens *prompt, c
         prompt->len >= s->checkpoint.len &&
         ds4_tokens_starts_with(prompt, &s->checkpoint))
     {
+        *retained_tokens = s->checkpoint.len;
         s->mtp_draft_valid = false;
         const int suffix = prompt->len - s->checkpoint.len;
         const uint32_t resume_min = metal_graph_resume_prefill_min_tokens();

--- a/ds4.h
+++ b/ds4.h
@@ -184,7 +184,12 @@ typedef struct {
     uint32_t height;
     uint32_t content_width;
     uint32_t content_height;
+    /* Decoded source-image identity, used for live same-engine matching. */
     uint8_t fingerprint[32];
+    /* Exact vectors supplied to the language model, including DeepSeek's
+     * vision-sidecar sentinel vectors. Used for process-boundary cache keys. */
+    uint8_t state_fingerprint[32];
+    bool state_fingerprint_valid;
 } ds4_vision_embedding;
 
 typedef struct {
@@ -433,8 +438,19 @@ int ds4_session_sync_multimodal(ds4_session *s,
 bool ds4_session_vision_state_matches(const ds4_session *s,
                                       const ds4_vision_span *images,
                                       size_t image_count);
+/* Inspect the exact conditioning-state identities of the live checkpoint. */
+size_t ds4_session_vision_identity_count(const ds4_session *s);
+bool ds4_session_vision_identity(const ds4_session *s, size_t index,
+                                 uint32_t *token_start,
+                                 uint32_t *token_count,
+                                 uint8_t state_fingerprint[32]);
+/* Attach already-verified request identities after restoring a disk payload.
+ * Every image must end at or before the restored token frontier. */
+bool ds4_session_restore_vision_identities(ds4_session *s,
+                                           const ds4_vision_span *images,
+                                           size_t image_count);
 /* True while a session contains, or is actively syncing, image-conditioned
- * state. Such state must not be written to the text-keyed disk KV cache. */
+ * state. Such state needs an image-identity-aware disk cache key. */
 bool ds4_session_has_vision_state(const ds4_session *s);
 bool ds4_session_rewrite_requires_rebuild(int live_len, int canonical_len, int common);
 ds4_session_rewrite_result ds4_session_rewrite_from_common(

--- a/ds4_image.c
+++ b/ds4_image.c
@@ -126,6 +126,15 @@ static void ds4_sha256_final(ds4_sha256 *sha, uint8_t out[32]) {
     }
 }
 
+void ds4_image_fingerprint_data(const void *data, size_t len,
+                                uint8_t fingerprint[32]) {
+    if (!fingerprint) return;
+    ds4_sha256 sha;
+    ds4_sha256_init(&sha);
+    if (data && len != 0) ds4_sha256_update(&sha, data, len);
+    ds4_sha256_final(&sha, fingerprint);
+}
+
 static void ds4_image_error(char *error, size_t cap, const char *message) {
     if (!error || cap == 0) return;
     snprintf(error, cap, "%s", message);

--- a/ds4_image.h
+++ b/ds4_image.h
@@ -74,6 +74,11 @@ int ds4_image_decode_file(
 
 void ds4_image_free(ds4_image *image);
 
+/* SHA-256 of an exact byte sequence. Used to bind cached multimodal state to
+ * the conditioning vectors that were actually supplied to the language model. */
+void ds4_image_fingerprint_data(const void *data, size_t len,
+                                uint8_t fingerprint[32]);
+
 int ds4_image_preprocess_glm53(
         ds4_image_patches *out,
         const ds4_image   *image,

--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -183,6 +183,7 @@ uint8_t ds4_kvstore_reason_code(const char *reason) {
 }
 
 const char *ds4_kvstore_key_kind(uint8_t ext_flags) {
+    if (ext_flags & DS4_KVSTORE_EXT_VISION_IDENTITY) return "vision-token-text";
     if (ext_flags & DS4_KVSTORE_EXT_RESPONSES_VISIBLE) return "responses-visible";
     if (ext_flags & DS4_KVSTORE_EXT_THINKING_VISIBLE) return "thinking-visible";
     return "token-text";
@@ -843,7 +844,8 @@ static bool kv_cache_file_text_matches(const char *path, const char sha[41],
 static bool kv_cache_existing_compatible(ds4_kvstore *kc, const char *path,
                                          const char sha[41],
                                          const char *text, size_t text_len,
-                                         int model_id, int quant_bits, int ctx_size) {
+                                         int model_id, int quant_bits,
+                                         int ctx_size, uint8_t ext_flags) {
     if (access(path, F_OK) != 0) return false;
     ds4_kvstore_entry e = {0};
     if (!ds4_kvstore_read_entry_file(path, sha, &e)) return false;
@@ -851,6 +853,8 @@ static bool kv_cache_existing_compatible(ds4_kvstore *kc, const char *path,
                       (!kc->reject_different_quant ||
                        e.quant_bits == (uint8_t)quant_bits) &&
                       e.ctx_size <= (uint32_t)ctx_size &&
+                      ((e.ext_flags ^ ext_flags) &
+                       DS4_KVSTORE_EXT_VISION_IDENTITY) == 0 &&
                       kv_cache_file_text_matches(path, sha, text, text_len);
     ds4_kvstore_entry_free(&e);
     if (!compatible) {
@@ -993,10 +997,13 @@ bool ds4_kvstore_store_live_prefix_text(ds4_kvstore *kc,
     ds4_kvstore_sha1_bytes_hex(text, text_len, sha);
     char *path = ds4_kvstore_path_for_sha(kc, sha);
     const uint8_t reason_code = ds4_kvstore_reason_code(reason);
+    uint8_t ext_flags = trailer_est_bytes > 0 && hooks ? hooks->ext_flag : 0;
+    if (text_override) ext_flags |= cache_text_ext;
 
     if (kv_cache_existing_compatible(kc, path, sha, text, text_len,
                                      model_id,
-                                     quant_bits, ds4_session_ctx(session))) {
+                                     quant_bits, ds4_session_ctx(session),
+                                     ext_flags)) {
         kv_cache_rewrite_trailer(kc, path, text, hooks);
         free(text);
         free(path);
@@ -1071,8 +1078,6 @@ bool ds4_kvstore_store_live_prefix_text(ds4_kvstore *kc,
 
     const uint64_t now = (uint64_t)time(NULL);
     uint8_t h[DS4_KVSTORE_FIXED_HEADER];
-    uint8_t ext_flags = trailer_est_bytes > 0 && hooks ? hooks->ext_flag : 0;
-    if (text_override) ext_flags |= cache_text_ext;
     ds4_kvstore_fill_header(h, (uint8_t)model_id, (uint8_t)quant_bits,
                             reason_code, ext_flags,
                             (uint32_t)store_tokens.len, 0,
@@ -1187,8 +1192,12 @@ bool ds4_kvstore_maybe_store_continued(ds4_kvstore *kc,
     return false;
 }
 
-int ds4_kvstore_find_text_prefix(ds4_kvstore *kc, const char *prompt_text,
-                                 int model_id, int quant_bits, int ctx_size) {
+int ds4_kvstore_find_text_prefix_filtered(ds4_kvstore *kc,
+                                          const char *prompt_text,
+                                          int model_id, int quant_bits,
+                                          int ctx_size,
+                                          uint8_t required_ext_flags,
+                                          uint8_t forbidden_ext_flags) {
     if (!prompt_text) return -1;
     const size_t prompt_bytes = strlen(prompt_text);
     kv_cache_refresh(kc);
@@ -1198,6 +1207,8 @@ int ds4_kvstore_find_text_prefix(ds4_kvstore *kc, const char *prompt_text,
         if (e->text_bytes > prompt_bytes || e->text_bytes > SIZE_MAX) continue;
         if ((int)e->tokens < kc->opt.min_tokens) continue;
         if (e->model_id != (uint8_t)model_id) continue;
+        if ((e->ext_flags & required_ext_flags) != required_ext_flags) continue;
+        if ((e->ext_flags & forbidden_ext_flags) != 0) continue;
         if ((uint32_t)ctx_size < e->ctx_size) continue;
         if (kc->reject_different_quant && e->quant_bits != (uint8_t)quant_bits) continue;
         if (best >= 0) {
@@ -1212,14 +1223,24 @@ int ds4_kvstore_find_text_prefix(ds4_kvstore *kc, const char *prompt_text,
     return best;
 }
 
-int ds4_kvstore_try_load_text(ds4_kvstore *kc,
-                              ds4_engine *engine,
-                              ds4_session *session,
-                              const char *prompt_text,
-                              ds4_tokens *effective_prompt,
-                              ds4_kvstore_load_result *result,
-                              const ds4_kvstore_trailer_hooks *hooks,
-                              bool responses_protocol) {
+int ds4_kvstore_find_text_prefix(ds4_kvstore *kc, const char *prompt_text,
+                                 int model_id, int quant_bits, int ctx_size) {
+    return ds4_kvstore_find_text_prefix_filtered(
+        kc, prompt_text, model_id, quant_bits, ctx_size, 0,
+        DS4_KVSTORE_EXT_VISION_IDENTITY);
+}
+
+int ds4_kvstore_try_load_text_filtered(
+        ds4_kvstore *kc,
+        ds4_engine *engine,
+        ds4_session *session,
+        const char *prompt_text,
+        ds4_tokens *effective_prompt,
+        ds4_kvstore_load_result *result,
+        const ds4_kvstore_trailer_hooks *hooks,
+        bool responses_protocol,
+        uint8_t required_ext_flags,
+        uint8_t forbidden_ext_flags) {
     if (result) memset(result, 0, sizeof(*result));
     if (effective_prompt) effective_prompt->len = 0;
     if (!kc->enabled || !prompt_text) return 0;
@@ -1227,8 +1248,9 @@ int ds4_kvstore_try_load_text(ds4_kvstore *kc,
     if (quant_bits != 2 && quant_bits != 4) return 0;
     const int model_id = ds4_engine_model_id(engine);
     const size_t prompt_bytes = strlen(prompt_text);
-    int idx = ds4_kvstore_find_text_prefix(kc, prompt_text, model_id, quant_bits,
-                                           ds4_session_ctx(session));
+    int idx = ds4_kvstore_find_text_prefix_filtered(
+        kc, prompt_text, model_id, quant_bits, ds4_session_ctx(session),
+        required_ext_flags, forbidden_ext_flags);
     if (idx < 0) return 0;
 
     ds4_kvstore_entry e = kc->entry[idx];
@@ -1248,6 +1270,10 @@ int ds4_kvstore_try_load_text(ds4_kvstore *kc,
         if (hdr.model_id != (uint8_t)model_id) {
             header_ok = false;
             fail_reason = "cached checkpoint was written for a different model";
+        } else if ((hdr.ext_flags & required_ext_flags) != required_ext_flags ||
+                   (hdr.ext_flags & forbidden_ext_flags) != 0) {
+            header_ok = false;
+            fail_reason = "cached checkpoint has the wrong key kind";
         } else if ((uint64_t)text_bytes > prompt_bytes) {
             header_ok = false;
             fail_reason = "cached text is longer than prompt";
@@ -1337,6 +1363,19 @@ int ds4_kvstore_try_load_text(ds4_kvstore *kc,
     free(cached_text);
     free(path);
     return loaded;
+}
+
+int ds4_kvstore_try_load_text(ds4_kvstore *kc,
+                              ds4_engine *engine,
+                              ds4_session *session,
+                              const char *prompt_text,
+                              ds4_tokens *effective_prompt,
+                              ds4_kvstore_load_result *result,
+                              const ds4_kvstore_trailer_hooks *hooks,
+                              bool responses_protocol) {
+    return ds4_kvstore_try_load_text_filtered(
+        kc, engine, session, prompt_text, effective_prompt, result, hooks,
+        responses_protocol, 0, DS4_KVSTORE_EXT_VISION_IDENTITY);
 }
 
 void ds4_kvstore_load_result_free(ds4_kvstore_load_result *result) {

--- a/ds4_kvstore.h
+++ b/ds4_kvstore.h
@@ -16,6 +16,7 @@
 #define DS4_KVSTORE_EXT_RESPONSES_VISIBLE (1u << 1)
 #define DS4_KVSTORE_EXT_THINKING_VISIBLE  (1u << 2)
 #define DS4_KVSTORE_EXT_SESSION_TITLE     (1u << 3)
+#define DS4_KVSTORE_EXT_VISION_IDENTITY   (1u << 4)
 
 typedef enum {
     DS4_KVSTORE_REASON_UNKNOWN   = 0,
@@ -34,10 +35,10 @@ typedef enum {
 } ds4_kvstore_log_type;
 
 typedef struct {
-    /* The file name is the rendered byte prefix, not the token sequence. The
-     * payload still carries the exact tokens and graph state; the hash only
-     * answers "does this checkpoint represent the bytes at the front of the
-     * incoming prompt?" */
+    /* The file name is the cache-key byte prefix, not the token sequence. This
+     * is normally rendered text; callers may prepend identity metadata for
+     * state, such as images, that text alone cannot distinguish. The payload
+     * still carries the exact tokens and graph state. */
     char sha[41];
     char *path;
     uint8_t quant_bits;
@@ -158,6 +159,12 @@ void ds4_kvstore_evict(ds4_kvstore *kc, const ds4_tokens *live,
                        const ds4_kvstore_eviction_context *incoming);
 int ds4_kvstore_find_text_prefix(ds4_kvstore *kc, const char *prompt_text,
                                  int model_id, int quant_bits, int ctx_size);
+int ds4_kvstore_find_text_prefix_filtered(ds4_kvstore *kc,
+                                          const char *prompt_text,
+                                          int model_id, int quant_bits,
+                                          int ctx_size,
+                                          uint8_t required_ext_flags,
+                                          uint8_t forbidden_ext_flags);
 
 bool ds4_kvstore_store_live_prefix_text(ds4_kvstore *kc,
                                         ds4_engine *engine,
@@ -194,6 +201,17 @@ int ds4_kvstore_try_load_text(ds4_kvstore *kc,
                               ds4_kvstore_load_result *result,
                               const ds4_kvstore_trailer_hooks *hooks,
                               bool responses_protocol);
+int ds4_kvstore_try_load_text_filtered(
+        ds4_kvstore *kc,
+        ds4_engine *engine,
+        ds4_session *session,
+        const char *prompt_text,
+        ds4_tokens *effective_prompt,
+        ds4_kvstore_load_result *result,
+        const ds4_kvstore_trailer_hooks *hooks,
+        bool responses_protocol,
+        uint8_t required_ext_flags,
+        uint8_t forbidden_ext_flags);
 void ds4_kvstore_load_result_free(ds4_kvstore_load_result *result);
 
 bool ds4_kvstore_read_header(FILE *fp, ds4_kvstore_entry *e,

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -3,6 +3,7 @@
 #include "ds4_distributed.h"
 #include "ds4_gpu_args.h"
 #include "ds4_help.h"
+#include "ds4_image.h"
 #include "ds4_kvstore.h"
 #include "ds4_tp.h"
 #include "rax.h"
@@ -9738,11 +9739,13 @@ static void apply_anthropic_stream_tool_ids(tool_calls *calls,
  *   DS4 engine payload written by ds4_session_save_payload()
  *   optional tool-id map section
  *
- * The filename is SHA1(cache text bytes), not SHA1(token ids).  For ordinary
- * checkpoints the cache text is the rendered token prefix.  For live hidden
- * state it can instead be the client-visible transcript: the payload still
- * contains sampled reasoning KV, but the lookup key must be what the client can
- * replay after a process restart or session switch.
+ * The filename is SHA1(cache key bytes), not SHA1(token ids).  For ordinary
+ * checkpoints the key is the rendered token prefix.  For live hidden state it
+ * can instead be the client-visible transcript. Image-conditioned checkpoints
+ * prepend exact image spans and hashes of the actual conditioning vectors to
+ * the rendered tokens, so identical placeholder tokens produced by different
+ * images or encoder weights cannot collide. The payload always contains the
+ * exact token and graph state being restored.
  *
  * The optional tool-id map is not part of model state, but it is needed to
  * render future client JSON back to the exact DSML sampled by the model.  We
@@ -9754,6 +9757,7 @@ static void apply_anthropic_stream_tool_ids(tool_calls *calls,
 #define KV_EXT_TOOL_MAP DS4_KVSTORE_EXT_TOOL_MAP
 #define KV_EXT_RESPONSES_VISIBLE DS4_KVSTORE_EXT_RESPONSES_VISIBLE
 #define KV_EXT_THINKING_VISIBLE DS4_KVSTORE_EXT_THINKING_VISIBLE
+#define KV_EXT_VISION_IDENTITY DS4_KVSTORE_EXT_VISION_IDENTITY
 #define KV_TOOL_MAP_MAGIC0 'K'
 #define KV_TOOL_MAP_MAGIC1 'T'
 #define KV_TOOL_MAP_MAGIC2 'M'
@@ -10099,6 +10103,122 @@ static char *render_tokens_text(ds4_engine *engine, const ds4_tokens *tokens, si
     return ds4_kvstore_render_tokens_text(engine, tokens, out_len);
 }
 
+static void vision_cache_key_header(buf *key, size_t image_count) {
+    buf_puts(key, "\036DS4_VISION_KV_V2\n");
+    buf_printf(key, "%zu\n", image_count);
+}
+
+static void vision_cache_key_identity(buf *key, uint32_t token_start,
+                                      uint32_t token_count,
+                                      const uint8_t fingerprint[32]) {
+    static const char hex[] = "0123456789abcdef";
+    buf_printf(key, "%08x%08x", token_start, token_count);
+    for (size_t i = 0; i < 32; i++) {
+        char encoded[2] = {
+            hex[fingerprint[i] >> 4],
+            hex[fingerprint[i] & 15],
+        };
+        buf_append(key, encoded, sizeof(encoded));
+    }
+    buf_puts(key, "\n");
+}
+
+static bool vision_embedding_fingerprint_state(
+        ds4_engine *engine, ds4_vision_embedding *embedding) {
+    if (!embedding) return false;
+    embedding->state_fingerprint_valid = false;
+    const int embd = ds4_engine_embd_dim(engine);
+    if (!embedding->data || embedding->token_count == 0 || embd <= 0)
+        return false;
+    const uint64_t values =
+        (uint64_t)embedding->token_count * (uint64_t)embd;
+    if (values > SIZE_MAX / sizeof(embedding->data[0])) return false;
+    ds4_image_fingerprint_data(
+        embedding->data, (size_t)values * sizeof(embedding->data[0]),
+        embedding->state_fingerprint);
+    embedding->state_fingerprint_valid = true;
+    return true;
+}
+
+static char *vision_cache_key_from_text(const char *text, size_t text_len,
+                                        const ds4_vision_span *images,
+                                        size_t image_count) {
+    if (!text || !images || image_count == 0) return NULL;
+    buf key = {0};
+    vision_cache_key_header(&key, image_count);
+    for (size_t i = 0; i < image_count; i++) {
+        if (!images[i].embedding.state_fingerprint_valid) {
+            buf_free(&key);
+            return NULL;
+        }
+        vision_cache_key_identity(&key, images[i].token_start,
+                                  images[i].embedding.token_count,
+                                  images[i].embedding.state_fingerprint);
+    }
+    buf_puts(&key, "\037");
+    buf_append(&key, text, text_len);
+    return buf_take(&key);
+}
+
+/* Image placeholder tokens are identical for different images. Prefix the
+ * rendered-token cache text with exact image spans and hashes of the vectors
+ * that conditioned KV so only equivalent model input can select the payload. */
+static char *vision_cache_key_for_request(ds4_engine *engine,
+                                          const ds4_tokens *tokens,
+                                          ds4_vision_span *images,
+                                          size_t image_count) {
+    if (!engine || !tokens || !images || image_count == 0) return NULL;
+    for (size_t i = 0; i < image_count; i++) {
+        if (!images[i].embedding.state_fingerprint_valid &&
+            !vision_embedding_fingerprint_state(engine, &images[i].embedding))
+            return NULL;
+    }
+    size_t text_len = 0;
+    char *text = render_tokens_text(engine, tokens, &text_len);
+    char *key = vision_cache_key_from_text(text, text_len, images, image_count);
+    free(text);
+    return key;
+}
+
+static char *vision_cache_key_for_session(server *s, server_slot *slot,
+                                          const ds4_tokens *tokens) {
+    if (!s || !slot || !tokens) return NULL;
+    pthread_mutex_lock(&s->inference_mu);
+    const size_t image_count =
+        ds4_session_vision_identity_count(slot->session);
+    if (image_count == 0) {
+        pthread_mutex_unlock(&s->inference_mu);
+        return NULL;
+    }
+
+    size_t text_len = 0;
+    char *text = render_tokens_text(s->engine, tokens, &text_len);
+    buf key = {0};
+    vision_cache_key_header(&key, image_count);
+    bool valid = true;
+    for (size_t i = 0; i < image_count; i++) {
+        uint32_t token_start = 0, token_count = 0;
+        uint8_t fingerprint[32];
+        if (!ds4_session_vision_identity(slot->session, i, &token_start,
+                                         &token_count, fingerprint) ||
+            (uint64_t)token_start + token_count > (uint64_t)tokens->len) {
+            valid = false;
+            break;
+        }
+        vision_cache_key_identity(&key, token_start, token_count, fingerprint);
+    }
+    pthread_mutex_unlock(&s->inference_mu);
+    if (!valid) {
+        buf_free(&key);
+        free(text);
+        return NULL;
+    }
+    buf_puts(&key, "\037");
+    buf_append(&key, text, text_len);
+    free(text);
+    return buf_take(&key);
+}
+
 static bool byte_prefix_match(const char *text, size_t text_len,
                               const char *prefix, size_t prefix_len) {
     return ds4_kvstore_byte_prefix_match(text, text_len, prefix, prefix_len);
@@ -10194,12 +10314,12 @@ static bool kv_cache_store_live_prefix_text(server *s, server_slot *slot,
     char err[160] = {0};
     ds4_kvstore_trailer_hooks hooks = kv_cache_tool_map_hooks(s, NULL);
     pthread_mutex_lock(&s->inference_mu);
-    /* The payload contains image-conditioned KV rows, but the disk key and
-     * trailer do not contain image fingerprints. Never let generic image
-     * placeholder tokens become a cache hit for a different image.
-     * sync_image_count covers progress-callback writes during prefill;
-     * checkpoint_image_count covers completed sessions. */
-    if (ds4_session_has_vision_state(slot->session)) {
+    const bool vision_state = ds4_session_has_vision_state(slot->session);
+    const bool vision_key = (cache_text_ext & KV_EXT_VISION_IDENTITY) != 0;
+    /* Image-conditioned rows may only be written under a key containing their
+     * exact span and fingerprint identities.  Conversely, never label an
+     * ordinary text payload as vision-conditioned. */
+    if (vision_state != vision_key) {
         pthread_mutex_unlock(&s->inference_mu);
         return false;
     }
@@ -10228,6 +10348,18 @@ static void kv_cache_store_current(server *s, server_slot *slot,
     if (!s || !slot) return;
     const ds4_tokens *tokens = ds4_session_tokens(slot->session);
     if (!tokens) return;
+
+    if (ds4_session_has_vision_state(slot->session)) {
+        char *vision_key = vision_cache_key_for_session(s, slot, tokens);
+        if (vision_key) {
+            kv_cache_store_live_prefix_text(s, slot, tokens, tokens->len,
+                                            reason, vision_key,
+                                            KV_EXT_VISION_IDENTITY,
+                                            "vision-token-text");
+            free(vision_key);
+        }
+        return;
+    }
 
     char *visible_text = NULL;
     uint8_t visible_ext = 0;
@@ -10347,30 +10479,42 @@ static int kv_cache_find_text_prefix(kv_disk_cache *kc, const char *prompt_text,
                                      int quant_bits, int ctx_size) {
     return ds4_kvstore_find_text_prefix(kc, prompt_text, 0, quant_bits, ctx_size);
 }
+
+static int kv_cache_find_text_prefix_filtered(
+        kv_disk_cache *kc, const char *prompt_text,
+        int quant_bits, int ctx_size,
+        uint8_t required_ext_flags, uint8_t forbidden_ext_flags) {
+    return ds4_kvstore_find_text_prefix_filtered(
+        kc, prompt_text, 0, quant_bits, ctx_size,
+        required_ext_flags, forbidden_ext_flags);
+}
 #endif
 
-static int kv_cache_try_load_text(server *s, server_slot *slot,
+static int kv_cache_try_load_text_filtered(
+                                  server *s, server_slot *slot,
                                   const char *prompt_text,
                                   ds4_tokens *effective_prompt,
                                   char **loaded_path_out,
                                   uint8_t *loaded_ext_flags_out,
-                                  bool responses_protocol) {
+                                  bool responses_protocol,
+                                  uint8_t required_ext_flags,
+                                  uint8_t forbidden_ext_flags) {
     if (!s || !slot) return 0;
     if (loaded_path_out) *loaded_path_out = NULL;
     if (loaded_ext_flags_out) *loaded_ext_flags_out = 0;
     ds4_kvstore_load_result lr = {0};
     ds4_kvstore_trailer_hooks hooks = kv_cache_tool_map_hooks(s, NULL);
     pthread_mutex_lock(&s->inference_mu);
-    /* Disk payloads intentionally carry no image identity. If this slot held
-     * vision state, discard it before restoring a text-only checkpoint so the
-     * next sync does not reject the fresh payload as a stale image match. */
+    /* A payload restore replaces the graph state. Clear identity from the
+     * slot's prior owner first; the vision caller reattaches the request's
+     * verified identities only after an image-keyed payload loads. */
     if (ds4_session_has_vision_state(slot->session)) {
         ds4_session_invalidate(slot->session);
     }
     pthread_mutex_lock(&s->kv_mu);
-    int loaded = ds4_kvstore_try_load_text(&s->kv, s->engine, slot->session,
-                                           prompt_text, effective_prompt, &lr,
-                                           &hooks, responses_protocol);
+    int loaded = ds4_kvstore_try_load_text_filtered(
+        &s->kv, s->engine, slot->session, prompt_text, effective_prompt, &lr,
+        &hooks, responses_protocol, required_ext_flags, forbidden_ext_flags);
     pthread_mutex_unlock(&s->kv_mu);
     pthread_mutex_unlock(&s->inference_mu);
     if (loaded > 0) {
@@ -10379,6 +10523,18 @@ static int kv_cache_try_load_text(server *s, server_slot *slot,
     }
     ds4_kvstore_load_result_free(&lr);
     return loaded;
+}
+
+static int kv_cache_try_load_text(server *s, server_slot *slot,
+                                  const char *prompt_text,
+                                  ds4_tokens *effective_prompt,
+                                  char **loaded_path_out,
+                                  uint8_t *loaded_ext_flags_out,
+                                  bool responses_protocol) {
+    return kv_cache_try_load_text_filtered(
+        s, slot, prompt_text, effective_prompt, loaded_path_out,
+        loaded_ext_flags_out, responses_protocol, 0,
+        KV_EXT_VISION_IDENTITY);
 }
 
 static int kv_cache_try_load(server *s, server_slot *slot, const request *req,
@@ -10390,6 +10546,49 @@ static int kv_cache_try_load(server *s, server_slot *slot, const request *req,
                                   loaded_path_out,
                                   loaded_ext_flags_out,
                                   req && req->api == API_RESPONSES);
+}
+
+static int kv_cache_try_load_vision(server *s, server_slot *slot,
+                                    request *req,
+                                    ds4_tokens *effective_prompt,
+                                    char **loaded_path_out,
+                                    uint8_t *loaded_ext_flags_out) {
+    if (!s || !slot || !req || !s->kv.enabled ||
+        req->image_count == 0 || !req->images) return 0;
+    char *cache_key = vision_cache_key_for_request(
+        s->engine, &req->prompt, req->images, req->image_count);
+    if (!cache_key) return 0;
+
+    uint8_t ext_flags = 0;
+    int loaded = kv_cache_try_load_text_filtered(
+        s, slot, cache_key, effective_prompt, loaded_path_out, &ext_flags,
+        req->api == API_RESPONSES, KV_EXT_VISION_IDENTITY, 0);
+    free(cache_key);
+    if (loaded <= 0) return 0;
+
+    bool restored = false;
+    if (ext_flags & KV_EXT_VISION_IDENTITY) {
+        pthread_mutex_lock(&s->inference_mu);
+        restored = ds4_session_restore_vision_identities(
+            slot->session, req->images, req->image_count);
+        pthread_mutex_unlock(&s->inference_mu);
+    }
+    if (!restored) {
+        server_log(DS4_LOG_WARNING,
+                   "ds4-server: rejected vision disk checkpoint tokens=%d reason=invalid-image-identity-frontier",
+                   loaded);
+        pthread_mutex_lock(&s->inference_mu);
+        ds4_session_invalidate(slot->session);
+        pthread_mutex_unlock(&s->inference_mu);
+        ds4_tokens_free(effective_prompt);
+        if (loaded_path_out) {
+            free(*loaded_path_out);
+            *loaded_path_out = NULL;
+        }
+        return 0;
+    }
+    if (loaded_ext_flags_out) *loaded_ext_flags_out = ext_flags;
+    return loaded;
 }
 
 static int live_text_prefix_prompt(server *s, server_slot *slot,
@@ -12170,20 +12369,23 @@ static void generate_job_inner(server *s, server_slot *slot, job *j) {
                    j->req.image_count, cached, prompt_for_sync->len);
     }
     if (cached == 0) slot->continued_last_store_tokens = 0;
-    if (!multimodal && s->kv.enabled && cached == 0 &&
-        old_pos >= s->kv.opt.min_tokens) {
+    if (s->kv.enabled && cached == 0 && old_pos >= s->kv.opt.min_tokens) {
         /* Loading a disk snapshot replaces the live Metal session.  Persist the
          * current checkpoint first, otherwise a cache hit for an older prefix
          * would silently discard the newer conversation state. */
         kv_cache_store_current(s, slot, "evict");
     }
-    if (!multimodal && cached == 0) {
-        disk_cached = kv_cache_try_load(s, slot, &j->req, &effective_prompt,
-                                        &disk_cache_path,
-                                        &disk_cache_ext_flags);
+    if (cached == 0) {
+        disk_cached = multimodal ?
+            kv_cache_try_load_vision(s, slot, &j->req, &effective_prompt,
+                                     &disk_cache_path,
+                                     &disk_cache_ext_flags) :
+            kv_cache_try_load(s, slot, &j->req, &effective_prompt,
+                              &disk_cache_path,
+                              &disk_cache_ext_flags);
         if (disk_cached > 0) {
             cached = disk_cached;
-            cache_source = "disk-text";
+            cache_source = multimodal ? "disk-vision" : "disk-text";
             prompt_for_sync = &effective_prompt;
         }
     }
@@ -18796,10 +18998,10 @@ static void test_kv_stub_file(const char *dir, const char *sha,
     free(path);
 }
 
-static void test_kv_text_stub_file_model(const char *dir, const char *text,
-                                         uint8_t model_id, uint8_t reason,
-                                         uint32_t tokens,
-                                         uint64_t payload_bytes) {
+static void test_kv_text_stub_file_model_ext(
+        const char *dir, const char *text,
+        uint8_t model_id, uint8_t reason, uint8_t ext_flags,
+        uint32_t tokens, uint64_t payload_bytes) {
     char sha[41];
     sha1_bytes_hex(text, strlen(text), sha);
     char name[44];
@@ -18813,7 +19015,7 @@ static void test_kv_text_stub_file_model(const char *dir, const char *text,
     }
 
     uint8_t h[KV_CACHE_FIXED_HEADER];
-    ds4_kvstore_fill_header(h, model_id, 2, reason, 0, tokens, 0,
+    ds4_kvstore_fill_header(h, model_id, 2, reason, ext_flags, tokens, 0,
                             32768, 100, 100, payload_bytes);
     uint8_t text_len[4];
     le_put32(text_len, (uint32_t)strlen(text));
@@ -18827,10 +19029,166 @@ static void test_kv_text_stub_file_model(const char *dir, const char *text,
     free(path);
 }
 
+static void test_kv_text_stub_file_model(const char *dir, const char *text,
+                                         uint8_t model_id, uint8_t reason,
+                                         uint32_t tokens,
+                                         uint64_t payload_bytes) {
+    test_kv_text_stub_file_model_ext(dir, text, model_id, reason, 0,
+                                     tokens, payload_bytes);
+}
+
 static void test_kv_text_stub_file(const char *dir, const char *text,
                                    uint8_t reason,
                                    uint32_t tokens, uint64_t payload_bytes) {
     test_kv_text_stub_file_model(dir, text, 0, reason, tokens, payload_bytes);
+}
+
+static void test_vision_kv_key_requires_exact_image_identity(void) {
+    const int embd = ds4_engine_embd_dim(NULL);
+    TEST_ASSERT(embd > 0);
+    if (embd <= 0) return;
+    float *conditioning = calloc((size_t)embd, sizeof(conditioning[0]));
+    TEST_ASSERT(conditioning != NULL);
+    if (!conditioning) return;
+    ds4_vision_embedding embedding = {
+        .data = conditioning,
+        .token_count = 1,
+    };
+    TEST_ASSERT(vision_embedding_fingerprint_state(NULL, &embedding));
+    TEST_ASSERT(embedding.state_fingerprint_valid);
+    uint8_t first_state_fingerprint[32];
+    memcpy(first_state_fingerprint, embedding.state_fingerprint,
+           sizeof(first_state_fingerprint));
+    conditioning[embd - 1] = 1.0f;
+    TEST_ASSERT(vision_embedding_fingerprint_state(NULL, &embedding));
+    TEST_ASSERT(embedding.state_fingerprint_valid);
+    TEST_ASSERT(memcmp(first_state_fingerprint, embedding.state_fingerprint,
+                       sizeof(first_state_fingerprint)) != 0);
+    free(conditioning);
+
+    ds4_vision_span image = {0};
+    image.token_start = 128;
+    image.embedding.token_count = 576;
+    for (size_t i = 0; i < sizeof(image.embedding.fingerprint); i++) {
+        image.embedding.fingerprint[i] = (uint8_t)i;
+        image.embedding.state_fingerprint[i] = (uint8_t)(0xa5u ^ i);
+    }
+    image.embedding.state_fingerprint_valid = true;
+
+    ds4_vision_span invalid = image;
+    invalid.embedding.state_fingerprint_valid = false;
+    char *invalid_key = vision_cache_key_from_text(
+        "decoded token prefix", strlen("decoded token prefix"), &invalid, 1);
+    TEST_ASSERT(invalid_key == NULL);
+    free(invalid_key);
+
+    const char *saved_text = "decoded token prefix";
+    const char *future_text = "decoded token prefix and suffix";
+    char *saved_key = vision_cache_key_from_text(
+        saved_text, strlen(saved_text), &image, 1);
+    char *future_key = vision_cache_key_from_text(
+        future_text, strlen(future_text), &image, 1);
+    TEST_ASSERT(saved_key != NULL && future_key != NULL);
+    TEST_ASSERT(saved_key && future_key &&
+                byte_prefix_match(future_key, strlen(future_key),
+                                  saved_key, strlen(saved_key)));
+
+    ds4_vision_span changed = image;
+    /* The same decoded pixels under different encoder-sidecar state are not
+     * interchangeable: disk identity follows the actual conditioning block. */
+    changed.embedding.state_fingerprint[17] ^= 0xff;
+    char *changed_key = vision_cache_key_from_text(
+        future_text, strlen(future_text), &changed, 1);
+    TEST_ASSERT(changed_key && saved_key &&
+                !byte_prefix_match(changed_key, strlen(changed_key),
+                                   saved_key, strlen(saved_key)));
+
+    ds4_vision_span moved = image;
+    moved.token_start++;
+    char *moved_key = vision_cache_key_from_text(
+        future_text, strlen(future_text), &moved, 1);
+    TEST_ASSERT(moved_key && saved_key &&
+                !byte_prefix_match(moved_key, strlen(moved_key),
+                                   saved_key, strlen(saved_key)));
+
+    ds4_vision_span two_images[2] = {image, image};
+    two_images[1].token_start = 1024;
+    two_images[1].embedding.fingerprint[0] ^= 0x80;
+    two_images[1].embedding.state_fingerprint[0] ^= 0x80;
+    char *appended_key = vision_cache_key_from_text(
+        future_text, strlen(future_text), two_images, 2);
+    TEST_ASSERT(appended_key && saved_key &&
+                !byte_prefix_match(appended_key, strlen(appended_key),
+                                   saved_key, strlen(saved_key)));
+    TEST_ASSERT(saved_key &&
+                !byte_prefix_match(future_text, strlen(future_text),
+                                   saved_key, strlen(saved_key)));
+
+    char tmpl[] = "/tmp/ds4-kv-vision-identity-test.XXXXXX";
+    char *dir = mkdtemp(tmpl);
+    TEST_ASSERT(dir != NULL);
+    if (dir && saved_key) {
+        test_kv_text_stub_file_model_ext(
+            dir, saved_key, 0, KV_REASON_EVICT,
+            KV_EXT_VISION_IDENTITY, 1024, 0);
+        kv_disk_cache kc = {0};
+        kc.enabled = true;
+        kc.dir = xstrdup(dir);
+        kc.opt = kv_cache_default_options();
+        TEST_ASSERT(kv_cache_find_text_prefix_filtered(
+                        &kc, future_key, 2, 32768,
+                        KV_EXT_VISION_IDENTITY, 0) >= 0);
+        /* A text request must not be able to select a vision payload even if
+         * it deliberately starts with the private vision-key bytes. */
+        TEST_ASSERT(kv_cache_find_text_prefix_filtered(
+                        &kc, future_key, 2, 32768,
+                        0, KV_EXT_VISION_IDENTITY) < 0);
+        TEST_ASSERT(kv_cache_find_text_prefix(
+                        &kc, future_key, 2, 32768) < 0);
+        TEST_ASSERT(kv_cache_find_text_prefix_filtered(
+                        &kc, future_text, 2, 32768,
+                        KV_EXT_VISION_IDENTITY, 0) < 0);
+        TEST_ASSERT(kv_cache_find_text_prefix_filtered(
+                        &kc, changed_key, 2, 32768,
+                        KV_EXT_VISION_IDENTITY, 0) < 0);
+        TEST_ASSERT(kv_cache_find_text_prefix_filtered(
+                        &kc, moved_key, 2, 32768,
+                        KV_EXT_VISION_IDENTITY, 0) < 0);
+        TEST_ASSERT(kv_cache_find_text_prefix_filtered(
+                        &kc, appended_key, 2, 32768,
+                        KV_EXT_VISION_IDENTITY, 0) < 0);
+        kv_cache_close(&kc);
+
+        /* The boundary is symmetric: an ordinary text payload must not be
+         * accepted by the image-conditioned loader. */
+        test_kv_text_stub_file_model_ext(
+            dir, saved_key, 0, KV_REASON_EVICT, 0, 1024, 0);
+        memset(&kc, 0, sizeof(kc));
+        kc.enabled = true;
+        kc.dir = xstrdup(dir);
+        kc.opt = kv_cache_default_options();
+        TEST_ASSERT(kv_cache_find_text_prefix_filtered(
+                        &kc, future_key, 2, 32768,
+                        0, KV_EXT_VISION_IDENTITY) >= 0);
+        TEST_ASSERT(kv_cache_find_text_prefix_filtered(
+                        &kc, future_key, 2, 32768,
+                        KV_EXT_VISION_IDENTITY, 0) < 0);
+        kv_cache_close(&kc);
+
+        char sha[41], name[44];
+        sha1_bytes_hex(saved_key, strlen(saved_key), sha);
+        snprintf(name, sizeof(name), "%.40s.kv", sha);
+        char *path = path_join(dir, name);
+        unlink(path);
+        free(path);
+        rmdir(dir);
+    }
+
+    free(saved_key);
+    free(future_key);
+    free(changed_key);
+    free(moved_key);
+    free(appended_key);
 }
 
 static void test_kv_cache_lookup_uses_longest_text_prefix(void) {
@@ -19867,6 +20225,7 @@ static void ds4_server_unit_tests_run(void) {
     test_kv_cache_cold_store_suppresses_duplicate_continued_boundary();
     test_kv_cache_file_size_must_fit_budget();
     test_sha1_bytes_hex_matches_known_vector();
+    test_vision_kv_key_requires_exact_image_identity();
     test_kv_cache_lookup_uses_longest_text_prefix();
     test_kv_cache_lookup_rejects_wrong_model();
     test_kv_cache_lookup_rejects_stale_payload_abi();

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -7,6 +7,9 @@
 
 bool ds4_test_dspark_cache_window_crop(void);
 bool ds4_test_dspark_prefix_capture(ds4_engine *engine, const ds4_tokens *prompt);
+bool ds4_test_multimodal_sync_finish_policy(void);
+bool ds4_test_vision_identity_carries_exact_state_fingerprint(void);
+bool ds4_test_vision_identity_keeps_retained_hash(void);
 
 static ds4_engine *test_engine_fast;
 static ds4_engine *test_engine_quality;
@@ -6815,6 +6818,11 @@ static void test_dspark_verify_depth(void) {
 #endif
 
 static void test_server_unit_group(void) {
+#ifndef DS4_NO_GPU
+    TEST_ASSERT(ds4_test_multimodal_sync_finish_policy());
+    TEST_ASSERT(ds4_test_vision_identity_carries_exact_state_fingerprint());
+    TEST_ASSERT(ds4_test_vision_identity_keeps_retained_hash());
+#endif
     ds4_server_unit_tests_run();
 }
 

--- a/tests/test_glm53_vision_prompt.c
+++ b/tests/test_glm53_vision_prompt.c
@@ -11,6 +11,15 @@ typedef struct {
     int total;
 } progress_counter;
 
+typedef struct {
+    int calls;
+} cancel_counter;
+
+static bool cancel_after_first_check(void *ud) {
+    cancel_counter *counter = ud;
+    return ++counter->calls > 1;
+}
+
 static void count_progress(void *ud, const char *event, int current, int total) {
     (void)event;
     progress_counter *counter = ud;
@@ -83,6 +92,21 @@ int main(int argc, char **argv) {
         ds4_session_vision_state_matches(session, NULL, 0)) {
         snprintf(error, sizeof(error),
                  "live session did not retain exact image identity");
+        goto done;
+    }
+
+    /* Cancellation has one authoritative no-work preflight.  A callback that
+     * changes immediately afterward must not turn an exact no-op sync into an
+     * interruption that discards the completed image checkpoint. */
+    cancel_counter cancel = {0};
+    ds4_session_set_cancel(session, cancel_after_first_check, &cancel);
+    int cancel_race_rc = ds4_session_sync_multimodal(
+        session, &prompt, &span, 1, error, sizeof(error));
+    ds4_session_set_cancel(session, NULL, NULL);
+    if (cancel_race_rc != 0 || cancel.calls != 1 ||
+        !ds4_session_vision_state_matches(session, &span, 1)) {
+        snprintf(error, sizeof(error),
+                 "no-work cancellation check discarded image checkpoint");
         goto done;
     }
 


### PR DESCRIPTION
## Summary

Persist image-conditioned KV under a key containing the exact conditioning that
produced it, and retain that provenance through prefix reuse.

## Why

Equal text tokens do not imply equal KV when images contributed embeddings. The
key therefore includes image count, token spans, hashes of the final
conditioning vectors and canonical token text. Loading reattaches image metadata
only when the key and restored frontier agree.

A retained prefix still contains its old conditioning even if a fresh encoder
call produces different candidate bytes. Sync reports what was actually kept:
wholly retained images keep their old hashes, rebuilt images use new hashes, and
partial or unknown provenance cannot be persisted. A GLM dense-cache gap does
not itself erase the authoritative compact prefix; the dense repair bridge is
separately marked unknown.

## Compatibility

Text-only cache files and payload ABI remain unchanged. Changed, moved or
missing images cannot select the checkpoint. Appended-image disk recovery is
excluded; live appended-image reuse remains #927. No model math, sampling,
launcher or default change.

## Practical impact

The benefit is reusing an exact image-conditioned checkpoint across a process restart while rejecting different conditioning. It avoids repeated vision prefill; it does not accelerate decode or provide #927's appended-image live reuse. The standalone Metal restart test below demonstrates restored tokens and cold rejection of a changed image. No marginal throughput or latency uplift over `f62ca29` is claimed.

## Combined runtime context

A [stock/full-stack engine comparison](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/README.md) measures pristine `f62ca29` against the complete integrated runtime on GB10 CUDA and M3 Ultra Metal, including full 262,144-token capacity. The original full sweeps used one process pair per machine and include additional changes beyond these 13 PRs. A [targeted M3 follow-up](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/m3-attribution/README.md) did not reproduce the original short-decode slowdown, using a reversed-order pair, same-process controls and an exact original-executable replay. These results do not isolate this PR’s marginal gain, establish universal speed or quality, or newly benchmark its server/cache workflows. See the [per-PR assessment](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/PR-ASSESSMENT.md) for its supported benefit and limits.

## Validation

The build and runtime checks below ran before upstream’s README-only update. The full PR diff and every other tracked file are byte-identical at this head; `git diff --check` passed again. The documentation-only rebase was not rebuilt.

One standalone commit, `5c697a48858f`, directly on upstream `f62ca29a3087` (2026-09-07). Tests cover retained/rebuilt/appended image provenance, interrupted sync, partial-image rejection, malformed metadata and text-only compatibility.

Checks on the preceding `b6af0ad` base passed on Apple M3 Ultra / Darwin 27.0 / Apple clang 21: clean default Metal build, `make test-frontends`, session-state, TP-command and vision-image tests, `make cpu`, and `git diff --check`. Fully instrumented host C/Objective-C ASan+UBSan tests also passed (`-O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all`, leak detection off). CPU portability is compile/link coverage; the sanitizer runs are host tests, not GPU instrumentation.

Before the Metal-only upstream update, the standalone patch passed fresh private-cache tests on M2 Max/Metal with DeepSeek-V4-Flash-Vision-Exp IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8 and its encoder, 65,536 context, 4,096 prefill and two resident sessions. After graceful restart, text replay loaded all 1,816 tokens; exact-image continuation loaded 1,132 tokens and evaluated ten new tokens. A changed image stayed cold. Supported text-tool continuation also passed. Inline tool-image messages require separate #927 and are not attributed to this PR. GLM provenance is source/unit tested, not GLM-model validated. #943 overlaps disk lookup and needs both regression groups retained.

Before the Metal-only upstream update, the same patch passed checks on NVIDIA DGX Spark / Ubuntu / Linux 6.17.0-1032-nvidia, GCC 13.3 and CUDA 13.0.88: clean `make -j4 cuda-spark` (`sm_121a`), `make CUDA_ARCH=sm_121a test-frontends`, session-state, TP-command and vision-image tests, and a clean `make -j4 cpu` build. CPU ASan+UBSan server/session/TP/vision tests passed with leak detection on; agent tests passed with leak detection off for the unchanged upstream fixture leak. These are host tests and compile/link coverage; CUDA execution is recorded separately. The later upstream updates are a five-line GLM SSD change inside a Metal-only guard and a README edit. CUDA source and the PR patch are unchanged; native Linux preprocessing of `ds4.c` was byte-identical for CUDA, CPU and sanitizer builds.

No full aggregate model-suite or untested-backend result is claimed.
