### PR TITLE
ds4-agent: fix every tool call failing on DeepSeek without --vision (+ regression test)

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -64144,6 +64144,14 @@ int ds4_chat_append_multimodal_message(
     }
     const bool tool = !strcmp(role, "tool") || !strcmp(role, "function");
     const bool user = !strcmp(role, "user");
+    /* A message without images is an ordinary chat message. Keep the native
+     * per-family rendering so a text-only tool observation never depends on
+     * vision support: DeepSeek text models render <tool_result> under the
+     * user role, not the observation tags used for image messages below. */
+    if (image_count == 0 && (tool || user)) {
+        ds4_chat_append_message(e, tokens, role, text_parts[0]);
+        return 1;
+    }
     if ((DS4_MODEL_FAMILY != DS4_MODEL_FAMILY_GLM_DSA &&
          e->vision_kind != DS4_VISION_DEEPSEEK4) || (!tool && !user)) {
         if (error && error_cap)

--- a/tests/ds4_test.c
+++ b/tests/ds4_test.c
@@ -145,6 +145,38 @@ static void test_close_engine(bool quality) {
     *slot = NULL;
 }
 
+/* A tool observation without images must render exactly like the plain chat
+ * path: the shortcut in ds4_chat_append_multimodal_message never inspects
+ * model family or vision_kind, so the guarantee holds regardless of build
+ * configuration, but this test only exercises it on the default (no vision
+ * loaded) engine. The agent sends every tool result through the multimodal
+ * entry point, so a text-only rejection breaks all tool calls on DeepSeek
+ * text models. */
+static void test_chat_append_multimodal_text_only(void) {
+    ds4_engine *engine = test_get_engine(false);
+    if (!engine) return;
+
+    static const char *const roles[] = {"tool", "user"};
+    const char *text = ".:\nd        96 src/\n-      1204 package.json\n";
+    const char *const parts[] = {text};
+    for (size_t r = 0; r < sizeof(roles) / sizeof(roles[0]); r++) {
+        ds4_tokens plain = {0};
+        ds4_tokens multimodal = {0};
+        char err[160] = {0};
+
+        ds4_chat_append_message(engine, &plain, roles[r], text);
+        int ok = ds4_chat_append_multimodal_message(engine, &multimodal,
+                                                    roles[r], parts, NULL, 0,
+                                                    NULL, err, sizeof(err));
+        TEST_ASSERT(ok == 1);
+        TEST_ASSERT(plain.len > 0 && multimodal.len == plain.len &&
+                    memcmp(multimodal.v, plain.v,
+                           (size_t)plain.len * sizeof(plain.v[0])) == 0);
+        ds4_tokens_free(&plain);
+        ds4_tokens_free(&multimodal);
+    }
+}
+
 static void test_session_snapshot_roundtrip(void) {
     ds4_engine *engine = test_get_engine(false);
     if (!engine) return;
@@ -6796,6 +6828,7 @@ typedef struct {
 static const ds4_test_entry test_entries[] = {
 #ifndef DS4_NO_GPU
     {"--session-snapshot", "session-snapshot", "session snapshot and recurrent-state round trip", test_session_snapshot_roundtrip},
+    {"--chat-multimodal-text-only", "chat-multimodal-text-only", "text-only multimodal message renders like the plain chat path", test_chat_append_multimodal_text_only},
     {"--long-context", "long-context", "long-context story fact-recall regression", test_long_story_fact_recall},
     {"--tool-call-quality", "tool-call-quality", "model tool call and post-result stop regression", test_tool_call_quality},
     {"--think-tool-recovery", "think-tool-recovery", "recover a complete tool call emitted inside unclosed reasoning", test_think_tool_recovery},


### PR DESCRIPTION
Since 4771329 ds4-agent cannot complete a single tool call on a DeepSeek text model. The first tool result dies with

```
COMPACTING tool result would exceed context: summarizing durable task state
ds4-agent: context full after compaction
```

at 1.9k of 262k context, on a 29-entry `list .`. Reproduced on an M5 Max 128 GB with DeepSeek V4 Flash 0731 IQ2_XXS, no `--vision`.

Root cause: `agent_tool_observation_build` sends every tool observation through `ds4_chat_append_multimodal_message`, whose guard rejects any model that is not GLM unless a DeepSeek vision encoder is loaded (fc8bf3c relaxed only that case). The observation never builds. `agent_tool_observation_fits` returns false on a build error as well, so the agent reads it as a context overflow, compacts, and gives up.

Fix, 8 lines in `ds4.c`: a user or tool message with zero images delegates to `ds4_chat_append_message`, the rendering the agent used before 4771329 (DeepSeek: user role plus `<tool_result>`; GLM: the same tokens the multimodal branch emits). The vision guard is untouched and still applies to messages carrying images.

Test, `tests/ds4_test.c`, `--chat-multimodal-text-only`: asserts token-identical output between the two entry points for the tool and user roles. On the engine before this patch it fails twice per role (`assertion failed: ok == 1`); with the patch it passes.

Validation on a MacBook Pro M5 Max 128 GB, Metal, Flash 0731 IQ2_XXS/Q2_K:
- `./ds4_test --chat-multimodal-text-only`: before 4 assertion failures, after OK
- `./ds4_test --server` OK, `./ds4_test --tool-call-quality` OK, `./ds4_agent_test` OK
- `ds4-agent --non-interactive` with one `list` tool call in a scratch project: no compaction, correct answer. An interactive session then ran 11 tool calls on a Next.js repo without a hitch.
- `make ds4_cpu.o` clean. The patch applies on current main b0a147a.

Not run: CUDA, ROCm, GLM models, `--logprob-vectors`.

Overlap with #924: same idea for the `ds4.c` hunk. #924 no longer applies to main after fc8bf3c, adds a second copy of the dispatch in `ds4_agent.c`, and has no test. If you would rather land #924 rebased, I can move the test there instead.

Two things I left out on purpose, both separate changes: `agent_tool_observation_fits` still reports any build error as a context overflow and drops the error text, and the image-bearing tool branch renders DeepSeek observations with GLM tags and no role token.

Implemented with the help of a coding agent ([Claude Code](https://claude.com/claude-code)) and reviewed locally by the author.
