### PR TITLE
cuda: avoid unstable 512-thread top-k exchange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -559,7 +559,7 @@ ds4_rocm_compat.o: ds4_rocm_compat.cu ds4_gpu.h ds4_gpu_mgpu.h ds4_gpu_args.h ds
 ds4_rocm_unavailable.o: ds4_rocm_unavailable.cu
 	$(HIPCC) $(ROCM_CFLAGS) -c -o $@ ds4_rocm_unavailable.cu
 
-tests/cuda_long_context_smoke: tests/cuda_long_context_smoke.o ds4_cuda.o $(MMQ_OBJS)
+tests/cuda_long_context_smoke: tests/cuda_long_context_smoke.o ds4_cuda.o ds4_image.o $(MMQ_OBJS)
 	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(CUDA_LDLIBS)
 
 tests/test_layer_pack.o: tests/test_layer_pack.c ds4_layer_pack.h

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -13946,14 +13946,17 @@ __global__ static void indexer_topk_tree_merge_pow2_kernel(
  * 512th-best key seen so far, so it can only discard candidates that cannot
  * belong to the final top set. Packing supplies the same value/index total
  * order as the existing bitonic and CUB tiers. */
-__global__ static void __launch_bounds__(512) indexer_topk_stream512_kernel(
+__global__ static void __launch_bounds__(256) indexer_topk_stream512_kernel(
         uint32_t *selected,
         const float *scores,
         uint32_t n_comp,
         uint32_t n_tokens,
         uint32_t top_k) {
-    constexpr uint32_t STREAM_THREADS = 512u;
-    constexpr uint32_t STREAM_ITEMS = 4u;
+    /* CUB's 512-thread x 4-item BlockExchange has produced rare, data-dependent
+     * out-of-range shared-memory accesses on Blackwell sm_120 and sm_121.
+     * Keep the same 2048-key capacity with the stable 256 x 8 layout. */
+    constexpr uint32_t STREAM_THREADS = 256u;
+    constexpr uint32_t STREAM_ITEMS = 8u;
     constexpr uint32_t STREAM_CAP = STREAM_THREADS * STREAM_ITEMS;
     using StreamSort = cub::BlockRadixSort<uint64_t, STREAM_THREADS, STREAM_ITEMS>;
     __shared__ uint64_t buf[STREAM_CAP];
@@ -14489,7 +14492,7 @@ extern "C" int ds4_gpu_indexer_topk_tensor(
     if (top_k == 512u && n_tokens >= 32u &&
         getenv("DS4_CUDA_NO_TOPK2048") == NULL &&
         getenv("DS4_CUDA_NO_TOPK_STREAM") == NULL) {
-        indexer_topk_stream512_kernel<<<n_tokens, 512>>>(
+        indexer_topk_stream512_kernel<<<n_tokens, 256>>>(
                 (uint32_t *)selected->ptr,
                 (const float *)scores->ptr,
                 n_comp, n_tokens, top_k);

--- a/tests/cuda_long_context_smoke.c
+++ b/tests/cuda_long_context_smoke.c
@@ -19,6 +19,90 @@ static double getenv_seconds(const char *name, double fallback) {
     return end != s && v > 0.0 ? v : fallback;
 }
 
+static float topk_adversarial_value(uint64_t i) {
+    uint32_t x = (uint32_t)i ^ (uint32_t)(i >> 32);
+    x ^= x >> 16;
+    x *= 0x7feb352du;
+    x ^= x >> 15;
+    x *= 0x846ca68bu;
+    x ^= x >> 16;
+    /* Deliberate collisions exercise the value/index tie break. */
+    if ((i % 29u) == 0u) return 0.5f;
+    if ((i % 113u) == 0u) return -0.0f;
+    return (float)(int32_t)(x & 0x1ffffu) * (1.0f / 65536.0f) - 1.0f;
+}
+
+static int check_stream_topk_matches_reference(void) {
+    static const uint32_t n_comp_cases[] = {8193u, 8448u, 32768u};
+    const uint32_t n_tokens = 32u;
+    const uint32_t top_k = 512u;
+
+    for (uint32_t c = 0; c < sizeof(n_comp_cases) / sizeof(n_comp_cases[0]); c++) {
+        const uint32_t n_comp = n_comp_cases[c];
+        const uint64_t score_count = (uint64_t)n_comp * n_tokens;
+        const uint64_t selected_count = (uint64_t)n_tokens * top_k;
+        float *scores_host = malloc((size_t)score_count * sizeof(*scores_host));
+        uint32_t *stream_host = malloc((size_t)selected_count * sizeof(*stream_host));
+        uint32_t *reference_host = malloc((size_t)selected_count * sizeof(*reference_host));
+        ds4_gpu_tensor *scores = ds4_gpu_tensor_alloc(score_count * sizeof(float));
+        ds4_gpu_tensor *selected = ds4_gpu_tensor_alloc(selected_count * sizeof(uint32_t));
+        int rc = 1;
+        if (!scores_host || !stream_host || !reference_host || !scores || !selected) {
+            goto cleanup;
+        }
+        for (uint64_t i = 0; i < score_count; i++) {
+            scores_host[i] = topk_adversarial_value(i + (uint64_t)c * 0x100000001b3ull);
+        }
+        if (!ds4_gpu_tensor_write(scores, 0, scores_host,
+                                  score_count * sizeof(float))) {
+            goto cleanup;
+        }
+
+        unsetenv("DS4_CUDA_NO_TOPK_STREAM");
+        if (!ds4_gpu_indexer_topk_tensor(selected, scores, n_comp, n_tokens, top_k) ||
+            !ds4_gpu_synchronize() ||
+            !ds4_gpu_tensor_read(selected, 0, stream_host,
+                                  selected_count * sizeof(uint32_t))) {
+            goto cleanup;
+        }
+
+        setenv("DS4_CUDA_NO_TOPK_STREAM", "1", 1);
+        if (!ds4_gpu_indexer_topk_tensor(selected, scores, n_comp, n_tokens, top_k) ||
+            !ds4_gpu_synchronize() ||
+            !ds4_gpu_tensor_read(selected, 0, reference_host,
+                                  selected_count * sizeof(uint32_t))) {
+            goto cleanup;
+        }
+        unsetenv("DS4_CUDA_NO_TOPK_STREAM");
+
+        for (uint64_t i = 0; i < selected_count; i++) {
+            if (stream_host[i] != reference_host[i]) {
+                fprintf(stderr,
+                        "stream top-k mismatch n_comp=%u token=%llu rank=%llu got=%u expected=%u\n",
+                        n_comp,
+                        (unsigned long long)(i / top_k),
+                        (unsigned long long)(i % top_k),
+                        stream_host[i], reference_host[i]);
+                goto cleanup;
+            }
+        }
+        fprintf(stderr,
+                "cuda-regression: stream top-k matches reference n_comp=%u n_tokens=%u\n",
+                n_comp, n_tokens);
+        rc = 0;
+
+cleanup:
+        unsetenv("DS4_CUDA_NO_TOPK_STREAM");
+        ds4_gpu_tensor_free(selected);
+        ds4_gpu_tensor_free(scores);
+        free(reference_host);
+        free(stream_host);
+        free(scores_host);
+        if (rc != 0) return rc;
+    }
+    return 0;
+}
+
 static int check_large_topk(void) {
     const uint32_t n_comp = 32768;
     const uint32_t n_tokens = 32;
@@ -159,6 +243,7 @@ static int check_decode_attention_overflow_path(void) {
 int main(void) {
     if (!ds4_gpu_init()) return 1;
     int rc = check_large_topk();
+    if (check_stream_topk_matches_reference() != 0) rc = 1;
     if (check_decode_attention_overflow_path() != 0) rc = 1;
     ds4_gpu_cleanup();
     if (rc == 0) puts("cuda long-context regression: OK");


### PR DESCRIPTION
## Summary

Run the exact streaming top-512 selector as 256 threads × 8 items instead of
512 × 4, preserving the same 2,048-key capacity and total value/index ordering.

## Why

Issue #847 contains a CUDA coredump from a long Blackwell prefill. The fault is
inside CUB's `BlockExchange<uint64_t, 512, 4>::ScatterToBlocked`, reached once
compressed context exceeds 8,192 rows. We observed the same production failure
signature on GB10/sm_121. A CUDA illegal access poisons the context, so all later
requests fail until restart.

The algorithm needs 2,048 sortable keys per block, not a particular thread/item
split. Using 256 × 8 avoids the reported CUB geometry without changing the
compaction threshold, final top-512 threshold, dispatch boundary or exact
ordering. The existing `DS4_CUDA_NO_TOPK_STREAM=1` fallback remains available.

## Compatibility

No option, dispatch threshold, output ordering, cache format, sampling behavior
or non-CUDA backend change. The opt-out remains unchanged.

## Practical impact

The primary contribution is keeping long-context streaming top-k usable without the reported CUDA failure. The earlier +4.40% prefill result compares streaming with its existing chunked opt-out; it does not measure this thread-geometry change against the upstream default. The rebased standalone selector test establishes exact output and successful execution at the affected boundaries. A new isolated speed comparison against `f62ca29` has not been run.

## Combined runtime context

A [stock/full-stack engine comparison](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/README.md) measures pristine `f62ca29` against the complete integrated runtime on GB10 CUDA and M3 Ultra Metal, including full 262,144-token capacity. The original full sweeps used one process pair per machine and include additional changes beyond these 13 PRs. A [targeted M3 follow-up](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/m3-attribution/README.md) did not reproduce the original short-decode slowdown, using a reversed-order pair, same-process controls and an exact original-executable replay. These results do not isolate this PR’s marginal gain, establish universal speed or quality, or newly benchmark its server/cache workflows. See the [per-PR assessment](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/PR-ASSESSMENT.md) for its supported benefit and limits.

## Validation

The build and runtime checks below ran before upstream’s README-only update. The full PR diff and every other tracked file are byte-identical at this head; `git diff --check` passed again. The documentation-only rebase was not rebuilt.

One standalone commit, `3cd95ba3e3bc`, directly on upstream `f62ca29a3087` (2026-09-07). The streaming selector regression compares exact selected indices at 8,193, 8,448 and 32,768 compressed rows, including score ties.

On the preceding `b6af0ad` base, clean default Metal and CPU builds, `make test-frontends`, session-state, TP-command and vision-image tests, and `git diff --check` passed on M3 Ultra / Darwin 27.0 / Apple clang 21. These portability and host checks load no model or GPU fixture.

Earlier GB10/sm_121 evidence: twenty repeated focused selector runs passed. With Vision-Exp IQ2XXS/AProjQ8, complete 129,280-logit vectors matched the exact chunked fallback at 33,792 and 65,536 tokens; streaming prefill at 65,536 was 862.90 versus 826.56 tok/s (+4.40%). This comparison predates the rebase and measures streaming against the existing opt-out, not a new whole-model speed claim. The historical memcheck run completed the top-k comparisons but later encountered the handled host-registration path; no full historical memcheck-suite pass is claimed.

Before the Metal-only upstream update, the same patch passed checks on NVIDIA DGX Spark / Ubuntu / Linux 6.17.0-1032-nvidia, GCC 13.3 and CUDA 13.0.88: clean `make -j4 cuda-spark` (`sm_121a`), `make CUDA_ARCH=sm_121a test-frontends`, session-state, TP-command and vision-image tests, and a clean `make -j4 cpu` build. These are host tests and compile/link coverage; CUDA execution is recorded separately. The later upstream updates are a five-line GLM SSD change inside a Metal-only guard and a README edit. CUDA source and the PR patch are unchanged; native Linux preprocessing of `ds4.c` was byte-identical for CUDA, CPU and sanitizer builds.

The standalone CUDA long-context regression passed on that GB10 build, including exact selected-index comparisons through 32768 compressed rows and the large streaming top-k cases. This run uses the actual isolated PR executable.

No full aggregate model-suite, other-GPU, other-quantization or multi-GPU result is claimed.
