### PR TITLE
metal: bypass DSpark speculation once a request proves unprofitable

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -54201,6 +54201,7 @@ struct ds4_session {
     uint32_t dspark_sched_accepted;
     uint32_t dspark_sched_no_draft;
     uint32_t dspark_sched_skip;
+    uint32_t dspark_sched_lifetime_cycles;
     uint32_t dspark_sched_lifetime_accepted;
     double dspark_sched_life_extra_ms;
     double dspark_sched_life_saved_ms;
@@ -54353,6 +54354,7 @@ static void ds4_session_dspark_scheduler_begin_request(ds4_session *s) {
     if (!s) return;
     ds4_session_dspark_scheduler_reset(s);
     s->dspark_sched_skip = 0;
+    s->dspark_sched_lifetime_cycles = 0;
     s->dspark_sched_lifetime_accepted = 0;
     s->dspark_sched_life_extra_ms = 0.0;
     s->dspark_sched_life_saved_ms = 0.0;
@@ -54393,6 +54395,7 @@ static void ds4_session_dspark_scheduler_note(
     }
 
     s->dspark_sched_cycles++;
+    s->dspark_sched_lifetime_cycles++;
     s->dspark_sched_accepted += accepted_drafts;
     if (accepted_drafts != 0) {
         if (s->dspark_sched_lifetime_accepted <=
@@ -54504,16 +54507,29 @@ static void ds4_session_dspark_scheduler_note(
         s->dspark_sched_accepted != 0 &&
         extra_per_accept_ms * 1000.0 > (double)max_ms_per_accept_milli;
     if (low_accept || many_no_draft || slow_accept || measured_unprofitable) {
-        if (ds4_session_dspark_rocm_gfx1151_fast_path(s)) {
+        /* Two windows avoid judging the warmup.  Below 0.5 accepted drafts
+         * per scheduler cycle each verified row costs more than it saves on
+         * Metal: 8k tokens of Italian prose measure 0.25 at this decision,
+         * reasoning 1.25, and code never reaches this branch.  Counters,
+         * not timings, keep greedy scheduling reproducible across runs. */
+        const bool low_lifetime_metal_bypass =
+            s->engine && s->engine->backend == DS4_BACKEND_METAL &&
+            s->dspark_sched_lifetime_cycles >= 2u * window &&
+            2u * s->dspark_sched_lifetime_accepted <
+                s->dspark_sched_lifetime_cycles;
+        if (ds4_session_dspark_rocm_gfx1151_fast_path(s) ||
+            low_lifetime_metal_bypass) {
             s->dspark_sched_bypass = true;
             s->dspark_sched_skip = 0;
             if (getenv("DS4_DSPARK_SPEC_LOG") != NULL) {
                 fprintf(stderr,
                         "ds4: DSpark scheduler bypass accepted=%u avg=%.3f "
-                        "no_draft=%u\n",
+                        "no_draft=%u lifetime=%u/%u\n",
                         s->dspark_sched_accepted,
                         (double)avg_milli / 1000.0,
-                        s->dspark_sched_no_draft);
+                        s->dspark_sched_no_draft,
+                        s->dspark_sched_lifetime_accepted,
+                        s->dspark_sched_lifetime_cycles);
             }
             ds4_session_dspark_scheduler_reset(s);
             return;


### PR DESCRIPTION
On Metal, `--dspark` is slower than plain decode on text the proposer cannot predict. The README measures 36-44 t/s against 46.5 plain on prose, and I get 35.9 against 40.6 after 8k tokens of Italian prose. The scheduler already pauses and re-probes on a bad window, but it never gives up, so the loss repeats for the whole request.

Change, 19 added and 3 edited lines in `ds4.c`: track accepted drafts and scheduler cycles for the lifetime of the request. Once two probe windows have run and the lifetime average is below 0.5 accepted drafts per cycle, disable speculation for the rest of the request, the same bypass the gfx1151 fast path already takes. Counters, not timings, so a greedy request follows the same schedule on every run. No new flags. The bypass is sticky for the request, like the gfx1151 one: a response that opens with unpredictable prose and later turns into code keeps plain decode. Reasoning text sits well above the floor, so the agent's usual think-then-edit turns are not affected.

Why 0.5 and not higher: the ratio the rule sees at its first decision point does not rank text the way full-run profit does. On this machine, reasoning with thinking reads 1.25 at the first decision and gains 6.5% from speculation; short English prose reads 1.75 at the first decision, then decays to 0.88 over the run, and loses 8%. A floor that would catch English prose would also catch reasoning. 0.5 catches only the regime where every verified row costs more than it saves, with a 2.5x margin below reasoning. English prose stays a mild loss, out of scope here.

Measured, MacBook Pro M5 Max 128 GB, Metal, DeepSeek V4 Flash 0731 IQ2_XXS/Q2_K, greedy:

| Text | Ratio at first decision | Bypass | Before | After | Plain |
|---|---:|---|---:|---:|---:|
| Italian prose, 8192-token prefill, 64 gen | 0.25 | yes, at 2/8 | 35.9 t/s | 38.5 t/s | 40.6 t/s |
| Reasoning with thinking, 384 tokens | 1.25 | no | 47.9 | 47.95 | 45.0 |
| Python class, 192 tokens | never unprofitable | no | 54.7 | 54.6 | 44.8 |
| English prose, 192 tokens | 1.75 | no | 41.6 | 41.6 | 45.0 |

The reasoning prompt produced byte-identical output across four runs with the bypass on and off. The pre-existing `--dspark` caveat about batched floating-point order is unchanged; `--dspark-strict` still gives one-token-decode equivalence.

Validation: `make dspark-verify-depth` OK with `worst_argmax_gap=0.000`; `make dspark-acceptance` OK, `c_add` accepts 21 drafts with no bypass and 4 of 5 cases match the plain baseline byte for byte, the fifth (`hello`) being the pre-existing allowed divergence; `./ds4_test --chat-multimodal-text-only`, `./ds4_test --server`, `./ds4_agent_test` OK; Metal build clean. No `ds4_test` case reaches this branch, since the only DSpark unit test runs with the scheduler disabled; coverage is the fixture plus the measurements above. Not run: CUDA, ROCm, GLM. The rule is gated on the Metal backend, so other backends are untouched.

A first version of this used a second rule that bypassed after one all-miss window plus two environment knobs. The all-miss rule fired on reasoning and cost 3.1 t/s there, so it is gone, and so are the knobs.

Implemented with the help of a coding agent ([Claude Code](https://claude.com/claude-code) and Codex) and reviewed locally by the author.
