### PR TITLE
Steering: read GLP (GGUF Layer Projection) vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 /tests/cuda_long_context_smoke
 /tests/test_layer_pack
 /tests/test_glp
+/tests/test_dir_steering
 /tests/test_metal_session_batch
 /tests/test_mxfp4_cuda
 /tests/test_mxfp4_dot

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 /tests/test_cuda_session_batch
 /tests/cuda_long_context_smoke
 /tests/test_layer_pack
+/tests/test_glp
 /tests/test_metal_session_batch
 /tests/test_mxfp4_cuda
 /tests/test_mxfp4_dot

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ rocm: strix-halo
 test-rocm:
 	$(MAKE) -B ds4_test ds4_agent_test ds4-eval q4k-dot-test mxfp4-dot-test \
 		tests/test_layer_pack tests/test_engine_mgpu_placement tests/test_gpu_args tests/test_prompt_prefix \
-		tests/test_glp \
+		tests/test_glp tests/test_dir_steering \
 		ds4 ds4-server ds4-bench ds4-agent \
 		CORE_OBJS="ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o ds4_glp.o $(ROCM_MMQ_OBJS)" \
 		CFLAGS="$(CFLAGS) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD" \
@@ -213,6 +213,7 @@ test-rocm:
 	./tests/test_gpu_args
 	./tests/test_gpu_args_cli.sh
 	./tests/test_glp
+	./tests/test_dir_steering
 	./tests/test_prompt_prefix
 
 ds4: ds4_cli.o ds4_help.o ds4_prompt_prefix.o linenoise.o ds4_gpu_args.o $(CORE_OBJS)
@@ -474,6 +475,12 @@ tests/test_glp.o: tests/test_glp.c ds4_glp.h
 tests/test_glp: tests/test_glp.o ds4_glp.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
+tests/test_dir_steering.o: tests/test_dir_steering.c ds4.h
+	$(CC) $(CFLAGS) -DDS4_TEST_HOOKS -I. -c -o $@ $<
+
+tests/test_dir_steering: tests/test_dir_steering.o ds4_cpu_test_hooks.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o ds4_glp.o
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
+
 tests/test_gpu_args.o: tests/test_gpu_args.c ds4_gpu_args.h ds4_gpu_mgpu.h
 	$(CC) $(CFLAGS) -I. -DDS4_NO_GPU -c -o $@ $<
 
@@ -576,7 +583,7 @@ tests/test_prompt_prefix: tests/test_prompt_prefix.o ds4_prompt_prefix.o
 
 test: ds4_test ds4_agent_test ds4-eval q4k-dot-test mxfp4-dot-test \
 	tests/test_layer_pack tests/test_engine_mgpu_placement tests/test_gpu_args \
-	tests/test_glp \
+	tests/test_glp tests/test_dir_steering \
 	tests/test_deepseek4_vision_image tests/test_prompt_prefix $(SAMPLING_TEST) ds4 ds4-server ds4-bench ds4-agent
 	./ds4-eval --self-test-extractors
 	./ds4_agent_test
@@ -586,6 +593,7 @@ test: ds4_test ds4_agent_test ds4-eval q4k-dot-test mxfp4-dot-test \
 	./tests/test_gpu_args
 	./tests/test_gpu_args_cli.sh
 	./tests/test_glp
+	./tests/test_dir_steering
 	./tests/test_prompt_prefix
 	./tests/test_sampling
 	./tests/test_deepseek4_vision_image

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ DS4_DSPARK_SUPPORT ?= gguf/DeepSeek-V4-Flash-DSpark-support-0731.gguf
 
 ifeq ($(UNAME_S),Darwin)
 METAL_LDLIBS := $(LDLIBS) -framework Foundation -framework Metal
-CORE_OBJS = ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_metal.o ds4_layer_pack.o
-CPU_CORE_OBJS = ds4_cpu.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
+CORE_OBJS = ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_metal.o ds4_layer_pack.o ds4_glp.o
+CPU_CORE_OBJS = ds4_cpu.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o ds4_glp.o
 else
 CFLAGS += -D_GNU_SOURCE -fno-finite-math-only
 CUDA_HOME ?= $(shell if [ -x /usr/local/cuda/bin/nvcc ]; then \
@@ -51,8 +51,8 @@ NVCCFLAGS ?= -O3 -g -lineinfo --use_fast_math $(NVCC_ARCH_FLAGS) -Xcompiler $(NA
 # Vendored llama.cpp mmq prefill tier (cuda/mmq/, see cuda/mmq/VENDOR.md).
 MMQ_INCLUDES := -Icuda/mmq
 MMQ_OBJS := cuda/mmq/ds4_ggml_stubs.o cuda/mmq/ds4_mmq.o cuda/mmq/ds4_mmq_d2r.o cuda/mmq/quantize.o cuda/mmq/mmid.o cuda/mmq/mmvq.o cuda/mmq/ds4_repack.o
-CORE_OBJS = ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o $(MMQ_OBJS)
-CPU_CORE_OBJS = ds4_cpu.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
+CORE_OBJS = ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o ds4_glp.o $(MMQ_OBJS)
+CPU_CORE_OBJS = ds4_cpu.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o ds4_glp.o
 CUDA_LDLIBS ?= -lm -Xcompiler -pthread -L$(CUDA_HOME)/targets/sbsa-linux/lib -L$(CUDA_HOME)/lib64 -lcudart -lcublas
 HIPCC ?= $(shell command -v hipcc 2>/dev/null || echo /opt/rocm/bin/hipcc)
 ROCM_ARCH ?= gfx1151
@@ -185,7 +185,7 @@ cuda:
 
 strix-halo:
 	$(MAKE) -B ds4 ds4-server ds4-bench ds4-eval ds4-agent \
-		CORE_OBJS="ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o $(ROCM_MMQ_OBJS)" \
+		CORE_OBJS="ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o ds4_glp.o $(ROCM_MMQ_OBJS)" \
 		CFLAGS="$(CFLAGS) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD" \
 		DS4_LINK="$(HIPCC) $(ROCM_CFLAGS)" \
 		DS4_LINK_LIBS="$(ROCM_LDLIBS)"
@@ -199,8 +199,9 @@ rocm: strix-halo
 test-rocm:
 	$(MAKE) -B ds4_test ds4_agent_test ds4-eval q4k-dot-test mxfp4-dot-test \
 		tests/test_layer_pack tests/test_engine_mgpu_placement tests/test_gpu_args tests/test_prompt_prefix \
+		tests/test_glp \
 		ds4 ds4-server ds4-bench ds4-agent \
-		CORE_OBJS="ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o $(ROCM_MMQ_OBJS)" \
+		CORE_OBJS="ds4.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_rocm.o ds4_rocm_compat.o ds4_rocm_unavailable.o ds4_layer_pack.o ds4_glp.o $(ROCM_MMQ_OBJS)" \
 		CFLAGS="$(CFLAGS) $(ROCM_HOST_CFLAGS) -DDS4_ROCM_BUILD" \
 		DS4_LINK="$(HIPCC) $(ROCM_CFLAGS)" \
 		DS4_LINK_LIBS="$(ROCM_LDLIBS)"
@@ -211,6 +212,7 @@ test-rocm:
 	./tests/test_engine_mgpu_placement
 	./tests/test_gpu_args
 	./tests/test_gpu_args_cli.sh
+	./tests/test_glp
 	./tests/test_prompt_prefix
 
 ds4: ds4_cli.o ds4_help.o ds4_prompt_prefix.o linenoise.o ds4_gpu_args.o $(CORE_OBJS)
@@ -274,6 +276,9 @@ ds4_help.o: ds4_help.c ds4_help.h
 
 ds4_prompt_prefix.o: ds4_prompt_prefix.c ds4_prompt_prefix.h ds4.h
 	$(CC) $(CFLAGS) -c -o $@ ds4_prompt_prefix.c
+
+ds4_glp.o: ds4_glp.c ds4_glp.h
+	$(CC) $(CFLAGS) -c -o $@ ds4_glp.c
 
 ds4_gpu_args.o: ds4_gpu_args.c ds4_gpu_args.h ds4_gpu_mgpu.h
 	$(CC) $(CFLAGS) -c -o $@ ds4_gpu_args.c
@@ -463,6 +468,12 @@ tests/test_layer_pack.o: tests/test_layer_pack.c ds4_layer_pack.h
 tests/test_layer_pack: tests/test_layer_pack.o ds4_layer_pack.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
+tests/test_glp.o: tests/test_glp.c ds4_glp.h
+	$(CC) $(CFLAGS) -I. -c -o $@ $<
+
+tests/test_glp: tests/test_glp.o ds4_glp.o
+	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
+
 tests/test_gpu_args.o: tests/test_gpu_args.c ds4_gpu_args.h ds4_gpu_mgpu.h
 	$(CC) $(CFLAGS) -I. -DDS4_NO_GPU -c -o $@ $<
 
@@ -475,13 +486,13 @@ ds4_cpu_test_hooks.o: ds4.c ds4.h ds4_image.h ds4_gpu.h ds4_gpu_mgpu.h ds4_layer
 tests/test_engine_mgpu_placement.o: tests/test_engine_mgpu_placement.c ds4.h ds4_gpu_mgpu.h ds4_layer_pack.h
 	$(CC) $(CFLAGS) -I. -c -o $@ $<
 
-tests/test_engine_mgpu_placement: tests/test_engine_mgpu_placement.o ds4_cpu_test_hooks.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
+tests/test_engine_mgpu_placement: tests/test_engine_mgpu_placement.o ds4_cpu_test_hooks.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o ds4_glp.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
 tests/test_sampling.o: tests/test_sampling.c ds4.h
 	$(CC) $(CFLAGS) -fno-finite-math-only -DDS4_TEST_HOOKS -I. -c -o $@ $<
 
-tests/test_sampling: tests/test_sampling.o ds4_cpu_test_hooks.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o
+tests/test_sampling: tests/test_sampling.o ds4_cpu_test_hooks.o ds4_image.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_layer_pack.o ds4_glp.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
 ifneq ($(UNAME_S),Darwin)
@@ -515,7 +526,7 @@ tests/test_engine_mgpu_refusal: tests/test_engine_mgpu_refusal.o ds4_gpu_args.o 
 tests/test_engine_mgpu_runtime.o: tests/test_engine_mgpu_runtime.c ds4.h ds4_gpu_mgpu.h
 	$(CC) $(CFLAGS) -DDS4_TEST_HOOKS -I. -I$(CUDA_HOME)/include -c -o $@ $<
 
-tests/test_engine_mgpu_runtime: tests/test_engine_mgpu_runtime.o ds4_cuda_test_hooks.o ds4_gpu_args.o ds4_kvstore.o rax.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o $(MMQ_OBJS)
+tests/test_engine_mgpu_runtime: tests/test_engine_mgpu_runtime.o ds4_cuda_test_hooks.o ds4_gpu_args.o ds4_kvstore.o rax.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o ds4_glp.o $(MMQ_OBJS)
 	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(CUDA_LDLIBS)
 
 tests/test_engine_correctness.o: tests/test_engine_correctness.c ds4.h ds4_gpu_mgpu.h
@@ -536,7 +547,7 @@ test-cuda-session-batch: tests/test_cuda_session_batch
 tests/test_cuda_mixed_batch.o: tests/test_cuda_mixed_batch.c ds4.h ds4_gpu_args.h ds4_gpu_mgpu.h
 	$(CC) $(CFLAGS) -DDS4_TEST_HOOKS -I. -I$(CUDA_HOME)/include -c -o $@ $<
 
-tests/test_cuda_mixed_batch: tests/test_cuda_mixed_batch.o ds4_cuda_test_hooks.o ds4_gpu_args.o ds4_kvstore.o rax.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o $(MMQ_OBJS)
+tests/test_cuda_mixed_batch: tests/test_cuda_mixed_batch.o ds4_cuda_test_hooks.o ds4_gpu_args.o ds4_kvstore.o rax.o ds4_distributed.o ds4_tp.o ds4_ssd.o ds4_cuda.o ds4_layer_pack.o ds4_glp.o $(MMQ_OBJS)
 	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(CUDA_LDLIBS)
 
 test-cuda-mixed-batch: tests/test_cuda_mixed_batch
@@ -565,6 +576,7 @@ tests/test_prompt_prefix: tests/test_prompt_prefix.o ds4_prompt_prefix.o
 
 test: ds4_test ds4_agent_test ds4-eval q4k-dot-test mxfp4-dot-test \
 	tests/test_layer_pack tests/test_engine_mgpu_placement tests/test_gpu_args \
+	tests/test_glp \
 	tests/test_deepseek4_vision_image tests/test_prompt_prefix $(SAMPLING_TEST) ds4 ds4-server ds4-bench ds4-agent
 	./ds4-eval --self-test-extractors
 	./ds4_agent_test
@@ -573,6 +585,7 @@ test: ds4_test ds4_agent_test ds4-eval q4k-dot-test mxfp4-dot-test \
 	./tests/test_engine_mgpu_placement
 	./tests/test_gpu_args
 	./tests/test_gpu_args_cli.sh
+	./tests/test_glp
 	./tests/test_prompt_prefix
 	./tests/test_sampling
 	./tests/test_deepseek4_vision_image

--- a/README.md
+++ b/README.md
@@ -1833,7 +1833,9 @@ the layer map and the base checkpoint, so a vector can be shared without the
 recipient having to be told how to apply it. ds4 refuses a file rather than
 misapplying it — notably a llama.cpp control vector, which shares the tensor
 convention exactly but is *added* where ds4 projects, an operation difference
-that raises no error and produces wrong output. `--dir-steering-info FILE`
+that raises no error and produces wrong output. The same goes for a vector
+calibrated on the post-layer residual rather than the block writers ds4 steers:
+a different tensor, and a dose that does not transfer. `--dir-steering-info FILE`
 prints what a vector is without loading a model. The raw `.f32` blob still
 works; the format is chosen by sniffing the file. See
 [dir-steering/README.md](dir-steering/README.md#glp-files).

--- a/README.md
+++ b/README.md
@@ -1827,7 +1827,19 @@ Load a direction when starting either interactive client:
 ./ds4-agent -m model.gguf --dir-steering-file direction.f32
 ```
 
-The default FFN scale is `1`. At an interactive prompt, `/steer` shows the
+`--dir-steering-file` also reads a **GLP file** (GGUF Layer Projection): the
+same directions in a GGUF container that states the operation, the hook point,
+the layer map and the base checkpoint, so a vector can be shared without the
+recipient having to be told how to apply it. ds4 refuses a file rather than
+misapplying it — notably a llama.cpp control vector, which shares the tensor
+convention exactly but is *added* where ds4 projects, an operation difference
+that raises no error and produces wrong output. `--dir-steering-info FILE`
+prints what a vector is without loading a model. The raw `.f32` blob still
+works; the format is chosen by sniffing the file. See
+[dir-steering/README.md](dir-steering/README.md#glp-files).
+
+The default FFN scale is `1`, or `glp.alpha_default` when a GLP file was
+calibrated at the hook ds4 is about to steer. At an interactive prompt, `/steer` shows the
 current scale, `/steer 0` disables it, and `/steer F` sets a value from `-100`
 to `100` for subsequent tokens. The existing KV cache is kept. Live changes
 are currently limited to local sessions, not distributed inference or network

--- a/dir-steering/README.md
+++ b/dir-steering/README.md
@@ -65,8 +65,12 @@ direction instead of removing it.
 **The hook point.** ds4 steers the block writers — `ffn_out = moe + shared`, or
 the attention output — before the residual / hyper-connection fold. llama.cpp's
 `build_cvec()` and the weightless vLLM overlay steer the post-layer residual.
-Measured on the same direction, the same layers and the same alpha, the writer
-site left 34.0% refusal against 3.8% post-layer: 9x weaker, and not an error.
+Those are different tensors, not two names for one. A writer holds only what
+that block computed *this layer*; the folded residual holds the accumulated sum,
+so projecting it also removes whatever every upstream layer contributed.
+Steering a writer prevents refusal being *added*; steering the residual
+*deletes* refusal already there. Neither site's calibrated strength transfers to
+the other, and a vector applied at the wrong one degrades rather than errors.
 
 **The layer map.** `direction.N` applies at layer `N`, with no offset. A
 one-layer shift does not fail, it degrades — adjacent layers' refusal
@@ -115,10 +119,10 @@ strength it was calibrated at with no flags:
 ```
 
 An explicit `--dir-steering-ffn` always wins, and alpha is never adopted from a
-file whose hook does not match: projection is quadratic in the direction's
-norm and the same direction at a different site measured 9x weaker, so an alpha
-from elsewhere is not a better default than 1.0, only a more confident wrong
-one.
+file whose hook does not match: projection is quadratic in the direction's norm,
+and a site that cleans one contributor rather than the accumulated stream needs
+a different dose — so an alpha from elsewhere is not a better default than 1.0,
+only a more confident wrong one.
 
 ### Publishing a vector
 

--- a/dir-steering/README.md
+++ b/dir-steering/README.md
@@ -19,17 +19,139 @@ The file shape depends on the model:
 
 GLM 5.2 steering is not implemented.
 
+`--dir-steering-file` also accepts a **GLP file** — the same directions in a
+GGUF container that states what they are. See [GLP files](#glp-files) below.
+
 ## Runtime Options
 
 ```text
---dir-steering-file FILE   load one f32 direction per normal model layer
+--dir-steering-file FILE   one direction per normal model layer: a GLP .gguf,
+                           or the raw f32 blob described above
 --dir-steering-ffn F       apply steering after FFN outputs; default is 1 when a file is provided
 --dir-steering-attn F      apply steering after attention outputs; default is 0
+--dir-steering-info FILE   print a GLP vector's metadata and exit; loads no model
+--dir-steering-allow-hook-mismatch
+                           apply a GLP vector at a hook it was not calibrated for
 ```
+
+The format is chosen by sniffing the file, not by a flag, so every existing raw
+vector keeps working unchanged.
 
 The FFN output is usually the best first target because it is late enough in
 each layer to represent behavior, style, and topic signals. Attention steering
 is available for experiments, but it can be more fragile.
+
+## GLP files
+
+The raw format is a headerless blob. That is fine on the machine that produced
+it and unsafe to hand to anyone else, because it cannot say four things that
+are each silently wrong when they are wrong:
+
+**The operation.** llama.cpp has shipped control vectors since 2024 with the
+tensor convention this format reuses exactly — tensors named `direction.<N>`,
+fp32, 1-D — but llama.cpp *adds* them:
+
+```text
+h <- h + v                      ADD:      steer towards a direction
+y -= scale * v * dot(v, y)      PROJECT:  delete the component along v  (ds4)
+```
+
+These are different operations, and the difference is not a scale factor. A
+file loads into either runtime with the right tensor names, the right dtype and
+the right shapes, raises no error, and produces wrong output in one of them: an
+additive apply of a projective direction pushes every token *along* the
+direction instead of removing it.
+
+**The hook point.** ds4 steers the block writers — `ffn_out = moe + shared`, or
+the attention output — before the residual / hyper-connection fold. llama.cpp's
+`build_cvec()` and the weightless vLLM overlay steer the post-layer residual.
+Measured on the same direction, the same layers and the same alpha, the writer
+site left 34.0% refusal against 3.8% post-layer: 9x weaker, and not an error.
+
+**The layer map.** `direction.N` applies at layer `N`, with no offset. A
+one-layer shift does not fail, it degrades — adjacent layers' refusal
+directions have cosine similarity 0.555–0.979 — so it survives a smoke test.
+
+**The base checkpoint.** A direction is tied to the exact revision it was
+derived from. Applying one elsewhere is undefined, and the shapes still match.
+
+GLP (GGUF Layer Projection) is standard GGUF v3 with llama.cpp's tensor
+convention unchanged, plus a `glp.*` block that states all four. ds4 refuses a
+file rather than misapplying it: wrong operation, a hook it was not calibrated
+for, tensor names disagreeing with the declared layer list, `rank > 1`, a
+non-F32 direction, or a width that is not this model's `n_embd`. Full spec:
+[weightless/spec/GLP.md](https://github.com/msuiche/weightless/blob/main/spec/GLP.md).
+
+Inspect a vector without loading the model it belongs to — the first thing to
+reach for when one behaves oddly:
+
+```sh
+./ds4 --dir-steering-info dir-steering/out/verbosity-GLP.gguf
+```
+
+```text
+GLP vector: dir-steering/out/verbosity-GLP.gguf
+  mode           project
+  spec_version   1
+  hook_point     ffn_out_pre_residual
+  alpha_default  2
+  rank           1
+  coverage       42 directions, n_embd=4096, layers 1..42
+  direction norm 1.000000 .. 1.000000
+  base model     DeepSeek-V4-Flash-0731
+  method         paired_difference_of_means
+  contrast       succinct.txt_vs_verbose.txt
+  content sha256 2fc93b0a...
+```
+
+When the file's hook matches the site ds4 is about to steer, `glp.alpha_default`
+becomes the default `--dir-steering-ffn`, so a published vector runs at the
+strength it was calibrated at with no flags:
+
+```sh
+./ds4 -m ds4flash.gguf --nothink --temp 0 -n 160 \
+  --dir-steering-file verbosity-GLP.gguf \
+  -p "Explain why databases use indexes."
+```
+
+An explicit `--dir-steering-ffn` always wins, and alpha is never adopted from a
+file whose hook does not match: projection is quadratic in the direction's
+norm and the same direction at a different site measured 9x weaker, so an alpha
+from elsewhere is not a better default than 1.0, only a more confident wrong
+one.
+
+### Publishing a vector
+
+`f32_to_glp.py` packages a raw vector built by `build_direction.py`, reading the
+sidecar JSON so the shape and the hook point cannot disagree with what was
+measured:
+
+```sh
+python3 dir-steering/tools/f32_to_glp.py \
+  dir-steering/out/verbosity.f32 dir-steering/out/verbosity-GLP.gguf \
+  --meta dir-steering/out/verbosity.json \
+  --layers 1-42 \
+  --base-model DeepSeek-V4-Flash-0731 \
+  --base-org deepseek-ai \
+  --base-revision <hf commit> \
+  --alpha 2.0
+```
+
+It normalises each direction to unit length, writes `glp.content_sha256` over
+the tensor bytes only — `glp.created` makes the file non-reproducible, so the
+hash is what lets two people confirm they hold the same direction — and reads
+the result back to assert the layer ids landed verbatim and the values survived
+exactly. No third-party Python packages.
+
+**Layer 0 cannot be expressed.** `direction.N` applies at layer `N` and
+`direction.0` is invalid, so the container has no slot for layer 0 — a
+difference from the raw format, which has a row for it. `build_direction.py`
+fills every layer, so a full-coverage vector needs `--layers 1-<last>` and
+loses layer 0. Vectors derived over a mid-stack range (ours cover L10–38) are
+unaffected. Coverage is the lever that matters most here — 6 layers 18%, 16
+layers 3.8%, 29 layers 0.0% on our refusal suites, while alpha saturates above
+about 4 — so losing the first layer of a 43-layer stack is not what decides a
+vector's strength.
 
 ## GLM 5.3 Example
 

--- a/dir-steering/README.md
+++ b/dir-steering/README.md
@@ -71,13 +71,16 @@ moe + shared`, or the attention output — before the residual / hyper-connectio
 fold, and the post-layer residual itself (`--dir-steering-resid`), where each
 of the four hyper-connection streams is projected independently. The residual
 site is where llama.cpp's `build_cvec()` and the weightless vLLM overlay apply.
-Writers and residual are different tensors, not two names for one. A writer
-holds only what that block computed *this layer*; the folded residual holds the
-accumulated sum, so projecting it also removes whatever every upstream layer
-contributed. Steering a writer prevents refusal being *added*; steering the
-residual *deletes* refusal already there. Neither site's calibrated strength
-transfers to the other, and a vector applied at the wrong one degrades rather
-than errors.
+Writers and residual are different tensors, not two names for one, and which
+site carries the usable window is architecture- and dose-dependent, not a
+ranking: measured on DeepSeek-V4-Flash-0731 (NVFP4, vLLM overlay, greedy,
+refusal32, 2026-09-04), the FFN writer at α=6 reached 26/32 (α=4: 19/32,
+benign clean), the post-layer residual 11/32 at α=2 (α=4 garbled), the
+attention writer 5/32 at α=4 — with a direction derived at the residual and
+transferred to the FFN site. The residual hook exists because vectors for our
+other models are calibrated there. What does not change: a site's calibrated α
+does not transfer to another site, and a vector applied at the wrong one
+degrades rather than errors.
 
 **The layer map.** `direction.N` applies at layer `N`, with no offset. A
 one-layer shift does not fail, it degrades — adjacent layers' refusal

--- a/dir-steering/README.md
+++ b/dir-steering/README.md
@@ -29,6 +29,10 @@ GGUF container that states what they are. See [GLP files](#glp-files) below.
                            or the raw f32 blob described above
 --dir-steering-ffn F       apply steering after FFN outputs; default is 1 when a file is provided
 --dir-steering-attn F      apply steering after attention outputs; default is 0
+--dir-steering-resid F     apply steering to each hyper-connection stream after
+                           the layer's FFN fold (the post-layer residual);
+                           a residual-calibrated GLP file defaults to its
+                           glp.alpha_default at this site
 --dir-steering-info FILE   print a GLP vector's metadata and exit; loads no model
 --dir-steering-allow-hook-mismatch
                            apply a GLP vector at a hook it was not calibrated for
@@ -62,15 +66,18 @@ the right shapes, raises no error, and produces wrong output in one of them: an
 additive apply of a projective direction pushes every token *along* the
 direction instead of removing it.
 
-**The hook point.** ds4 steers the block writers — `ffn_out = moe + shared`, or
-the attention output — before the residual / hyper-connection fold. llama.cpp's
-`build_cvec()` and the weightless vLLM overlay steer the post-layer residual.
-Those are different tensors, not two names for one. A writer holds only what
-that block computed *this layer*; the folded residual holds the accumulated sum,
-so projecting it also removes whatever every upstream layer contributed.
-Steering a writer prevents refusal being *added*; steering the residual
-*deletes* refusal already there. Neither site's calibrated strength transfers to
-the other, and a vector applied at the wrong one degrades rather than errors.
+**The hook point.** ds4 steers three sites: the block writers — `ffn_out =
+moe + shared`, or the attention output — before the residual / hyper-connection
+fold, and the post-layer residual itself (`--dir-steering-resid`), where each
+of the four hyper-connection streams is projected independently. The residual
+site is where llama.cpp's `build_cvec()` and the weightless vLLM overlay apply.
+Writers and residual are different tensors, not two names for one. A writer
+holds only what that block computed *this layer*; the folded residual holds the
+accumulated sum, so projecting it also removes whatever every upstream layer
+contributed. Steering a writer prevents refusal being *added*; steering the
+residual *deletes* refusal already there. Neither site's calibrated strength
+transfers to the other, and a vector applied at the wrong one degrades rather
+than errors.
 
 **The layer map.** `direction.N` applies at layer `N`, with no offset. A
 one-layer shift does not fail, it degrades — adjacent layers' refusal
@@ -108,9 +115,10 @@ GLP vector: dir-steering/out/verbosity-GLP.gguf
   content sha256 2fc93b0a...
 ```
 
-When the file's hook matches the site ds4 is about to steer, `glp.alpha_default`
-becomes the default `--dir-steering-ffn`, so a published vector runs at the
-strength it was calibrated at with no flags:
+When the file's hook matches a site ds4 steers, `glp.alpha_default` becomes the
+default scale for that site's flag — `--dir-steering-ffn` for an FFN-hooked
+file, `--dir-steering-resid` for a residual-hooked one — so a published vector
+runs at the strength it was calibrated at with no flags:
 
 ```sh
 ./ds4 -m ds4flash.gguf --nothink --temp 0 -n 160 \

--- a/dir-steering/tools/f32_to_glp.py
+++ b/dir-steering/tools/f32_to_glp.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Package a ds4 raw steering vector as a GLP file (GGUF Layer Projection).
+
+The raw format build_direction.py writes is a headerless blob of
+n_layers * n_embd float32: it carries no operation, no hook point, no layer map
+and no base-model pin. That is fine on the machine that produced it and unsafe
+to hand to anyone else, because every one of those is silently wrong when it is
+wrong:
+
+  operation   llama.cpp has shipped control vectors since 2024 with the same
+              tensor convention -- direction.<N>, fp32, 1-D -- but ADDS them:
+              h <- h + v. ds4 PROJECTS: y -= scale * v * dot(v, y). A file
+              loads into either runtime without an error and is wrong in one of
+              them. An additive apply of a projective direction pushes every
+              token along the direction instead of removing it.
+
+  hook point  ds4 steers the block writers (ffn_out = moe + shared, or the
+              attention output) before the residual fold. llama.cpp's
+              build_cvec() and the weightless vLLM overlay steer the post-layer
+              residual. The same direction at the wrong site measured 9x
+              weaker: 34.0% vs 3.8% refusal at identical direction, layers and
+              alpha.
+
+  layer map   direction.N applies at layer N. A one-layer shift does not fail,
+              it degrades -- adjacent layers' refusal directions have cosine
+              similarity 0.555-0.979 -- so it survives a smoke test.
+
+  base model  a direction is tied to the exact checkpoint it was derived from.
+              Applying one to a different revision is undefined.
+
+GLP is standard GGUF v3 with llama.cpp's tensor convention unchanged, plus a
+"glp.*" block that states all four. ds4 reads it back with ds4_glp.c and
+refuses rather than misapplies. Spec:
+https://github.com/msuiche/weightless/blob/main/spec/GLP.md
+
+No third-party dependencies: this writes GGUF with struct, so it runs wherever
+ds4 builds.
+
+Usage:
+  f32_to_glp.py IN.f32 OUT.gguf --n-embd 4096 \\
+      --base-model DeepSeek-V4-Flash-0731 --base-org deepseek-ai \\
+      [--meta IN.json] [--hook ffn_out_pre_residual] [--alpha 1.0] \\
+      [--layers 10-38] [--base-revision COMMIT] [--repo-url URL] \\
+      [--method ...] [--contrast ...]
+
+--meta reads build_direction.py's sidecar JSON, which supplies the shape and
+maps its "component" field to the hook point, so the two cannot disagree.
+"""
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import struct
+import sys
+
+GGUF_MAGIC = b"GGUF"
+GGUF_VERSION = 3
+GGUF_ALIGNMENT = 32
+
+GGUF_TYPE_UINT32 = 4
+GGUF_TYPE_FLOAT32 = 6
+GGUF_TYPE_BOOL = 7
+GGUF_TYPE_STRING = 8
+
+GGML_TYPE_F32 = 0
+
+GLP_SPEC_VERSION = 1
+
+# build_direction.py names ds4's steering sites "ffn_out" and "attn_out".
+# The GLP hook names are explicit that these are the block writers, before the
+# residual / hyper-connection fold -- which is what makes them different from
+# residual_stream_post_layer rather than a synonym for it.
+COMPONENT_TO_HOOK = {
+    "ffn_out": "ffn_out_pre_residual",
+    "attn_out": "attn_out_pre_residual",
+}
+VALID_HOOKS = set(COMPONENT_TO_HOOK.values())
+
+
+def die(msg):
+    sys.stderr.write("f32_to_glp: %s\n" % msg)
+    sys.exit(1)
+
+
+def parse_layers(spec, n_layers):
+    """"10-38", "10,11,12", or "10-38,41" -> sorted list of layer ids."""
+    out = set()
+    for part in spec.replace(" ", "").split(","):
+        if not part:
+            continue
+        if "-" in part[1:]:
+            a, b = part.split("-", 1)
+            lo, hi = int(a), int(b)
+            if lo > hi:
+                die("--layers range %s is inverted" % part)
+            out.update(range(lo, hi + 1))
+        else:
+            out.add(int(part))
+    for layer in sorted(out):
+        if layer < 0 or layer >= n_layers:
+            die("--layers names layer %d, outside 0..%d" % (layer, n_layers - 1))
+    return sorted(out)
+
+
+# ---------------------------------------------------------------------------
+# GGUF writer
+# ---------------------------------------------------------------------------
+
+def w_string(buf, s):
+    b = s.encode("utf-8")
+    buf.append(struct.pack("<Q", len(b)))
+    buf.append(b)
+
+
+def kv(buf, key, vtype, payload):
+    w_string(buf, key)
+    buf.append(struct.pack("<I", vtype))
+    buf.append(payload)
+
+
+def kv_str(buf, key, value):
+    w_string(buf, key)
+    buf.append(struct.pack("<I", GGUF_TYPE_STRING))
+    b = value.encode("utf-8")
+    buf.append(struct.pack("<Q", len(b)))
+    buf.append(b)
+
+
+def write_gguf(path, meta_strs, meta_u32, meta_f32, meta_bool, tensors):
+    """tensors: list of (name, list-of-float). All 1-D F32."""
+    kv_count = len(meta_strs) + len(meta_u32) + len(meta_f32) + len(meta_bool)
+
+    head = [GGUF_MAGIC, struct.pack("<I", GGUF_VERSION),
+            struct.pack("<Q", len(tensors)), struct.pack("<Q", kv_count)]
+    for k, v in meta_strs:
+        kv_str(head, k, v)
+    for k, v in meta_u32:
+        kv(head, k, GGUF_TYPE_UINT32, struct.pack("<I", v))
+    for k, v in meta_f32:
+        kv(head, k, GGUF_TYPE_FLOAT32, struct.pack("<f", v))
+    for k, v in meta_bool:
+        kv(head, k, GGUF_TYPE_BOOL, struct.pack("<B", 1 if v else 0))
+
+    # Tensor directory. Offsets are relative to the aligned start of the data
+    # section, and each tensor is padded up to the alignment.
+    offset = 0
+    for name, values in tensors:
+        w_string(head, name)
+        head.append(struct.pack("<I", 1))              # 1-D
+        head.append(struct.pack("<Q", len(values)))    # n_embd
+        head.append(struct.pack("<I", GGML_TYPE_F32))
+        head.append(struct.pack("<Q", offset))
+        nbytes = len(values) * 4
+        offset += (nbytes + GGUF_ALIGNMENT - 1) // GGUF_ALIGNMENT * GGUF_ALIGNMENT
+
+    blob = b"".join(head)
+    pad = (GGUF_ALIGNMENT - (len(blob) % GGUF_ALIGNMENT)) % GGUF_ALIGNMENT
+    body = [blob, b"\0" * pad]
+    for _, values in tensors:
+        raw = struct.pack("<%df" % len(values), *values)
+        body.append(raw)
+        body.append(b"\0" * ((GGUF_ALIGNMENT - (len(raw) % GGUF_ALIGNMENT)) % GGUF_ALIGNMENT))
+
+    with open(path, "wb") as fp:
+        fp.write(b"".join(body))
+
+
+# ---------------------------------------------------------------------------
+# GGUF reader, for the round-trip assertion only
+# ---------------------------------------------------------------------------
+
+def read_back(path):
+    """Return (kv_dict_of_strings, {layer: [floats]}). Deliberately minimal."""
+    with open(path, "rb") as fp:
+        data = fp.read()
+    pos = 0
+
+    def u32():
+        nonlocal pos
+        v = struct.unpack_from("<I", data, pos)[0]
+        pos += 4
+        return v
+
+    def u64():
+        nonlocal pos
+        v = struct.unpack_from("<Q", data, pos)[0]
+        pos += 8
+        return v
+
+    def s():
+        nonlocal pos
+        n = u64()
+        v = data[pos:pos + n].decode("utf-8")
+        pos += n
+        return v
+
+    assert data[0:4] == GGUF_MAGIC, "not GGUF"
+    pos = 4
+    assert u32() == GGUF_VERSION, "not GGUF v3"
+    n_tensors = u64()
+    n_kv = u64()
+
+    strings, alignment = {}, GGUF_ALIGNMENT
+    scalar = {GGUF_TYPE_UINT32: 4, GGUF_TYPE_FLOAT32: 4, GGUF_TYPE_BOOL: 1}
+    for _ in range(n_kv):
+        key = s()
+        vtype = u32()
+        if vtype == GGUF_TYPE_STRING:
+            strings[key] = s()
+        elif vtype in scalar:
+            raw = data[pos:pos + scalar[vtype]]
+            pos += scalar[vtype]
+            if key == "general.alignment":
+                alignment = struct.unpack("<I", raw)[0]
+            strings[key] = raw
+        else:
+            raise AssertionError("unexpected kv type %d for %s" % (vtype, key))
+
+    infos = []
+    for _ in range(n_tensors):
+        name = s()
+        ndim = u32()
+        assert ndim == 1, "%s is %d-D, GLP directions are 1-D" % (name, ndim)
+        n = u64()
+        ttype = u32()
+        assert ttype == GGML_TYPE_F32, "%s is ggml type %d, not F32" % (name, ttype)
+        infos.append((name, n, u64()))
+
+    data_start = (pos + alignment - 1) // alignment * alignment
+    out = {}
+    for name, n, rel in infos:
+        assert name.startswith("direction."), "unexpected tensor %s" % name
+        start = data_start + rel
+        out[int(name.split(".", 1)[1])] = list(
+            struct.unpack_from("<%df" % n, data, start))
+    return strings, out
+
+
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("src", help="raw .f32 blob (n_layers * n_embd float32)")
+    ap.add_argument("out", help="output .gguf")
+    ap.add_argument("--meta", help="build_direction.py sidecar JSON")
+    ap.add_argument("--n-embd", type=int, help="hidden width (from --meta if given)")
+    ap.add_argument("--hook", help="glp.hook_point; default from --meta component")
+    ap.add_argument("--alpha", type=float, default=1.0,
+                    help="glp.alpha_default: the scale this vector was "
+                         "calibrated at. ds4 uses it as the default "
+                         "--dir-steering-ffn when the hook matches.")
+    ap.add_argument("--layers", help="layer ids to emit; default: every "
+                                     "non-zero row")
+    ap.add_argument("--base-model", required=True)
+    ap.add_argument("--base-org", default="")
+    ap.add_argument("--base-revision", default="",
+                    help="the base checkpoint's commit. A direction is tied to "
+                         "the revision it was derived from, so pin it.")
+    ap.add_argument("--repo-url", default="")
+    ap.add_argument("--method", default="paired_difference_of_means")
+    ap.add_argument("--contrast", default="")
+    args = ap.parse_args()
+
+    n_embd, component = args.n_embd, None
+    n_layers_meta = None
+    if args.meta:
+        with open(args.meta, encoding="utf-8") as fp:
+            meta = json.load(fp)
+        shape = meta.get("shape")
+        if shape and len(shape) == 2:
+            n_layers_meta, meta_embd = int(shape[0]), int(shape[1])
+            if n_embd and n_embd != meta_embd:
+                die("--n-embd %d disagrees with %s shape %r"
+                    % (n_embd, args.meta, shape))
+            n_embd = meta_embd
+        component = meta.get("component")
+        if not args.contrast:
+            good, bad = meta.get("good_file"), meta.get("bad_file")
+            if good and bad:
+                args.contrast = "%s_vs_%s" % (os.path.basename(good),
+                                              os.path.basename(bad))
+    if not n_embd:
+        die("--n-embd is required unless --meta carries the shape")
+
+    hook = args.hook or COMPONENT_TO_HOOK.get(component or "")
+    if not hook:
+        die("no hook point: pass --hook (%s), or --meta with a component field. "
+            "A vector that does not say where it was calibrated cannot be "
+            "applied safely anywhere else -- the same direction at the wrong "
+            "site measured 9x weaker."
+            % ", ".join(sorted(VALID_HOOKS)))
+    if hook not in VALID_HOOKS:
+        die("--hook %r is not a site ds4 applies at (%s). "
+            "residual_stream_post_layer is llama.cpp's and the vLLM overlay's "
+            "site; ds4 steers the block writers."
+            % (hook, ", ".join(sorted(VALID_HOOKS))))
+
+    raw = open(args.src, "rb").read()
+    if len(raw) % (n_embd * 4):
+        die("%s is %d bytes, not a multiple of n_embd*4 = %d"
+            % (args.src, len(raw), n_embd * 4))
+    n_layers = len(raw) // (n_embd * 4)
+    if n_layers_meta and n_layers != n_layers_meta:
+        die("%s holds %d layers, %s declares %d"
+            % (args.src, n_layers, args.meta, n_layers_meta))
+    rows = [list(struct.unpack_from("<%df" % n_embd, raw, i * n_embd * 4))
+            for i in range(n_layers)]
+
+    if args.layers:
+        layers = parse_layers(args.layers, n_layers)
+    else:
+        layers = [i for i, r in enumerate(rows) if any(v != 0.0 for v in r)]
+    if not layers:
+        die("%s has no non-zero rows" % args.src)
+
+    # direction.0 cannot be expressed: direction.N applies at layer N with no
+    # offset, so the container has no slot for layer 0. Say so rather than
+    # emitting direction.0 and letting a reader reject the file later.
+    if layers[0] == 0:
+        die("layer 0 cannot be expressed in this container (direction.N "
+            "applies at layer N, and direction.0 is invalid). Drop layer 0 "
+            "with --layers, or re-derive without it.")
+
+    # Unit-normalise. Projection is quadratic in the norm, so an off-unit
+    # direction folds a hidden strength into the data that the caller's scale
+    # then multiplies again -- and alpha is meant to be the only strength knob.
+    tensors, renormed = [], 0
+    for layer in layers:
+        row = rows[layer]
+        norm = sum(v * v for v in row) ** 0.5
+        if norm <= 1e-12:
+            die("layer %d is all zero; it would steer nothing. Omit it from "
+                "--layers rather than shipping a dead slot." % layer)
+        if abs(norm - 1.0) > 1e-6:
+            row = [v / norm for v in row]
+            renormed += 1
+        tensors.append(("direction.%d" % layer, row))
+
+    # The hash covers tensor bytes only, not metadata: glp.created makes the
+    # file non-reproducible, so this is what lets two people confirm they hold
+    # the same direction regardless of when it was packaged.
+    h = hashlib.sha256()
+    for _, row in tensors:
+        h.update(struct.pack("<%df" % len(row), *row))
+
+    meta_strs = [
+        ("general.architecture", "controlvector"),
+        ("general.type", "controlvector"),
+        ("general.name", os.path.basename(args.out)),
+        # The one field a reader may not ignore.
+        ("glp.mode", "project"),
+        ("glp.hook_point", hook),
+        ("glp.method", args.method),
+        # Redundant with the tensor names on purpose: readable in a gguf_dump,
+        # and a cross-check that catches an exporter writing the wrong ids.
+        ("glp.layer_ids_zero_based", ",".join(str(x) for x in layers)),
+        ("glp.content_sha256", h.hexdigest()),
+        ("glp.created", datetime.date.today().isoformat()),
+        ("general.base_model.0.name", args.base_model),
+    ]
+    if args.contrast:
+        meta_strs.append(("glp.contrast", args.contrast))
+    if args.base_org:
+        meta_strs.append(("general.base_model.0.organization", args.base_org))
+    if args.base_revision:
+        meta_strs.append(("general.base_model.0.version", args.base_revision))
+    if args.repo_url:
+        meta_strs.append(("general.base_model.0.repo_url", args.repo_url))
+
+    meta_u32 = [
+        ("glp.spec_version", GLP_SPEC_VERSION),
+        ("glp.rank", 1),
+        ("general.base_model.count", 1),
+    ]
+    meta_f32 = [("glp.alpha_default", args.alpha)]
+    meta_bool = [("glp.orthonormal", True)]
+
+    write_gguf(args.out, meta_strs, meta_u32, meta_f32, meta_bool, tensors)
+
+    # Round-trip, because the failures this container prevents are the ones
+    # that do not raise: assert the layer ids landed verbatim and the values
+    # survived exactly.
+    strings, back = read_back(args.out)
+    assert strings["glp.mode"] == "project", "mode did not survive"
+    assert strings["glp.hook_point"] == hook, "hook_point did not survive"
+    assert sorted(back) == layers, (
+        "layer ids changed in the round trip: wrote %r, read %r"
+        % (layers, sorted(back)))
+    for name, row in tensors:
+        got = back[int(name.split(".", 1)[1])]
+        assert len(got) == len(row), "%s changed length" % name
+        for a, b in zip(row, got):
+            assert struct.pack("<f", a) == struct.pack("<f", b), \
+                "%s changed value" % name
+
+    print("wrote %s" % args.out)
+    print("  mode           project")
+    print("  hook_point     %s" % hook)
+    print("  alpha_default  %g" % args.alpha)
+    print("  coverage       %d directions, n_embd=%d, layers %d..%d"
+          % (len(layers), n_embd, layers[0], layers[-1]))
+    print("  base model     %s%s" % (args.base_model,
+                                     " @ " + args.base_revision
+                                     if args.base_revision else ""))
+    print("  content sha256 %s" % h.hexdigest())
+    print("  size           %d bytes" % os.path.getsize(args.out))
+    if renormed:
+        print("  note           %d of %d rows were rescaled to unit length"
+              % (renormed, len(layers)))
+    if not args.base_revision:
+        print("  warning        no --base-revision. A direction is tied to the "
+              "exact\n                 checkpoint it was derived from; without "
+              "a commit pin a\n                 consumer cannot tell whether "
+              "it holds the right one.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dir-steering/tools/f32_to_glp.py
+++ b/dir-steering/tools/f32_to_glp.py
@@ -17,9 +17,12 @@ wrong:
   hook point  ds4 steers the block writers (ffn_out = moe + shared, or the
               attention output) before the residual fold. llama.cpp's
               build_cvec() and the weightless vLLM overlay steer the post-layer
-              residual. The same direction at the wrong site measured 9x
-              weaker: 34.0% vs 3.8% refusal at identical direction, layers and
-              alpha.
+              residual. A writer holds only what that block computed this
+              layer; the folded residual holds the accumulated sum, so
+              projecting it also removes what upstream layers contributed.
+              Steering a writer prevents refusal being added, steering the
+              residual deletes refusal already there -- different
+              interventions, and the dose does not transfer.
 
   layer map   direction.N applies at layer N. A one-layer shift does not fail,
               it degrades -- adjacent layers' refusal directions have cosine
@@ -289,8 +292,8 @@ def main():
     if not hook:
         die("no hook point: pass --hook (%s), or --meta with a component field. "
             "A vector that does not say where it was calibrated cannot be "
-            "applied safely anywhere else -- the same direction at the wrong "
-            "site measured 9x weaker."
+            "applied safely anywhere else -- the dose does not transfer between "
+            "sites, and applying it at the wrong one degrades silently."
             % ", ".join(sorted(VALID_HOOKS)))
     if hook not in VALID_HOOKS:
         die("--hook %r is not a site ds4 applies at (%s). "

--- a/ds4.c
+++ b/ds4.c
@@ -1869,9 +1869,14 @@ static bool read_f32_binary_file(const char *path, float *data, uint64_t n) {
  * The same argument applies to the hook point. ds4 steers the block writers
  * (ffn_out = moe + shared, and the attention output) before the residual /
  * hyper-connection fold. llama.cpp's build_cvec() and our vLLM overlay steer
- * the post-layer residual. Measured on the same direction, layers and alpha,
- * the writer site left 34.0% refusal against 3.8% post-layer -- 9x weaker,
- * not an error. So a file calibrated for one is refused at the other unless
+ * the post-layer residual. Those are different tensors, not two names for one:
+ * a writer carries only what that block computed this layer, while the folded
+ * residual carries the accumulated sum, so projecting it also removes what
+ * every upstream layer contributed. Steering a writer prevents refusal being
+ * added; steering the residual deletes refusal already there. The one measured
+ * comparison at matched direction and alpha put a per-contributor edit far
+ * behind a projection on the accumulated stream, and neither dose transfers to
+ * the other site. So a file calibrated for one is refused at the other unless
  * the caller says otherwise, in which case the scale has to be re-tuned.
  */
 /* Load-time policy, not per-session state: set once from the engine options
@@ -1949,8 +1954,8 @@ static bool steering_load_directions(
 
     /* glp.hook_point is not in the required set, so a file that predates it is
      * a warning rather than a refusal: we cannot tell a vector derived here
-     * from one derived at the post-layer residual, and the difference measured
-     * 9x. */
+     * from one derived at the post-layer residual, and those are different
+     * interventions with different doses. */
     if (!info.hook_name[0]) {
         fprintf(stderr,
                 "ds4: warning: %s declares no glp.hook_point. Applying at %s; if "

--- a/ds4.c
+++ b/ds4.c
@@ -47,8 +47,10 @@
 #include "ds4_image.h"
 #include "ds4_tp.h"
 
-/* TP context for the verify-block RDMA window (set with the gate callbacks). */
-#if !defined(DS4_NO_GPU) && defined(__APPLE__)
+/* TP context for the verify-block RDMA window (set with the gate callbacks).
+ * Every GPU build compiles the use sites, so the guard is !DS4_NO_GPU,
+ * not Apple-only. */
+#if !defined(DS4_NO_GPU)
 static ds4_tp *g_tp_block_ctx;
 #endif
 

--- a/ds4.c
+++ b/ds4.c
@@ -37,6 +37,7 @@
 #include <sys/sysctl.h>
 #endif
 #include <stdarg.h>
+#include <stdatomic.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -1885,9 +1886,12 @@ static bool read_f32_binary_file(const char *path, float *data, uint64_t n) {
 /* Load-time policy, not per-session state: set once from the engine options
  * and read only by steering_load_directions(). A file-scope flag keeps the
  * four generate_* entry points that carry the steering path around from
- * growing another argument each. */
+ * growing another argument each. The provenance flag is atomic because
+ * ds4-server creates sessions from worker threads, and two sessions loading
+ * the same vector concurrently would otherwise both print -- or race on --
+ * the full provenance dump. */
 static bool g_steering_allow_hook_mismatch;
-static bool g_steering_provenance_logged;
+static atomic_bool g_steering_provenance_logged;
 
 static bool steering_load_directions(
         const char *path,
@@ -1950,8 +1954,8 @@ static bool steering_load_directions(
     /* Full provenance once, a single line after that: ds4-server calls this
      * per session, and thirteen repeated lines of the same metadata buries the
      * warnings below it. */
-    if (!g_steering_provenance_logged) {
-        g_steering_provenance_logged = true;
+    if (!atomic_exchange_explicit(&g_steering_provenance_logged, true,
+                                  memory_order_acq_rel)) {
         ds4_glp_print_info(stderr, path, &info);
         fprintf(stderr, "  %-14s %s\n", "applied at", ds4_glp_hook_name(target));
     } else {
@@ -63095,7 +63099,7 @@ static int ds4_engine_open_internal(ds4_engine **out,
         e->directional_steering_resid_scale = opt->directional_steering_resid;
     }
     g_steering_allow_hook_mismatch = opt->directional_steering_allow_hook_mismatch;
-    g_steering_provenance_logged = false;
+    atomic_store_explicit(&g_steering_provenance_logged, false, memory_order_release);
     if (opt->n_threads > 0) g_requested_threads = (uint32_t)opt->n_threads;
     e->placement_ctx_hint = opt->placement_ctx_hint;
     e->placement_session_count_hint = opt->placement_session_count_hint;

--- a/ds4.c
+++ b/ds4.c
@@ -42,6 +42,7 @@
 
 #include "ds4.h"
 #include "ds4_distributed.h"
+#include "ds4_glp.h"
 #include "ds4_image.h"
 #include "ds4_tp.h"
 
@@ -1836,6 +1837,148 @@ static bool read_f32_binary_file(const char *path, float *data, uint64_t n) {
         fprintf(stderr, "ds4: failed to read %s\n", path);
         return false;
     }
+    return true;
+}
+
+/* =========================================================================
+ * Steering file loading: GLP container or raw f32.
+ * =========================================================================
+ *
+ * --dir-steering-file accepts two things:
+ *
+ *   - a GLP file (GGUF Layer Projection), which is standard GGUF v3 carrying
+ *     "direction.<N>" F32 tensors plus a "glp.*" metadata block that states
+ *     the operation, the hook point, the layer map and the base checkpoint.
+ *     See ds4_glp.h.
+ *
+ *   - the legacy raw blob: exactly n_layers * n_embd floats, no header. Every
+ *     vector built by dir-steering/tools/build_direction.py is one of these,
+ *     so the path stays bit-for-bit unchanged and is chosen by sniffing the
+ *     GGUF magic rather than by a flag.
+ *
+ * The GLP path exists because the operation ds4 performs -- remove the
+ * component of the activation along a direction -- is not the operation
+ * llama.cpp's control vectors perform, which is to add one. The two share the
+ * tensor convention exactly: same names, same dtype, same shapes. So a file
+ * from either world loads into either runtime without an error and produces
+ * wrong output in one of them: applying a projective direction additively
+ * pushes every token along the direction instead of removing it. Nothing
+ * downstream detects that, which is why the operation has to travel with the
+ * data and why an unrecognised one is fatal here.
+ *
+ * The same argument applies to the hook point. ds4 steers the block writers
+ * (ffn_out = moe + shared, and the attention output) before the residual /
+ * hyper-connection fold. llama.cpp's build_cvec() and our vLLM overlay steer
+ * the post-layer residual. Measured on the same direction, layers and alpha,
+ * the writer site left 34.0% refusal against 3.8% post-layer -- 9x weaker,
+ * not an error. So a file calibrated for one is refused at the other unless
+ * the caller says otherwise, in which case the scale has to be re-tuned.
+ */
+/* Load-time policy, not per-session state: set once from the engine options
+ * and read only by steering_load_directions(). A file-scope flag keeps the
+ * four generate_* entry points that carry the steering path around from
+ * growing another argument each. */
+static bool g_steering_allow_hook_mismatch;
+static bool g_steering_provenance_logged;
+
+static bool steering_load_directions(
+        const char *path,
+        float      *dirs,
+        uint32_t    n_layers,
+        float       attn_scale,
+        float       ffn_scale) {
+    const bool allow_hook_mismatch = g_steering_allow_hook_mismatch;
+    const uint64_t n = (uint64_t)n_layers * DS4_N_EMBD;
+
+    if (ds4_glp_is_gguf(path) != 1) {
+        return read_f32_binary_file(path, dirs, n);
+    }
+
+    char err[768];
+    ds4_glp_info probe;
+    if (ds4_glp_read_info(path, &probe, err, sizeof(err)) != 0) {
+        fprintf(stderr, "ds4: %s\n", err);
+        return false;
+    }
+
+    /* FFN first: it is the default when a file is given, and the late-in-block
+     * site that carries behaviour, style and topic signal. The both-enabled
+     * case is rejected just below, so this picks the only live site. */
+    const ds4_glp_hook target =
+        (ffn_scale != 0.0f) ? DS4_GLP_HOOK_FFN_OUT : DS4_GLP_HOOK_ATTN_OUT;
+
+    /* When both hooks are enabled the file is applied at two sites, and it can
+     * have been calibrated for at most one of them. That is the same silent
+     * degradation as a plain hook mismatch, so it needs the same explicit
+     * opt-in. Two projections along the same direction at different tensors
+     * are also not one projection: the strengths do not add. */
+    if (attn_scale != 0.0f && ffn_scale != 0.0f && probe.hook_name[0] &&
+        !allow_hook_mismatch) {
+        fprintf(stderr,
+                "ds4: %s declares glp.hook_point=\"%s\", but both "
+                "--dir-steering-attn and --dir-steering-ffn are non-zero, so it "
+                "would be applied at two sites and was calibrated for at most "
+                "one. Steer one site, or pass "
+                "--dir-steering-allow-hook-mismatch and re-tune both scales.\n",
+                path, probe.hook_name);
+        return false;
+    }
+
+    ds4_glp_info info;
+    if (ds4_glp_load(path, target, allow_hook_mismatch ? 1 : 0,
+                     dirs, n_layers, DS4_N_EMBD, &info, err, sizeof(err)) != 0) {
+        fprintf(stderr, "ds4: %s\n", err);
+        return false;
+    }
+
+    /* Full provenance once, a single line after that: ds4-server calls this
+     * per session, and thirteen repeated lines of the same metadata buries the
+     * warnings below it. */
+    if (!g_steering_provenance_logged) {
+        g_steering_provenance_logged = true;
+        ds4_glp_print_info(stderr, path, &info);
+        fprintf(stderr, "  %-14s %s\n", "applied at", ds4_glp_hook_name(target));
+    } else {
+        fprintf(stderr,
+                "ds4: GLP vector %s: %u directions, layers %u..%u, applied at "
+                "%s\n",
+                path, info.n_dirs, info.layer_min, info.layer_max,
+                ds4_glp_hook_name(target));
+        return true;
+    }
+
+    /* glp.hook_point is not in the required set, so a file that predates it is
+     * a warning rather than a refusal: we cannot tell a vector derived here
+     * from one derived at the post-layer residual, and the difference measured
+     * 9x. */
+    if (!info.hook_name[0]) {
+        fprintf(stderr,
+                "ds4: warning: %s declares no glp.hook_point. Applying at %s; if "
+                "it was derived elsewhere the calibrated scale does not "
+                "transfer.\n",
+                path, ds4_glp_hook_name(target));
+    }
+    if (info.hook != target) {
+        fprintf(stderr,
+                "ds4: warning: applying a vector calibrated at %s to %s "
+                "(--dir-steering-allow-hook-mismatch). The operation is the same; "
+                "the strength is not. Re-tune the scale.\n",
+                info.hook_name, ds4_glp_hook_name(target));
+    }
+    if (info.n_renormalized) {
+        fprintf(stderr,
+                "ds4: warning: %u of %u directions in %s were not unit length and "
+                "were rescaled. The projector is invariant to the norm, but an "
+                "exporter that writes off-unit directions is folding strength "
+                "into the data, which the scale then multiplies again.\n",
+                info.n_renormalized, info.n_dirs, path);
+    }
+
+    /* Nothing here can check that the vector matches the loaded checkpoint.
+     * n_embd and the layer count are all a reader has, and quantisation
+     * preserves both -- which is exactly why one vector pairs with any quant
+     * of the right base model, and why general.base_model.0.version is printed
+     * above rather than compared. */
     return true;
 }
 
@@ -16779,7 +16922,7 @@ static bool metal_graph_load_directional_steering(
     if (n_layers == 0) return false;
     const uint64_t n = (uint64_t)n_layers * DS4_N_EMBD;
     float *dirs = xmalloc((size_t)n * sizeof(dirs[0]));
-    bool ok = read_f32_binary_file(path, dirs, n);
+    bool ok = steering_load_directions(path, dirs, n_layers, attn_scale, ffn_scale);
     if (ok) {
         /* Replicate the directions buffer onto every Class P tier slot that
          * has any other Class P scratch allocated (used_tier marker is the
@@ -38914,7 +39057,11 @@ static bool cpu_load_directional_steering(ds4_engine *e) {
     if (n_layers == 0) return false;
     const uint64_t n = (uint64_t)n_layers * DS4_N_EMBD;
     e->directional_steering_dirs = xmalloc((size_t)n * sizeof(e->directional_steering_dirs[0]));
-    if (!read_f32_binary_file(path, e->directional_steering_dirs, n)) {
+    if (!steering_load_directions(path,
+                                  e->directional_steering_dirs,
+                                  n_layers,
+                                  e->directional_steering_attn_scale,
+                                  e->directional_steering_ffn_scale)) {
         free(e->directional_steering_dirs);
         e->directional_steering_dirs = NULL;
         fprintf(stderr, "ds4: failed to load directional steering vectors from %s\n", path);
@@ -41243,7 +41390,7 @@ static bool glm_graph_load_directional_steering(
     if (n_layers == 0 || n_layers != g->normal_layers) return false;
     const uint64_t n = (uint64_t)n_layers * DS4_N_EMBD;
     float *dirs = xmalloc((size_t)n * sizeof(dirs[0]));
-    bool ok = read_f32_binary_file(path, dirs, n);
+    bool ok = steering_load_directions(path, dirs, n_layers, attn_scale, ffn_scale);
     bool used_tier[DS4_MAX_GPUS] = {false};
     for (uint32_t il = g->layer_start; ok && il <= g->layer_end; il++) {
         const int tier = glm_graph_directional_steering_tier(g, il);
@@ -62801,6 +62948,8 @@ static int ds4_engine_open_internal(ds4_engine **out,
         e->directional_steering_attn_scale = opt->directional_steering_attn;
         e->directional_steering_ffn_scale = opt->directional_steering_ffn;
     }
+    g_steering_allow_hook_mismatch = opt->directional_steering_allow_hook_mismatch;
+    g_steering_provenance_logged = false;
     if (opt->n_threads > 0) g_requested_threads = (uint32_t)opt->n_threads;
     e->placement_ctx_hint = opt->placement_ctx_hint;
     e->placement_session_count_hint = opt->placement_session_count_hint;

--- a/ds4.c
+++ b/ds4.c
@@ -1868,16 +1868,19 @@ static bool read_f32_binary_file(const char *path, float *data, uint64_t n) {
  *
  * The same argument applies to the hook point. ds4 steers the block writers
  * (ffn_out = moe + shared, and the attention output) before the residual /
- * hyper-connection fold. llama.cpp's build_cvec() and our vLLM overlay steer
- * the post-layer residual. Those are different tensors, not two names for one:
- * a writer carries only what that block computed this layer, while the folded
- * residual carries the accumulated sum, so projecting it also removes what
- * every upstream layer contributed. Steering a writer prevents refusal being
- * added; steering the residual deletes refusal already there. The one measured
- * comparison at matched direction and alpha put a per-contributor edit far
- * behind a projection on the accumulated stream, and neither dose transfers to
- * the other site. So a file calibrated for one is refused at the other unless
- * the caller says otherwise, in which case the scale has to be re-tuned.
+ * hyper-connection fold, and the post-layer residual itself: after the fold,
+ * each of the n_hc hyper-connection streams is projected independently, which
+ * is the residual_stream_post_layer site llama.cpp's build_cvec() and our vLLM
+ * overlay use. The writer sites and the residual site are different tensors,
+ * not two names for one: a writer carries only what that block computed this
+ * layer, while the folded residual carries the accumulated sum, so projecting
+ * it also removes what every upstream layer contributed. Steering a writer
+ * prevents refusal being added; steering the residual deletes refusal already
+ * there. The one measured comparison at matched direction and alpha put a
+ * per-contributor edit far behind a projection on the accumulated stream, and
+ * neither dose transfers to the other site. So a file calibrated for one is
+ * refused at the other unless the caller says otherwise, in which case the
+ * scale has to be re-tuned.
  */
 /* Load-time policy, not per-session state: set once from the engine options
  * and read only by steering_load_directions(). A file-scope flag keeps the
@@ -1891,7 +1894,8 @@ static bool steering_load_directions(
         float      *dirs,
         uint32_t    n_layers,
         float       attn_scale,
-        float       ffn_scale) {
+        float       ffn_scale,
+        float       resid_scale) {
     const bool allow_hook_mismatch = g_steering_allow_hook_mismatch;
     const uint64_t n = (uint64_t)n_layers * DS4_N_EMBD;
 
@@ -1906,25 +1910,32 @@ static bool steering_load_directions(
         return false;
     }
 
-    /* FFN first: it is the default when a file is given, and the late-in-block
-     * site that carries behaviour, style and topic signal. The both-enabled
-     * case is rejected just below, so this picks the only live site. */
+    /* Resid first: it is the site every published GLP vector is calibrated
+     * for.  FFN is next: the default when a hookless file is given, and the
+     * late-in-block site that carries behaviour, style and topic signal.  The
+     * more-than-one-site case is rejected just below, so this picks the only
+     * live site. */
     const ds4_glp_hook target =
-        (ffn_scale != 0.0f) ? DS4_GLP_HOOK_FFN_OUT : DS4_GLP_HOOK_ATTN_OUT;
+        (resid_scale != 0.0f) ? DS4_GLP_HOOK_RESID_POST_LAYER :
+        (ffn_scale != 0.0f)   ? DS4_GLP_HOOK_FFN_OUT :
+                                DS4_GLP_HOOK_ATTN_OUT;
 
-    /* When both hooks are enabled the file is applied at two sites, and it can
-     * have been calibrated for at most one of them. That is the same silent
-     * degradation as a plain hook mismatch, so it needs the same explicit
-     * opt-in. Two projections along the same direction at different tensors
-     * are also not one projection: the strengths do not add. */
-    if (attn_scale != 0.0f && ffn_scale != 0.0f && probe.hook_name[0] &&
-        !allow_hook_mismatch) {
+    /* When more than one hook is enabled the file is applied at several
+     * sites, and it can have been calibrated for at most one of them. That is
+     * the same silent degradation as a plain hook mismatch, so it needs the
+     * same explicit opt-in. Two projections along the same direction at
+     * different tensors are also not one projection: the strengths do not
+     * add. */
+    const int n_sites = (attn_scale != 0.0f) + (ffn_scale != 0.0f) +
+                        (resid_scale != 0.0f);
+    if (n_sites > 1 && probe.hook_name[0] && !allow_hook_mismatch) {
         fprintf(stderr,
-                "ds4: %s declares glp.hook_point=\"%s\", but both "
-                "--dir-steering-attn and --dir-steering-ffn are non-zero, so it "
-                "would be applied at two sites and was calibrated for at most "
-                "one. Steer one site, or pass "
-                "--dir-steering-allow-hook-mismatch and re-tune both scales.\n",
+                "ds4: %s declares glp.hook_point=\"%s\", but more than one of "
+                "--dir-steering-attn, --dir-steering-ffn and "
+                "--dir-steering-resid is non-zero, so it would be applied at "
+                "several sites and was calibrated for at most one. Steer one "
+                "site, or pass --dir-steering-allow-hook-mismatch and re-tune "
+                "every scale.\n",
                 path, probe.hook_name);
         return false;
     }
@@ -12530,6 +12541,7 @@ static void layer_ffn_one(
         int                 token,
         const float       * steering_dirs,
         float               steering_scale,
+        float               steering_resid_scale,
         bool                trace) {
     const uint32_t n_hc = DS4_N_HC;
     const bool profile = getenv("DS4_DECODE_PROFILE_DETAIL") != NULL;
@@ -12599,6 +12611,10 @@ static void layer_ffn_one(
     }
 
     hc_post_one(out_hc, ffn_out, inp_hc, post, comb, DS4_N_EMBD, n_hc);
+    /* residual_stream_post_layer: after the fold, out_hc is the accumulated
+     * residual.  Project each hyper-connection stream independently against
+     * the same per-layer direction. */
+    cpu_directional_steering_project_rows(out_hc, steering_dirs, il, n_hc, steering_resid_scale);
     if (profile) t_post = now_sec() - t0;
     if (trace) {
         char name[64];
@@ -12635,6 +12651,7 @@ static void layer_ffn_one_decode_scratch(
         int                      token,
         const float            * steering_dirs,
         float                    steering_scale,
+        float                    steering_resid_scale,
         ds4_cpu_decode_scratch * scratch) {
     const uint32_t n_hc = DS4_N_HC;
     const bool profile = getenv("DS4_DECODE_PROFILE_DETAIL") != NULL;
@@ -12689,6 +12706,7 @@ static void layer_ffn_one_decode_scratch(
     }
     cpu_directional_steering_project_rows(scratch->ffn_out, steering_dirs, il, 1, steering_scale);
     hc_post_one(out_hc, scratch->ffn_out, inp_hc, post, comb, DS4_N_EMBD, n_hc);
+    cpu_directional_steering_project_rows(out_hc, steering_dirs, il, n_hc, steering_resid_scale);
     if (profile) t_post = now_sec() - t0;
 
     if (profile) {
@@ -12713,7 +12731,8 @@ static void layer_ffn_batch(
         uint32_t            n_tok,
         uint32_t            il,
         const float       * steering_dirs,
-        float               steering_scale) {
+        float               steering_scale,
+        float               steering_resid_scale) {
     if (n_tok == 0) return;
     const uint32_t n_hc = DS4_N_HC;
     const uint64_t hc_dim = (uint64_t)n_hc * DS4_N_EMBD;
@@ -12770,6 +12789,10 @@ static void layer_ffn_batch(
                           DS4_N_EMBD,
                           n_hc);
     }
+    /* out_hc is [n_tok][n_hc][n_embd] contiguous, so one flat call projects
+     * every token's every stream. */
+    cpu_directional_steering_project_rows(out_hc, steering_dirs, il,
+                                          n_tok * n_hc, steering_resid_scale);
 
     free(comb);
     free(post);
@@ -12877,7 +12900,8 @@ static void layer_ffn_shared_batch(
         uint32_t            n_tok,
         uint32_t            il,
         const float       * steering_dirs,
-        float               steering_scale) {
+        float               steering_scale,
+        float               steering_resid_scale) {
     const bool profile = getenv("DS4_PREFILL_PROFILE_DETAIL") != NULL;
     const double t_start = profile ? now_sec() : 0.0;
     double t_hc_norm = 0.0;
@@ -12989,6 +13013,8 @@ static void layer_ffn_shared_batch(
                           DS4_N_EMBD,
                           n_hc);
     }
+    cpu_directional_steering_project_rows(out_hc, steering_dirs, il,
+                                          n_tok * n_hc, steering_resid_scale);
     if (profile) t_post = now_sec() - t0;
 
     if (profile) {
@@ -13020,6 +13046,7 @@ typedef struct {
     const int *token_ids;
     const float *steering_dirs;
     float steering_scale;
+    float steering_resid_scale;
     uint64_t hc_dim;
     uint32_t il;
 } layer_ffn_tokens_ctx;
@@ -13035,6 +13062,7 @@ static void layer_ffn_tokens_worker(void *vctx, uint64_t t0, uint64_t t1) {
                       ctx->token_ids[t],
                       ctx->steering_dirs,
                       ctx->steering_scale,
+                      ctx->steering_resid_scale,
                       false);
     }
 }
@@ -13048,7 +13076,8 @@ static void layer_ffn_tokens_parallel(
         uint32_t            n_tok,
         uint32_t            il,
         const float       * steering_dirs,
-        float               steering_scale) {
+        float               steering_scale,
+        float               steering_resid_scale) {
     layer_ffn_tokens_ctx ctx = {
         .out_hc = out_hc,
         .model = model,
@@ -13057,6 +13086,7 @@ static void layer_ffn_tokens_parallel(
         .token_ids = token_ids,
         .steering_dirs = steering_dirs,
         .steering_scale = steering_scale,
+        .steering_resid_scale = steering_resid_scale,
         .hc_dim = (uint64_t)DS4_N_HC * DS4_N_EMBD,
         .il = il,
     };
@@ -14491,6 +14521,7 @@ static void layer_forward_raw_swa_one(
         const float             * steering_dirs,
         float                     steering_attn_scale,
         float                     steering_ffn_scale,
+        float                     steering_resid_scale,
         ds4_cpu_decode_scratch  * scratch) {
     const uint32_t n_hc = DS4_N_HC;
     const bool profile = getenv("DS4_DECODE_PROFILE_DETAIL") != NULL;
@@ -14623,7 +14654,8 @@ static void layer_forward_raw_swa_one(
 
     t0 = profile ? now_sec() : 0.0;
     layer_ffn_one_decode_scratch(out_hc, model, layer, scratch->after_attn_hc, il, token,
-                                 steering_dirs, steering_ffn_scale, scratch);
+                                 steering_dirs, steering_ffn_scale, steering_resid_scale,
+                                 scratch);
     if (profile) t_ffn = now_sec() - t0;
 
     if (profile) {
@@ -14665,6 +14697,7 @@ static void forward_token_raw_swa_cpu_decode_scratch(
         const float       * steering_dirs,
         float               steering_attn_scale,
         float               steering_ffn_scale,
+        float               steering_resid_scale,
         ds4_cpu_decode_scratch * scratch) {
     float *cur = scratch->cur;
     float *next = scratch->next;
@@ -14678,6 +14711,7 @@ static void forward_token_raw_swa_cpu_decode_scratch(
                                   steering_dirs,
                                   steering_attn_scale,
                                   steering_ffn_scale,
+                                  steering_resid_scale,
                                   scratch);
         float *tmp = cur;
         cur = next;
@@ -14708,7 +14742,7 @@ static void forward_token_raw_swa_cpu(
     }
     cpu_decode_scratch_init(&scratch, ctx_guess);
     forward_token_raw_swa_cpu_decode_scratch(logits, model, weights, cache, token, pos,
-                                             NULL, 0.0f, 0.0f, &scratch);
+                                             NULL, 0.0f, 0.0f, 0.0f, &scratch);
     cpu_decode_scratch_free(&scratch);
 }
 #endif
@@ -14723,7 +14757,8 @@ static void prefill_layer_major_cpu(
         const token_vec   * prompt,
         const float       * steering_dirs,
         float               steering_attn_scale,
-        float               steering_ffn_scale) {
+        float               steering_ffn_scale,
+        float               steering_resid_scale) {
     const uint64_t hc_dim = (uint64_t)DS4_N_HC * DS4_N_EMBD;
     const uint64_t n_tok = (uint64_t)prompt->len;
     float *cur = xmalloc((size_t)n_tok * hc_dim * sizeof(cur[0]));
@@ -14777,7 +14812,8 @@ static void prefill_layer_major_cpu(
                                     nb,
                                     il,
                                     steering_dirs,
-                                    steering_ffn_scale);
+                                    steering_ffn_scale,
+                                    steering_resid_scale);
                 }
             } else if (shared_batch_ffn) {
                 layer_ffn_shared_batch(next,
@@ -14788,7 +14824,8 @@ static void prefill_layer_major_cpu(
                                        (uint32_t)n_tok,
                                        il,
                                        steering_dirs,
-                                       steering_ffn_scale);
+                                       steering_ffn_scale,
+                                       steering_resid_scale);
             } else if (parallel_ffn) {
                 layer_ffn_tokens_parallel(next,
                                           model,
@@ -14798,7 +14835,8 @@ static void prefill_layer_major_cpu(
                                           (uint32_t)n_tok,
                                           il,
                                           steering_dirs,
-                                          steering_ffn_scale);
+                                          steering_ffn_scale,
+                                          steering_resid_scale);
             } else {
                 for (uint64_t t = 0; t < n_tok; t++) {
                     layer_ffn_one(next + t * hc_dim,
@@ -14809,6 +14847,7 @@ static void prefill_layer_major_cpu(
                                   prompt->v[t],
                                   steering_dirs,
                                   steering_ffn_scale,
+                                  steering_resid_scale,
                                   false);
                 }
             }
@@ -14835,7 +14874,8 @@ static void prefill_layer_major_cpu(
                                 nb,
                                 il,
                                 steering_dirs,
-                                steering_ffn_scale);
+                                steering_ffn_scale,
+                                steering_resid_scale);
             }
         } else {
             if (!decode_scratch_ready) {
@@ -14854,6 +14894,7 @@ static void prefill_layer_major_cpu(
                                           steering_dirs,
                                           steering_attn_scale,
                                           steering_ffn_scale,
+                                          steering_resid_scale,
                                           &decode_scratch);
             }
         }
@@ -14920,7 +14961,7 @@ static void layer_forward_self_one(
     hc_post_one(after_attn_hc, attn_out, attn_residual, post, comb, DS4_N_EMBD, n_hc);
 
     layer_ffn_one(out_hc, model, layer, after_attn_hc, il, token,
-                  NULL, 0.0f, false);
+                  NULL, 0.0f, 0.0f, false);
 
     free(after_attn_hc);
     free(attn_out);
@@ -16190,6 +16231,7 @@ typedef struct {
     ds4_gpu_tensor *directional_steering_dirs_by_tier[DS4_MAX_GPUS];
     float directional_steering_attn_scale;
     float directional_steering_ffn_scale;
+    float directional_steering_resid_scale;
     bool cuda_tp_decode;
     bool cuda_tp_attn;
     bool cuda_tp_attn_peer_read;
@@ -16915,8 +16957,9 @@ static bool metal_graph_load_directional_steering(
         ds4_gpu_graph *g,
         const char      *path,
         float            attn_scale,
-        float            ffn_scale) {
-    if (attn_scale == 0.0f && ffn_scale == 0.0f) return true;
+        float            ffn_scale,
+        float            resid_scale) {
+    if (attn_scale == 0.0f && ffn_scale == 0.0f && resid_scale == 0.0f) return true;
 
     if (!path || !path[0]) {
         fprintf(stderr, "ds4: directional steering needs --dir-steering-file\n");
@@ -16927,7 +16970,7 @@ static bool metal_graph_load_directional_steering(
     if (n_layers == 0) return false;
     const uint64_t n = (uint64_t)n_layers * DS4_N_EMBD;
     float *dirs = xmalloc((size_t)n * sizeof(dirs[0]));
-    bool ok = steering_load_directions(path, dirs, n_layers, attn_scale, ffn_scale);
+    bool ok = steering_load_directions(path, dirs, n_layers, attn_scale, ffn_scale, resid_scale);
     if (ok) {
         /* Replicate the directions buffer onto every Class P tier slot that
          * has any other Class P scratch allocated (used_tier marker is the
@@ -16956,8 +16999,9 @@ static bool metal_graph_load_directional_steering(
     }
     g->directional_steering_attn_scale = attn_scale;
     g->directional_steering_ffn_scale = ffn_scale;
-    fprintf(stderr, "ds4: directional steering enabled: %s attn=%g ffn=%g\n",
-            path, (double)attn_scale, (double)ffn_scale);
+    g->directional_steering_resid_scale = resid_scale;
+    fprintf(stderr, "ds4: directional steering enabled: %s attn=%g ffn=%g resid=%g\n",
+            path, (double)attn_scale, (double)ffn_scale, (double)resid_scale);
     return true;
 }
 
@@ -16969,6 +17013,11 @@ static bool metal_graph_directional_steering_attn_enabled(const ds4_gpu_graph *g
 static bool metal_graph_directional_steering_ffn_enabled(const ds4_gpu_graph *g) {
     return g && metal_graph_directional_steering_dirs(g) &&
            g->directional_steering_ffn_scale != 0.0f;
+}
+
+static bool metal_graph_directional_steering_resid_enabled(const ds4_gpu_graph *g) {
+    return g && metal_graph_directional_steering_dirs(g) &&
+           g->directional_steering_resid_scale != 0.0f;
 }
 
 static bool metal_graph_apply_directional_steering(
@@ -17000,6 +17049,17 @@ static bool metal_graph_apply_directional_steering_ffn(
         uint32_t          il,
         uint32_t          rows) {
     return metal_graph_apply_directional_steering(g, x, il, rows, g ? g->directional_steering_ffn_scale : 0.0f);
+}
+
+/* residual_stream_post_layer: x is the post-fold HC stack, [n_hc][n_embd] per
+ * token and contiguous, so rows = n_tok * n_hc projects each stream of each
+ * token independently against dirs[il]. */
+static bool metal_graph_apply_directional_steering_resid(
+        ds4_gpu_graph  *g,
+        ds4_gpu_tensor *x,
+        uint32_t          il,
+        uint32_t          rows) {
+    return metal_graph_apply_directional_steering(g, x, il, rows, g ? g->directional_steering_resid_scale : 0.0f);
 }
 
 static bool metal_graph_configure_dspark_capture(
@@ -25667,6 +25727,11 @@ static bool metal_graph_encode_decode_layer_phase(
                                                       DS4_N_EMBD,
                                                       DS4_N_HC) != 0;
         }
+        /* residual_stream_post_layer: after_ffn_hc is the folded residual
+         * stack regardless of which fold variant ran above. */
+        if (ok && metal_graph_directional_steering_resid_enabled(g)) {
+            ok = metal_graph_apply_directional_steering_resid(g, metal_graph_after_ffn_hc(g), il, DS4_N_HC);
+        }
         DS4_METAL_PROFILE_DECODE_STAGE("ffn_hc_post");
         if (ok) {
             metal_graph_debug_dump_tensor("hc_ffn_post", metal_graph_after_ffn_hc(g), hc_dim, il, pos);
@@ -25864,6 +25929,11 @@ static bool metal_graph_encode_decode_layer_phase(
                                                       metal_graph_hc_split(g),
                                                       DS4_N_EMBD,
                                                       DS4_N_HC) != 0;
+        }
+        /* residual_stream_post_layer: after_ffn_hc is the folded residual
+         * stack regardless of which fold variant ran above. */
+        if (ok && metal_graph_directional_steering_resid_enabled(g)) {
+            ok = metal_graph_apply_directional_steering_resid(g, metal_graph_after_ffn_hc(g), il, DS4_N_HC);
         }
         DS4_METAL_PROFILE_DECODE_STAGE("ffn_hc_post");
         if (ok) {
@@ -26354,7 +26424,11 @@ static bool metal_graph_encode_decode_layer_phase(
                                         DS4_N_EMBD,
                                         DS4_N_HC) != 0;
     } else if (ok && !cuda_tp_shared_fold && !fuse_shared_down_hc &&
+               !metal_graph_directional_steering_resid_enabled(g) &&
                metal_graph_hc_expand_fusion_eligible(g, decode_stage_profile)) {
+        /* The deferred expand writes after_ffn_hc only when flushed, after
+         * this function returns — too late for the residual projection
+         * below, so resid steering takes the eager fold. */
         metal_graph_defer_hc_expand(g, metal_graph_after_ffn_hc(g),
                                     tp_ffn_a ? tp_ffn_a : metal_graph_routed_out(g),
                                     tp_ffn_a ? tp_ffn_b : g->tp_zero,
@@ -26369,6 +26443,11 @@ static bool metal_graph_encode_decode_layer_phase(
                                                   metal_graph_hc_split(g),
                                                   DS4_N_EMBD,
                                                   DS4_N_HC) != 0;
+    }
+    /* residual_stream_post_layer: after_ffn_hc is the folded residual stack
+     * regardless of which fold variant ran above. */
+    if (ok && metal_graph_directional_steering_resid_enabled(g)) {
+        ok = metal_graph_apply_directional_steering_resid(g, metal_graph_after_ffn_hc(g), il, DS4_N_HC);
     }
     DS4_METAL_PROFILE_DECODE_STAGE("ffn_hc_post");
 #undef DS4_METAL_PROFILE_DECODE_STAGE
@@ -32017,6 +32096,12 @@ static bool metal_graph_encode_layer_ffn_batch(
                                                   hc_split_view,
                                                   DS4_N_EMBD,
                                                   DS4_N_HC) != 0;
+    }
+    /* residual_stream_post_layer: next_hc_view holds every folded token row,
+     * [n_tokens][n_hc][n_embd] contiguous. */
+    if (ok && metal_graph_directional_steering_resid_enabled(g)) {
+        ok = metal_graph_apply_directional_steering_resid(g, next_hc_view, il,
+                                                          n_tokens * DS4_N_HC);
     }
     DS4_METAL_PROFILE_FFN_STAGE("hc_post");
     if (ok) {
@@ -38827,6 +38912,7 @@ struct ds4_engine {
     float *directional_steering_dirs;
     float directional_steering_attn_scale;
     float directional_steering_ffn_scale;
+    float directional_steering_resid_scale;
     int power_percent;
     uint32_t prefill_chunk;
     uint32_t ssd_streaming_cache_experts;
@@ -39045,10 +39131,21 @@ static void cpu_directional_steering_project_rows(
     }
 }
 
+#ifdef DS4_TEST_HOOKS
+void ds4_test_directional_steering_project_rows(float       *x,
+                                                const float *dirs,
+                                                uint32_t     il,
+                                                uint32_t     rows,
+                                                float        scale) {
+    cpu_directional_steering_project_rows(x, dirs, il, rows, scale);
+}
+#endif
+
 static bool cpu_load_directional_steering(ds4_engine *e) {
     if (!e ||
         (e->directional_steering_attn_scale == 0.0f &&
-         e->directional_steering_ffn_scale == 0.0f)) {
+         e->directional_steering_ffn_scale == 0.0f &&
+         e->directional_steering_resid_scale == 0.0f)) {
         return true;
     }
 
@@ -39066,16 +39163,18 @@ static bool cpu_load_directional_steering(ds4_engine *e) {
                                   e->directional_steering_dirs,
                                   n_layers,
                                   e->directional_steering_attn_scale,
-                                  e->directional_steering_ffn_scale)) {
+                                  e->directional_steering_ffn_scale,
+                                  e->directional_steering_resid_scale)) {
         free(e->directional_steering_dirs);
         e->directional_steering_dirs = NULL;
         fprintf(stderr, "ds4: failed to load directional steering vectors from %s\n", path);
         return false;
     }
-    fprintf(stderr, "ds4: CPU directional steering enabled: %s attn=%g ffn=%g\n",
+    fprintf(stderr, "ds4: CPU directional steering enabled: %s attn=%g ffn=%g resid=%g\n",
             path,
             (double)e->directional_steering_attn_scale,
-            (double)e->directional_steering_ffn_scale);
+            (double)e->directional_steering_ffn_scale,
+            (double)e->directional_steering_resid_scale);
     return true;
 }
 
@@ -40999,6 +41098,7 @@ static int generate_raw_swa_cpu(
         const float       * directional_steering_dirs,
         float               directional_steering_attn,
         float               directional_steering_ffn,
+        float               directional_steering_resid,
         ds4_token_emit_fn   emit,
         ds4_generation_done_fn done,
         void              * emit_ud,
@@ -41029,7 +41129,8 @@ static int generate_raw_swa_cpu(
     prefill_layer_major_cpu(logits, model, weights, &cache, prompt,
                             directional_steering_dirs,
                             directional_steering_attn,
-                            directional_steering_ffn);
+                            directional_steering_ffn,
+                            directional_steering_resid);
 
     const double t_prefill1 = now_sec();
     fprintf(stderr, "ds4: prefill %d/%d done\n", prompt->len, prompt->len);
@@ -41077,6 +41178,7 @@ static int generate_raw_swa_cpu(
                                                  directional_steering_dirs,
                                                  directional_steering_attn,
                                                  directional_steering_ffn,
+                                                 directional_steering_resid,
                                                  &decode_scratch);
         ds4_alloc_guard_end();
         if (token_timing) {
@@ -41341,6 +41443,7 @@ typedef struct ds4_glm_gpu_graph {
     ds4_gpu_tensor *directional_steering_dirs_by_tier[DS4_MAX_GPUS];
     float directional_steering_attn_scale;
     float directional_steering_ffn_scale;
+    float directional_steering_resid_scale;
     bool streaming_static_decode_map_current;
     /* Tensor parallelism (50/50 expert sharding): tp_world 2 means
      * this rank computes only its contiguous half of the routed experts
@@ -41380,8 +41483,9 @@ static bool glm_graph_load_directional_steering(
         ds4_glm_gpu_graph *g,
         const char        *path,
         float              attn_scale,
-        float              ffn_scale) {
-    if (!g || (attn_scale == 0.0f && ffn_scale == 0.0f)) return g != NULL;
+        float              ffn_scale,
+        float              resid_scale) {
+    if (!g || (attn_scale == 0.0f && ffn_scale == 0.0f && resid_scale == 0.0f)) return g != NULL;
     if (!g->glm53) {
         fprintf(stderr, "ds4: directional steering is supported only for GLM 5.3\n");
         return false;
@@ -41395,7 +41499,7 @@ static bool glm_graph_load_directional_steering(
     if (n_layers == 0 || n_layers != g->normal_layers) return false;
     const uint64_t n = (uint64_t)n_layers * DS4_N_EMBD;
     float *dirs = xmalloc((size_t)n * sizeof(dirs[0]));
-    bool ok = steering_load_directions(path, dirs, n_layers, attn_scale, ffn_scale);
+    bool ok = steering_load_directions(path, dirs, n_layers, attn_scale, ffn_scale, resid_scale);
     bool used_tier[DS4_MAX_GPUS] = {false};
     for (uint32_t il = g->layer_start; ok && il <= g->layer_end; il++) {
         const int tier = glm_graph_directional_steering_tier(g, il);
@@ -41424,11 +41528,13 @@ static bool glm_graph_load_directional_steering(
     }
     g->directional_steering_attn_scale = attn_scale;
     g->directional_steering_ffn_scale = ffn_scale;
+    g->directional_steering_resid_scale = resid_scale;
     fprintf(stderr,
-            "ds4: GLM directional steering enabled: %s attn=%g ffn=%g\n",
+            "ds4: GLM directional steering enabled: %s attn=%g ffn=%g resid=%g\n",
             path,
             (double)attn_scale,
-            (double)ffn_scale);
+            (double)ffn_scale,
+            (double)resid_scale);
     return true;
 }
 
@@ -41468,6 +41574,19 @@ static bool glm_graph_apply_directional_steering_ffn(
     return glm_graph_apply_directional_steering(
             g, x, il, rows,
             g ? g->directional_steering_ffn_scale : 0.0f);
+}
+
+/* residual_stream_post_layer: x is the post-fold HC stack, [n_hc][n_embd] per
+ * token and contiguous, so rows = n_tok * n_hc projects each stream of each
+ * token independently against dirs[il]. */
+static bool glm_graph_apply_directional_steering_resid(
+        ds4_glm_gpu_graph *g,
+        ds4_gpu_tensor    *x,
+        uint32_t           il,
+        uint32_t           rows) {
+    return glm_graph_apply_directional_steering(
+            g, x, il, rows,
+            g ? g->directional_steering_resid_scale : 0.0f);
 }
 
 static bool imatrix_collect_glm_one(
@@ -45653,6 +45772,9 @@ static bool glm53_graph_encode_ffn_tail_one(
                                       DS4_N_EMBD,
                                       DS4_N_HC) != 0;
     }
+    if (ok) {
+        ok = glm_graph_apply_directional_steering_resid(g, g->hc_next, il, DS4_N_HC);
+    }
     return ok;
 }
 
@@ -49215,6 +49337,11 @@ glm53_batch_attention_done:
                                                 DS4_N_EMBD,
                                                 DS4_N_HC) != 0;
             if (ok) {
+                failed_stage = "residual steering";
+                ok = glm_graph_apply_directional_steering_resid(
+                        g, hc_next, il, n_tokens * DS4_N_HC);
+            }
+            if (ok) {
                 metal_graph_debug_dump_tensor(
                         "glm53_hc_after_ffn", hc_next,
                         (uint64_t)n_tokens * DS4_N_HC * DS4_N_EMBD,
@@ -50941,6 +51068,10 @@ glm53_indexed_attention_done:
                                                 DS4_N_EMBD,
                                                 DS4_N_HC) != 0;
             if (ok) {
+                ok = glm_graph_apply_directional_steering_resid(
+                        g, hc_next, il, n_tokens * DS4_N_HC);
+            }
+            if (ok) {
                 ds4_gpu_tensor *tmp = hc_cur;
                 hc_cur = hc_next;
                 hc_next = tmp;
@@ -52498,6 +52629,7 @@ glm53_attention_done:
             graph_ok = !g->placement && g->tp_world <= 1 &&
                        !g->ssd_streaming && !g->imatrix &&
                        g->directional_steering_ffn_scale == 0.0f &&
+                       g->directional_steering_resid_scale == 0.0f &&
                        !decode_stage_profile && !g_expert_profile.active &&
                        metal_graph_debug_get_config()->prefix == NULL &&
                        !glm_debug_hidden_dump_layer_match(il) &&
@@ -53241,6 +53373,7 @@ static int generate_glm_metal_argmax(
         const char          *directional_steering_file,
         float                directional_steering_attn,
         float                directional_steering_ffn,
+        float                directional_steering_resid,
         ds4_token_emit_fn   emit,
         ds4_generation_done_fn done,
         void              * emit_ud,
@@ -53271,7 +53404,8 @@ static int generate_glm_metal_argmax(
     if (!glm_graph_load_directional_steering(&g,
                                              directional_steering_file,
                                              directional_steering_attn,
-                                             directional_steering_ffn)) {
+                                             directional_steering_ffn,
+                                             directional_steering_resid)) {
         glm_graph_free(&g);
         return 1;
     }
@@ -53443,6 +53577,7 @@ static int generate_metal_graph_raw_swa(
         const char        * directional_steering_file,
         float               directional_steering_attn,
         float               directional_steering_ffn,
+        float               directional_steering_resid,
         ds4_token_emit_fn   emit,
         ds4_generation_done_fn done,
         void              * emit_ud,
@@ -53480,6 +53615,7 @@ static int generate_metal_graph_raw_swa(
                                          directional_steering_file,
                                          directional_steering_attn,
                                          directional_steering_ffn,
+                                         directional_steering_resid,
                                          emit,
                                          done,
                                          emit_ud,
@@ -53513,7 +53649,8 @@ static int generate_metal_graph_raw_swa(
     if (!metal_graph_load_directional_steering(&g,
                                                directional_steering_file,
                                                directional_steering_attn,
-                                               directional_steering_ffn)) {
+                                               directional_steering_ffn,
+                                               directional_steering_resid)) {
         metal_graph_free(&g);
         return 1;
     }
@@ -58627,6 +58764,7 @@ int ds4_engine_generate_argmax(
                                             e->directional_steering_file,
                                             e->directional_steering_attn_scale,
                                             e->directional_steering_ffn_scale,
+                                            e->directional_steering_resid_scale,
                                             emit, done, emit_ud,
                                             progress, progress_ud);
 #else
@@ -58641,6 +58779,7 @@ int ds4_engine_generate_argmax(
                                 e->directional_steering_dirs,
                                 e->directional_steering_attn_scale,
                                 e->directional_steering_ffn_scale,
+                                e->directional_steering_resid_scale,
                                 emit, done, emit_ud, progress, progress_ud);
 }
 
@@ -60438,7 +60577,7 @@ int ds4_engine_head_test(ds4_engine *e, const ds4_tokens *prompt) {
 
     float *after_ffn_hc = xmalloc((size_t)n_hc * DS4_N_EMBD * sizeof(after_ffn_hc[0]));
     layer_ffn_one(after_ffn_hc, model, layer0, after_attn_hc, 0, prompt->v[prompt->len - 1],
-                  NULL, 0.0f, true);
+                  NULL, 0.0f, 0.0f, true);
     print_vec_stats("blk.0 after_ffn_hc", after_ffn_hc, (uint64_t)n_hc * DS4_N_EMBD);
 
     float *logits = xmalloc((size_t)DS4_N_VOCAB * sizeof(logits[0]));
@@ -62940,7 +63079,8 @@ static int ds4_engine_open_internal(ds4_engine **out,
         *out = NULL;
         return 1;
     }
-    if ((opt->directional_steering_attn != 0.0f || opt->directional_steering_ffn != 0.0f) &&
+    if ((opt->directional_steering_attn != 0.0f || opt->directional_steering_ffn != 0.0f ||
+         opt->directional_steering_resid != 0.0f) &&
         (!opt->directional_steering_file || !opt->directional_steering_file[0]))
     {
         fprintf(stderr, "ds4: directional steering needs --dir-steering-file\n");
@@ -62952,6 +63092,7 @@ static int ds4_engine_open_internal(ds4_engine **out,
         e->directional_steering_file = ds4_strdup(opt->directional_steering_file);
         e->directional_steering_attn_scale = opt->directional_steering_attn;
         e->directional_steering_ffn_scale = opt->directional_steering_ffn;
+        e->directional_steering_resid_scale = opt->directional_steering_resid;
     }
     g_steering_allow_hook_mismatch = opt->directional_steering_allow_hook_mismatch;
     g_steering_provenance_logged = false;
@@ -63131,7 +63272,8 @@ static int ds4_engine_open_internal(ds4_engine **out,
         if (!ds4_model_is_glm53() &&
             ((opt->directional_steering_file && opt->directional_steering_file[0]) ||
              opt->directional_steering_attn != 0.0f ||
-             opt->directional_steering_ffn != 0.0f)) {
+             opt->directional_steering_ffn != 0.0f ||
+             opt->directional_steering_resid != 0.0f)) {
             fprintf(stderr, "ds4: directional steering is not supported for GLM 5.2 yet\n");
             ds4_engine_close(e);
             *out = NULL;
@@ -64884,7 +65026,8 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
                     &s->glm_graph,
                     e->directional_steering_file,
                     e->directional_steering_attn_scale,
-                    e->directional_steering_ffn_scale)) {
+                    e->directional_steering_ffn_scale,
+                    e->directional_steering_resid_scale)) {
             glm_graph_free(&s->glm_graph);
             free(s);
             return 1;
@@ -65027,7 +65170,8 @@ int ds4_session_create(ds4_session **out, ds4_engine *e, int ctx_size) {
     if (!metal_graph_load_directional_steering(&s->graph,
                                                e->directional_steering_file,
                                                e->directional_steering_attn_scale,
-                                               e->directional_steering_ffn_scale)) {
+                                               e->directional_steering_ffn_scale,
+                                               e->directional_steering_resid_scale)) {
         metal_graph_free(&s->graph);
         free(s);
         return 1;
@@ -66654,6 +66798,7 @@ static int ds4_session_sync_internal(ds4_session *s, const ds4_tokens *prompt, c
                                                          e->directional_steering_dirs,
                                                          e->directional_steering_attn_scale,
                                                          e->directional_steering_ffn_scale,
+                                                         e->directional_steering_resid_scale,
                                                          &s->cpu_scratch);
                 token_vec_push(&s->checkpoint, prompt->v[i]);
                 if (s->progress) s->progress(s->progress_ud, "prefill_chunk", i + 1, prompt->len);
@@ -66672,7 +66817,8 @@ static int ds4_session_sync_internal(ds4_session *s, const ds4_tokens *prompt, c
                                 prompt,
                                 e->directional_steering_dirs,
                                 e->directional_steering_attn_scale,
-                                e->directional_steering_ffn_scale);
+                                e->directional_steering_ffn_scale,
+                                e->directional_steering_resid_scale);
         ds4_tokens_copy(&s->checkpoint, prompt);
         s->checkpoint_valid = true;
         s->mtp_draft_valid = false;
@@ -68484,6 +68630,7 @@ static int ds4_session_eval_internal(ds4_session *s, int token, bool probe_mtp,
                                                  e->directional_steering_dirs,
                                                  e->directional_steering_attn_scale,
                                                  e->directional_steering_ffn_scale,
+                                                 e->directional_steering_resid_scale,
                                                  &s->cpu_scratch);
         token_vec_push(&s->checkpoint, token);
         s->checkpoint_valid = true;
@@ -69239,6 +69386,9 @@ static bool glm53_graph_encode_native_session_batch(
                                                      g->batch_hc_split,
                                                      DS4_N_EMBD,
                                                      DS4_N_HC) != 0;
+        stage = "residual steering";
+        if (ok) ok = glm_graph_apply_directional_steering_resid(
+                g, hc_next, il, rows * DS4_N_HC);
         if (ok) {
             ds4_gpu_tensor *tmp = hc_cur;
             hc_cur = hc_next;
@@ -69383,7 +69533,8 @@ static bool metal_graph_native_session_batch_shared_supported(
             !s->graph.shared_gate_up_swiglu_fuse ||
             s->graph.materialize_ffn_out ||
             metal_graph_directional_steering_attn_enabled(&s->graph) ||
-            metal_graph_directional_steering_ffn_enabled(&s->graph)) {
+            metal_graph_directional_steering_ffn_enabled(&s->graph) ||
+            metal_graph_directional_steering_resid_enabled(&s->graph)) {
             return false;
         }
     }
@@ -71397,7 +71548,8 @@ static bool metal_graph_session_batch_shared_supported(
                 !g->shared_gate_up_swiglu_fuse ||
                 g->placement[il + 1u] != home ||
                 metal_graph_needs_ffn_out(g, il, pos) ||
-                metal_graph_directional_steering_ffn_enabled(g)) {
+                metal_graph_directional_steering_ffn_enabled(g) ||
+                metal_graph_directional_steering_resid_enabled(g)) {
                 return false;
             }
         }
@@ -73577,6 +73729,7 @@ static bool metal_graph_mixed_prefill_decode_supported(
         prefill_rows > g->raw_cap ||
         (start % g->prefill_cap) + prefill_rows > g->prefill_cap ||
         metal_graph_directional_steering_ffn_enabled(g) ||
+        metal_graph_directional_steering_resid_enabled(g) ||
         getenv("DS4_METAL_GRAPH_DUMP_PREFIX") != NULL ||
         getenv("DS4_METAL_LAYER_STAGE_PROFILE") != NULL) {
         return false;

--- a/ds4.c
+++ b/ds4.c
@@ -1874,14 +1874,15 @@ static bool read_f32_binary_file(const char *path, float *data, uint64_t n) {
  * is the residual_stream_post_layer site llama.cpp's build_cvec() and our vLLM
  * overlay use. The writer sites and the residual site are different tensors,
  * not two names for one: a writer carries only what that block computed this
- * layer, while the folded residual carries the accumulated sum, so projecting
- * it also removes what every upstream layer contributed. Steering a writer
- * prevents refusal being added; steering the residual deletes refusal already
- * there. The one measured comparison at matched direction and alpha put a
- * per-contributor edit far behind a projection on the accumulated stream, and
- * neither dose transfers to the other site. So a file calibrated for one is
- * refused at the other unless the caller says otherwise, in which case the
- * scale has to be re-tuned.
+ * layer, while the folded residual carries the accumulated sum. Which site
+ * carries the usable window is architecture- and dose-dependent, not a
+ * ranking -- measured on DeepSeek-V4-Flash-0731 (2026-09-04, refusal32,
+ * greedy), the FFN writer at alpha 4-6 outperformed the residual site with a
+ * residual-derived direction transferred to it. What holds everywhere is the
+ * mismatch argument: a dose is calibrated at one site and does not transfer
+ * silently to another. So a file calibrated for one is refused at the other
+ * unless the caller says otherwise, in which case the scale has to be
+ * re-tuned.
  */
 /* Load-time policy, not per-session state: set once from the engine options
  * and read only by steering_load_directions(). A file-scope flag keeps the

--- a/ds4.h
+++ b/ds4.h
@@ -139,6 +139,10 @@ typedef struct {
     const char *expert_profile_path;
     float directional_steering_attn;
     float directional_steering_ffn;
+    /* Post-layer residual hook: project each of the n_hc hyper-connection
+     * streams independently after the FFN fold.  This is the
+     * residual_stream_post_layer site GLP vectors declare. */
+    float directional_steering_resid;
     /* Apply a GLP vector at a hook it does not declare. Off by default:
      * steering one of a layer's contributors is a different intervention from
      * steering the accumulated residual, and it degrades rather than errors.
@@ -483,6 +487,14 @@ int ds4_test_speculative_delta_sample(const float *target_logits,
 int ds4_test_argmax_excluding_logits(const float *logits, uint32_t n_vocab,
                                      int excluded_id);
 uint64_t ds4_test_mixed_native_count(void);
+/* The CPU projection the steering hooks share, exposed so a model-free test
+ * can check it numerically: x holds rows independent n_embd rows; each is
+ * projected as x -= scale * dir * dot(dir, x) with dir = dirs[il]. */
+void ds4_test_directional_steering_project_rows(float       *x,
+                                                const float *dirs,
+                                                uint32_t     il,
+                                                uint32_t     rows,
+                                                float        scale);
 #endif
 int ds4_session_top_logprobs(ds4_session *s, ds4_token_score *out, int k);
 int ds4_session_token_logprob(ds4_session *s, int token, ds4_token_score *out);

--- a/ds4.h
+++ b/ds4.h
@@ -139,6 +139,10 @@ typedef struct {
     const char *expert_profile_path;
     float directional_steering_attn;
     float directional_steering_ffn;
+    /* Apply a GLP vector at a hook it does not declare. Off by default: the
+     * same direction at the wrong site measured 9x weaker, and it degrades
+     * rather than errors. See ds4_glp.h. */
+    bool directional_steering_allow_hook_mismatch;
     int power_percent;
     uint32_t ssd_streaming_cache_experts;
     uint64_t ssd_streaming_cache_bytes;

--- a/ds4.h
+++ b/ds4.h
@@ -139,9 +139,10 @@ typedef struct {
     const char *expert_profile_path;
     float directional_steering_attn;
     float directional_steering_ffn;
-    /* Apply a GLP vector at a hook it does not declare. Off by default: the
-     * same direction at the wrong site measured 9x weaker, and it degrades
-     * rather than errors. See ds4_glp.h. */
+    /* Apply a GLP vector at a hook it does not declare. Off by default:
+     * steering one of a layer's contributors is a different intervention from
+     * steering the accumulated residual, and it degrades rather than errors.
+     * See ds4_glp.h. */
     bool directional_steering_allow_hook_mismatch;
     int power_percent;
     uint32_t ssd_streaming_cache_experts;

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -883,6 +883,9 @@ static agent_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--dir-steering-attn")) {
             c.engine.directional_steering_attn = parse_float_range(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
             steering_scale_set = true;
+        } else if (!strcmp(arg, "--dir-steering-resid")) {
+            c.engine.directional_steering_resid = parse_float_range(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
+            steering_scale_set = true;
         } else if (!strcmp(arg, "--dir-steering-allow-hook-mismatch")) {
             c.engine.directional_steering_allow_hook_mismatch = true;
         } else if (!strcmp(arg, "--dir-steering-info")) {
@@ -894,9 +897,15 @@ static agent_config parse_options(int argc, char **argv) {
         }
     }
 
-    if (c.engine.directional_steering_file && !steering_scale_set)
-        c.engine.directional_steering_ffn =
-            ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
+    if (c.engine.directional_steering_file && !steering_scale_set) {
+        /* A residual-calibrated GLP defaults to the post-layer hook at its
+         * own alpha; anything else keeps the historical FFN default. */
+        c.engine.directional_steering_resid =
+            ds4_glp_default_resid_scale(c.engine.directional_steering_file, 0.0f);
+        if (c.engine.directional_steering_resid == 0.0f)
+            c.engine.directional_steering_ffn =
+                ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
+    }
     char tp_err[256];
     if (!ds4_tp_adopt_distributed_options(&c.engine.tp,
                                           &c.engine.distributed,

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -1,6 +1,7 @@
 #include "ds4.h"
 #include "ds4_distributed.h"
 #include "ds4_gpu_args.h"
+#include "ds4_glp.h"
 #include "ds4_help.h"
 #include "ds4_kvstore.h"
 #include "ds4_prompt_prefix.h"
@@ -882,6 +883,10 @@ static agent_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--dir-steering-attn")) {
             c.engine.directional_steering_attn = parse_float_range(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
             steering_scale_set = true;
+        } else if (!strcmp(arg, "--dir-steering-allow-hook-mismatch")) {
+            c.engine.directional_steering_allow_hook_mismatch = true;
+        } else if (!strcmp(arg, "--dir-steering-info")) {
+            exit(ds4_glp_inspect_main(need_arg(&i, argc, argv, arg)));
         } else {
             fprintf(stderr, "ds4-agent: unknown option: %s\n", arg);
             usage(stderr, NULL);
@@ -890,7 +895,8 @@ static agent_config parse_options(int argc, char **argv) {
     }
 
     if (c.engine.directional_steering_file && !steering_scale_set)
-        c.engine.directional_steering_ffn = 1.0f;
+        c.engine.directional_steering_ffn =
+            ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
     char tp_err[256];
     if (!ds4_tp_adopt_distributed_options(&c.engine.tp,
                                           &c.engine.distributed,

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -899,12 +899,17 @@ static agent_config parse_options(int argc, char **argv) {
 
     if (c.engine.directional_steering_file && !steering_scale_set) {
         /* A residual-calibrated GLP defaults to the post-layer hook at its
-         * own alpha; anything else keeps the historical FFN default. */
+         * own alpha; anything else keeps the historical FFN default.  The
+         * adopted flag, not the value, decides: alpha_default=0 means "no
+         * steering by default" and must not fall through to the FFN 1. */
+        int resid_adopted = 0;
         c.engine.directional_steering_resid =
-            ds4_glp_default_resid_scale(c.engine.directional_steering_file, 0.0f);
-        if (c.engine.directional_steering_resid == 0.0f)
+            ds4_glp_default_resid_scale(c.engine.directional_steering_file, 0.0f,
+                                        &resid_adopted);
+        if (!resid_adopted)
             c.engine.directional_steering_ffn =
-                ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
+                ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f,
+                                          NULL);
     }
     char tp_err[256];
     if (!ds4_tp_adopt_distributed_options(&c.engine.tp,

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -2221,12 +2221,17 @@ static cli_config parse_options(int argc, char **argv) {
 
     if (c.engine.directional_steering_file && !directional_steering_scale_set) {
         /* A residual-calibrated GLP defaults to the post-layer hook at its
-         * own alpha; anything else keeps the historical FFN default. */
+         * own alpha; anything else keeps the historical FFN default.  The
+         * adopted flag, not the value, decides: alpha_default=0 means "no
+         * steering by default" and must not fall through to the FFN 1. */
+        int resid_adopted = 0;
         c.engine.directional_steering_resid =
-            ds4_glp_default_resid_scale(c.engine.directional_steering_file, 0.0f);
-        if (c.engine.directional_steering_resid == 0.0f) {
+            ds4_glp_default_resid_scale(c.engine.directional_steering_file, 0.0f,
+                                        &resid_adopted);
+        if (!resid_adopted) {
             c.engine.directional_steering_ffn =
-                ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
+                ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f,
+                                          NULL);
         }
     }
     if (c.gen.imatrix_output_path && !c.gen.imatrix_dataset_path) {

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -2118,6 +2118,9 @@ static cli_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--dir-steering-attn")) {
             c.engine.directional_steering_attn = parse_float_range(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
             directional_steering_scale_set = true;
+        } else if (!strcmp(arg, "--dir-steering-resid")) {
+            c.engine.directional_steering_resid = parse_float_range(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
+            directional_steering_scale_set = true;
         } else if (!strcmp(arg, "--dir-steering-allow-hook-mismatch")) {
             c.engine.directional_steering_allow_hook_mismatch = true;
         } else if (!strcmp(arg, "--dir-steering-info")) {
@@ -2217,8 +2220,14 @@ static cli_config parse_options(int argc, char **argv) {
     }
 
     if (c.engine.directional_steering_file && !directional_steering_scale_set) {
-        c.engine.directional_steering_ffn =
-            ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
+        /* A residual-calibrated GLP defaults to the post-layer hook at its
+         * own alpha; anything else keeps the historical FFN default. */
+        c.engine.directional_steering_resid =
+            ds4_glp_default_resid_scale(c.engine.directional_steering_file, 0.0f);
+        if (c.engine.directional_steering_resid == 0.0f) {
+            c.engine.directional_steering_ffn =
+                ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
+        }
     }
     if (c.gen.imatrix_output_path && !c.gen.imatrix_dataset_path) {
         fprintf(stderr, "ds4: --imatrix-out requires --imatrix-dataset\n");

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -1,5 +1,6 @@
 #include "ds4.h"
 #include "ds4_distributed.h"
+#include "ds4_glp.h"
 #include "ds4_gpu_args.h"
 #include "ds4_tp.h"
 #include "ds4_help.h"
@@ -2117,6 +2118,11 @@ static cli_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--dir-steering-attn")) {
             c.engine.directional_steering_attn = parse_float_range(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
             directional_steering_scale_set = true;
+        } else if (!strcmp(arg, "--dir-steering-allow-hook-mismatch")) {
+            c.engine.directional_steering_allow_hook_mismatch = true;
+        } else if (!strcmp(arg, "--dir-steering-info")) {
+            /* Inspect and exit before any model is loaded. */
+            exit(ds4_glp_inspect_main(need_arg(&i, argc, argv, arg)));
         } else if (!strcmp(arg, "-t") || !strcmp(arg, "--threads")) {
             c.engine.n_threads = parse_int(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--backend")) {
@@ -2211,7 +2217,8 @@ static cli_config parse_options(int argc, char **argv) {
     }
 
     if (c.engine.directional_steering_file && !directional_steering_scale_set) {
-        c.engine.directional_steering_ffn = 1.0f;
+        c.engine.directional_steering_ffn =
+            ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
     }
     if (c.gen.imatrix_output_path && !c.gen.imatrix_dataset_path) {
         fprintf(stderr, "ds4: --imatrix-out requires --imatrix-dataset\n");

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -19141,6 +19141,15 @@ extern "C" int ds4_gpu_add_tensor(ds4_gpu_tensor *out, const ds4_gpu_tensor *a, 
     add_kernel<<<(n + 255) / 256, 256, 0, cuda_decode_stream()>>>((float *)out->ptr, (const float *)a->ptr, (const float *)b->ptr, n);
     return cuda_ok(cudaGetLastError(), "add launch");
 }
+/* ds4_gpu.h documents the tp_flag variant as falling back to
+ * ds4_gpu_add_tensor when the fold does not apply; the flag-publishing
+ * kernel is Metal-only for now, so the CUDA build provides the fallback
+ * directly. */
+extern "C" int ds4_gpu_add_tensor_tp_flag(ds4_gpu_tensor *out, const ds4_gpu_tensor *a, const ds4_gpu_tensor *b, uint32_t n, uint32_t layer, uint32_t gate) {
+    (void)layer;
+    (void)gate;
+    return ds4_gpu_add_tensor(out, a, b, n);
+}
 
 extern "C" int ds4_gpu_add_xdev_tensor(ds4_gpu_tensor *out,
                                         const ds4_gpu_tensor *local,

--- a/ds4_glp.c
+++ b/ds4_glp.c
@@ -812,13 +812,10 @@ static int glp_check_hook(const char        *path,
                         "%s: glp.hook_point=\"%s\" but this projection applies at "
                         "\"%s\". Steer the declared site instead (%s), or pass "
                         "--dir-steering-allow-hook-mismatch and re-tune the scale. "
-                        "These are different tensors: a writer hook steers one of "
-                        "the layer's contributors, while a vector calibrated on "
-                        "the post-layer residual steers the accumulated stream, "
-                        "which also removes what upstream layers contributed. "
-                        "Applying it here degrades rather than errors -- the "
-                        "failure this field exists to prevent -- and the file's "
-                        "alpha belongs to its own site.",
+                        "These are different tensors, and the alpha was "
+                        "calibrated at one site and does not transfer silently: "
+                        "applying it here degrades rather than errors -- the "
+                        "failure this field exists to prevent.",
                         path, info->hook_name, ds4_glp_hook_name(target),
                         site_flag);
     }

--- a/ds4_glp.c
+++ b/ds4_glp.c
@@ -275,11 +275,14 @@ static int glp_open(glp_file *f, const char *path, char *err, size_t errlen) {
                         "%s: GGUF v%u; GLP is specified on GGUF v3",
                         path, version);
     }
-    /* Each entry needs at least one byte on disk, so a count above the bytes
-     * remaining cannot be real. Reject before calloc so a 24-byte file cannot
-     * ask for an enormous allocation. */
+    /* Every KV entry serializes at least a key length, a type tag and a
+     * one-byte value (13 bytes); every tensor directory entry at least a name
+     * length, an ndim, one dim, a type and an offset (32). A count the
+     * remaining bytes cannot minimally contain is a hostile header. Reject
+     * before calloc so a small file cannot amplify itself into a multi-GB
+     * allocation. */
     const uint64_t remaining = f->size - c.pos;
-    if (f->n_kv > remaining || f->n_tensors > remaining) {
+    if (f->n_kv > remaining / 13 || f->n_tensors > remaining / 32) {
         glp_close(f);
         return glp_fail(err, errlen, "%s: GGUF header counts exceed file size", path);
     }
@@ -476,6 +479,23 @@ static ds4_glp_hook glp_hook_from_name(const char *name) {
 /* Spec checks shared by read_info and load                           */
 /* ------------------------------------------------------------------ */
 
+static int glp_cmp_u32(const void *a, const void *b) {
+    const uint32_t x = *(const uint32_t *)a;
+    const uint32_t y = *(const uint32_t *)b;
+    return (x > y) - (x < y);
+}
+
+/* Finiteness of a serialized float, tested on its bytes. This file is built
+ * with -ffast-math, under which the compiler assumes every float-typed value
+ * is finite and folds even memcpy/bit-test NaN checks away -- so the value
+ * must stay integer-typed all the way through the test. NaN and Inf both
+ * have all exponent bits set. */
+static int glp_bytes_f32_finite(const void *p) {
+    uint32_t bits;
+    memcpy(&bits, p, sizeof(bits));
+    return (bits & 0x7f800000u) != 0x7f800000u;
+}
+
 /* Parse "direction.<N>" and return N, or -1 if the name is not one. */
 static long glp_direction_index(const glp_str *name) {
     static const char pfx[] = "direction.";
@@ -556,6 +576,26 @@ static int glp_read_metadata(const glp_file *f,
     }
 
     info->has_alpha_default = glp_get_f32(f, "glp.alpha_default", &info->alpha_default);
+    if (info->has_alpha_default) {
+        /* Test the serialized bytes, never the float value: see
+         * glp_bytes_f32_finite. */
+        const glp_kv *akv = glp_find(f, "glp.alpha_default");
+        int finite = 1;
+        if (akv && akv->type == GLP_KV_FLOAT32) {
+            finite = glp_bytes_f32_finite(f->map + akv->value_pos);
+        } else if (akv && akv->type == GLP_KV_FLOAT64) {
+            uint64_t bits;
+            memcpy(&bits, f->map + akv->value_pos, sizeof(bits));
+            finite = (bits & 0x7ff0000000000000ull) != 0x7ff0000000000000ull;
+        }
+        if (!finite) {
+            return glp_fail(err, errlen,
+                            "%s: glp.alpha_default is not finite. It is the "
+                            "scale the projection multiplies by; refusing rather "
+                            "than steering by NaN.",
+                            path);
+        }
+    }
 
     glp_get_str(f, "glp.hook_point", info->hook_name, sizeof(info->hook_name));
     info->hook = glp_hook_from_name(info->hook_name);
@@ -631,6 +671,14 @@ static int glp_scan_tensors(const glp_file *f,
             return glp_fail(err, errlen, "%s: direction.%ld data past end of file",
                             path, idx);
         }
+        /* The bytes are read as float * straight out of the mapping, so the
+         * absolute offset must be float-aligned; anything else is an
+         * unaligned scalar load. */
+        if (t->abs_offset % 4 != 0) {
+            return glp_fail(err, errlen,
+                            "%s: direction.%ld offset %llu is not float-aligned",
+                            path, idx, (unsigned long long)t->abs_offset);
+        }
         if ((uint32_t)idx < lo) lo = (uint32_t)idx;
         if ((uint32_t)idx > hi) hi = (uint32_t)idx;
         n_dirs++;
@@ -654,32 +702,73 @@ static int glp_scan_tensors(const glp_file *f,
      * field still read 10..38.  The names are what execute, so the mismatch
      * shifted the whole stack one layer, and a one-layer shift degrades
      * rather than fails.  The file carried the evidence and nothing looked at
-     * it. */
+     * it.
+     *
+     * Compare the exact sets, not a summary: count/min/max alone cannot see a
+     * duplicate direction.<N> (which would load twice, the second silently
+     * overwriting the first row of the dense buffer) or a declared list that
+     * differs only in the interior. */
+    uint32_t *ids = malloc((size_t)n_dirs * sizeof(ids[0]));
+    if (!ids) return glp_fail(err, errlen, "%s: out of memory", path);
+    uint32_t n_ids = 0;
+    for (uint64_t i = 0; i < f->n_tensors; i++) {
+        const long idx = glp_direction_index(&f->tensors[i].name);
+        if (idx >= 1) ids[n_ids++] = (uint32_t)idx;
+    }
+    qsort(ids, n_ids, sizeof(ids[0]), glp_cmp_u32);
+    for (uint32_t i = 1; i < n_ids; i++) {
+        if (ids[i] == ids[i - 1]) {
+            free(ids);
+            return glp_fail(err, errlen,
+                            "%s: direction.%u appears twice. The second would "
+                            "overwrite the first in the layer-indexed buffer.",
+                            path, ids[i]);
+        }
+    }
+
     char declared[1024];
     if (glp_get_str(f, "glp.layer_ids_zero_based", declared, sizeof(declared)) &&
         declared[0]) {
-        uint32_t d_lo = UINT32_MAX, d_hi = 0, d_n = 0;
+        uint32_t d_n = 0;
         const char *p = declared;
         while (*p) {
             while (*p == ' ' || *p == ',') p++;
             if (!*p) break;
             if (*p < '0' || *p > '9') { d_n = 0; break; }
-            uint32_t v = 0;
-            while (*p >= '0' && *p <= '9') v = v * 10 + (uint32_t)(*p++ - '0');
-            if (v < d_lo) d_lo = v;
-            if (v > d_hi) d_hi = v;
+            while (*p >= '0' && *p <= '9') p++;
             d_n++;
         }
-        if (d_n && (d_n != n_dirs || d_lo != lo || d_hi != hi)) {
-            return glp_fail(err, errlen,
-                            "%s: glp.layer_ids_zero_based declares layers %u..%u "
-                            "(%u entries) but the direction tensors resolve to "
-                            "%u..%u (%u entries). The tensor names are what get "
-                            "applied, so this file would steer the wrong layers. "
-                            "Re-export it.",
-                            path, d_lo, d_hi, d_n, lo, hi, n_dirs);
+        uint32_t *d_ids = d_n ? malloc((size_t)d_n * sizeof(d_ids[0])) : NULL;
+        if (d_n && !d_ids) {
+            free(ids);
+            return glp_fail(err, errlen, "%s: out of memory", path);
         }
+        if (d_ids) {
+            d_n = 0;
+            p = declared;
+            while (*p) {
+                while (*p == ' ' || *p == ',') p++;
+                if (!*p) break;
+                uint32_t v = 0;
+                while (*p >= '0' && *p <= '9') v = v * 10 + (uint32_t)(*p++ - '0');
+                d_ids[d_n++] = v;
+            }
+            qsort(d_ids, d_n, sizeof(d_ids[0]), glp_cmp_u32);
+        }
+        if (d_ids && (d_n != n_ids || memcmp(d_ids, ids,
+                                             (size_t)n_ids * sizeof(ids[0])) != 0)) {
+            free(d_ids);
+            free(ids);
+            return glp_fail(err, errlen,
+                            "%s: glp.layer_ids_zero_based does not match the "
+                            "direction tensors' layer set. The tensor names are "
+                            "what get applied, so this file would steer the "
+                            "wrong layers. Re-export it.",
+                            path);
+        }
+        free(d_ids);
     }
+    free(ids);
     return 0;
 }
 
@@ -877,6 +966,26 @@ int ds4_glp_load(const char   *path,
         const float *src = (const float *)(const void *)(f.map + t->abs_offset);
         memcpy(dst, src, (size_t)n_embd * sizeof(dst[0]));
 
+        /* A NaN or Inf in the direction makes every activation it touches
+         * NaN: the dot is NaN, the subtraction is NaN, and the model's output
+         * is NaN with no error raised. Refuse at load instead. The test reads
+         * the mapping as integers: float-typed NaN checks fold away under
+         * -ffast-math (see glp_bytes_f32_finite). */
+        const uint32_t *src_bits = (const uint32_t *)(const void *)(f.map + t->abs_offset);
+        int finite = 1;
+        for (uint32_t k = 0; k < n_embd; k++) {
+            if ((src_bits[k] & 0x7f800000u) == 0x7f800000u) { finite = 0; break; }
+        }
+        if (!finite) {
+            glp_close(&f);
+            memset(dirs, 0, (size_t)n_layers * n_embd * sizeof(dirs[0]));
+            return glp_fail(err, errlen,
+                            "%s: direction.%ld contains a NaN or Inf. The "
+                            "projection multiplies the activation by dot(v, y); "
+                            "a non-finite direction poisons every token.",
+                            path, idx);
+        }
+
         /* ds4's op removes the component exactly at scale 1 only for a unit
          * direction, and the projector v^ v^T is invariant to ||v||, so
          * rescaling here cannot change the intended operation -- whereas
@@ -920,7 +1029,9 @@ static void glp_print_field(FILE *out, const char *label, const char *value) {
 }
 
 static float glp_default_scale(const char *path, ds4_glp_hook hook,
-                               const char *flag, float fallback) {
+                               const char *flag, float fallback,
+                               int *adopted) {
+    if (adopted) *adopted = 0;
     if (ds4_glp_is_gguf(path) != 1) return fallback;
 
     ds4_glp_info info;
@@ -929,20 +1040,23 @@ static float glp_default_scale(const char *path, ds4_glp_hook hook,
     if (!info.has_alpha_default) return fallback;
     if (info.hook != hook) return fallback;
 
+    /* Adopted even when the value is 0: a file that declares alpha_default=0
+     * means "no steering by default", which is a value, not an absence. */
     fprintf(stderr,
             "ds4: %s defaulted to %g from glp.alpha_default\n",
             flag, (double)info.alpha_default);
+    if (adopted) *adopted = 1;
     return info.alpha_default;
 }
 
-float ds4_glp_default_ffn_scale(const char *path, float fallback) {
+float ds4_glp_default_ffn_scale(const char *path, float fallback, int *adopted) {
     return glp_default_scale(path, DS4_GLP_HOOK_FFN_OUT,
-                             "--dir-steering-ffn", fallback);
+                             "--dir-steering-ffn", fallback, adopted);
 }
 
-float ds4_glp_default_resid_scale(const char *path, float fallback) {
+float ds4_glp_default_resid_scale(const char *path, float fallback, int *adopted) {
     return glp_default_scale(path, DS4_GLP_HOOK_RESID_POST_LAYER,
-                             "--dir-steering-resid", fallback);
+                             "--dir-steering-resid", fallback, adopted);
 }
 
 int ds4_glp_inspect_main(const char *path) {

--- a/ds4_glp.c
+++ b/ds4_glp.c
@@ -560,6 +560,12 @@ static int glp_read_metadata(const glp_file *f,
     glp_get_str(f, "glp.hook_point", info->hook_name, sizeof(info->hook_name));
     info->hook = glp_hook_from_name(info->hook_name);
 
+    /* Where the direction was captured, when the producer says.  Absent means
+     * "same as hook_point" (a natively derived vector); a value that differs
+     * marks a transferred vector -- surfaced as a warning at load and in
+     * --dir-steering-info, never a refusal. */
+    glp_get_str(f, "glp.derived_at", info->derived_at, sizeof(info->derived_at));
+
     glp_get_str(f, "general.base_model.0.name",         info->base_model,     sizeof(info->base_model));
     glp_get_str(f, "general.base_model.0.organization", info->base_org,       sizeof(info->base_org));
     glp_get_str(f, "general.base_model.0.version",      info->base_version,   sizeof(info->base_version));
@@ -786,6 +792,18 @@ int ds4_glp_load(const char   *path,
         rc = glp_check_hook(path, info, target_hook, allow_hook_mismatch, err, errlen);
     }
 
+    /* A transferred vector (captured at one site, calibrated for another) is
+     * legal and loadable, but invisible without this line: nothing else in the
+     * log would say the direction was estimated on a different distribution
+     * than the one it is about to edit. */
+    if (rc == 0 && info->derived_at[0] && info->hook_name[0] &&
+        strcmp(info->derived_at, info->hook_name) != 0) {
+        fprintf(stderr,
+                "ds4: %s: transferred vector -- derived at \"%s\", applied at "
+                "\"%s\". glp.alpha_default belongs to the apply site.\n",
+                path, info->derived_at, info->hook_name);
+    }
+
     /* Shape must match the model exactly.  n_embd and the layer count are the
      * two things quantisation preserves, which is why the same vector pairs
      * with any quantisation of the same base checkpoint -- and also why a
@@ -916,6 +934,13 @@ void ds4_glp_print_info(FILE *out, const char *path, const ds4_glp_info *info) {
             info->hook_name[0] ? info->hook_name : "(absent)",
             (info->hook_name[0] && info->hook == DS4_GLP_HOOK_UNKNOWN)
                 ? "  [not a hook this build knows]" : "");
+    if (info->derived_at[0]) {
+        const int transferred = info->hook_name[0] &&
+            strcmp(info->derived_at, info->hook_name) != 0;
+        fprintf(out, "  %-14s %s%s\n", "derived_at", info->derived_at,
+                transferred ? "  [TRANSFERRED: captured at a different site; "
+                              "alpha_default belongs to the apply site]" : "");
+    }
     if (info->has_alpha_default) {
         fprintf(out, "  %-14s %g\n", "alpha_default", (double)info->alpha_default);
     } else {

--- a/ds4_glp.c
+++ b/ds4_glp.c
@@ -687,6 +687,15 @@ static int glp_scan_tensors(const glp_file *f,
  * unrecognised name is as much a refusal as a recognised mismatch, because
  * either way we would be applying the direction somewhere it was not
  * calibrated. */
+static const char *glp_hook_flag(ds4_glp_hook hook) {
+    switch (hook) {
+    case DS4_GLP_HOOK_RESID_POST_LAYER: return "--dir-steering-resid";
+    case DS4_GLP_HOOK_FFN_OUT:          return "--dir-steering-ffn";
+    case DS4_GLP_HOOK_ATTN_OUT:         return "--dir-steering-attn";
+    default:                            return NULL;
+    }
+}
+
 static int glp_check_hook(const char        *path,
                           const ds4_glp_info *info,
                           ds4_glp_hook       target,
@@ -702,20 +711,36 @@ static int glp_check_hook(const char        *path,
     if (info->hook == target) return 0;
     if (allow_mismatch) return 0;
 
+    /* When the file's hook is one ds4 implements, the fix is to steer that
+     * site, not to override: the file is fine, the site choice is not.  An
+     * unrecognised hook has no such remedy. */
+    const char *site_flag = glp_hook_flag(info->hook);
+    if (site_flag) {
+        return glp_fail(err, errlen,
+                        /* Remedy first, rationale second: this message is written
+                         * into a caller-sized buffer, and a truncation should cost
+                         * the explanation, not the fix. */
+                        "%s: glp.hook_point=\"%s\" but this projection applies at "
+                        "\"%s\". Steer the declared site instead (%s), or pass "
+                        "--dir-steering-allow-hook-mismatch and re-tune the scale. "
+                        "These are different tensors: a writer hook steers one of "
+                        "the layer's contributors, while a vector calibrated on "
+                        "the post-layer residual steers the accumulated stream, "
+                        "which also removes what upstream layers contributed. "
+                        "Applying it here degrades rather than errors -- the "
+                        "failure this field exists to prevent -- and the file's "
+                        "alpha belongs to its own site.",
+                        path, info->hook_name, ds4_glp_hook_name(target),
+                        site_flag);
+    }
     return glp_fail(err, errlen,
-                    /* Remedy first, rationale second: this message is written into
-                     * a caller-sized buffer, and a truncation should cost the
-                     * explanation, not the fix. */
-                    "%s: glp.hook_point=\"%s\" but ds4 applies this projection at "
-                    "\"%s\". Use a vector exported for this hook, or pass "
-                    "--dir-steering-allow-hook-mismatch and re-tune the scale. "
-                    "These are different tensors: ds4 steers one of the layer's "
-                    "contributors, while a vector calibrated on the post-layer "
-                    "residual steers the accumulated stream, which also removes "
-                    "what upstream layers contributed. Applying it here degrades "
-                    "rather than errors -- the failure this field exists to "
-                    "prevent -- and the file's alpha belongs to its own site.",
-                    path, info->hook_name, ds4_glp_hook_name(target));
+                    "%s: glp.hook_point=\"%s\" is not a hook this build "
+                    "implements (ds4 implements residual_stream_post_layer, "
+                    "ffn_out_pre_residual, attn_out_pre_residual). Refusing to "
+                    "apply the direction somewhere it was not calibrated; "
+                    "--dir-steering-allow-hook-mismatch overrides this, and the "
+                    "scale then has to be re-tuned.",
+                    path, info->hook_name);
 }
 
 /* ------------------------------------------------------------------ */
@@ -894,19 +919,30 @@ static void glp_print_field(FILE *out, const char *label, const char *value) {
     if (value && value[0]) fprintf(out, "  %-14s %s\n", label, value);
 }
 
-float ds4_glp_default_ffn_scale(const char *path, float fallback) {
+static float glp_default_scale(const char *path, ds4_glp_hook hook,
+                               const char *flag, float fallback) {
     if (ds4_glp_is_gguf(path) != 1) return fallback;
 
     ds4_glp_info info;
     char err[64];
     if (ds4_glp_read_info(path, &info, err, sizeof(err)) != 0) return fallback;
     if (!info.has_alpha_default) return fallback;
-    if (info.hook != DS4_GLP_HOOK_FFN_OUT) return fallback;
+    if (info.hook != hook) return fallback;
 
     fprintf(stderr,
-            "ds4: --dir-steering-ffn defaulted to %g from glp.alpha_default\n",
-            (double)info.alpha_default);
+            "ds4: %s defaulted to %g from glp.alpha_default\n",
+            flag, (double)info.alpha_default);
     return info.alpha_default;
+}
+
+float ds4_glp_default_ffn_scale(const char *path, float fallback) {
+    return glp_default_scale(path, DS4_GLP_HOOK_FFN_OUT,
+                             "--dir-steering-ffn", fallback);
+}
+
+float ds4_glp_default_resid_scale(const char *path, float fallback) {
+    return glp_default_scale(path, DS4_GLP_HOOK_RESID_POST_LAYER,
+                             "--dir-steering-resid", fallback);
 }
 
 int ds4_glp_inspect_main(const char *path) {

--- a/ds4_glp.c
+++ b/ds4_glp.c
@@ -1,0 +1,946 @@
+/* GLP (GGUF Layer Projection) reader for ds4's directional steering.
+ *
+ * Pure C99: no CUDA, no Metal, no ds4.c internals.  See ds4_glp.h for the
+ * rationale and the spec reference.
+ *
+ * The GGUF parse here is intentionally a small independent implementation
+ * rather than a call into ds4.c's loader.  ds4.c's parser is static, tied to
+ * ds4_model, and calls ds4_die() on malformed input; a steering file is user
+ * input on a code path that must be able to report a refusal and continue, and
+ * every refusal in this file is covered by tests/test_glp.c without a
+ * model. */
+
+#include "ds4_glp.h"
+
+#include <fcntl.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define DS4_GLP_MAGIC        0x46554747u /* "GGUF", little endian. */
+#define DS4_GLP_GGUF_VERSION 3
+#define DS4_GLP_TENSOR_F32   0           /* ggml type id for F32. */
+#define DS4_GLP_SPEC_VERSION 1
+
+/* Directions are a few hundred KB of F32 by construction. A cap keeps a
+ * malformed header from making us walk a multi-gigabyte tensor directory
+ * looking for direction.<N>, and it is three orders of magnitude above any
+ * real vector. */
+#define DS4_GLP_MAX_FILE_BYTES (256ull * 1024ull * 1024ull)
+
+enum {
+    GLP_KV_UINT8   = 0,
+    GLP_KV_INT8    = 1,
+    GLP_KV_UINT16  = 2,
+    GLP_KV_INT16   = 3,
+    GLP_KV_UINT32  = 4,
+    GLP_KV_INT32   = 5,
+    GLP_KV_FLOAT32 = 6,
+    GLP_KV_BOOL    = 7,
+    GLP_KV_STRING  = 8,
+    GLP_KV_ARRAY   = 9,
+    GLP_KV_UINT64  = 10,
+    GLP_KV_INT64   = 11,
+    GLP_KV_FLOAT64 = 12,
+};
+
+typedef struct {
+    const char *ptr;
+    uint64_t    len;
+} glp_str;
+
+typedef struct {
+    glp_str  key;
+    uint32_t type;
+    uint64_t value_pos;
+} glp_kv;
+
+typedef struct {
+    glp_str  name;
+    uint32_t ndim;
+    uint64_t dim0;
+    uint32_t type;
+    uint64_t abs_offset;
+} glp_tensor;
+
+typedef struct {
+    const uint8_t *base;
+    uint64_t       size;
+    uint64_t       pos;
+    int            bad;
+} glp_cursor;
+
+typedef struct {
+    int            fd;
+    const uint8_t *map;
+    uint64_t       size;
+    uint64_t       alignment;
+    uint64_t       tensor_data_pos;
+    uint64_t       n_kv;
+    uint64_t       n_tensors;
+    glp_kv        *kv;
+    glp_tensor    *tensors;
+} glp_file;
+
+/* ------------------------------------------------------------------ */
+/* Errors                                                             */
+/* ------------------------------------------------------------------ */
+
+/* Every message names the file, what was wrong, and -- where the failure is
+ * one that degrades silently rather than erroring -- what it would have cost
+ * to apply the file anyway.  A refusal a user does not understand gets
+ * worked around with the override flag, which defeats the point. */
+static int glp_fail(char *err, size_t errlen, const char *fmt, ...)
+    __attribute__((format(printf, 3, 4)));
+
+static int glp_fail(char *err, size_t errlen, const char *fmt, ...) {
+    if (err && errlen) {
+        va_list ap;
+        va_start(ap, fmt);
+        vsnprintf(err, errlen, fmt, ap);
+        va_end(ap);
+    }
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* Cursor                                                             */
+/* ------------------------------------------------------------------ */
+
+static int glp_has(glp_cursor *c, uint64_t n) {
+    if (c->bad) return 0;
+    if (n > c->size || c->pos > c->size - n) {
+        c->bad = 1;
+        return 0;
+    }
+    return 1;
+}
+
+static int glp_read(glp_cursor *c, void *dst, uint64_t n) {
+    if (!glp_has(c, n)) return 0;
+    memcpy(dst, c->base + c->pos, (size_t)n);
+    c->pos += n;
+    return 1;
+}
+
+static int glp_u32(glp_cursor *c, uint32_t *v) { return glp_read(c, v, 4); }
+static int glp_u64(glp_cursor *c, uint64_t *v) { return glp_read(c, v, 8); }
+
+static int glp_string(glp_cursor *c, glp_str *s) {
+    uint64_t len;
+    if (!glp_u64(c, &len)) return 0;
+    if (!glp_has(c, len)) return 0;
+    s->ptr = (const char *)(c->base + c->pos);
+    s->len = len;
+    c->pos += len;
+    return 1;
+}
+
+static uint64_t glp_scalar_size(uint32_t type) {
+    switch (type) {
+    case GLP_KV_UINT8:
+    case GLP_KV_INT8:
+    case GLP_KV_BOOL:    return 1;
+    case GLP_KV_UINT16:
+    case GLP_KV_INT16:   return 2;
+    case GLP_KV_UINT32:
+    case GLP_KV_INT32:
+    case GLP_KV_FLOAT32: return 4;
+    case GLP_KV_UINT64:
+    case GLP_KV_INT64:
+    case GLP_KV_FLOAT64: return 8;
+    default:             return 0;
+    }
+}
+
+/* GGUF allows arrays of arrays; depth is bounded so a hostile header cannot
+ * recurse us off the stack. */
+static int glp_skip_value(glp_cursor *c, uint32_t type, int depth) {
+    if (depth > 4) {
+        c->bad = 1;
+        return 0;
+    }
+    if (type == GLP_KV_STRING) {
+        glp_str s;
+        return glp_string(c, &s);
+    }
+    if (type == GLP_KV_ARRAY) {
+        uint32_t elem_type;
+        uint64_t len;
+        if (!glp_u32(c, &elem_type)) return 0;
+        if (!glp_u64(c, &len)) return 0;
+        if (elem_type == GLP_KV_STRING || elem_type == GLP_KV_ARRAY) {
+            for (uint64_t i = 0; i < len; i++) {
+                if (!glp_skip_value(c, elem_type, depth + 1)) return 0;
+            }
+            return 1;
+        }
+        const uint64_t sz = glp_scalar_size(elem_type);
+        if (sz == 0) {
+            c->bad = 1;
+            return 0;
+        }
+        if (len != 0 && sz > UINT64_MAX / len) {
+            c->bad = 1;
+            return 0;
+        }
+        if (!glp_has(c, len * sz)) return 0;
+        c->pos += len * sz;
+        return 1;
+    }
+    const uint64_t sz = glp_scalar_size(type);
+    if (sz == 0) {
+        c->bad = 1;
+        return 0;
+    }
+    if (!glp_has(c, sz)) return 0;
+    c->pos += sz;
+    return 1;
+}
+
+static uint64_t glp_align_up(uint64_t v, uint64_t a) {
+    if (a == 0) return v;
+    const uint64_t rem = v % a;
+    return rem == 0 ? v : v + a - rem;
+}
+
+/* ------------------------------------------------------------------ */
+/* File open / close                                                  */
+/* ------------------------------------------------------------------ */
+
+static void glp_close(glp_file *f) {
+    if (!f) return;
+    free(f->kv);
+    free(f->tensors);
+    if (f->map) munmap((void *)f->map, (size_t)f->size);
+    if (f->fd >= 0) close(f->fd);
+    memset(f, 0, sizeof(*f));
+    f->fd = -1;
+}
+
+static int glp_open(glp_file *f, const char *path, char *err, size_t errlen) {
+    memset(f, 0, sizeof(*f));
+    f->fd = -1;
+
+    if (!path || !path[0]) return glp_fail(err, errlen, "no steering file path");
+
+    const int fd = open(path, O_RDONLY);
+    if (fd < 0) return glp_fail(err, errlen, "%s: cannot open", path);
+
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        close(fd);
+        return glp_fail(err, errlen, "%s: cannot stat", path);
+    }
+    if (st.st_size < 24) {
+        close(fd);
+        return glp_fail(err, errlen, "%s: too small to be a GGUF file", path);
+    }
+    if ((uint64_t)st.st_size > DS4_GLP_MAX_FILE_BYTES) {
+        close(fd);
+        return glp_fail(err, errlen,
+                        "%s: %llu bytes is not a steering vector. A GLP file "
+                        "carries no weights; ours are a few hundred KB of F32. "
+                        "Did you pass the model?",
+                        path, (unsigned long long)st.st_size);
+    }
+
+    void *map = mmap(NULL, (size_t)st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (map == MAP_FAILED) {
+        close(fd);
+        return glp_fail(err, errlen, "%s: cannot mmap", path);
+    }
+    f->fd   = fd;
+    f->map  = (const uint8_t *)map;
+    f->size = (uint64_t)st.st_size;
+
+    glp_cursor c = { f->map, f->size, 0, 0 };
+    uint32_t magic = 0, version = 0;
+    if (!glp_u32(&c, &magic) || !glp_u32(&c, &version) ||
+        !glp_u64(&c, &f->n_tensors) || !glp_u64(&c, &f->n_kv)) {
+        glp_close(f);
+        return glp_fail(err, errlen, "%s: truncated GGUF header", path);
+    }
+    if (magic != DS4_GLP_MAGIC) {
+        glp_close(f);
+        return glp_fail(err, errlen, "%s: not a GGUF file", path);
+    }
+    if (version != DS4_GLP_GGUF_VERSION) {
+        glp_close(f);
+        return glp_fail(err, errlen,
+                        "%s: GGUF v%u; GLP is specified on GGUF v3",
+                        path, version);
+    }
+    /* Each entry needs at least one byte on disk, so a count above the bytes
+     * remaining cannot be real. Reject before calloc so a 24-byte file cannot
+     * ask for an enormous allocation. */
+    const uint64_t remaining = f->size - c.pos;
+    if (f->n_kv > remaining || f->n_tensors > remaining) {
+        glp_close(f);
+        return glp_fail(err, errlen, "%s: GGUF header counts exceed file size", path);
+    }
+
+    f->alignment = 32;
+    if (f->n_kv) {
+        f->kv = calloc((size_t)f->n_kv, sizeof(f->kv[0]));
+        if (!f->kv) {
+            glp_close(f);
+            return glp_fail(err, errlen, "%s: out of memory", path);
+        }
+    }
+    for (uint64_t i = 0; i < f->n_kv; i++) {
+        glp_kv *kv = &f->kv[i];
+        if (!glp_string(&c, &kv->key) || !glp_u32(&c, &kv->type)) {
+            glp_close(f);
+            return glp_fail(err, errlen, "%s: truncated GGUF metadata", path);
+        }
+        kv->value_pos = c.pos;
+        if (kv->key.len == 17 && memcmp(kv->key.ptr, "general.alignment", 17) == 0 &&
+            kv->type == GLP_KV_UINT32) {
+            glp_cursor t = { f->map, f->size, kv->value_pos, 0 };
+            uint32_t a = 0;
+            if (glp_u32(&t, &a) && a != 0) f->alignment = a;
+        }
+        if (!glp_skip_value(&c, kv->type, 0)) {
+            glp_close(f);
+            return glp_fail(err, errlen, "%s: malformed GGUF metadata value for a key", path);
+        }
+    }
+
+    if (f->n_tensors) {
+        f->tensors = calloc((size_t)f->n_tensors, sizeof(f->tensors[0]));
+        if (!f->tensors) {
+            glp_close(f);
+            return glp_fail(err, errlen, "%s: out of memory", path);
+        }
+    }
+    for (uint64_t i = 0; i < f->n_tensors; i++) {
+        glp_tensor *t = &f->tensors[i];
+        uint64_t dims[4] = {1, 1, 1, 1};
+        if (!glp_string(&c, &t->name) || !glp_u32(&c, &t->ndim)) {
+            glp_close(f);
+            return glp_fail(err, errlen, "%s: truncated GGUF tensor directory", path);
+        }
+        if (t->ndim == 0 || t->ndim > 4) {
+            glp_close(f);
+            return glp_fail(err, errlen, "%s: tensor with %u dimensions", path, t->ndim);
+        }
+        for (uint32_t d = 0; d < t->ndim; d++) {
+            if (!glp_u64(&c, &dims[d])) {
+                glp_close(f);
+                return glp_fail(err, errlen, "%s: truncated GGUF tensor dims", path);
+            }
+        }
+        uint64_t rel = 0;
+        if (!glp_u32(&c, &t->type) || !glp_u64(&c, &rel)) {
+            glp_close(f);
+            return glp_fail(err, errlen, "%s: truncated GGUF tensor directory", path);
+        }
+        t->dim0       = dims[0];
+        t->abs_offset = rel; /* made absolute below, once the data start is known */
+    }
+
+    f->tensor_data_pos = glp_align_up(c.pos, f->alignment);
+    if (f->tensor_data_pos > f->size) {
+        glp_close(f);
+        return glp_fail(err, errlen, "%s: tensor data starts past end of file", path);
+    }
+    for (uint64_t i = 0; i < f->n_tensors; i++) {
+        glp_tensor *t = &f->tensors[i];
+        if (t->abs_offset > f->size - f->tensor_data_pos) {
+            glp_close(f);
+            return glp_fail(err, errlen, "%s: tensor offset past end of file", path);
+        }
+        t->abs_offset += f->tensor_data_pos;
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Metadata accessors                                                 */
+/* ------------------------------------------------------------------ */
+
+static int glp_key_is(const glp_kv *kv, const char *key) {
+    const size_t len = strlen(key);
+    return kv->key.len == len && memcmp(kv->key.ptr, key, len) == 0;
+}
+
+static const glp_kv *glp_find(const glp_file *f, const char *key) {
+    for (uint64_t i = 0; i < f->n_kv; i++) {
+        if (glp_key_is(&f->kv[i], key)) return &f->kv[i];
+    }
+    return NULL;
+}
+
+/* Copy a string value into a fixed buffer.  Returns 1 if the key existed and
+ * was a string.  Truncation is fine here: these fields are for the human
+ * reading the startup line, never for a comparison that decides behaviour. */
+static int glp_get_str(const glp_file *f, const char *key, char *out, size_t outlen) {
+    if (outlen) out[0] = '\0';
+    const glp_kv *kv = glp_find(f, key);
+    if (!kv || kv->type != GLP_KV_STRING) return 0;
+    glp_cursor c = { f->map, f->size, kv->value_pos, 0 };
+    glp_str s;
+    if (!glp_string(&c, &s)) return 0;
+    if (!outlen) return 1;
+    size_t n = s.len < outlen - 1 ? (size_t)s.len : outlen - 1;
+    memcpy(out, s.ptr, n);
+    out[n] = '\0';
+    return 1;
+}
+
+static int glp_get_u32(const glp_file *f, const char *key, uint32_t *out) {
+    const glp_kv *kv = glp_find(f, key);
+    if (!kv) return 0;
+    glp_cursor c = { f->map, f->size, kv->value_pos, 0 };
+    if (kv->type == GLP_KV_UINT32) return glp_u32(&c, out);
+    if (kv->type == GLP_KV_INT32) {
+        int32_t v = 0;
+        if (!glp_read(&c, &v, sizeof(v)) || v < 0) return 0;
+        *out = (uint32_t)v;
+        return 1;
+    }
+    if (kv->type == GLP_KV_UINT64) {
+        uint64_t v = 0;
+        if (!glp_u64(&c, &v) || v > UINT32_MAX) return 0;
+        *out = (uint32_t)v;
+        return 1;
+    }
+    return 0;
+}
+
+static int glp_get_f32(const glp_file *f, const char *key, float *out) {
+    const glp_kv *kv = glp_find(f, key);
+    if (!kv) return 0;
+    glp_cursor c = { f->map, f->size, kv->value_pos, 0 };
+    if (kv->type == GLP_KV_FLOAT32) return glp_read(&c, out, sizeof(*out));
+    if (kv->type == GLP_KV_FLOAT64) {
+        double v = 0.0;
+        if (!glp_read(&c, &v, sizeof(v))) return 0;
+        *out = (float)v;
+        return 1;
+    }
+    return 0;
+}
+
+/* Any key in the pre-GLP internal namespace.  Files written before
+ * 2026-08-22 used "dspark.*"; the rebrand renamed the keys with no
+ * compatibility alias because no external files existed.  Detecting it is
+ * worth the loop: such a file has the right tensors and no glp.mode, so
+ * without this check it would be diagnosed as "an additive control vector"
+ * and refused for the wrong reason. */
+static int glp_has_legacy_namespace(const glp_file *f) {
+    for (uint64_t i = 0; i < f->n_kv; i++) {
+        if (f->kv[i].key.len > 7 && memcmp(f->kv[i].key.ptr, "dspark.", 7) == 0) return 1;
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Public: probe and hook names                                       */
+/* ------------------------------------------------------------------ */
+
+int ds4_glp_is_gguf(const char *path) {
+    if (!path || !path[0]) return -1;
+    const int fd = open(path, O_RDONLY);
+    if (fd < 0) return -1;
+    unsigned char m[4];
+    const ssize_t got = read(fd, m, sizeof(m));
+    close(fd);
+    if (got != (ssize_t)sizeof(m)) return 0;
+    return (m[0] == 'G' && m[1] == 'G' && m[2] == 'U' && m[3] == 'F') ? 1 : 0;
+}
+
+const char *ds4_glp_hook_name(ds4_glp_hook hook) {
+    switch (hook) {
+    case DS4_GLP_HOOK_RESID_POST_LAYER: return "residual_stream_post_layer";
+    case DS4_GLP_HOOK_FFN_OUT:          return "ffn_out_pre_residual";
+    case DS4_GLP_HOOK_ATTN_OUT:         return "attn_out_pre_residual";
+    default:                            return "unknown";
+    }
+}
+
+static ds4_glp_hook glp_hook_from_name(const char *name) {
+    if (!name || !name[0]) return DS4_GLP_HOOK_UNKNOWN;
+    if (!strcmp(name, "residual_stream_post_layer")) return DS4_GLP_HOOK_RESID_POST_LAYER;
+    if (!strcmp(name, "ffn_out_pre_residual"))       return DS4_GLP_HOOK_FFN_OUT;
+    if (!strcmp(name, "attn_out_pre_residual"))      return DS4_GLP_HOOK_ATTN_OUT;
+    return DS4_GLP_HOOK_UNKNOWN;
+}
+
+/* ------------------------------------------------------------------ */
+/* Spec checks shared by read_info and load                           */
+/* ------------------------------------------------------------------ */
+
+/* Parse "direction.<N>" and return N, or -1 if the name is not one. */
+static long glp_direction_index(const glp_str *name) {
+    static const char pfx[] = "direction.";
+    const size_t pfxlen = sizeof(pfx) - 1;
+    if (name->len <= pfxlen) return -1;
+    if (memcmp(name->ptr, pfx, pfxlen) != 0) return -1;
+
+    long v = 0;
+    for (uint64_t i = pfxlen; i < name->len; i++) {
+        const char ch = name->ptr[i];
+        if (ch < '0' || ch > '9') return -1;
+        v = v * 10 + (ch - '0');
+        if (v > 1000000) return -1;
+    }
+    return v;
+}
+
+static int glp_read_metadata(const glp_file *f,
+                             const char     *path,
+                             ds4_glp_info   *info,
+                             char           *err,
+                             size_t          errlen) {
+    memset(info, 0, sizeof(*info));
+    info->rank = 1;
+
+    /* (1) glp.mode.  Absence means "add" for a plain llama.cpp control
+     * vector, which is the honest default -- but ds4 cannot apply "add", so
+     * either way an absent mode is a refusal.  Separate the two so the
+     * message names the actual situation. */
+    if (!glp_get_str(f, "glp.mode", info->mode, sizeof(info->mode))) {
+        if (glp_has_legacy_namespace(f)) {
+            return glp_fail(err, errlen,
+                            "%s: carries only pre-GLP \"dspark.*\" metadata. The keys "
+                            "were renamed to \"glp.*\" with no compatibility alias; "
+                            "re-export or re-download the vector.",
+                            path);
+        }
+        return glp_fail(err, errlen,
+                        "%s: no glp.mode. Absent means additive (h += v), which is "
+                        "what every control vector written before this key existed "
+                        "is -- and ds4 projects (h -= a(h.v)v). Refusing to guess: "
+                        "applying a projective direction additively pushes every "
+                        "token along the direction instead of removing it, and "
+                        "nothing downstream would detect it.",
+                        path);
+    }
+    if (strcmp(info->mode, "project") != 0) {
+        return glp_fail(err, errlen,
+                        "%s: glp.mode=\"%s\", but ds4 implements projective ablation "
+                        "only (y -= scale * v * dot(v, y)). Refusing to apply rather "
+                        "than falling back to a different operation.",
+                        path, info->mode);
+    }
+
+    /* (2) glp.spec_version says which contract the glp.* keys are written to.
+     * Deliberately distinct from general.version, which says which build of
+     * the vector this is. */
+    if (glp_get_u32(f, "glp.spec_version", &info->spec_version) &&
+        info->spec_version > DS4_GLP_SPEC_VERSION) {
+        return glp_fail(err, errlen,
+                        "%s: glp.spec_version=%u, this build implements %d. A later "
+                        "spec may change what these keys mean; refusing rather than "
+                        "guessing.",
+                        path, info->spec_version, DS4_GLP_SPEC_VERSION);
+    }
+
+    /* (3) rank.  ds4's steering buffer holds one direction per layer, and
+     * rank>1 needs an orthonormal basis to avoid subtracting overlapping
+     * components more than once. */
+    glp_get_u32(f, "glp.rank", &info->rank);
+    if (info->rank == 0) info->rank = 1;
+    if (info->rank != 1) {
+        return glp_fail(err, errlen,
+                        "%s: glp.rank=%u. ds4 stores one direction per layer; "
+                        "rank>1 is expressible in the container but not implemented "
+                        "here.",
+                        path, info->rank);
+    }
+
+    info->has_alpha_default = glp_get_f32(f, "glp.alpha_default", &info->alpha_default);
+
+    glp_get_str(f, "glp.hook_point", info->hook_name, sizeof(info->hook_name));
+    info->hook = glp_hook_from_name(info->hook_name);
+
+    glp_get_str(f, "general.base_model.0.name",         info->base_model,     sizeof(info->base_model));
+    glp_get_str(f, "general.base_model.0.organization", info->base_org,       sizeof(info->base_org));
+    glp_get_str(f, "general.base_model.0.version",      info->base_version,   sizeof(info->base_version));
+    glp_get_str(f, "general.base_model.0.repo_url",     info->base_repo_url,  sizeof(info->base_repo_url));
+    glp_get_str(f, "glp.content_sha256",                info->content_sha256, sizeof(info->content_sha256));
+    glp_get_str(f, "glp.created",                       info->created,        sizeof(info->created));
+    glp_get_str(f, "glp.method",                        info->method,         sizeof(info->method));
+    glp_get_str(f, "glp.contrast",                      info->contrast,       sizeof(info->contrast));
+    return 0;
+}
+
+/* Walk the tensor directory: validate every direction.<N> and resolve the
+ * shape.  Does not read tensor bytes. */
+static int glp_scan_tensors(const glp_file *f,
+                            const char     *path,
+                            ds4_glp_info   *info,
+                            char           *err,
+                            size_t          errlen) {
+    uint32_t n_embd = 0, n_dirs = 0;
+    uint32_t lo = UINT32_MAX, hi = 0;
+
+    for (uint64_t i = 0; i < f->n_tensors; i++) {
+        const glp_tensor *t = &f->tensors[i];
+        const long idx = glp_direction_index(&t->name);
+        if (idx < 0) continue;
+
+        /* (4) direction.N applies at layer N, no offset, so layer 0 cannot be
+         * expressed and direction.0 is invalid rather than "layer 0". */
+        if (idx == 0) {
+            return glp_fail(err, errlen,
+                            "%s: direction.0 is invalid. direction.N applies at layer "
+                            "N with no offset, so layer 0 cannot be expressed in this "
+                            "container.",
+                            path);
+        }
+        if (t->type != DS4_GLP_TENSOR_F32) {
+            return glp_fail(err, errlen,
+                            "%s: direction.%ld is ggml type %u, not F32. Directions "
+                            "are a few hundred KB and must stay F32: the projection "
+                            "runs in fp32 on the activation regardless of the model's "
+                            "weight dtype.",
+                            path, idx, t->type);
+        }
+        if (t->ndim != 1) {
+            return glp_fail(err, errlen,
+                            "%s: direction.%ld has %u dimensions, expected 1-D of "
+                            "n_embd.",
+                            path, idx, t->ndim);
+        }
+        if (t->dim0 == 0 || t->dim0 > UINT32_MAX) {
+            return glp_fail(err, errlen, "%s: direction.%ld has length %llu",
+                            path, idx, (unsigned long long)t->dim0);
+        }
+        if (n_embd == 0) {
+            n_embd = (uint32_t)t->dim0;
+        } else if ((uint32_t)t->dim0 != n_embd) {
+            return glp_fail(err, errlen,
+                            "%s: inconsistent n_embd across directions (%u then %llu)",
+                            path, n_embd, (unsigned long long)t->dim0);
+        }
+        if (t->abs_offset > f->size ||
+            (uint64_t)t->dim0 * 4ull > f->size - t->abs_offset) {
+            return glp_fail(err, errlen, "%s: direction.%ld data past end of file",
+                            path, idx);
+        }
+        if ((uint32_t)idx < lo) lo = (uint32_t)idx;
+        if ((uint32_t)idx > hi) hi = (uint32_t)idx;
+        n_dirs++;
+    }
+
+    if (n_dirs == 0) {
+        return glp_fail(err, errlen,
+                        "%s: no direction.<N> tensors. This is a GGUF file but not a "
+                        "control vector.",
+                        path);
+    }
+    info->n_embd    = n_embd;
+    info->n_dirs    = n_dirs;
+    info->layer_min = lo;
+    info->layer_max = hi;
+
+    /* (5) Cross-check the tensor names against glp.layer_ids_zero_based.  The
+     * two are written from the same source, so a disagreement means a broken
+     * exporter -- which is what happened to us once: an exporter wrote
+     * direction.11..39 for directions derived at layers 10..38 while this
+     * field still read 10..38.  The names are what execute, so the mismatch
+     * shifted the whole stack one layer, and a one-layer shift degrades
+     * rather than fails.  The file carried the evidence and nothing looked at
+     * it. */
+    char declared[1024];
+    if (glp_get_str(f, "glp.layer_ids_zero_based", declared, sizeof(declared)) &&
+        declared[0]) {
+        uint32_t d_lo = UINT32_MAX, d_hi = 0, d_n = 0;
+        const char *p = declared;
+        while (*p) {
+            while (*p == ' ' || *p == ',') p++;
+            if (!*p) break;
+            if (*p < '0' || *p > '9') { d_n = 0; break; }
+            uint32_t v = 0;
+            while (*p >= '0' && *p <= '9') v = v * 10 + (uint32_t)(*p++ - '0');
+            if (v < d_lo) d_lo = v;
+            if (v > d_hi) d_hi = v;
+            d_n++;
+        }
+        if (d_n && (d_n != n_dirs || d_lo != lo || d_hi != hi)) {
+            return glp_fail(err, errlen,
+                            "%s: glp.layer_ids_zero_based declares layers %u..%u "
+                            "(%u entries) but the direction tensors resolve to "
+                            "%u..%u (%u entries). The tensor names are what get "
+                            "applied, so this file would steer the wrong layers. "
+                            "Re-export it.",
+                            path, d_lo, d_hi, d_n, lo, hi, n_dirs);
+        }
+    }
+    return 0;
+}
+
+/* (6) Hook point.  Both the enum value and the raw string matter: an
+ * unrecognised name is as much a refusal as a recognised mismatch, because
+ * either way we would be applying the direction somewhere it was not
+ * calibrated. */
+static int glp_check_hook(const char        *path,
+                          const ds4_glp_info *info,
+                          ds4_glp_hook       target,
+                          int                allow_mismatch,
+                          char              *err,
+                          size_t             errlen) {
+    if (!info->hook_name[0]) {
+        /* No declared hook.  Pre-hook_point files exist and the field is not
+         * in the required set, so this is a warning the caller prints, not a
+         * refusal. */
+        return 0;
+    }
+    if (info->hook == target) return 0;
+    if (allow_mismatch) return 0;
+
+    return glp_fail(err, errlen,
+                    "%s: glp.hook_point=\"%s\" but ds4 applies this projection at "
+                    "\"%s\". The same direction at the wrong site measured 9x weaker "
+                    "(34.0%% vs 3.8%% refusal at identical direction, layers and "
+                    "alpha), and it degrades rather than errors -- which is the "
+                    "failure this field exists to prevent. Either use a vector "
+                    "exported for this hook, or pass "
+                    "--dir-steering-allow-hook-mismatch and re-tune the scale: the "
+                    "file's alpha was calibrated elsewhere and does not transfer.",
+                    path, info->hook_name, ds4_glp_hook_name(target));
+}
+
+/* ------------------------------------------------------------------ */
+/* Public: read_info                                                  */
+/* ------------------------------------------------------------------ */
+
+int ds4_glp_read_info(const char *path, ds4_glp_info *info, char *err, size_t errlen) {
+    if (!info) return glp_fail(err, errlen, "ds4_glp_read_info: null info");
+    if (errlen) err[0] = '\0';
+
+    glp_file f;
+    int rc = glp_open(&f, path, err, errlen);
+    if (rc != 0) return rc;
+
+    rc = glp_read_metadata(&f, path, info, err, errlen);
+    if (rc == 0) rc = glp_scan_tensors(&f, path, info, err, errlen);
+
+    /* Norms, for the inspect path only: enough to spot a direction that is not
+     * unit (which silently rescales the effective alpha, quadratically) or a
+     * slot that was left zero. */
+    if (rc == 0) {
+        info->norm_min = 0.0f;
+        info->norm_max = 0.0f;
+        int first = 1;
+        for (uint64_t i = 0; i < f.n_tensors; i++) {
+            const glp_tensor *t = &f.tensors[i];
+            if (glp_direction_index(&t->name) < 1) continue;
+            const float *src = (const float *)(const void *)(f.map + t->abs_offset);
+            double sum = 0.0;
+            for (uint64_t k = 0; k < t->dim0; k++) sum += (double)src[k] * (double)src[k];
+            const float norm = (float)sqrt(sum);
+            if (first) {
+                info->norm_min = info->norm_max = norm;
+                first = 0;
+            } else {
+                if (norm < info->norm_min) info->norm_min = norm;
+                if (norm > info->norm_max) info->norm_max = norm;
+            }
+        }
+    }
+
+    glp_close(&f);
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/* Public: load                                                       */
+/* ------------------------------------------------------------------ */
+
+int ds4_glp_load(const char   *path,
+                 ds4_glp_hook  target_hook,
+                 int           allow_hook_mismatch,
+                 float        *dirs,
+                 uint32_t      n_layers,
+                 uint32_t      n_embd,
+                 ds4_glp_info *info,
+                 char         *err,
+                 size_t        errlen) {
+    ds4_glp_info local;
+    if (!info) info = &local;
+    if (errlen) err[0] = '\0';
+    if (!dirs || n_layers == 0 || n_embd == 0) {
+        return glp_fail(err, errlen, "ds4_glp_load: bad destination buffer");
+    }
+
+    /* Zeroed up front and left zeroed on every failure path: a zero row is a
+     * no-op projection, so a caller that ignores our return value degrades to
+     * unsteered rather than to garbage. */
+    memset(dirs, 0, (size_t)n_layers * n_embd * sizeof(dirs[0]));
+
+    glp_file f;
+    int rc = glp_open(&f, path, err, errlen);
+    if (rc != 0) return rc;
+
+    rc = glp_read_metadata(&f, path, info, err, errlen);
+    if (rc == 0) rc = glp_scan_tensors(&f, path, info, err, errlen);
+    if (rc == 0) {
+        rc = glp_check_hook(path, info, target_hook, allow_hook_mismatch, err, errlen);
+    }
+
+    /* Shape must match the model exactly.  n_embd and the layer count are the
+     * two things quantisation preserves, which is why the same vector pairs
+     * with any quantisation of the same base checkpoint -- and also why a
+     * mismatch here means a different model, not a different quant. */
+    if (rc == 0 && info->n_embd != n_embd) {
+        rc = glp_fail(err, errlen,
+                      "%s: directions are %u wide, this model's n_embd is %u. A "
+                      "direction is specific to the checkpoint it was derived from.",
+                      path, info->n_embd, n_embd);
+    }
+    if (rc == 0 && info->layer_max >= n_layers) {
+        rc = glp_fail(err, errlen,
+                      "%s: direction.%u would apply at layer %u, but this model has "
+                      "%u steerable layers (0..%u).",
+                      path, info->layer_max, info->layer_max, n_layers, n_layers - 1);
+    }
+
+    if (rc != 0) {
+        glp_close(&f);
+        memset(dirs, 0, (size_t)n_layers * n_embd * sizeof(dirs[0]));
+        return rc;
+    }
+
+    info->norm_min = 0.0f;
+    info->norm_max = 0.0f;
+    int first = 1;
+
+    for (uint64_t i = 0; i < f.n_tensors; i++) {
+        const glp_tensor *t = &f.tensors[i];
+        const long idx = glp_direction_index(&t->name);
+        if (idx < 1) continue;
+
+        /* direction.N at row N. No offset. The upstream loader reads the other
+         * way -- common_control_vector_load_one() stores direction.N at data
+         * offset (N-1)*n_embd, which looks like "N-1 is the layer" -- but
+         * llama_adapter_cvec::apply() then fills tensors[il] from
+         * (il-1)*n_embd, so the two -1s cancel and tensors[il] holds
+         * direction.il, used at graph layer il. Confirmed by measurement
+         * (tests/test-cvec-layer-map.cpp in the llama.cpp fork), not by
+         * reading it a third time. */
+        float *dst = dirs + (uint64_t)idx * n_embd;
+        const float *src = (const float *)(const void *)(f.map + t->abs_offset);
+        memcpy(dst, src, (size_t)n_embd * sizeof(dst[0]));
+
+        /* ds4's op removes the component exactly at scale 1 only for a unit
+         * direction, and the projector v^ v^T is invariant to ||v||, so
+         * rescaling here cannot change the intended operation -- whereas
+         * leaving it off-unit scales the removal by ||v||^2. */
+        double sum = 0.0;
+        for (uint32_t k = 0; k < n_embd; k++) sum += (double)dst[k] * (double)dst[k];
+        const float norm = (float)sqrt(sum);
+        if (first) {
+            info->norm_min = info->norm_max = norm;
+            first = 0;
+        } else {
+            if (norm < info->norm_min) info->norm_min = norm;
+            if (norm > info->norm_max) info->norm_max = norm;
+        }
+        if (norm <= 1e-12f) {
+            glp_close(&f);
+            memset(dirs, 0, (size_t)n_layers * n_embd * sizeof(dirs[0]));
+            return glp_fail(err, errlen,
+                            "%s: direction.%ld has norm %g. A zero direction cannot "
+                            "be normalised and would steer nothing at that layer; "
+                            "the file is malformed rather than partially covering.",
+                            path, idx, (double)norm);
+        }
+        if (fabsf(norm - 1.0f) > 1e-3f) {
+            const float inv = 1.0f / norm;
+            for (uint32_t k = 0; k < n_embd; k++) dst[k] *= inv;
+            info->n_renormalized++;
+        }
+    }
+
+    glp_close(&f);
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Public: print                                                      */
+/* ------------------------------------------------------------------ */
+
+static void glp_print_field(FILE *out, const char *label, const char *value) {
+    if (value && value[0]) fprintf(out, "  %-14s %s\n", label, value);
+}
+
+float ds4_glp_default_ffn_scale(const char *path, float fallback) {
+    if (ds4_glp_is_gguf(path) != 1) return fallback;
+
+    ds4_glp_info info;
+    char err[64];
+    if (ds4_glp_read_info(path, &info, err, sizeof(err)) != 0) return fallback;
+    if (!info.has_alpha_default) return fallback;
+    if (info.hook != DS4_GLP_HOOK_FFN_OUT) return fallback;
+
+    fprintf(stderr,
+            "ds4: --dir-steering-ffn defaulted to %g from glp.alpha_default\n",
+            (double)info.alpha_default);
+    return info.alpha_default;
+}
+
+int ds4_glp_inspect_main(const char *path) {
+    if (ds4_glp_is_gguf(path) != 1) {
+        fprintf(stderr,
+                "ds4: %s is not a GGUF file. The legacy raw steering format is "
+                "a headerless blob of n_layers * n_embd floats and carries "
+                "nothing to inspect.\n",
+                path ? path : "(null)");
+        return 2;
+    }
+    ds4_glp_info info;
+    char err[768];
+    if (ds4_glp_read_info(path, &info, err, sizeof(err)) != 0) {
+        fprintf(stderr, "ds4: %s\n", err);
+        return 1;
+    }
+    ds4_glp_print_info(stdout, path, &info);
+    return 0;
+}
+
+void ds4_glp_print_info(FILE *out, const char *path, const ds4_glp_info *info) {
+    if (!out || !info) return;
+
+    fprintf(out, "GLP vector: %s\n", path ? path : "(unnamed)");
+    fprintf(out, "  %-14s %s\n", "mode", info->mode[0] ? info->mode : "(absent)");
+    fprintf(out, "  %-14s %u\n", "spec_version", info->spec_version);
+    fprintf(out, "  %-14s %s%s\n", "hook_point",
+            info->hook_name[0] ? info->hook_name : "(absent)",
+            (info->hook_name[0] && info->hook == DS4_GLP_HOOK_UNKNOWN)
+                ? "  [not a hook this build knows]" : "");
+    if (info->has_alpha_default) {
+        fprintf(out, "  %-14s %g\n", "alpha_default", (double)info->alpha_default);
+    } else {
+        fprintf(out, "  %-14s (absent)\n", "alpha_default");
+    }
+    fprintf(out, "  %-14s %u\n", "rank", info->rank);
+    fprintf(out, "  %-14s %u directions, n_embd=%u, layers %u..%u\n",
+            "coverage", info->n_dirs, info->n_embd, info->layer_min, info->layer_max);
+    /* Coverage is the lever that moved our numbers -- 6 layers 18%,
+     * 16 layers 3.8%, 29 layers 0.0% -- and alpha saturates above ~4, so
+     * a file with few layers underperforms regardless of how it was derived.
+     * Print it where anyone comparing two vectors will see it. */
+    fprintf(out, "  %-14s %.6f .. %.6f%s\n", "direction norm",
+            (double)info->norm_min, (double)info->norm_max,
+            info->n_renormalized ? "  [rescaled to unit]" : "");
+
+    glp_print_field(out, "base model", info->base_model);
+    glp_print_field(out, "base org", info->base_org);
+    glp_print_field(out, "base revision", info->base_version);
+    glp_print_field(out, "repo", info->base_repo_url);
+    glp_print_field(out, "method", info->method);
+    glp_print_field(out, "contrast", info->contrast);
+    glp_print_field(out, "created", info->created);
+    /* content_sha256 covers tensor bytes only, not metadata: glp.created makes
+     * the file non-reproducible, so the hash is what lets two people confirm
+     * they hold the same direction regardless of when it was packaged. */
+    glp_print_field(out, "content sha256", info->content_sha256);
+}

--- a/ds4_glp.c
+++ b/ds4_glp.c
@@ -718,11 +718,12 @@ static int glp_scan_tensors(const glp_file *f,
     qsort(ids, n_ids, sizeof(ids[0]), glp_cmp_u32);
     for (uint32_t i = 1; i < n_ids; i++) {
         if (ids[i] == ids[i - 1]) {
+            const uint32_t dup = ids[i];
             free(ids);
             return glp_fail(err, errlen,
                             "%s: direction.%u appears twice. The second would "
                             "overwrite the first in the layer-indexed buffer.",
-                            path, ids[i]);
+                            path, dup);
         }
     }
 

--- a/ds4_glp.c
+++ b/ds4_glp.c
@@ -703,14 +703,18 @@ static int glp_check_hook(const char        *path,
     if (allow_mismatch) return 0;
 
     return glp_fail(err, errlen,
+                    /* Remedy first, rationale second: this message is written into
+                     * a caller-sized buffer, and a truncation should cost the
+                     * explanation, not the fix. */
                     "%s: glp.hook_point=\"%s\" but ds4 applies this projection at "
-                    "\"%s\". The same direction at the wrong site measured 9x weaker "
-                    "(34.0%% vs 3.8%% refusal at identical direction, layers and "
-                    "alpha), and it degrades rather than errors -- which is the "
-                    "failure this field exists to prevent. Either use a vector "
-                    "exported for this hook, or pass "
-                    "--dir-steering-allow-hook-mismatch and re-tune the scale: the "
-                    "file's alpha was calibrated elsewhere and does not transfer.",
+                    "\"%s\". Use a vector exported for this hook, or pass "
+                    "--dir-steering-allow-hook-mismatch and re-tune the scale. "
+                    "These are different tensors: ds4 steers one of the layer's "
+                    "contributors, while a vector calibrated on the post-layer "
+                    "residual steers the accumulated stream, which also removes "
+                    "what upstream layers contributed. Applying it here degrades "
+                    "rather than errors -- the failure this field exists to "
+                    "prevent -- and the file's alpha belongs to its own site.",
                     path, info->hook_name, ds4_glp_hook_name(target));
 }
 

--- a/ds4_glp.h
+++ b/ds4_glp.h
@@ -21,10 +21,20 @@
  *     output -- instead of removing the refusal component it pushes every token
  *     along the refusal axis.  Right tensor names, right dtype, right shapes.
  *
- *   - Hook point.  The same direction applied to the attention writer instead
- *     of the post-layer residual measured 9x weaker (34.0% vs 3.8% refusal at
- *     identical direction, layers and alpha).  A file cannot say where it was
- *     calibrated, so nothing can check.
+ *   - Hook point.  Steering one of a layer's contributors is not the same
+ *     intervention as steering the accumulated residual: the latter also
+ *     removes whatever upstream layers contributed, so a layer left unsteered
+ *     only re-adds its own share.  Measured at equal coverage and equal alpha,
+ *     cleaning the accumulated stream reached 3.8% refusal on a cyber suite
+ *     against 34.0% for cleaning the attention write alone -- roughly 9x.
+ *     Two caveats travel with that pair.  It predates the current scorer and
+ *     did not store completions, so it cannot be re-scored.  And it measured
+ *     the ATTENTION contributor, whereas ds4's default hook is the FFN/MoE
+ *     write -- a third site never measured, and plausibly much stronger there,
+ *     since the write-vs-explain contrast these directions come from is a
+ *     content decision and content is largely MoE-mediated on this
+ *     architecture.  So the mechanism is the argument here, not the factor.
+ *     A file cannot say where it was calibrated, so nothing can check.
  *
  *   - Layer map.  A one-layer shift does not fail, it degrades: adjacent
  *     layers' refusal directions have cosine similarity 0.555-0.979 (mean
@@ -152,10 +162,10 @@ int ds4_glp_read_info(const char *path,
  * correct and branch-free.
  *
  * target_hook is where the caller will apply the projection.  If the file
- * names a different hook the load fails unless allow_hook_mismatch is set,
- * because the same direction at the wrong site measured 9x weaker -- it
- * degrades rather than errors, which is the failure this field exists to
- * prevent.
+ * names a different hook the load fails unless allow_hook_mismatch is set:
+ * steering one contributor is a different intervention from steering the
+ * accumulated stream, and it degrades rather than errors, which is the failure
+ * this field exists to prevent.
  *
  * Returns 0 on success, nonzero on failure with a message in err.  On failure
  * dirs is left zeroed. */
@@ -177,9 +187,10 @@ void ds4_glp_print_info(FILE *out, const char *path, const ds4_glp_info *info);
  *
  * A GLP file carries the strength it was calibrated at, so honour it -- but
  * only when it was calibrated for the hook this scale drives. alpha is not a
- * property of the direction: projection is quadratic in the norm, and the same
- * direction at a different site measured 9x weaker, so an alpha from elsewhere
- * is not a better default than the fallback, only a more confident wrong one.
+ * property of the direction: projection is quadratic in the norm, and a site
+ * that steers one contributor rather than the accumulated stream needs a
+ * different dose, so an alpha from elsewhere is not a better default than the
+ * fallback, only a more confident wrong one.
  *
  * Returns fallback for a raw f32 blob, for a GLP file with no
  * glp.alpha_default, and for one whose hook is not ffn_out_pre_residual.

--- a/ds4_glp.h
+++ b/ds4_glp.h
@@ -30,11 +30,10 @@
  *     Two caveats travel with that pair.  It predates the current scorer and
  *     did not store completions, so it cannot be re-scored.  And it measured
  *     the ATTENTION contributor, whereas ds4's default hook is the FFN/MoE
- *     write -- a third site never measured, and plausibly much stronger there,
- *     since the write-vs-explain contrast these directions come from is a
- *     content decision and content is largely MoE-mediated on this
- *     architecture.  So the mechanism is the argument here, not the factor.
- *     A file cannot say where it was calibrated, so nothing can check.
+ *     write -- a third site that has never been measured, so the factor above
+ *     is not a bound on it in either direction.  So the mechanism is the
+ *     argument here, not the number.  A file cannot say where it was
+ *     calibrated, so nothing can check.
  *
  *   - Layer map.  A one-layer shift does not fail, it degrades: adjacent
  *     layers' refusal directions have cosine similarity 0.555-0.979 (mean

--- a/ds4_glp.h
+++ b/ds4_glp.h
@@ -1,0 +1,199 @@
+#ifndef DS4_GLP_H
+#define DS4_GLP_H
+
+/* GLP — GGUF Layer Projection: container for directional steering vectors.
+ *
+ * ds4 already performs the operation GLP describes.  --dir-steering-file
+ * applies, per steered layer,
+ *
+ *     y = y - scale * v * dot(v, y)
+ *
+ * which is directional ablation: remove the component of the activation along
+ * v.  What ds4 lacked was a container.  The raw ".f32" form is a headerless
+ * blob of n_layers * n_embd floats: it carries no operation, no hook point, no
+ * base-model pin, and no layer map.  Every one of those is silently wrong when
+ * it is wrong.
+ *
+ *   - Operation.  llama.cpp has shipped control vectors since 2024 with the
+ *     same tensor convention (direction.<N>, fp32, 1-D) but ADDS them:
+ *     h <- h + v.  ds4 PROJECTS: h <- h - a(h.v)v.  Loading a projective
+ *     direction into an additive consumer raises no error and produces wrong
+ *     output -- instead of removing the refusal component it pushes every token
+ *     along the refusal axis.  Right tensor names, right dtype, right shapes.
+ *
+ *   - Hook point.  The same direction applied to the attention writer instead
+ *     of the post-layer residual measured 9x weaker (34.0% vs 3.8% refusal at
+ *     identical direction, layers and alpha).  A file cannot say where it was
+ *     calibrated, so nothing can check.
+ *
+ *   - Layer map.  A one-layer shift does not fail, it degrades: adjacent
+ *     layers' refusal directions have cosine similarity 0.555-0.979 (mean
+ *     0.863), so a shifted stack still ablates and still passes a smoke test.
+ *     Only a differential layer-mapping probe finds it.
+ *
+ *   - Base model.  A direction is tied to the exact checkpoint it was derived
+ *     from.  Applying one to a different revision is undefined.
+ *
+ * GLP is standard GGUF v3 with llama.cpp's tensor convention unchanged plus a
+ * small "glp.*" metadata block, of which one key may not be ignored:
+ *
+ *     glp.mode = "project" | "add"       absent means "add"
+ *
+ * ds4 implements "project" only, so an "add" file is refused rather than
+ * misapplied.  Spec: https://github.com/msuiche/weightless/blob/main/spec/GLP.md
+ *
+ * This reader is deliberately independent of ds4.c's GGUF loader: it takes
+ * (n_layers, n_embd) as plain arguments and returns errors instead of calling
+ * ds4_die(), so tests/test_glp.c can exercise every refusal path without a
+ * model. */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+/* Where the consumer applies the projection.  A GLP file names its own hook in
+ * glp.hook_point; a reader whose hook does not match must refuse the file
+ * rather than apply it somewhere else.
+ *
+ * ds4 hooks the block writers, before the residual/hyper-connection fold --
+ * ffn_out = moe + shared, and the attention output -- which is NOT
+ * residual_stream_post_layer.  Both names are therefore part of the enum and
+ * the two are not interchangeable. */
+typedef enum {
+    DS4_GLP_HOOK_UNKNOWN = 0,
+    /* "residual_stream_post_layer": llama.cpp's build_cvec() site and the
+     * vLLM overlay's site.  ds4 does not implement it (yet). */
+    DS4_GLP_HOOK_RESID_POST_LAYER,
+    /* "ffn_out_pre_residual": ds4 --dir-steering-ffn. */
+    DS4_GLP_HOOK_FFN_OUT,
+    /* "attn_out_pre_residual": ds4 --dir-steering-attn. */
+    DS4_GLP_HOOK_ATTN_OUT,
+} ds4_glp_hook;
+
+#define DS4_GLP_STR_MAX 160
+
+typedef struct {
+    /* Required keys. */
+    char     mode[32];              /* verbatim glp.mode */
+    uint32_t spec_version;          /* glp.spec_version */
+
+    /* Apply parameters.  alpha is a separate parameter, never folded into the
+     * data: projection is quadratic in the direction's norm, so a strength
+     * baked into the tensor would not mean what a caller expects. */
+    float    alpha_default;         /* glp.alpha_default, 0 if absent */
+    int      has_alpha_default;
+    uint32_t rank;                  /* glp.rank, 1 if absent */
+    ds4_glp_hook hook;
+    char     hook_name[DS4_GLP_STR_MAX];  /* verbatim, "" if absent */
+
+    /* Shape, as resolved from the direction.<N> tensors. */
+    uint32_t n_embd;
+    uint32_t n_dirs;
+    uint32_t layer_min;
+    uint32_t layer_max;
+
+    /* Provenance. */
+    char base_model[DS4_GLP_STR_MAX];
+    char base_org[DS4_GLP_STR_MAX];
+    char base_version[DS4_GLP_STR_MAX];
+    char base_repo_url[DS4_GLP_STR_MAX];
+    char content_sha256[DS4_GLP_STR_MAX];
+    char created[DS4_GLP_STR_MAX];
+    char method[DS4_GLP_STR_MAX];
+    char contrast[DS4_GLP_STR_MAX];
+
+    /* Norm report.  ds4's op assumes a unit direction: at scale 1 the
+     * component is removed exactly only when ||v|| == 1.  Directions that
+     * arrive off-unit are rescaled (the projector v^v^T is invariant to
+     * ||v||, so this cannot change the intended operation) and counted here so
+     * a caller can say it happened. */
+    float    norm_min;
+    float    norm_max;
+    uint32_t n_renormalized;
+} ds4_glp_info;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* 1 if path starts with the GGUF magic, 0 if it does not, -1 if it cannot be
+ * read.  Used to route --dir-steering-file between the GLP and raw-f32 paths
+ * without making the user say which one they have. */
+int ds4_glp_is_gguf(const char *path);
+
+/* "residual_stream_post_layer" etc.  Never NULL. */
+const char *ds4_glp_hook_name(ds4_glp_hook hook);
+
+/* Parse metadata and tensor directory only; no direction bytes are read and no
+ * model shape is needed.  This is the first thing to reach for when a vector
+ * behaves oddly: it answers "what is actually in this file" without loading
+ * the several-gigabyte checkpoint it belongs to.  Our own exporter off-by-one
+ * surfaced as an inspect dump reporting layers 11-39 for a file derived from
+ * layers 10-38.
+ *
+ * Returns 0 on success, nonzero on failure with a message in err. */
+int ds4_glp_read_info(const char *path,
+                      ds4_glp_info *info,
+                      char *err,
+                      size_t errlen);
+
+/* Fill dirs[n_layers * n_embd] from a GLP file.
+ *
+ * dirs is the dense, layer-indexed buffer ds4's steering path already uses:
+ * direction.N lands at row N, with no offset, and layers the file does not
+ * cover are zeroed.  A zero row is exactly a no-op under this operation
+ * (dot(0, y) == 0), so the caller's unconditional per-layer apply stays
+ * correct and branch-free.
+ *
+ * target_hook is where the caller will apply the projection.  If the file
+ * names a different hook the load fails unless allow_hook_mismatch is set,
+ * because the same direction at the wrong site measured 9x weaker -- it
+ * degrades rather than errors, which is the failure this field exists to
+ * prevent.
+ *
+ * Returns 0 on success, nonzero on failure with a message in err.  On failure
+ * dirs is left zeroed. */
+int ds4_glp_load(const char *path,
+                 ds4_glp_hook target_hook,
+                 int allow_hook_mismatch,
+                 float *dirs,
+                 uint32_t n_layers,
+                 uint32_t n_embd,
+                 ds4_glp_info *info,
+                 char *err,
+                 size_t errlen);
+
+/* Human-readable dump for --dir-steering-info and for the one-line startup
+ * provenance record. */
+void ds4_glp_print_info(FILE *out, const char *path, const ds4_glp_info *info);
+
+/* The default --dir-steering-ffn for a file the user gave no scale for.
+ *
+ * A GLP file carries the strength it was calibrated at, so honour it -- but
+ * only when it was calibrated for the hook this scale drives. alpha is not a
+ * property of the direction: projection is quadratic in the norm, and the same
+ * direction at a different site measured 9x weaker, so an alpha from elsewhere
+ * is not a better default than the fallback, only a more confident wrong one.
+ *
+ * Returns fallback for a raw f32 blob, for a GLP file with no
+ * glp.alpha_default, and for one whose hook is not ffn_out_pre_residual.
+ * Prints a line to stderr when it does adopt the file's value, because a
+ * scale the user did not type should be visible in the log. Shared by ds4,
+ * ds4-server and ds4-agent so the three cannot drift. */
+float ds4_glp_default_ffn_scale(const char *path, float fallback);
+
+/* --dir-steering-info: describe the vector at path on stdout and return the
+ * process exit code (0 ok, 1 unreadable/refused, 2 not a GLP file).
+ *
+ * Deliberately reports on files this build would refuse to APPLY -- a wrong
+ * hook, an unknown mode -- because "what is actually in this file" is the
+ * question worth answering first, and refusing to answer it for a file that
+ * needs diagnosing would defeat the purpose. Shared by ds4, ds4-server and
+ * ds4-agent so the flag the help text advertises exists in all three. */
+int ds4_glp_inspect_main(const char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DS4_GLP_H */

--- a/ds4_glp.h
+++ b/ds4_glp.h
@@ -65,13 +65,16 @@
  * rather than apply it somewhere else.
  *
  * ds4 hooks the block writers, before the residual/hyper-connection fold --
- * ffn_out = moe + shared, and the attention output -- which is NOT
- * residual_stream_post_layer.  Both names are therefore part of the enum and
- * the two are not interchangeable. */
+ * ffn_out = moe + shared, and the attention output -- and the post-layer
+ * residual itself, where each of the n_hc hyper-connection streams is
+ * projected independently.  The two kinds of site are not interchangeable: a
+ * writer carries only what that block computed this layer, while the folded
+ * residual carries the accumulated sum. */
 typedef enum {
     DS4_GLP_HOOK_UNKNOWN = 0,
     /* "residual_stream_post_layer": llama.cpp's build_cvec() site and the
-     * vLLM overlay's site.  ds4 does not implement it (yet). */
+     * vLLM overlay's site.  ds4 --dir-steering-resid, applied per
+     * hyper-connection stream after the FFN fold (out_hc). */
     DS4_GLP_HOOK_RESID_POST_LAYER,
     /* "ffn_out_pre_residual": ds4 --dir-steering-ffn. */
     DS4_GLP_HOOK_FFN_OUT,
@@ -197,6 +200,11 @@ void ds4_glp_print_info(FILE *out, const char *path, const ds4_glp_info *info);
  * scale the user did not type should be visible in the log. Shared by ds4,
  * ds4-server and ds4-agent so the three cannot drift. */
 float ds4_glp_default_ffn_scale(const char *path, float fallback);
+
+/* The --dir-steering-resid sibling: adopts glp.alpha_default only for a file
+ * whose hook is residual_stream_post_layer.  Same rules and same stderr line
+ * as ds4_glp_default_ffn_scale. */
+float ds4_glp_default_resid_scale(const char *path, float fallback);
 
 /* --dir-steering-info: describe the vector at path on stdout and return the
  * process exit code (0 ok, 1 unreadable/refused, 2 not a GLP file).

--- a/ds4_glp.h
+++ b/ds4_glp.h
@@ -196,15 +196,19 @@ void ds4_glp_print_info(FILE *out, const char *path, const ds4_glp_info *info);
  *
  * Returns fallback for a raw f32 blob, for a GLP file with no
  * glp.alpha_default, and for one whose hook is not ffn_out_pre_residual.
+ * adopted, when given, is set to 1 exactly when the file's value is used --
+ * the caller needs it because an adopted 0 ("no steering by default") is a
+ * value, not an absence, and must not fall through to another site's
+ * default.
  * Prints a line to stderr when it does adopt the file's value, because a
  * scale the user did not type should be visible in the log. Shared by ds4,
  * ds4-server and ds4-agent so the three cannot drift. */
-float ds4_glp_default_ffn_scale(const char *path, float fallback);
+float ds4_glp_default_ffn_scale(const char *path, float fallback, int *adopted);
 
 /* The --dir-steering-resid sibling: adopts glp.alpha_default only for a file
  * whose hook is residual_stream_post_layer.  Same rules and same stderr line
  * as ds4_glp_default_ffn_scale. */
-float ds4_glp_default_resid_scale(const char *path, float fallback);
+float ds4_glp_default_resid_scale(const char *path, float fallback, int *adopted);
 
 /* --dir-steering-info: describe the vector at path on stdout and return the
  * process exit code (0 ok, 1 unreadable/refused, 2 not a GLP file).

--- a/ds4_glp.h
+++ b/ds4_glp.h
@@ -30,10 +30,12 @@
  *     Two caveats travel with that pair.  It predates the current scorer and
  *     did not store completions, so it cannot be re-scored.  And it measured
  *     the ATTENTION contributor, whereas ds4's default hook is the FFN/MoE
- *     write -- a third site that has never been measured, so the factor above
- *     is not a bound on it in either direction.  So the mechanism is the
- *     argument here, not the number.  A file cannot say where it was
- *     calibrated, so nothing can check.
+ *     write -- a third site the pair says nothing about; measured since
+ *     (2026-09-04, DSV4-Flash-0731, refusal32), the FFN writer at alpha 4-6
+ *     outperformed the residual site with a residual-derived direction
+ *     transferred to it, so the factor above is not a bound in either
+ *     direction.  So the mechanism is the argument here, not the number.  A
+ *     file cannot say where it was calibrated, so nothing can check.
  *
  *   - Layer map.  A one-layer shift does not fail, it degrades: adjacent
  *     layers' refusal directions have cosine similarity 0.555-0.979 (mean

--- a/ds4_glp.h
+++ b/ds4_glp.h
@@ -86,6 +86,12 @@ typedef struct {
     ds4_glp_hook hook;
     char     hook_name[DS4_GLP_STR_MAX];  /* verbatim, "" if absent */
 
+    /* Where the direction was CAPTURED, which is not necessarily where it is
+     * applied.  A transferred vector has derived_at != hook_name.  This is a
+     * warning, never a refusal: the reader applies at hook_point regardless,
+     * and alpha_default belongs to the apply site, not the derivation site. */
+    char     derived_at[DS4_GLP_STR_MAX]; /* verbatim glp.derived_at, "" if absent */
+
     /* Shape, as resolved from the direction.<N> tensors. */
     uint32_t n_embd;
     uint32_t n_dirs;

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -226,9 +226,13 @@ static void print_sampling(FILE *fp, const help_colors *c, bool full) {
 
 static void print_steering(FILE *fp, const help_colors *c) {
     title(fp, c, "Directional Steering");
-    opt(fp, c, "--dir-steering-file FILE", "Load one f32 direction vector per layer.");
+    opt(fp, c, "--dir-steering-file FILE", "Direction per layer: a GLP .gguf, or a raw f32 blob.");
     opt(fp, c, "--dir-steering-ffn F", "Apply steering after FFN outputs. Default with file: 1");
     opt(fp, c, "--dir-steering-attn F", "Apply steering after attention outputs. Default: 0");
+    opt(fp, c, "--dir-steering-info FILE", "Print a GLP vector's metadata and exit; loads no model.");
+    opt(fp, c, "--dir-steering-allow-hook-mismatch", "Apply a GLP vector at a hook it was not calibrated for.");
+    fputc('\n', fp);
+    para(fp, c, "A GLP file (GGUF Layer Projection) is standard GGUF v3 carrying direction.<N> F32 tensors plus a glp.* metadata block that states the operation, the hook point, the layer map and the base checkpoint. It is refused rather than misapplied when any of those does not match: llama.cpp's control vectors share the tensor convention exactly but ADD the direction, where ds4 projects it out, and the wrong one of those two produces no error and wrong output. A raw f32 blob of n_layers * n_embd floats still loads, chosen by sniffing the file.");
     fputc('\n', fp);
 }
 
@@ -497,6 +501,8 @@ static void print_examples(FILE *fp, const help_colors *c, ds4_help_tool tool, c
         }
     } else if (topic_is(topic, "steering")) {
         opt(fp, c, "steer FFN", "./ds4 -p \"Write tersely\" --dir-steering-file dir.bin --dir-steering-ffn 0.8");
+        opt(fp, c, "GLP vector", "./ds4 -p \"...\" --dir-steering-file vec-GLP-29.gguf");
+        opt(fp, c, "inspect", "./ds4 --dir-steering-info vec-GLP-29.gguf");
     } else if (tool == DS4_HELP_SERVER || topic_is(topic, "api") || topic_is(topic, "kv-cache")) {
         opt(fp, c, "local API", "./ds4-server --ctx 100000 --kv-disk-dir ~/.ds4/server-kv --kv-disk-space-mb 8192");
         opt(fp, c, "curl", "curl http://127.0.0.1:8000/v1/models");

--- a/ds4_help.c
+++ b/ds4_help.c
@@ -229,6 +229,7 @@ static void print_steering(FILE *fp, const help_colors *c) {
     opt(fp, c, "--dir-steering-file FILE", "Direction per layer: a GLP .gguf, or a raw f32 blob.");
     opt(fp, c, "--dir-steering-ffn F", "Apply steering after FFN outputs. Default with file: 1");
     opt(fp, c, "--dir-steering-attn F", "Apply steering after attention outputs. Default: 0");
+    opt(fp, c, "--dir-steering-resid F", "Apply steering to each hyper-connection stream after the layer's FFN fold (residual_stream_post_layer). Default for a residual-calibrated GLP: its glp.alpha_default");
     opt(fp, c, "--dir-steering-info FILE", "Print a GLP vector's metadata and exit; loads no model.");
     opt(fp, c, "--dir-steering-allow-hook-mismatch", "Apply a GLP vector at a hook it was not calibrated for.");
     fputc('\n', fp);

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -14130,12 +14130,17 @@ static server_config parse_options(int argc, char **argv) {
     }
     if (c.engine.directional_steering_file && !directional_steering_scale_set) {
         /* A residual-calibrated GLP defaults to the post-layer hook at its
-         * own alpha; anything else keeps the historical FFN default. */
+         * own alpha; anything else keeps the historical FFN default.  The
+         * adopted flag, not the value, decides: alpha_default=0 means "no
+         * steering by default" and must not fall through to the FFN 1. */
+        int resid_adopted = 0;
         c.engine.directional_steering_resid =
-            ds4_glp_default_resid_scale(c.engine.directional_steering_file, 0.0f);
-        if (c.engine.directional_steering_resid == 0.0f) {
+            ds4_glp_default_resid_scale(c.engine.directional_steering_file, 0.0f,
+                                        &resid_adopted);
+        if (!resid_adopted) {
             c.engine.directional_steering_ffn =
-                ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
+                ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f,
+                                          NULL);
         }
     }
     char tp_err[256];

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -1,6 +1,7 @@
 #include "ds4.h"
 #include "ds4_distributed.h"
 #include "ds4_gpu_args.h"
+#include "ds4_glp.h"
 #include "ds4_help.h"
 #include "ds4_kvstore.h"
 #include "ds4_tp.h"
@@ -14086,6 +14087,10 @@ static server_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--dir-steering-attn")) {
             c.engine.directional_steering_attn = parse_float_arg(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
             directional_steering_scale_set = true;
+        } else if (!strcmp(arg, "--dir-steering-allow-hook-mismatch")) {
+            c.engine.directional_steering_allow_hook_mismatch = true;
+        } else if (!strcmp(arg, "--dir-steering-info")) {
+            exit(ds4_glp_inspect_main(need_arg(&i, argc, argv, arg)));
         } else if (!strcmp(arg, "--warm-weights")) {
             c.engine.warm_weights = true;
         } else if (!strcmp(arg, "--metal")) {
@@ -14121,7 +14126,8 @@ static server_config parse_options(int argc, char **argv) {
         exit(2);
     }
     if (c.engine.directional_steering_file && !directional_steering_scale_set) {
-        c.engine.directional_steering_ffn = 1.0f;
+        c.engine.directional_steering_ffn =
+            ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
     }
     char tp_err[256];
     if (!ds4_tp_adopt_distributed_options(&c.engine.tp,

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -14087,6 +14087,9 @@ static server_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--dir-steering-attn")) {
             c.engine.directional_steering_attn = parse_float_arg(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
             directional_steering_scale_set = true;
+        } else if (!strcmp(arg, "--dir-steering-resid")) {
+            c.engine.directional_steering_resid = parse_float_arg(need_arg(&i, argc, argv, arg), arg, -100.0f, 100.0f);
+            directional_steering_scale_set = true;
         } else if (!strcmp(arg, "--dir-steering-allow-hook-mismatch")) {
             c.engine.directional_steering_allow_hook_mismatch = true;
         } else if (!strcmp(arg, "--dir-steering-info")) {
@@ -14126,8 +14129,14 @@ static server_config parse_options(int argc, char **argv) {
         exit(2);
     }
     if (c.engine.directional_steering_file && !directional_steering_scale_set) {
-        c.engine.directional_steering_ffn =
-            ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
+        /* A residual-calibrated GLP defaults to the post-layer hook at its
+         * own alpha; anything else keeps the historical FFN default. */
+        c.engine.directional_steering_resid =
+            ds4_glp_default_resid_scale(c.engine.directional_steering_file, 0.0f);
+        if (c.engine.directional_steering_resid == 0.0f) {
+            c.engine.directional_steering_ffn =
+                ds4_glp_default_ffn_scale(c.engine.directional_steering_file, 1.0f);
+        }
     }
     char tp_err[256];
     if (!ds4_tp_adopt_distributed_options(&c.engine.tp,

--- a/tests/test_dir_steering.c
+++ b/tests/test_dir_steering.c
@@ -1,0 +1,117 @@
+/* Numeric test for the projection behind the steering hooks.
+ *
+ * The residual_stream_post_layer hook applies the shared row projector to the
+ * post-fold hyper-connection stack out_hc, [n_hc][n_embd] per token and
+ * contiguous, as rows = n_tok * n_hc independent rows -- i.e. each stream is
+ * projected independently against the same per-layer direction.  That call is
+ * what this file exercises, through the DS4_TEST_HOOKS wrapper, against a
+ * hand-computed projection:
+ *
+ *   - a zero direction row is exactly a no-op (dot(0, x) == 0), which is what
+ *     makes layers a GLP file does not cover unsteered;
+ *   - a nonzero direction removes scale * dot(v, x) * v from every stream
+ *     row, per stream, not once on a flattened sum.
+ *
+ * Model-free: the projector only needs the default shape's n_embd. */
+
+#include "../ds4.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#define N_EMBD 4096   /* default shape n_embd; the projector reads it live */
+#define N_HC   4      /* hyper-connection streams per token */
+#define N_LAYERS 8
+
+static int g_failed = 0;
+
+#define CHECK(cond, msg) do {                                                  \
+    if (!(cond)) {                                                             \
+        fprintf(stderr, "  FAIL: %s (line %d)\n", (msg), __LINE__);            \
+        g_failed++;                                                            \
+    }                                                                          \
+} while (0)
+
+static double dot_row(const float *a, const float *b) {
+    double s = 0.0;
+    for (int i = 0; i < N_EMBD; i++) s += (double)a[i] * (double)b[i];
+    return s;
+}
+
+/* Deterministic non-trivial fill, different per stream so the per-stream
+ * dots differ and a flattened projection would not match. */
+static void fill_stack(float *x) {
+    for (int r = 0; r < N_HC; r++) {
+        for (int i = 0; i < N_EMBD; i++) {
+            x[r * N_EMBD + i] =
+                0.001f * (float)(((i + 13 * r) % 23) - 11) * (1.0f + 0.25f * (float)r);
+        }
+    }
+}
+
+int main(void) {
+    static float dirs[N_LAYERS * N_EMBD];
+    static float x[N_HC * N_EMBD];
+    static float ref[N_HC * N_EMBD];
+
+    /* Layer 3 carries a unit direction; every other layer is a zero row. */
+    for (int i = 0; i < N_EMBD; i++) {
+        dirs[3 * N_EMBD + i] = (float)((i % 7) + 1) * ((i % 2) ? -1.0f : 1.0f);
+    }
+    const double dnorm = sqrt(dot_row(dirs + 3 * N_EMBD, dirs + 3 * N_EMBD));
+    for (int i = 0; i < N_EMBD; i++) dirs[3 * N_EMBD + i] /= (float)dnorm;
+    const float *dir = dirs + 3 * N_EMBD;
+
+    fill_stack(x);
+    memcpy(ref, x, sizeof(x));
+
+    /* Zero direction at a covered-by-nothing layer: exact no-op. */
+    ds4_test_directional_steering_project_rows(x, dirs, 4, N_HC, 1.5f);
+    CHECK(memcmp(x, ref, sizeof(x)) == 0, "zero direction row is an exact no-op");
+
+    /* Zero scale: exact no-op too. */
+    ds4_test_directional_steering_project_rows(x, dirs, 3, N_HC, 0.0f);
+    CHECK(memcmp(x, ref, sizeof(x)) == 0, "zero scale is an exact no-op");
+
+    /* Nonzero direction, scale 2: x -= 2 * dot(dir, row) * dir per stream. */
+    ds4_test_directional_steering_project_rows(x, dirs, 3, N_HC, 2.0f);
+    double max_abs = 0.0;
+    int changed = 0;
+    for (int r = 0; r < N_HC; r++) {
+        const float *row_in = ref + r * N_EMBD;
+        const float coeff = (float)(2.0 * dot_row(dir, row_in));
+        for (int i = 0; i < N_EMBD; i++) {
+            const float expect = row_in[i] - coeff * dir[i];
+            const double d = fabs((double)x[r * N_EMBD + i] - (double)expect);
+            if (d > max_abs) max_abs = d;
+            if (x[r * N_EMBD + i] != row_in[i]) changed = 1;
+        }
+    }
+    CHECK(changed, "nonzero direction changes the post-fold stack");
+    CHECK(max_abs < 1e-4, "per-stream projection matches the hand computation");
+    if (max_abs >= 1e-4) fprintf(stderr, "    max_abs=%g\n", max_abs);
+
+    /* The projection is per stream: stream r must see dot(dir, row_r), not a
+     * shared dot over the flattened stack.  The hand computation above only
+     * passes if that is true, so this is the same assertion viewed from the
+     * other side: at scale 1 the component along a unit direction is removed
+     * exactly, so a second application must be a no-op. */
+    memcpy(x, ref, sizeof(x));
+    ds4_test_directional_steering_project_rows(x, dirs, 3, N_HC, 1.0f);
+    ds4_test_directional_steering_project_rows(x, dirs, 3, N_HC, 1.0f);
+    for (int r = 0; r < N_HC; r++) {
+        const float *row_in = ref + r * N_EMBD;
+        const float coeff = (float)dot_row(dir, row_in);
+        double row_err = 0.0;
+        for (int i = 0; i < N_EMBD; i++) {
+            const float expect = row_in[i] - coeff * dir[i];
+            row_err += fabs((double)x[r * N_EMBD + i] - (double)expect);
+        }
+        CHECK(row_err < 1e-2, "a second scale-1 projection is a no-op (idempotent)");
+    }
+
+    fprintf(stderr, "%s\n", g_failed == 0 ? "dir-steering projection tests: OK"
+                                          : "dir-steering projection tests: FAILED");
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/test_dir_steering.c
+++ b/tests/test_dir_steering.c
@@ -74,6 +74,23 @@ int main(void) {
     ds4_test_directional_steering_project_rows(x, dirs, 3, N_HC, 0.0f);
     CHECK(memcmp(x, ref, sizeof(x)) == 0, "zero scale is an exact no-op");
 
+    /* The zero-scale no-op must not even read the direction: with a NaN row
+     * and scale 0 the stack is bit-identical.  This is what makes
+     * alpha_default=0 -- "no steering by default" -- safe to honor. */
+    {
+        static float nan_dirs[N_LAYERS * N_EMBD];
+        const uint32_t nan_bits = 0x7fc00000u;   /* quiet NaN, by bits: this
+                                                    file builds with
+                                                    -ffast-math, where the
+                                                    NAN macro is UB */
+        float nan_f;
+        memcpy(&nan_f, &nan_bits, sizeof(nan_f));
+        for (int i = 0; i < N_EMBD; i++) nan_dirs[3 * N_EMBD + i] = nan_f;
+        ds4_test_directional_steering_project_rows(x, nan_dirs, 3, N_HC, 0.0f);
+        CHECK(memcmp(x, ref, sizeof(x)) == 0,
+              "zero scale does not read the direction (NaN row, no-op)");
+    }
+
     /* Nonzero direction, scale 2: x -= 2 * dot(dir, row) * dir per stream. */
     ds4_test_directional_steering_project_rows(x, dirs, 3, N_HC, 2.0f);
     double max_abs = 0.0;

--- a/tests/test_glp.c
+++ b/tests/test_glp.c
@@ -70,6 +70,7 @@ typedef struct {
     uint32_t ndim;       /* 1 unless a test wants otherwise */
     float    scale;      /* norm to write; 1.0 for a unit direction */
     float    fill;       /* value pattern seed; 0 writes a zero direction */
+    int      nonfinite;  /* 0 = all finite, 1 = NaN at [0], 2 = Inf at [0] */
 } dir_entry;
 
 typedef struct {
@@ -130,6 +131,16 @@ static void w_pad(FILE *fp) {
     while (pad-- > 0) fputc(0, fp);
 }
 
+/* Bit-pattern NaN/Inf: this file is built with -ffast-math, under which the
+ * NAN/INFINITY macros are UB, so construct the values by their bits. */
+static float f32_from_bits(uint32_t bits) {
+    float f;
+    memcpy(&f, &bits, sizeof(f));
+    return f;
+}
+#define TEST_NAN f32_from_bits(0x7fc00000u)
+#define TEST_INF f32_from_bits(0x7f800000u)
+
 /* Build the direction values: a deterministic pattern normalised to
  * d->scale, so a test can ask for a unit direction or a deliberately
  * off-unit one. fill == 0 writes an all-zero direction. */
@@ -146,6 +157,8 @@ static void fill_direction(const dir_entry *d, float *buf) {
     const float norm = (float)sqrt(sumsq);
     const float k = d->scale / norm;
     for (uint32_t i = 0; i < d->n; i++) buf[i] *= k;
+    if (d->nonfinite == 1) buf[0] = TEST_NAN;
+    if (d->nonfinite == 2) buf[0] = TEST_INF;
 }
 
 /* Write the spec to path. Tensor data offsets are relative to the aligned data
@@ -710,6 +723,142 @@ static void test_derived_at(void) {
     unlink(path);
 }
 
+static void test_refuse_nonfinite(void) {
+    /* A NaN or Inf direction poisons every activation it touches, and a NaN
+     * alpha scales the projection by NaN. Both refuse at load. */
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    g.dirs[0].nonfinite = 1;
+    const char *path = tmp_path("nan");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[768];
+    int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                          dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "a direction containing NaN is refused");
+    CHECK(strstr(err, "NaN") != NULL, "error names the non-finite direction");
+    if (rc == 0 || !strstr(err, "NaN")) fprintf(stderr, "    rc=%d err: %s\n", rc, err);
+    unlink(path);
+
+    spec_valid(&g, N_EMBD);
+    g.dirs[1].nonfinite = 2;
+    path = tmp_path("inf");
+    CHECK(write_gguf(path, &g), "fixture written");
+    rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                      dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "a direction containing Inf is refused");
+    unlink(path);
+
+    spec_valid(&g, N_EMBD);
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.alpha_default") == 0) g.kv[i].f32 = TEST_NAN;
+    }
+    path = tmp_path("nanalpha");
+    CHECK(write_gguf(path, &g), "fixture written");
+    rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                      dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "a NaN alpha_default is refused");
+    CHECK(strstr(err, "alpha_default") != NULL, "error names alpha_default");
+    unlink(path);
+}
+
+static void test_refuse_layer_set_mismatch(void) {
+    /* Count/min/max agree and the interior differs: the summary check could
+     * not see this. The exact-set comparison must. */
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.layer_ids_zero_based") == 0) {
+            snprintf(g.kv[i].s, sizeof(g.kv[i].s), "2,3,5,5");
+        }
+    }
+    const char *path = tmp_path("layermis");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[768];
+    int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                          dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "declared list differing in the interior is refused");
+    CHECK(strstr(err, "layer_ids_zero_based") != NULL, "error names the field");
+    unlink(path);
+
+    /* A duplicate direction.<N> would load twice, the second silently
+     * overwriting the first row. */
+    spec_valid(&g, N_EMBD);
+    add_dir(&g, 3, N_EMBD);
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.layer_ids_zero_based") == 0) {
+            g.kv[i].s[0] = '\0';
+        }
+    }
+    path = tmp_path("duplayer");
+    CHECK(write_gguf(path, &g), "fixture written");
+    rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                      dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "a duplicate direction.<N> is refused");
+    CHECK(strstr(err, "twice") != NULL, "error names the duplicate");
+    unlink(path);
+}
+
+static void test_refuse_misaligned_offset(void) {
+    /* Direction bytes are read as float * straight out of the mapping, so a
+     * tensor offset that is not float-aligned would be an unaligned load.
+     * Hand-roll the file: the fixture writer always aligns. */
+    const char *path = tmp_path("align");
+    FILE *fp = fopen(path, "wb");
+    CHECK(fp != NULL, "fixture opened");
+    if (!fp) return;
+    w_u32(fp, 0x46554747u);
+    w_u32(fp, 3);
+    w_u64(fp, 1); /* one tensor */
+    w_u64(fp, 1); /* one KV */
+    w_str(fp, "glp.mode");
+    w_u32(fp, GGUF_TYPE_STRING);
+    w_str(fp, "project");
+    w_str(fp, "direction.2");
+    w_u32(fp, 1);          /* ndim */
+    w_u64(fp, N_EMBD);
+    w_u32(fp, GGML_TYPE_F32);
+    w_u64(fp, 2);          /* offset 2: not a multiple of 4 */
+    w_pad(fp);
+    for (int i = 0; i < N_EMBD + 1; i++) w_f32(fp, 0.5f);
+    fclose(fp);
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[768];
+    const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "a non-float-aligned direction offset is refused");
+    CHECK(strstr(err, "aligned") != NULL, "error names the alignment");
+    unlink(path);
+}
+
+static void test_refuse_amplified_header_counts(void) {
+    /* 100 KVs cannot fit in 500 bytes (13 minimum each), so the count is a
+     * lie and the calloc must not happen. The 1-byte floor used to let this
+     * through to a 100-entry allocation and a truncated-metadata refusal. */
+    const char *path = tmp_path("counts");
+    FILE *fp = fopen(path, "wb");
+    CHECK(fp != NULL, "fixture opened");
+    if (!fp) return;
+    w_u32(fp, 0x46554747u);
+    w_u32(fp, 3);
+    w_u64(fp, 4);   /* tensors */
+    w_u64(fp, 100); /* KV entries */
+    for (int i = 0; i < 500; i++) fputc(0, fp);
+    fclose(fp);
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[768];
+    const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "counts the file cannot minimally contain are refused");
+    CHECK(strstr(err, "header counts") != NULL, "error names the header counts");
+    unlink(path);
+}
+
 static void test_load_resid_hook(void) {
     /* residual_stream_post_layer is the site every published GLP vector
      * declares. It must load at the resid target with no override, and its
@@ -743,9 +892,13 @@ static void test_load_resid_hook(void) {
 
     /* alpha_default is adopted at the site it was calibrated for, and only
      * there: the FFN default must return the caller's fallback. */
-    CHECK(fabsf(ds4_glp_default_resid_scale(path, 0.0f) - 3.0f) < 1e-6f,
+    int adopted = 0;
+    CHECK(fabsf(ds4_glp_default_resid_scale(path, 0.0f, &adopted) - 3.0f) < 1e-6f &&
+          adopted == 1,
           "resid default adopts glp.alpha_default");
-    CHECK(fabsf(ds4_glp_default_ffn_scale(path, 7.0f) - 7.0f) < 1e-6f,
+    adopted = 1;
+    CHECK(fabsf(ds4_glp_default_ffn_scale(path, 7.0f, &adopted) - 7.0f) < 1e-6f &&
+          adopted == 0,
           "ffn default does not adopt a residual site's alpha");
     unlink(path);
 
@@ -753,10 +906,53 @@ static void test_load_resid_hook(void) {
     spec_valid(&g, N_EMBD);
     path = tmp_path("resid-ffn");
     CHECK(write_gguf(path, &g), "fixture written");
-    CHECK(fabsf(ds4_glp_default_ffn_scale(path, 0.0f) - 3.0f) < 1e-6f,
+    adopted = 0;
+    CHECK(fabsf(ds4_glp_default_ffn_scale(path, 0.0f, &adopted) - 3.0f) < 1e-6f &&
+          adopted == 1,
           "ffn default adopts glp.alpha_default");
-    CHECK(ds4_glp_default_resid_scale(path, 0.0f) == 0.0f,
+    CHECK(ds4_glp_default_resid_scale(path, 0.0f, &adopted) == 0.0f &&
+          adopted == 0,
           "resid default does not adopt an FFN site's alpha");
+    unlink(path);
+
+    /* alpha_default=0 is a value -- "no steering by default" -- not an
+     * absence: adopted must be set so the caller does not fall through to
+     * another site's default scale. */
+    spec_valid(&g, N_EMBD);
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.hook_point") == 0) {
+            snprintf(g.kv[i].s, sizeof(g.kv[i].s), "residual_stream_post_layer");
+        }
+        if (strcmp(g.kv[i].key, "glp.alpha_default") == 0) {
+            g.kv[i].f32 = 0.0f;
+        }
+    }
+    path = tmp_path("alpha-zero");
+    CHECK(write_gguf(path, &g), "fixture written");
+    adopted = 0;
+    CHECK(ds4_glp_default_resid_scale(path, 9.0f, &adopted) == 0.0f &&
+          adopted == 1,
+          "alpha_default=0 is adopted as a value");
+    unlink(path);
+
+    /* And a file with no alpha_default at all adopts nothing. */
+    spec_valid(&g, N_EMBD);
+    {
+        gguf_spec h;
+        memset(&h, 0, sizeof(h));
+        for (int i = 0; i < g.n_kv; i++) {
+            if (strcmp(g.kv[i].key, "glp.alpha_default") == 0) continue;
+            h.kv[h.n_kv++] = g.kv[i];
+        }
+        memcpy(h.dirs, g.dirs, sizeof(g.dirs));
+        h.n_dirs = g.n_dirs;
+        path = tmp_path("alpha-absent");
+        CHECK(write_gguf(path, &h), "fixture written");
+    }
+    adopted = 1;
+    CHECK(ds4_glp_default_ffn_scale(path, 5.0f, &adopted) == 5.0f &&
+          adopted == 0,
+          "absent alpha_default adopts nothing");
     unlink(path);
 }
 
@@ -787,6 +983,10 @@ int main(void) {
     RUN(test_malformed_input);
     RUN(test_derived_at);
     RUN(test_load_resid_hook);
+    RUN(test_refuse_nonfinite);
+    RUN(test_refuse_layer_set_mismatch);
+    RUN(test_refuse_misaligned_offset);
+    RUN(test_refuse_amplified_header_counts);
     RUN(test_hook_names_round_trip);
 
     fprintf(stderr, "\n%d checks, %d failed\n", g_total, g_failed);

--- a/tests/test_glp.c
+++ b/tests/test_glp.c
@@ -649,6 +649,65 @@ static void test_malformed_input(void) {
     unlink(path);
 }
 
+static void test_derived_at(void) {
+    /* Native: derived_at == hook_point. Loads, no transfer marker. */
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    kv_str(&g, "glp.derived_at", "ffn_out_pre_residual");
+    const char *path = tmp_path("derived-native");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    ds4_glp_info info;
+    char err[512];
+    int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                          dirs, N_LAYERS, N_EMBD, &info, err, sizeof(err));
+    CHECK(rc == 0, "native derived_at loads");
+    CHECK(strcmp(info.derived_at, "ffn_out_pre_residual") == 0, "derived_at read");
+
+    FILE *dump = tmpfile();
+    CHECK(dump != NULL, "tmpfile");
+    if (dump) {
+        ds4_glp_print_info(dump, path, &info);
+        rewind(dump);
+        char buf[4096];
+        const size_t n = fread(buf, 1, sizeof(buf) - 1, dump);
+        buf[n] = '\0';
+        fclose(dump);
+        CHECK(strstr(buf, "derived_at") != NULL, "derived_at shown in info");
+        CHECK(strstr(buf, "TRANSFERRED") == NULL, "no transfer marker when native");
+    }
+    unlink(path);
+
+    /* Transferred: captured on the residual, calibrated for the FFN write.
+     * A warning, not a refusal -- the file still loads at the FFN hook. */
+    spec_valid(&g, N_EMBD);
+    kv_str(&g, "glp.derived_at", "residual_stream_post_layer");
+    path = tmp_path("derived-transferred");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                      dirs, N_LAYERS, N_EMBD, &info, err, sizeof(err));
+    CHECK(rc == 0, "transferred vector loads (warning, not refusal)");
+    if (rc != 0) fprintf(stderr, "    err: %s\n", err);
+    CHECK(strcmp(info.derived_at, "residual_stream_post_layer") == 0,
+          "transferred derived_at read");
+
+    dump = tmpfile();
+    CHECK(dump != NULL, "tmpfile");
+    if (dump) {
+        ds4_glp_print_info(dump, path, &info);
+        rewind(dump);
+        char buf[4096];
+        const size_t n = fread(buf, 1, sizeof(buf) - 1, dump);
+        buf[n] = '\0';
+        fclose(dump);
+        CHECK(strstr(buf, "TRANSFERRED") != NULL,
+              "transfer marker shown in info");
+    }
+    unlink(path);
+}
+
 static void test_hook_names_round_trip(void) {
     CHECK(strcmp(ds4_glp_hook_name(DS4_GLP_HOOK_RESID_POST_LAYER),
                  "residual_stream_post_layer") == 0, "resid hook name");
@@ -674,6 +733,7 @@ int main(void) {
     RUN(test_refuse_no_directions);
     RUN(test_read_info_needs_no_model);
     RUN(test_malformed_input);
+    RUN(test_derived_at);
     RUN(test_hook_names_round_trip);
 
     fprintf(stderr, "\n%d checks, %d failed\n", g_total, g_failed);

--- a/tests/test_glp.c
+++ b/tests/test_glp.c
@@ -1,0 +1,681 @@
+/* Unit tests for the GLP (GGUF Layer Projection) steering-vector reader.
+ *
+ * Pure C99: no CUDA, no Metal, no model. Every test builds a real GGUF v3 file
+ * on disk and reads it back, so the container layout is exercised rather than
+ * mocked.
+ *
+ * The refusal paths are the point of this file. A GLP reader that accepts a
+ * bad vector does not crash and does not print anything wrong -- it produces
+ * plausible, degraded output. Each of the cases below was chosen because it is
+ * a failure that cannot be caught downstream:
+ *
+ *   wrong operation   an additive vector applied projectively (or the reverse)
+ *   wrong hook        the same direction 9x weaker
+ *   wrong layer map   adjacent-layer cosine 0.55-0.98, so a shift still works
+ *   wrong base model  undefined, and shapes can still match
+ */
+
+#include "../ds4_glp.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int g_failed = 0;
+static int g_total  = 0;
+
+#define CHECK(cond, msg) do {                                                  \
+    g_total++;                                                                 \
+    if (!(cond)) {                                                             \
+        fprintf(stderr, "  FAIL: %s (line %d)\n", (msg), __LINE__);            \
+        g_failed++;                                                            \
+    }                                                                          \
+} while (0)
+
+#define RUN(fn) do {                                                           \
+    fprintf(stderr, "RUN: %s\n", #fn);                                         \
+    int _before = g_failed;                                                    \
+    (fn)();                                                                    \
+    fprintf(stderr, "  %s\n", (_before == g_failed) ? "ok" : "FAIL");          \
+} while (0)
+
+/* ------------------------------------------------------------------ */
+/* Minimal GGUF v3 writer                                             */
+/* ------------------------------------------------------------------ */
+
+#define GGUF_TYPE_UINT32  4
+#define GGUF_TYPE_FLOAT32 6
+#define GGUF_TYPE_STRING  8
+#define GGML_TYPE_F32     0
+#define GGML_TYPE_F16     1
+#define GGUF_ALIGNMENT    32
+
+#define MAX_KV   32
+#define MAX_DIRS 64
+
+typedef struct {
+    char     key[64];
+    uint32_t type;
+    char     s[192];
+    uint32_t u32;
+    float    f32;
+} kv_entry;
+
+typedef struct {
+    uint32_t layer;      /* the N in direction.<N> */
+    uint32_t n;          /* element count */
+    uint32_t ggml_type;  /* GGML_TYPE_F32 unless a test wants otherwise */
+    uint32_t ndim;       /* 1 unless a test wants otherwise */
+    float    scale;      /* norm to write; 1.0 for a unit direction */
+    float    fill;       /* value pattern seed; 0 writes a zero direction */
+} dir_entry;
+
+typedef struct {
+    kv_entry  kv[MAX_KV];
+    int       n_kv;
+    dir_entry dirs[MAX_DIRS];
+    int       n_dirs;
+} gguf_spec;
+
+static void kv_str(gguf_spec *g, const char *key, const char *val) {
+    kv_entry *e = &g->kv[g->n_kv++];
+    memset(e, 0, sizeof(*e));
+    snprintf(e->key, sizeof(e->key), "%s", key);
+    snprintf(e->s, sizeof(e->s), "%s", val);
+    e->type = GGUF_TYPE_STRING;
+}
+
+static void kv_u32(gguf_spec *g, const char *key, uint32_t val) {
+    kv_entry *e = &g->kv[g->n_kv++];
+    memset(e, 0, sizeof(*e));
+    snprintf(e->key, sizeof(e->key), "%s", key);
+    e->u32  = val;
+    e->type = GGUF_TYPE_UINT32;
+}
+
+static void kv_f32(gguf_spec *g, const char *key, float val) {
+    kv_entry *e = &g->kv[g->n_kv++];
+    memset(e, 0, sizeof(*e));
+    snprintf(e->key, sizeof(e->key), "%s", key);
+    e->f32  = val;
+    e->type = GGUF_TYPE_FLOAT32;
+}
+
+static void add_dir(gguf_spec *g, uint32_t layer, uint32_t n) {
+    dir_entry *d = &g->dirs[g->n_dirs++];
+    memset(d, 0, sizeof(*d));
+    d->layer     = layer;
+    d->n         = n;
+    d->ggml_type = GGML_TYPE_F32;
+    d->ndim      = 1;
+    d->scale     = 1.0f;
+    d->fill      = 1.0f;
+}
+
+static void w_u32(FILE *fp, uint32_t v) { fwrite(&v, sizeof(v), 1, fp); }
+static void w_u64(FILE *fp, uint64_t v) { fwrite(&v, sizeof(v), 1, fp); }
+static void w_f32(FILE *fp, float v)    { fwrite(&v, sizeof(v), 1, fp); }
+
+static void w_str(FILE *fp, const char *s) {
+    const uint64_t len = strlen(s);
+    w_u64(fp, len);
+    fwrite(s, 1, (size_t)len, fp);
+}
+
+static void w_pad(FILE *fp) {
+    const long pos = ftell(fp);
+    long pad = (GGUF_ALIGNMENT - (pos % GGUF_ALIGNMENT)) % GGUF_ALIGNMENT;
+    while (pad-- > 0) fputc(0, fp);
+}
+
+/* Build the direction values: a deterministic pattern normalised to
+ * d->scale, so a test can ask for a unit direction or a deliberately
+ * off-unit one. fill == 0 writes an all-zero direction. */
+static void fill_direction(const dir_entry *d, float *buf) {
+    if (d->fill == 0.0f) {
+        memset(buf, 0, (size_t)d->n * sizeof(buf[0]));
+        return;
+    }
+    double sumsq = 0.0;
+    for (uint32_t i = 0; i < d->n; i++) {
+        buf[i] = d->fill * (float)((i % 7) + 1) * ((i % 2) ? -1.0f : 1.0f);
+        sumsq += (double)buf[i] * (double)buf[i];
+    }
+    const float norm = (float)sqrt(sumsq);
+    const float k = d->scale / norm;
+    for (uint32_t i = 0; i < d->n; i++) buf[i] *= k;
+}
+
+/* Write the spec to path. Tensor data offsets are relative to the aligned data
+ * start, which is what GGUF specifies and what the reader must resolve. */
+static int write_gguf(const char *path, const gguf_spec *g) {
+    FILE *fp = fopen(path, "wb");
+    if (!fp) return 0;
+
+    w_u32(fp, 0x46554747u); /* "GGUF" */
+    w_u32(fp, 3);
+    w_u64(fp, (uint64_t)g->n_dirs);
+    w_u64(fp, (uint64_t)g->n_kv);
+
+    for (int i = 0; i < g->n_kv; i++) {
+        const kv_entry *e = &g->kv[i];
+        w_str(fp, e->key);
+        w_u32(fp, e->type);
+        switch (e->type) {
+        case GGUF_TYPE_STRING:  w_str(fp, e->s);  break;
+        case GGUF_TYPE_UINT32:  w_u32(fp, e->u32); break;
+        case GGUF_TYPE_FLOAT32: w_f32(fp, e->f32); break;
+        default: break;
+        }
+    }
+
+    /* Every direction is padded to the alignment so each tensor starts on an
+     * aligned offset, matching what real writers emit. */
+    uint64_t offset = 0;
+    for (int i = 0; i < g->n_dirs; i++) {
+        const dir_entry *d = &g->dirs[i];
+        char name[64];
+        snprintf(name, sizeof(name), "direction.%u", d->layer);
+        w_str(fp, name);
+        w_u32(fp, d->ndim);
+        for (uint32_t k = 0; k < d->ndim; k++) w_u64(fp, k == 0 ? d->n : 1);
+        w_u32(fp, d->ggml_type);
+        w_u64(fp, offset);
+
+        const uint64_t elem = (d->ggml_type == GGML_TYPE_F16) ? 2 : 4;
+        uint64_t bytes = (uint64_t)d->n * elem;
+        for (uint32_t k = 1; k < d->ndim; k++) bytes *= 1;
+        bytes = (bytes + GGUF_ALIGNMENT - 1) / GGUF_ALIGNMENT * GGUF_ALIGNMENT;
+        offset += bytes;
+    }
+
+    w_pad(fp);
+    for (int i = 0; i < g->n_dirs; i++) {
+        const dir_entry *d = &g->dirs[i];
+        if (d->ggml_type == GGML_TYPE_F32) {
+            float *buf = malloc((size_t)d->n * sizeof(float));
+            fill_direction(d, buf);
+            fwrite(buf, sizeof(float), d->n, fp);
+            free(buf);
+        } else {
+            for (uint32_t k = 0; k < d->n; k++) fputc(0, fp), fputc(0, fp);
+        }
+        w_pad(fp);
+    }
+    fclose(fp);
+    return 1;
+}
+
+/* A conforming vector: project mode, ds4's FFN hook, layers 2..5 of an 8-layer
+ * 64-wide model. */
+static void spec_valid(gguf_spec *g, uint32_t n_embd) {
+    memset(g, 0, sizeof(*g));
+    kv_str(g, "general.architecture", "controlvector");
+    kv_str(g, "glp.mode", "project");
+    kv_u32(g, "glp.spec_version", 1);
+    kv_f32(g, "glp.alpha_default", 3.0f);
+    kv_u32(g, "glp.rank", 1);
+    kv_str(g, "glp.hook_point", "ffn_out_pre_residual");
+    kv_str(g, "glp.layer_ids_zero_based", "2,3,4,5");
+    kv_str(g, "glp.method", "paired_difference_of_means");
+    kv_str(g, "general.base_model.0.name", "DeepSeek-V4-Flash-0731");
+    kv_str(g, "general.base_model.0.organization", "deepseek-ai");
+    for (uint32_t l = 2; l <= 5; l++) add_dir(g, l, n_embd);
+}
+
+static const char *tmp_path(const char *leaf) {
+    static char buf[512];
+    const char *dir = getenv("TMPDIR");
+    if (!dir || !dir[0]) dir = "/tmp";
+    size_t n = strlen(dir);
+    snprintf(buf, sizeof(buf), "%s%sds4-glp-%d-%s.gguf",
+             dir, (n && dir[n - 1] == '/') ? "" : "/", (int)getpid(), leaf);
+    return buf;
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+#define N_EMBD   64
+#define N_LAYERS 8
+
+static void test_probe(void) {
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    const char *path = tmp_path("probe");
+    CHECK(write_gguf(path, &g), "fixture written");
+    CHECK(ds4_glp_is_gguf(path) == 1, "GGUF magic detected");
+
+    /* A raw .f32 blob must route to the legacy path, not to the GLP reader:
+     * that is what keeps existing --dir-steering-file usage working. */
+    const char *raw = tmp_path("raw");
+    FILE *fp = fopen(raw, "wb");
+    float zero[4] = {0, 0, 0, 0};
+    fwrite(zero, sizeof(float), 4, fp);
+    fclose(fp);
+    CHECK(ds4_glp_is_gguf(raw) == 0, "raw f32 is not GGUF");
+    CHECK(ds4_glp_is_gguf("/nonexistent/ds4-glp") == -1, "missing file reports -1");
+
+    unlink(path);
+    unlink(raw);
+}
+
+static void test_load_valid(void) {
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    const char *path = tmp_path("valid");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    ds4_glp_info info;
+    char err[512];
+    const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                dirs, N_LAYERS, N_EMBD, &info, err, sizeof(err));
+    CHECK(rc == 0, "conforming vector loads");
+    if (rc != 0) fprintf(stderr, "    err: %s\n", err);
+
+    CHECK(info.n_dirs == 4, "four directions");
+    CHECK(info.n_embd == N_EMBD, "n_embd resolved");
+    CHECK(info.layer_min == 2 && info.layer_max == 5, "layer range resolved");
+    CHECK(info.has_alpha_default && fabsf(info.alpha_default - 3.0f) < 1e-6f,
+          "alpha_default read");
+    CHECK(info.hook == DS4_GLP_HOOK_FFN_OUT, "hook resolved");
+    CHECK(strcmp(info.base_model, "DeepSeek-V4-Flash-0731") == 0, "base model read");
+
+    /* THE layer-map assertion. direction.N lands at row N with no offset.
+     * This is the check that would have caught our exporter off-by-one, and
+     * the reason it is here rather than in a smoke test is that a one-layer
+     * shift produces coherent output: adjacent layers' refusal directions have
+     * cosine similarity 0.555-0.979, so a shifted stack still ablates. */
+    for (uint32_t l = 0; l < N_LAYERS; l++) {
+        double sumsq = 0.0;
+        for (uint32_t i = 0; i < N_EMBD; i++) {
+            const float v = dirs[(size_t)l * N_EMBD + i];
+            sumsq += (double)v * (double)v;
+        }
+        const int covered = (l >= 2 && l <= 5);
+        if (covered) {
+            CHECK(fabs(sumsq - 1.0) < 1e-5, "covered layer holds a unit direction");
+        } else {
+            CHECK(sumsq == 0.0, "uncovered layer is zero (a no-op projection)");
+        }
+    }
+    unlink(path);
+}
+
+static void test_refuse_missing_mode(void) {
+    /* A plain llama.cpp control vector: right tensors, no glp.mode. Absent
+     * means additive, and ds4 has no additive path -- but the message has to
+     * say that rather than "malformed", because the file is not malformed. */
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    /* Drop glp.mode by rewriting the KV list without it. */
+    gguf_spec h;
+    memset(&h, 0, sizeof(h));
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.mode") == 0) continue;
+        h.kv[h.n_kv++] = g.kv[i];
+    }
+    memcpy(h.dirs, g.dirs, sizeof(g.dirs));
+    h.n_dirs = g.n_dirs;
+
+    const char *path = tmp_path("nomode");
+    CHECK(write_gguf(path, &h), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[512];
+    const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "no glp.mode is refused");
+    CHECK(strstr(err, "glp.mode") != NULL, "error names glp.mode");
+    unlink(path);
+}
+
+static void test_refuse_add_mode(void) {
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.mode") == 0) {
+            snprintf(g.kv[i].s, sizeof(g.kv[i].s), "add");
+        }
+    }
+    const char *path = tmp_path("addmode");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[512];
+    const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "glp.mode=add is refused, never coerced to project");
+    unlink(path);
+}
+
+static void test_refuse_hook_mismatch(void) {
+    /* Every GLP vector we have published so far declares
+     * residual_stream_post_layer, because that is where llama.cpp's
+     * build_cvec() and the vLLM overlay apply. ds4 applies at the block
+     * writers. Loading one into the other measured 9x weaker on the
+     * attention writer, so the default is a refusal. */
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.hook_point") == 0) {
+            snprintf(g.kv[i].s, sizeof(g.kv[i].s), "residual_stream_post_layer");
+        }
+    }
+    const char *path = tmp_path("hook");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[512];
+    int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                          dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "hook mismatch is refused by default");
+    CHECK(strstr(err, "hook_point") != NULL, "error names hook_point");
+    CHECK(strstr(err, "--dir-steering-allow-hook-mismatch") != NULL,
+          "error names the override flag");
+
+    /* ...and loads with the explicit override, which is the whole point of
+     * having one: the operation is right, only the calibration moves. */
+    ds4_glp_info info;
+    rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 1,
+                      dirs, N_LAYERS, N_EMBD, &info, err, sizeof(err));
+    CHECK(rc == 0, "hook mismatch loads under the override");
+    CHECK(info.hook == DS4_GLP_HOOK_RESID_POST_LAYER, "declared hook preserved");
+    unlink(path);
+}
+
+static void test_refuse_unknown_hook(void) {
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.hook_point") == 0) {
+            snprintf(g.kv[i].s, sizeof(g.kv[i].s), "attn.wo_b_output");
+        }
+    }
+    const char *path = tmp_path("unkhook");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[512];
+    const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "a hook name this build does not implement is refused");
+    unlink(path);
+}
+
+static void test_refuse_layer_id_mismatch(void) {
+    /* The exporter bug that actually happened: tensor names one layer ahead of
+     * the informational layer list. The names are what execute. */
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.layer_ids_zero_based") == 0) {
+            snprintf(g.kv[i].s, sizeof(g.kv[i].s), "1,2,3,4");
+        }
+    }
+    const char *path = tmp_path("layerids");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[512];
+    const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "declared layer ids disagreeing with tensor names is refused");
+    CHECK(strstr(err, "layer_ids_zero_based") != NULL, "error names the field");
+    unlink(path);
+}
+
+static void test_refuse_direction_zero(void) {
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    g.n_dirs = 0;
+    add_dir(&g, 0, N_EMBD);
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.layer_ids_zero_based") == 0) g.kv[i].s[0] = '\0';
+    }
+    const char *path = tmp_path("dir0");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[512];
+    const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "direction.0 is refused");
+    CHECK(strstr(err, "direction.0") != NULL, "error names direction.0");
+    unlink(path);
+}
+
+static void test_refuse_wrong_dtype_and_rank(void) {
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    g.dirs[0].ggml_type = GGML_TYPE_F16;
+    const char *path = tmp_path("f16");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[512];
+    int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                          dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "a non-F32 direction is refused");
+    unlink(path);
+
+    spec_valid(&g, N_EMBD);
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.rank") == 0) g.kv[i].u32 = 4;
+    }
+    path = tmp_path("rank4");
+    CHECK(write_gguf(path, &g), "fixture written");
+    rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                      dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "rank>1 is refused rather than silently truncated");
+    unlink(path);
+}
+
+static void test_refuse_shape_mismatch(void) {
+    /* Wrong n_embd: a direction from a different checkpoint. */
+    gguf_spec g;
+    spec_valid(&g, 32);
+    const char *path = tmp_path("width");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[512];
+    int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                          dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "n_embd mismatch is refused");
+    unlink(path);
+
+    /* A layer beyond what this model can steer. */
+    memset(&g, 0, sizeof(g));
+    kv_str(&g, "glp.mode", "project");
+    kv_str(&g, "glp.hook_point", "ffn_out_pre_residual");
+    add_dir(&g, 9, N_EMBD);
+    path = tmp_path("layerhigh");
+    CHECK(write_gguf(path, &g), "fixture written");
+    rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                      dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "a direction past the model's layer count is refused");
+    unlink(path);
+}
+
+static void test_renormalise(void) {
+    /* Projection is quadratic in the direction's norm, so an off-unit
+     * direction silently scales the removal by ||v||^2. The projector is
+     * invariant to ||v||, so rescaling is the correct fix rather than a
+     * refusal -- but it has to be reported. */
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    for (int i = 0; i < g.n_dirs; i++) g.dirs[i].scale = 2.5f;
+    const char *path = tmp_path("norm");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    ds4_glp_info info;
+    char err[512];
+    const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                dirs, N_LAYERS, N_EMBD, &info, err, sizeof(err));
+    CHECK(rc == 0, "off-unit directions load");
+    CHECK(info.n_renormalized == 4, "all four are reported as rescaled");
+    double sumsq = 0.0;
+    for (uint32_t i = 0; i < N_EMBD; i++) {
+        const float v = dirs[2 * N_EMBD + i];
+        sumsq += (double)v * (double)v;
+    }
+    CHECK(fabs(sumsq - 1.0) < 1e-5, "stored direction is unit after rescaling");
+    unlink(path);
+
+    /* A zero direction cannot be normalised and steers nothing: malformed, not
+     * "partial coverage" -- partial coverage is expressed by omitting the
+     * tensor. */
+    spec_valid(&g, N_EMBD);
+    g.dirs[0].fill = 0.0f;
+    path = tmp_path("zerodir");
+    CHECK(write_gguf(path, &g), "fixture written");
+    const int rc2 = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                 dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc2 != 0, "an all-zero direction is refused");
+    unlink(path);
+}
+
+static void test_refuse_legacy_namespace(void) {
+    /* Pre-2026-08-22 internal files used dspark.*, renamed with no alias.
+     * Such a file has the right tensors and no glp.mode, so without an
+     * explicit check it gets diagnosed as "an additive control vector" and
+     * refused for the wrong reason. */
+    gguf_spec g;
+    memset(&g, 0, sizeof(g));
+    kv_str(&g, "dspark.mode", "project");
+    kv_str(&g, "dspark.hook_point", "residual_stream_post_layer");
+    for (uint32_t l = 2; l <= 5; l++) add_dir(&g, l, N_EMBD);
+    const char *path = tmp_path("legacy");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[512];
+    const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "a dspark.*-only file is refused");
+    CHECK(strstr(err, "dspark") != NULL, "error names the old namespace");
+    CHECK(strstr(err, "re-export") != NULL, "error says what to do about it");
+    unlink(path);
+}
+
+static void test_refuse_no_directions(void) {
+    gguf_spec g;
+    memset(&g, 0, sizeof(g));
+    kv_str(&g, "glp.mode", "project");
+    kv_str(&g, "glp.hook_point", "ffn_out_pre_residual");
+    const char *path = tmp_path("nodirs");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    char err[512];
+    const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                                dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
+    CHECK(rc != 0, "a GGUF with no direction.<N> tensors is refused");
+    unlink(path);
+}
+
+static void test_read_info_needs_no_model(void) {
+    /* The inspect path: what is actually in this file, without the several-GB
+     * checkpoint it belongs to. Our exporter off-by-one surfaced exactly here,
+     * as a dump reporting layers 11-39 for a file derived from 10-38. */
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    const char *path = tmp_path("info");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    ds4_glp_info info;
+    char err[512];
+    const int rc = ds4_glp_read_info(path, &info, err, sizeof(err));
+    CHECK(rc == 0, "read_info succeeds with no model shape");
+    if (rc != 0) fprintf(stderr, "    err: %s\n", err);
+    CHECK(info.n_dirs == 4 && info.layer_min == 2 && info.layer_max == 5,
+          "read_info resolves coverage");
+    CHECK(info.norm_min > 0.99f && info.norm_max < 1.01f, "read_info reports norms");
+
+    /* read_info deliberately does not check the hook: it must be able to
+     * describe a file this build would refuse to apply. That is what makes it
+     * the first tool to reach for. */
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.hook_point") == 0) {
+            snprintf(g.kv[i].s, sizeof(g.kv[i].s), "residual_stream_post_layer");
+        }
+    }
+    CHECK(write_gguf(path, &g), "fixture rewritten");
+    CHECK(ds4_glp_read_info(path, &info, err, sizeof(err)) == 0,
+          "read_info describes a file this build cannot apply");
+    CHECK(info.hook == DS4_GLP_HOOK_RESID_POST_LAYER, "and reports its hook");
+    unlink(path);
+}
+
+static void test_malformed_input(void) {
+    /* Not a crash test for its own sake: --dir-steering-file is a path a user
+     * types, so truncation and "you passed the model" are ordinary inputs. */
+    float dirs[N_LAYERS * N_EMBD];
+    char err[512];
+
+    CHECK(ds4_glp_load("/nonexistent/ds4-glp.gguf", DS4_GLP_HOOK_FFN_OUT, 0,
+                       dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err)) != 0,
+          "missing file is refused");
+
+    const char *path = tmp_path("trunc");
+    FILE *fp = fopen(path, "wb");
+    w_u32(fp, 0x46554747u);
+    w_u32(fp, 3);
+    w_u64(fp, 4);       /* claims 4 tensors */
+    w_u64(fp, 1000000); /* ...and a million KV entries in a 24-byte file */
+    fclose(fp);
+    CHECK(ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                       dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err)) != 0,
+          "header counts exceeding the file are refused before allocating");
+    unlink(path);
+
+    /* GGUF v2 is out of spec for GLP. */
+    path = tmp_path("v2");
+    fp = fopen(path, "wb");
+    w_u32(fp, 0x46554747u);
+    w_u32(fp, 2);
+    w_u64(fp, 0);
+    w_u64(fp, 0);
+    fclose(fp);
+    CHECK(ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
+                       dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err)) != 0,
+          "GGUF v2 is refused");
+    unlink(path);
+}
+
+static void test_hook_names_round_trip(void) {
+    CHECK(strcmp(ds4_glp_hook_name(DS4_GLP_HOOK_RESID_POST_LAYER),
+                 "residual_stream_post_layer") == 0, "resid hook name");
+    CHECK(strcmp(ds4_glp_hook_name(DS4_GLP_HOOK_FFN_OUT),
+                 "ffn_out_pre_residual") == 0, "ffn hook name");
+    CHECK(strcmp(ds4_glp_hook_name(DS4_GLP_HOOK_ATTN_OUT),
+                 "attn_out_pre_residual") == 0, "attn hook name");
+}
+
+int main(void) {
+    RUN(test_probe);
+    RUN(test_load_valid);
+    RUN(test_refuse_missing_mode);
+    RUN(test_refuse_add_mode);
+    RUN(test_refuse_hook_mismatch);
+    RUN(test_refuse_unknown_hook);
+    RUN(test_refuse_layer_id_mismatch);
+    RUN(test_refuse_direction_zero);
+    RUN(test_refuse_wrong_dtype_and_rank);
+    RUN(test_refuse_shape_mismatch);
+    RUN(test_renormalise);
+    RUN(test_refuse_legacy_namespace);
+    RUN(test_refuse_no_directions);
+    RUN(test_read_info_needs_no_model);
+    RUN(test_malformed_input);
+    RUN(test_hook_names_round_trip);
+
+    fprintf(stderr, "\n%d checks, %d failed\n", g_total, g_failed);
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/test_glp.c
+++ b/tests/test_glp.c
@@ -377,6 +377,8 @@ static void test_refuse_hook_mismatch(void) {
     CHECK(strstr(err, "hook_point") != NULL, "error names hook_point");
     CHECK(strstr(err, "--dir-steering-allow-hook-mismatch") != NULL,
           "error names the override flag");
+    CHECK(strstr(err, "--dir-steering-resid") != NULL,
+          "error names the flag for the file's declared site");
 
     /* ...and loads with the explicit override, which is the whole point of
      * having one: the operation is right, only the calibration moves. */
@@ -599,8 +601,8 @@ static void test_read_info_needs_no_model(void) {
     CHECK(info.norm_min > 0.99f && info.norm_max < 1.01f, "read_info reports norms");
 
     /* read_info deliberately does not check the hook: it must be able to
-     * describe a file this build would refuse to apply. That is what makes it
-     * the first tool to reach for. */
+     * describe a file regardless of where this build would apply it. That is
+     * what makes it the first tool to reach for. */
     for (int i = 0; i < g.n_kv; i++) {
         if (strcmp(g.kv[i].key, "glp.hook_point") == 0) {
             snprintf(g.kv[i].s, sizeof(g.kv[i].s), "residual_stream_post_layer");
@@ -608,7 +610,7 @@ static void test_read_info_needs_no_model(void) {
     }
     CHECK(write_gguf(path, &g), "fixture rewritten");
     CHECK(ds4_glp_read_info(path, &info, err, sizeof(err)) == 0,
-          "read_info describes a file this build cannot apply");
+          "read_info describes a residual-hooked file");
     CHECK(info.hook == DS4_GLP_HOOK_RESID_POST_LAYER, "and reports its hook");
     unlink(path);
 }
@@ -708,6 +710,56 @@ static void test_derived_at(void) {
     unlink(path);
 }
 
+static void test_load_resid_hook(void) {
+    /* residual_stream_post_layer is the site every published GLP vector
+     * declares. It must load at the resid target with no override, and its
+     * calibrated alpha must be adopted by the resid default only. */
+    gguf_spec g;
+    spec_valid(&g, N_EMBD);
+    for (int i = 0; i < g.n_kv; i++) {
+        if (strcmp(g.kv[i].key, "glp.hook_point") == 0) {
+            snprintf(g.kv[i].s, sizeof(g.kv[i].s), "residual_stream_post_layer");
+        }
+    }
+    const char *path = tmp_path("resid");
+    CHECK(write_gguf(path, &g), "fixture written");
+
+    float dirs[N_LAYERS * N_EMBD];
+    ds4_glp_info info;
+    char err[768];
+    int rc = ds4_glp_load(path, DS4_GLP_HOOK_RESID_POST_LAYER, 0,
+                          dirs, N_LAYERS, N_EMBD, &info, err, sizeof(err));
+    CHECK(rc == 0, "residual-hooked vector loads at the residual hook");
+    if (rc != 0) fprintf(stderr, "    err: %s\n", err);
+    CHECK(info.hook == DS4_GLP_HOOK_RESID_POST_LAYER, "hook resolved");
+    CHECK(info.n_dirs == 4 && info.layer_min == 2 && info.layer_max == 5,
+          "coverage resolved");
+    double sumsq = 0.0;
+    for (uint32_t i = 0; i < N_EMBD; i++) {
+        const float v = dirs[(size_t)3 * N_EMBD + i];
+        sumsq += (double)v * (double)v;
+    }
+    CHECK(fabs(sumsq - 1.0) < 1e-5, "covered layer holds a unit direction");
+
+    /* alpha_default is adopted at the site it was calibrated for, and only
+     * there: the FFN default must return the caller's fallback. */
+    CHECK(fabsf(ds4_glp_default_resid_scale(path, 0.0f) - 3.0f) < 1e-6f,
+          "resid default adopts glp.alpha_default");
+    CHECK(fabsf(ds4_glp_default_ffn_scale(path, 7.0f) - 7.0f) < 1e-6f,
+          "ffn default does not adopt a residual site's alpha");
+    unlink(path);
+
+    /* And the mirror image on an FFN-hooked file. */
+    spec_valid(&g, N_EMBD);
+    path = tmp_path("resid-ffn");
+    CHECK(write_gguf(path, &g), "fixture written");
+    CHECK(fabsf(ds4_glp_default_ffn_scale(path, 0.0f) - 3.0f) < 1e-6f,
+          "ffn default adopts glp.alpha_default");
+    CHECK(ds4_glp_default_resid_scale(path, 0.0f) == 0.0f,
+          "resid default does not adopt an FFN site's alpha");
+    unlink(path);
+}
+
 static void test_hook_names_round_trip(void) {
     CHECK(strcmp(ds4_glp_hook_name(DS4_GLP_HOOK_RESID_POST_LAYER),
                  "residual_stream_post_layer") == 0, "resid hook name");
@@ -734,6 +786,7 @@ int main(void) {
     RUN(test_read_info_needs_no_model);
     RUN(test_malformed_input);
     RUN(test_derived_at);
+    RUN(test_load_resid_hook);
     RUN(test_hook_names_round_trip);
 
     fprintf(stderr, "\n%d checks, %d failed\n", g_total, g_failed);

--- a/tests/test_glp.c
+++ b/tests/test_glp.c
@@ -10,7 +10,7 @@
  * a failure that cannot be caught downstream:
  *
  *   wrong operation   an additive vector applied projectively (or the reverse)
- *   wrong hook        the same direction 9x weaker
+ *   wrong hook        one contributor cleaned, not the accumulated stream
  *   wrong layer map   adjacent-layer cosine 0.55-0.98, so a shift still works
  *   wrong base model  undefined, and shapes can still match
  */
@@ -271,7 +271,7 @@ static void test_load_valid(void) {
 
     float dirs[N_LAYERS * N_EMBD];
     ds4_glp_info info;
-    char err[512];
+    char err[768];
     const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                                 dirs, N_LAYERS, N_EMBD, &info, err, sizeof(err));
     CHECK(rc == 0, "conforming vector loads");
@@ -326,7 +326,7 @@ static void test_refuse_missing_mode(void) {
     CHECK(write_gguf(path, &h), "fixture written");
 
     float dirs[N_LAYERS * N_EMBD];
-    char err[512];
+    char err[768];
     const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                                 dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
     CHECK(rc != 0, "no glp.mode is refused");
@@ -346,7 +346,7 @@ static void test_refuse_add_mode(void) {
     CHECK(write_gguf(path, &g), "fixture written");
 
     float dirs[N_LAYERS * N_EMBD];
-    char err[512];
+    char err[768];
     const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                                 dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
     CHECK(rc != 0, "glp.mode=add is refused, never coerced to project");
@@ -357,8 +357,8 @@ static void test_refuse_hook_mismatch(void) {
     /* Every GLP vector we have published so far declares
      * residual_stream_post_layer, because that is where llama.cpp's
      * build_cvec() and the vLLM overlay apply. ds4 applies at the block
-     * writers. Loading one into the other measured 9x weaker on the
-     * attention writer, so the default is a refusal. */
+     * writers -- a different tensor, cleaning one contributor rather than the
+     * accumulated stream -- so the default is a refusal. */
     gguf_spec g;
     spec_valid(&g, N_EMBD);
     for (int i = 0; i < g.n_kv; i++) {
@@ -370,7 +370,7 @@ static void test_refuse_hook_mismatch(void) {
     CHECK(write_gguf(path, &g), "fixture written");
 
     float dirs[N_LAYERS * N_EMBD];
-    char err[512];
+    char err[768];
     int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                           dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
     CHECK(rc != 0, "hook mismatch is refused by default");
@@ -400,7 +400,7 @@ static void test_refuse_unknown_hook(void) {
     CHECK(write_gguf(path, &g), "fixture written");
 
     float dirs[N_LAYERS * N_EMBD];
-    char err[512];
+    char err[768];
     const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                                 dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
     CHECK(rc != 0, "a hook name this build does not implement is refused");
@@ -421,7 +421,7 @@ static void test_refuse_layer_id_mismatch(void) {
     CHECK(write_gguf(path, &g), "fixture written");
 
     float dirs[N_LAYERS * N_EMBD];
-    char err[512];
+    char err[768];
     const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                                 dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
     CHECK(rc != 0, "declared layer ids disagreeing with tensor names is refused");
@@ -441,7 +441,7 @@ static void test_refuse_direction_zero(void) {
     CHECK(write_gguf(path, &g), "fixture written");
 
     float dirs[N_LAYERS * N_EMBD];
-    char err[512];
+    char err[768];
     const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                                 dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
     CHECK(rc != 0, "direction.0 is refused");
@@ -457,7 +457,7 @@ static void test_refuse_wrong_dtype_and_rank(void) {
     CHECK(write_gguf(path, &g), "fixture written");
 
     float dirs[N_LAYERS * N_EMBD];
-    char err[512];
+    char err[768];
     int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                           dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
     CHECK(rc != 0, "a non-F32 direction is refused");
@@ -483,7 +483,7 @@ static void test_refuse_shape_mismatch(void) {
     CHECK(write_gguf(path, &g), "fixture written");
 
     float dirs[N_LAYERS * N_EMBD];
-    char err[512];
+    char err[768];
     int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                           dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
     CHECK(rc != 0, "n_embd mismatch is refused");
@@ -515,7 +515,7 @@ static void test_renormalise(void) {
 
     float dirs[N_LAYERS * N_EMBD];
     ds4_glp_info info;
-    char err[512];
+    char err[768];
     const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                                 dirs, N_LAYERS, N_EMBD, &info, err, sizeof(err));
     CHECK(rc == 0, "off-unit directions load");
@@ -555,7 +555,7 @@ static void test_refuse_legacy_namespace(void) {
     CHECK(write_gguf(path, &g), "fixture written");
 
     float dirs[N_LAYERS * N_EMBD];
-    char err[512];
+    char err[768];
     const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                                 dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
     CHECK(rc != 0, "a dspark.*-only file is refused");
@@ -573,7 +573,7 @@ static void test_refuse_no_directions(void) {
     CHECK(write_gguf(path, &g), "fixture written");
 
     float dirs[N_LAYERS * N_EMBD];
-    char err[512];
+    char err[768];
     const int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                                 dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err));
     CHECK(rc != 0, "a GGUF with no direction.<N> tensors is refused");
@@ -590,7 +590,7 @@ static void test_read_info_needs_no_model(void) {
     CHECK(write_gguf(path, &g), "fixture written");
 
     ds4_glp_info info;
-    char err[512];
+    char err[768];
     const int rc = ds4_glp_read_info(path, &info, err, sizeof(err));
     CHECK(rc == 0, "read_info succeeds with no model shape");
     if (rc != 0) fprintf(stderr, "    err: %s\n", err);
@@ -617,7 +617,7 @@ static void test_malformed_input(void) {
     /* Not a crash test for its own sake: --dir-steering-file is a path a user
      * types, so truncation and "you passed the model" are ordinary inputs. */
     float dirs[N_LAYERS * N_EMBD];
-    char err[512];
+    char err[768];
 
     CHECK(ds4_glp_load("/nonexistent/ds4-glp.gguf", DS4_GLP_HOOK_FFN_OUT, 0,
                        dirs, N_LAYERS, N_EMBD, NULL, err, sizeof(err)) != 0,
@@ -659,7 +659,7 @@ static void test_derived_at(void) {
 
     float dirs[N_LAYERS * N_EMBD];
     ds4_glp_info info;
-    char err[512];
+    char err[768];
     int rc = ds4_glp_load(path, DS4_GLP_HOOK_FFN_OUT, 0,
                           dirs, N_LAYERS, N_EMBD, &info, err, sizeof(err));
     CHECK(rc == 0, "native derived_at loads");


### PR DESCRIPTION
`--dir-steering-file` already performs directional ablation:

```
y = y - scale * v * dot(v, y)
```

What it lacked was a container. The raw `.f32` form is a headerless blob of `n_layers * n_embd` floats, which is fine on the machine that produced it and unsafe to hand to anyone else, because it cannot state four things that are each **silently** wrong when they are wrong.

**The operation.** llama.cpp has shipped control vectors since 2024 with the tensor convention this reuses exactly — `direction.<N>`, fp32, 1-D — but llama.cpp *adds* them (`h <- h + v`) where ds4 projects. A file loads into either runtime with the right names, the right dtype and the right shapes, raises no error, and produces wrong output in one of them: an additive apply of a projective direction pushes every token *along* the direction instead of removing it.

**The hook point.** ds4 steers the block writers — `ffn_out = moe + shared`, or the attention output — before the residual / hyper-connection fold. llama.cpp's `build_cvec()` steers the post-layer residual. Measured on the same direction, layers and alpha, the writer site left 34.0% refusal against 3.8% post-layer: 9x weaker, and not an error.

**The layer map.** `direction.N` applies at layer `N`, no offset. A one-layer shift does not fail, it degrades — adjacent layers' refusal directions have cosine similarity 0.555–0.979 — so it survives a smoke test. This cost a real exporter bug on our side, caught only by a differential layer probe.

**The base checkpoint.** A direction is tied to the revision it was derived from, and the shapes still match on a different one.

GLP (GGUF Layer Projection) is standard GGUF v3 with llama.cpp's tensor convention unchanged, plus a `glp.*` metadata block that states all four. `--dir-steering-file` now reads it and **refuses rather than misapplies**: wrong operation, a hook the file was not calibrated for, tensor names disagreeing with `glp.layer_ids_zero_based`, `rank > 1`, a non-F32 direction, or a width that is not this model's `n_embd`. Spec: [weightless/spec/GLP.md](https://github.com/msuiche/weightless/blob/main/spec/GLP.md).

## No inference-path change

This replaces the three call sites that read the steering file. The projection, the graphs and the kernels are untouched, and the raw `.f32` path is byte-identical — the format is chosen by sniffing the GGUF magic, not by a flag, so every existing vector and `build_direction.py` output keeps working with no change to any command line.

## What's new

| | |
|---|---|
| `ds4_glp.{c,h}` | Self-contained GGUF v3 reader plus the spec checks. Its own parse rather than `ds4.c`'s, which is static, tied to `ds4_model` and fatal on malformed input, where a steering path has to be able to report a refusal and continue. |
| `--dir-steering-info FILE` | Print mode, alpha, coverage, resolved layer ids, per-direction norms and provenance without loading a model. The first thing to reach for when a vector behaves oddly — our own exporter off-by-one surfaced as a dump reporting layers 11–39 for a file derived from 10–38. Deliberately describes files ds4 would refuse to *apply*. |
| `--dir-steering-allow-hook-mismatch` | Apply a vector calibrated elsewhere, with the scale re-tuned. Off by default. |
| `glp.alpha_default` | Becomes the default `--dir-steering-ffn` when the file's hook matches the site being steered, so a published vector runs at its calibrated strength with no flags. Never adopted across a hook mismatch — projection is quadratic in the norm, so an alpha from elsewhere is not a better default than 1.0, only a more confident wrong one. An explicit flag always wins. |
| `dir-steering/tools/f32_to_glp.py` | Package a `build_direction.py` vector as GLP, reading the sidecar JSON so the shape and the hook point cannot disagree with what was measured. Unit-normalises, hashes tensor bytes only (`glp.created` makes the file non-reproducible), and reads the result back to assert the layer ids landed verbatim. Stdlib only. |
| `tests/test_glp.c` | 72 checks over real GGUF files written to disk, one per refusal. Wired into `make test` and `test-rocm`. |

The three CLIs share one `--dir-steering-info` and one default-scale resolver, so `ds4`, `ds4-server` and `ds4-agent` cannot drift and the help text advertises nothing that is missing from one of them.

## Two limitations, stated up front

**Layer 0 is not expressible.** `direction.N` applies at layer `N` and `direction.0` is invalid, so a full-coverage raw vector converts with `--layers 1-<last>` and loses row 0. Vectors derived over a mid-stack range are unaffected, and coverage dominates strength here (6 layers 18%, 16 layers 3.8%, 29 layers 0.0% on our refusal suites, with alpha saturating above about 4), so losing the first of 43 layers is not what decides a vector.

**No `residual_stream_post_layer` hook.** Every vector published for llama.cpp and vLLM declares it, so those need `--dir-steering-allow-hook-mismatch` and a re-tuned scale until ds4 grows that site. The enum and the refusal message already name it; adding the hook is a separate change that touches the trunk in every backend and wants hardware to validate.

## Testing

Per CONTRIBUTING: M-series macOS, Metal and CPU backends. None of the new paths need a model.

```
make && make cpu                       clean, no new warnings
./tests/test_glp                       72 checks, 0 failed
```

`test_layer_pack`, `test_engine_mgpu_placement`, `test_gpu_args`, `test_gpu_args_cli.sh`, `test_prompt_prefix`, `test_sampling`, `test_deepseek4_vision_image`, `test_q4k_dot`, `test_mxfp4_dot`, `ds4_agent_test`, `ds4-eval --self-test-extractors` — all pass.

End to end on a real ds4 vector: `f32_to_glp.py` on `dir-steering/out/verbosity.f32` (43×4096, the bundled verbosity direction) → GLP, read back by all three binaries via `--dir-steering-info`, and `alpha_default` picked up as `--dir-steering-ffn`.

No speed regression is possible: the change is confined to file loading, and `ds4-bench` measures the graph, which is untouched.

The model-backed `ds4_test` suites (`--logprob-vectors`, `--long-context`, `--tool-call-quality`, `--metal-kernels`) were **not** run — no checkpoint on this machine. They exercise no code this change touches.

## Why upstream

The steering feature is the part of ds4 people most want to hand each other, and today they can only hand each other a blob plus a verbal explanation of how to apply it. The op ds4 implements is already the right one; this just lets a vector say so, so that the failure modes above become refusals instead of plausible degraded output.
