### PR TITLE
cuda: reduce GB10 Q8 attention-output prefill overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 /tests/test_cuda_mixed_batch
 /tests/test_cuda_session_batch
 /tests/cuda_long_context_smoke
+/tests/test_cuda_q8_prefill
 /tests/test_layer_pack
 /tests/test_metal_session_batch
 /tests/test_metal_tp_spec

--- a/Makefile
+++ b/Makefile
@@ -298,8 +298,9 @@ cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_eval_cpu.o ds4_eval_case
 	$(CC) $(CFLAGS) -o ds4-eval ds4_eval_cpu.o ds4_eval_cases.o ds4_help.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-agent ds4_agent_cpu.o ds4_help.o ds4_prompt_prefix.o ds4_web.o ds4_kvstore.o linenoise.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 
-cuda-regression: tests/cuda_long_context_smoke
+cuda-regression: tests/cuda_long_context_smoke tests/test_cuda_q8_prefill
 	./tests/cuda_long_context_smoke
+	./tests/test_cuda_q8_prefill
 
 tests/test_mxfp4_cuda: tests/test_mxfp4_cuda.cu $(MMQ_OBJS)
 	$(NVCC) $(NVCCFLAGS) -std=c++17 $(MMQ_INCLUDES) -o $@ $^ $(CUDA_LDLIBS)
@@ -559,7 +560,13 @@ ds4_rocm_compat.o: ds4_rocm_compat.cu ds4_gpu.h ds4_gpu_mgpu.h ds4_gpu_args.h ds
 ds4_rocm_unavailable.o: ds4_rocm_unavailable.cu
 	$(HIPCC) $(ROCM_CFLAGS) -c -o $@ ds4_rocm_unavailable.cu
 
-tests/cuda_long_context_smoke: tests/cuda_long_context_smoke.o ds4_cuda.o $(MMQ_OBJS)
+tests/cuda_long_context_smoke: tests/cuda_long_context_smoke.o ds4_cuda.o ds4_image.o $(MMQ_OBJS)
+	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(CUDA_LDLIBS)
+
+tests/test_cuda_q8_prefill.o: tests/test_cuda_q8_prefill.c ds4_gpu.h
+	$(CC) $(CFLAGS) -I. -I$(CUDA_HOME)/include -c -o $@ $<
+
+tests/test_cuda_q8_prefill: tests/test_cuda_q8_prefill.o ds4_cuda.o ds4_image.o $(MMQ_OBJS)
 	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(CUDA_LDLIBS)
 
 tests/test_layer_pack.o: tests/test_layer_pack.c ds4_layer_pack.h
@@ -769,4 +776,4 @@ clean:
 	rm -f tests/test_ssd_cache
 	rm -f tests/test_session_state tests/test_session_state_gpu tests/test_tp_commands
 	rm -f tests/test_metal_tp_spec
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_rocm tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_metal_moe_prefill tests/test_metal_dense_mpp tests/test_glm53_kda tests/test_glm53_kda_rocm tests/test_glm53_vision_engine tests/test_glm53_vision_prompt tests/test_deepseek4_vision_image tests/test_prompt_prefix tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_rocm tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_metal_moe_prefill tests/test_metal_dense_mpp tests/test_glm53_kda tests/test_glm53_kda_rocm tests/test_glm53_vision_engine tests/test_glm53_vision_prompt tests/test_deepseek4_vision_image tests/test_prompt_prefix tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o tests/test_cuda_q8_prefill

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -128,6 +128,7 @@ static int g_cuda_exact_score_split_fuse_inv_rope;
 static int g_cuda_moe_decode_graph;
 static int g_current_logical_tier = -1;
 static int g_ssd_streaming_mode;
+static int g_cuda_is_gb10[DS4_MAX_GPUS];
 
 typedef struct {
     int valid;
@@ -2581,6 +2582,7 @@ static int cublas_ok(cublasStatus_t st, const char *what) {
 
 extern "C" int ds4_gpu_init_multi(const ds4_gpu_config *cfg) {
     if (!cfg || cfg->n_gpus < 1 || cfg->n_gpus > DS4_MAX_GPUS) return 0;
+    memset(g_cuda_is_gb10, 0, sizeof(g_cuda_is_gb10));
     cuda_xdev_env_refresh();
     cuda_decode_dispatch_env_refresh();
     g_current_logical_tier = -1;
@@ -2605,6 +2607,8 @@ extern "C" int ds4_gpu_init_multi(const ds4_gpu_config *cfg) {
         if (cudaGetDeviceProperties(&prop, c->device_id) == cudaSuccess) {
             if (i == 0) g_device_is_spark =
                 prop.integrated && prop.major == 12 && prop.minor == 1;
+            g_cuda_is_gb10[i] =
+                prop.major == 12 && prop.minor == 1 && prop.integrated;
             fprintf(stderr, "ds4: CUDA backend initialized on %s (sm_%d%d) dev=%d\n",
                     prop.name, prop.major, prop.minor, c->device_id);
         }
@@ -5034,6 +5038,40 @@ __global__ static void quantize_q8_0_f32_kernel(
     }
 }
 
+/* Batch eight independent Q8_0 blocks without changing the lane-zero max
+ * tree, scale expression, rounding or partial-block zero padding. */
+__global__ static void quantize_q8_0_f32_warps_kernel(
+        int8_t *xq,
+        float *xscale,
+        const float *x,
+        uint64_t in_dim,
+        uint64_t blocks) {
+    const uint64_t b = (uint64_t)blockIdx.x * 8u + (threadIdx.x >> 5u);
+    const uint64_t tok = blockIdx.y;
+    const uint32_t lane = threadIdx.x & 31u;
+    if (b >= blocks) return;
+    const uint64_t i0 = b * 32u;
+    const uint64_t bn = in_dim - i0 < 32u ? in_dim - i0 : 32u;
+    const float *xr = x + tok * in_dim + i0;
+    float a = lane < bn ? fabsf(xr[lane]) : 0.0f;
+    for (uint32_t stride = 16u; stride > 0u; stride >>= 1u) {
+        const float other = __shfl_down_sync(0xffffffffu, a, stride);
+        if (lane < stride) a = fmaxf(a, other);
+    }
+    a = __shfl_sync(0xffffffffu, a, 0);
+    const float d = a / 127.0f;
+    const float id = d != 0.0f ? 1.0f / d : 0.0f;
+    if (lane == 0u) xscale[tok * blocks + b] = d;
+    int8_t *dst = xq + (tok * blocks + b) * 32u;
+    if (lane < bn) {
+        int v = (int)lrintf(xr[lane] * id);
+        v = v > 127 ? 127 : (v < -128 ? -128 : v);
+        dst[lane] = (int8_t)v;
+    } else {
+        dst[lane] = 0;
+    }
+}
+
 __global__ static void quantize_q8_0_group_slice_rows_kernel(
         int8_t *xq,
         float *xscale,
@@ -6031,7 +6069,7 @@ __device__ __forceinline__ static uint32_t bitrev5(uint32_t i) {
     return ((i & 1u) << 4) | ((i & 2u) << 2) | (i & 4u) | ((i & 8u) >> 2) | ((i & 16u) >> 4);
 }
 
-template <uint32_t T>
+template <uint32_t T, bool ALIGNED = false, bool PAD = false>
 __global__ static void matmul_q8_0_mma_exact_kernel(
         float *out,
         const unsigned char *w,
@@ -6042,10 +6080,12 @@ __global__ static void matmul_q8_0_mma_exact_kernel(
         uint64_t n_tok,
         uint64_t blocks,
         uint64_t a_stride_blocks, /* activation row stride in blocks (>= blocks) */
-        uint64_t out_stride) {    /* output token stride in floats (>= out_dim) */
+        uint64_t out_stride,      /* output token stride in floats (>= out_dim) */
+        const __half *aligned_scales = NULL) {
     extern __shared__ unsigned char q8mma_sh[];
-    __half *sh_ws = (__half *)q8mma_sh;                    /* 64 rows x blocks */
-    float *sh_xs = (float *)(q8mma_sh + 64u * blocks * 2u); /* 16 toks x blocks */
+    const uint32_t pitch = (uint32_t)blocks + (PAD ? 1u : 0u);
+    __half *sh_ws = (__half *)q8mma_sh;                   /* 64 rows x pitch */
+    float *sh_xs = (float *)(q8mma_sh + 64u * pitch * 2u); /* 16 toks x pitch */
     const uint32_t lane = threadIdx.x & 31u;
     const uint32_t warp = threadIdx.x >> 5u;
     const uint64_t row_base = (uint64_t)blockIdx.x * 64u;
@@ -6057,13 +6097,14 @@ __global__ static void matmul_q8_0_mma_exact_kernel(
         const uint32_t b = idx - rl * (uint32_t)blocks;
         uint64_t row = row_base + rl;
         if (row >= out_dim) row = out_dim - 1u;
-        sh_ws[idx] = *(const __half *)(w + row * blocks * 34u + (uint64_t)b * 34u);
+        sh_ws[PAD ? rl * pitch + b : idx] = ALIGNED ? aligned_scales[row * blocks + b]
+            : *(const __half *)(w + row * blocks * 34u + (uint64_t)b * 34u);
     }
     for (uint32_t idx = threadIdx.x; idx < 16u * (uint32_t)blocks; idx += blockDim.x) {
         const uint32_t tl = idx / (uint32_t)blocks;
         const uint32_t b = idx - tl * (uint32_t)blocks;
         const uint64_t tok = tok_base + tl;
-        sh_xs[idx] = tok < n_tok ? xscale[tok * a_stride_blocks + b] : 0.0f;
+        sh_xs[PAD ? tl * pitch + b : idx] = tok < n_tok ? xscale[tok * a_stride_blocks + b] : 0.0f;
     }
     __syncthreads();
 
@@ -6083,7 +6124,7 @@ __global__ static void matmul_q8_0_mma_exact_kernel(
     /* B source row for loads: row lane>>2 within the warp tile */
     uint64_t b_row = row0 + (lane >> 2u);
     if (b_row >= out_dim) b_row = out_dim - 1u;
-    const unsigned char *b_wr = w + b_row * blocks * 34u;
+    const unsigned char *b_wr = w + b_row * blocks * (ALIGNED ? 32u : 34u);
 
     /* per-element (4) x per-(j&3) accumulators */
     float acc00 = 0.0f, acc01 = 0.0f, acc02 = 0.0f, acc03 = 0.0f;
@@ -6117,16 +6158,19 @@ __global__ static void matmul_q8_0_mma_exact_kernel(
                 const uint32_t a1 = a_hi_ok ? *(const uint32_t *)(ablk_hi + koff) : 0u;
                 const uint32_t a2 = a_lo_ok ? *(const uint32_t *)(ablk_lo + 16u + koff) : 0u;
                 const uint32_t a3 = a_hi_ok ? *(const uint32_t *)(ablk_hi + 16u + koff) : 0u;
-                const uint8_t *bq = (const uint8_t *)(b_wr + (uint64_t)b * 34u + 2u);
-                const uint32_t b0 = ldu32_unaligned(bq + koff);
-                const uint32_t b1 = ldu32_unaligned(bq + 16u + koff);
+                const uint8_t *bq = (const uint8_t *)(b_wr +
+                    (uint64_t)b * (ALIGNED ? 32u : 34u) + (ALIGNED ? 0u : 2u));
+                const uint32_t b0 = ALIGNED ? *(const uint32_t *)(bq + koff)
+                    : ldu32_unaligned(bq + koff);
+                const uint32_t b1 = ALIGNED ? *(const uint32_t *)(bq + 16u + koff)
+                    : ldu32_unaligned(bq + 16u + koff);
                 int32_t c0 = 0, c1 = 0, c2 = 0, c3 = 0;
                 mma_m16n8k32_s8(c0, c1, c2, c3, a0, a1, a2, a3, b0, b1);
                 /* term = ws * xs * dot, same expression as reference */
-                const float ws0 = __half2float(sh_ws[rl_ws0 * (uint32_t)blocks + b]);
-                const float ws1 = __half2float(sh_ws[(rl_ws0 + 1u) * (uint32_t)blocks + b]);
-                const float xsA = sh_xs[tl_xsA * (uint32_t)blocks + b];
-                const float xsB = sh_xs[tl_xsB * (uint32_t)blocks + b];
+                const float ws0 = __half2float(sh_ws[rl_ws0 * pitch + b]);
+                const float ws1 = __half2float(sh_ws[(rl_ws0 + 1u) * pitch + b]);
+                const float xsA = sh_xs[tl_xsA * pitch + b];
+                const float xsB = sh_xs[tl_xsB * pitch + b];
                 t0 += ws0 * xsA * (float)c0;
                 t1 += ws1 * xsA * (float)c1;
                 t2 += ws0 * xsB * (float)c2;
@@ -6207,7 +6251,7 @@ static int cuda_q4_mma_ok(void) {
     }
     return cached;
 }
-static int cuda_q8_mma_attr_ready[DS4_MAX_GPUS][4];
+static int cuda_q8_mma_attr_ready[DS4_MAX_GPUS][6];
 static int cuda_q8_mma_try_launch(
         float *out,
         const unsigned char *w,
@@ -6219,7 +6263,9 @@ static int cuda_q8_mma_try_launch(
         uint64_t blocks,
         uint64_t a_stride_blocks,
         uint64_t out_stride,
-        uint32_t T) {
+        uint32_t T,
+        const unsigned char *aligned_w = NULL,
+        const __half *aligned_scales = NULL) {
     static int disabled = -1;
     if (disabled < 0) disabled = getenv("DS4_CUDA_NO_Q8_MMA") != NULL ? 1 : 0;
     if (disabled || !cuda_q4_mma_ok()) return 0;
@@ -6231,6 +6277,42 @@ static int cuda_q8_mma_try_launch(
     if (dev < 0 || dev >= DS4_MAX_GPUS) return 0;
     const int ti = T == 32u ? 0 : (T == 64u ? 1 : (T == 128u ? 2 : 3));
     dim3 grid(((unsigned)out_dim + 63u) / 64u, ((unsigned)n_tok + 15u) / 16u, 1);
+    if (T == 32u && aligned_w && aligned_scales) {
+        /* One spare scale per row separates same-column shared-bank reads.
+         * Codes, scales and the accumulation order are unchanged. */
+        if ((blocks & 31u) == 0u &&
+            getenv("DS4_CUDA_NO_Q8_MMA_SCALE_PADDING") == NULL) {
+            if (!cuda_q8_mma_attr_ready[dev][5]) {
+                cudaFuncAttributes fn_attr;
+                if (cudaFuncGetAttributes(&fn_attr,
+                        matmul_q8_0_mma_exact_kernel<32u, true, true>) != cudaSuccess ||
+                    fn_attr.binaryVersion < 80 || fn_attr.ptxVersion < 80 ||
+                    cudaFuncSetAttribute(matmul_q8_0_mma_exact_kernel<32u, true, true>,
+                        cudaFuncAttributeMaxDynamicSharedMemorySize, 49344) != cudaSuccess)
+                    return 0;
+                cuda_q8_mma_attr_ready[dev][5] = 1;
+            }
+            matmul_q8_0_mma_exact_kernel<32u, true, true><<<grid, 256, shmem + 192>>>(
+                out, aligned_w, xq, xscale, in_dim, out_dim, n_tok, blocks,
+                a_stride_blocks, out_stride, aligned_scales);
+            return cuda_ok(cudaGetLastError(), "padded exact Q8 MMA launch") ? 1 : -1;
+        }
+        if (!cuda_q8_mma_attr_ready[dev][4]) {
+            cudaFuncAttributes fn_attr;
+            if (cudaFuncGetAttributes(&fn_attr,
+                    matmul_q8_0_mma_exact_kernel<32u, true>) != cudaSuccess ||
+                fn_attr.binaryVersion < 80 || fn_attr.ptxVersion < 80 ||
+                cudaFuncSetAttribute(matmul_q8_0_mma_exact_kernel<32u, true>,
+                    cudaFuncAttributeMaxDynamicSharedMemorySize, 49152) != cudaSuccess) {
+                return 0;
+            }
+            cuda_q8_mma_attr_ready[dev][4] = 1;
+        }
+        matmul_q8_0_mma_exact_kernel<32u, true><<<grid, 256, shmem>>>(
+            out, aligned_w, xq, xscale, in_dim, out_dim, n_tok, blocks,
+            a_stride_blocks, out_stride, aligned_scales);
+        return cuda_ok(cudaGetLastError(), "aligned exact Q8 MMA launch") ? 1 : -1;
+    }
 #define DS4_Q8_MMA_LAUNCH(TT) \
     do { \
         if (!cuda_q8_mma_attr_ready[dev][ti]) { \
@@ -18746,13 +18828,32 @@ extern "C" int ds4_gpu_attention_output_q8_batch_tensor(
         int8_t *xq = (int8_t *)tmp;
         float *xscale = (float *)((char *)tmp + scale_offset);
         const int use_dp4a = cuda_q8_use_dp4a();
-        dim3 qgrid((unsigned)blocks_a, (unsigned)x_rows, 1);
-        quantize_q8_0_f32_kernel<<<qgrid, 32, 0, cuda_decode_stream()>>>(xq,
-                                                xscale,
-                                                (const float *)heads->ptr,
-                                                group_dim,
-                                                blocks_a);
+        const bool gb10_prefill = g_n_gpus == 1 &&
+            logical_tier >= 0 && logical_tier < DS4_MAX_GPUS &&
+            g_cuda_is_gb10[logical_tier] && n_tokens >= 8u;
+        if (gb10_prefill && getenv("DS4_CUDA_NO_Q8_0_QUANT_WARPS") == NULL) {
+            dim3 qgrid((unsigned)((blocks_a + 7u) / 8u), (unsigned)x_rows, 1);
+            quantize_q8_0_f32_warps_kernel<<<qgrid, 256, 0, cuda_decode_stream()>>>(
+                xq, xscale, (const float *)heads->ptr, group_dim, blocks_a);
+        } else {
+            dim3 qgrid((unsigned)blocks_a, (unsigned)x_rows, 1);
+            quantize_q8_0_f32_kernel<<<qgrid, 32, 0, cuda_decode_stream()>>>(
+                xq, xscale, (const float *)heads->ptr, group_dim, blocks_a);
+        }
         if (!cuda_ok(cudaGetLastError(), "attention_output_q8_a prequant launch")) return 0;
+        /* Reuse the startup artifact when present; never allocate/repack here.
+         * Only addressing changes. The exact MMA reduction stays unchanged. */
+        const bool use_aligned = gb10_prefill &&
+            group_dim <= INT_MAX && low_dim <= INT_MAX &&
+            (group_dim % 1024u) == 0u && (low_dim % 128u) == 0u &&
+            cuda_aligned_q8_enabled() &&
+            getenv("DS4_CUDA_NO_Q8_MMA_ALIGNED") == NULL;
+        const uint64_t aligned_bytes = use_aligned
+            ? ds4_mmq_q8_0_aligned_bytes((int)low_dim, (int)group_dim) : 0u;
+        const char *aligned = aligned_bytes ? cuda_derived_weight_ptr(
+            model_map, out_a_offset, out_a_bytes, CUDA_DERIVED_Q8_0_ALIGNED_DENSE,
+            group_dim, low_dim, 1u, aligned_bytes) : NULL;
+        const uint64_t dq_bytes = (low_dim * blocks_a * sizeof(__half) + 63u) & ~63ull;
         int grouped_mma_done = 0;
         if (n_tokens >= 8u) {
             /* One mma launch per group: T=32 matches the warp tree of the
@@ -18766,7 +18867,11 @@ extern "C" int ds4_gpu_attention_output_q8_batch_tensor(
                         xq + (uint64_t)g * blocks_a * 32u,
                         xscale + (uint64_t)g * blocks_a,
                         group_dim, rank, n_tokens, blocks_a,
-                        (uint64_t)n_groups * blocks_a, low_dim, 32u);
+                        (uint64_t)n_groups * blocks_a, low_dim, 32u,
+                        aligned ? (const unsigned char *)aligned + dq_bytes +
+                            (uint64_t)g * rank * blocks_a * 32u : NULL,
+                        aligned ? (const __half *)aligned +
+                            (uint64_t)g * rank * blocks_a : NULL);
                 if (rc < 0) return 0;
                 if (rc == 0) grouped_mma_done = 0;
             }

--- a/tests/test_cuda_q8_prefill.c
+++ b/tests/test_cuda_q8_prefill.c
@@ -1,0 +1,163 @@
+/* Model-free checks of GB10 Q8 attention-output prefill through the public API.
+ * Compare each optimization independently and together against the old path,
+ * with and without the startup artifact. No external GGUF is required. */
+#include "ds4_gpu.h"
+#include <cuda_runtime.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define CHECK(c) do { if (!(c)) { \
+    fprintf(stderr, "Q8 prefill failure at line %d\n", __LINE__); \
+    goto cleanup; \
+} } while (0)
+
+static void put32(unsigned char *p, size_t *off, uint32_t x) {
+    memcpy(p + *off, &x, 4); *off += 4;
+}
+
+static void put64(unsigned char *p, size_t *off, uint64_t x) {
+    memcpy(p + *off, &x, 8); *off += 8;
+}
+
+static void tensor_info(unsigned char *p, size_t *off, const char *name,
+                        uint64_t cols, uint64_t rows, uint64_t offset) {
+    const size_t len = strlen(name);
+    put64(p, off, len);
+    memcpy(p + *off, name, len); *off += len;
+    put32(p, off, 2);
+    put64(p, off, cols); put64(p, off, rows);
+    put32(p, off, 8); /* GGML_TYPE_Q8_0 */
+    put64(p, off, offset);
+}
+
+static void pack_weights(unsigned char *p, size_t blocks) {
+    for (size_t b = 0; b < blocks; b++) {
+        /* Finite, nonuniform FP16 scales and signed Q8 codes. */
+        const uint16_t scale = (uint16_t)(0x2000u + (b * 19u % 4096u));
+        memcpy(p + b * 34u, &scale, 2);
+        for (unsigned j = 0; j < 32; j++)
+            p[b * 34u + 2u + j] = (unsigned char)(b * 23u + j * 41u);
+    }
+}
+
+static int check_shape(uint64_t width, uint64_t rank, uint32_t groups,
+                       uint32_t tokens, int artifact) {
+    const uint64_t low_dim = rank * groups, out_dim = 37;
+    const uint64_t a_bytes = low_dim * ((width + 31) / 32) * 34;
+    const uint64_t b_bytes = out_dim * ((low_dim + 31) / 32) * 34;
+    const size_t nx = (size_t)tokens * groups * width;
+    const size_t nl = (size_t)tokens * low_dim, ny = (size_t)tokens * out_dim;
+    unsigned char header[512] = {0};
+    size_t pos = 0;
+    put32(header, &pos, 0x46554747); put32(header, &pos, 3);
+    put64(header, &pos, 2); put64(header, &pos, 0);
+    tensor_info(header, &pos, "blk.0.attn_output_a.weight", width, low_dim, 0);
+    tensor_info(header, &pos, "blk.0.attn_output_b.weight", low_dim, out_dim, a_bytes);
+    const size_t a_off = (pos + 31u) & ~(size_t)31u;
+    const size_t size = a_off + a_bytes + b_bytes + 4; /* Raw unaligned-load padding. */
+    unsigned char *model = calloc(1, size);
+    float *x = malloc(nx * sizeof(float));
+    float *got = malloc((nl + ny + 8) * sizeof(float));
+    float *ref = malloc((nl + ny + 8) * sizeof(float));
+    ds4_gpu_tensor *heads = NULL, *low = NULL, *out = NULL;
+    char path[] = "/tmp/ds4-q8-prefill-XXXXXX";
+    FILE *file = NULL;
+    int fd = -1, path_created = 0, initialized = 0, rc = 1;
+    CHECK(model && x && got && ref);
+    memcpy(model, header, pos);
+    pack_weights(model + a_off, a_bytes / 34);
+    pack_weights(model + a_off + a_bytes, b_bytes / 34);
+    for (size_t i = 0; i < nx; i++)
+        x[i] = (float)((int)(i * 17u % 257u) - 128) * 0.015625f;
+    /* A zero block, signed zero, and nonuniform final partial blocks. */
+    for (size_t i = 0; i < nx && i < 32; i++) x[i] = i & 1 ? -0.0f : 0.0f;
+    CHECK(ds4_gpu_init());
+    initialized = 1;
+    CHECK(ds4_gpu_set_model_map(model, size));
+    if (artifact) {
+        fd = mkstemp(path);
+        CHECK(fd >= 0);
+        path_created = 1;
+        file = fdopen(fd, "wb");
+        CHECK(file);
+        fd = -1;
+        CHECK(fwrite(model, 1, size, file) == size);
+        const int closed = fclose(file);
+        file = NULL;
+        CHECK(closed == 0);
+        CHECK(ds4_gpu_build_derived_artifacts(model, size, path) == 1);
+    }
+    heads = ds4_gpu_tensor_alloc(nx * sizeof(float));
+    low = ds4_gpu_tensor_alloc((nl + 4) * sizeof(float));
+    out = ds4_gpu_tensor_alloc((ny + 4) * sizeof(float));
+    CHECK(heads && low && out);
+    CHECK(ds4_gpu_tensor_write(heads, 0, x, nx * sizeof(float)));
+    for (unsigned variant = 0; variant < 8; variant++) {
+        fprintf(stderr, "Q8 fixture width=%llu rank=%llu groups=%u tokens=%u artifact=%d variant=%u\n",
+                (unsigned long long)width, (unsigned long long)rank, groups, tokens, artifact, variant);
+        if (variant & 1) unsetenv("DS4_CUDA_NO_Q8_0_QUANT_WARPS");
+        else setenv("DS4_CUDA_NO_Q8_0_QUANT_WARPS", "1", 1);
+        if (variant & 2) unsetenv("DS4_CUDA_NO_Q8_MMA_ALIGNED");
+        else setenv("DS4_CUDA_NO_Q8_MMA_ALIGNED", "1", 1);
+        if (variant & 4) unsetenv("DS4_CUDA_NO_Q8_MMA_SCALE_PADDING");
+        else setenv("DS4_CUDA_NO_Q8_MMA_SCALE_PADDING", "1", 1);
+        for (size_t i = 0; i < nl + ny + 8; i++) got[i] = 123456.0f;
+        CHECK(ds4_gpu_tensor_write(low, 0, got, (nl + 4) * sizeof(float)));
+        CHECK(ds4_gpu_tensor_write(out, 0, got + nl + 4, (ny + 4) * sizeof(float)));
+        CHECK(ds4_gpu_attention_output_q8_batch_tensor(out, low, NULL, NULL,
+            model, size, a_off, a_off + a_bytes, width, rank, groups, out_dim,
+            heads, tokens));
+        CHECK(ds4_gpu_synchronize());
+        CHECK(ds4_gpu_tensor_read(low, 0, got, (nl + 4) * sizeof(float)));
+        CHECK(ds4_gpu_tensor_read(out, 0, got + nl + 4, (ny + 4) * sizeof(float)));
+        for (size_t i = 0; i < nl + ny + 8; i++) CHECK(isfinite(got[i]));
+        for (size_t i = 0; i < 4; i++) {
+            CHECK(got[nl + i] == 123456.0f);
+            CHECK(got[nl + 4 + ny + i] == 123456.0f);
+        }
+        if (!variant) memcpy(ref, got, (nl + ny + 8) * sizeof(float));
+        else CHECK(memcmp(ref, got, (nl + ny + 8) * sizeof(float)) == 0);
+    }
+    rc = 0;
+cleanup:
+    if (rc) fprintf(stderr, "shape width=%llu rank=%llu groups=%u tokens=%u artifact=%d\n",
+                    (unsigned long long)width, (unsigned long long)rank, groups, tokens, artifact);
+    if (file) fclose(file);
+    if (fd >= 0) close(fd);
+    if (path_created) unlink(path);
+    ds4_gpu_tensor_free(out); ds4_gpu_tensor_free(low); ds4_gpu_tensor_free(heads);
+    if (initialized) ds4_gpu_cleanup();
+    free(ref); free(got); free(x); free(model);
+    return rc;
+}
+
+int main(void) {
+    struct cudaDeviceProp prop;
+    if (cudaGetDeviceProperties(&prop, 0) != cudaSuccess ||
+        prop.major != 12 || prop.minor != 1 || !prop.integrated) {
+        fprintf(stderr, "SKIP: Q8 prefill fast paths require integrated sm_121\n");
+        return 0;
+    }
+    /* Force the existing Q8 path, not the separate optional FP16 cuBLAS path. */
+    setenv("DS4_CUDA_NO_CUBLAS_ATTENTION_OUTPUT_A", "1", 1);
+    /* Keep the tiny fixture and its raw-load padding in one device allocation.
+     * Exact-size raw tensor overreads are covered separately from this test. */
+    setenv("DS4_CUDA_COPY_MODEL", "1", 1);
+    const uint32_t counts[] = {1, 7, 8, 9, 15, 16, 17, 32};
+    for (size_t i = 0; i < sizeof(counts) / sizeof(counts[0]); i++) {
+        if (check_shape(33, 17, 3, counts[i], 0) ||
+            check_shape(4096, 128, 4, counts[i], 0) ||
+            check_shape(4096, 128, 4, counts[i], 1)) return 1;
+    }
+    /* A partial eight-warp CTA and ragged rows in the exact MMA tile. */
+    if (check_shape(257, 65, 3, 17, 0) ||
+        check_shape(4096, 65, 128, 17, 1) ||
+        check_shape(8192, 128, 4, 8, 1) ||
+        check_shape(4064, 128, 4, 8, 0)) return 1;
+    fprintf(stderr, "PASS: Q8 prefill paths are byte-identical across 28 shapes\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Optimize the existing Q8 attention-output prefill path on single-GPU GB10:

- Quantize eight independent 32-value activation blocks per thread block,
  preserving the original maximum-reduction tree and rounding.
- Let the exact grouped INT8 MMA kernel read the Q8 layout already prepared
  at startup, avoiding repeated unaligned weight loads.
- Pad the shared scale rows by one element to separate same-column bank
  accesses, using 192 additional bytes of shared memory per thread block.

## Why

On the tested IQ2XXS/Q2 model, these two stages accounted for roughly 4% and
23% of prefill GPU time. The activation kernel used one warp per block with
block-wide barriers. The grouped MMA kernel read the interleaved 34-byte Q8
format even when the same codes and scales were already available separately
in an aligned artifact. Its power-of-two shared scale-row stride also maps
different rows to the same banks. The padded path changes that stride, not
the scale values or accumulation order. This bank-conflict explanation follows
the address layout; hardware counters were unavailable (ERR_NVGPUCTRPERM).

The patch changes scheduling and addressing, not model math: Q8 codes, scales,
rounding, INT8 MMA operations and floating-point accumulation order are kept.
It neither allocates nor repacks weights at request time. Missing artifacts
retain the raw path. Decode, multi-GPU, non-GB10 and fewer-than-eight-token
calls retain their previous dispatch. The optional FP16 cuBLAS path is unchanged.

`DS4_CUDA_NO_Q8_0_QUANT_WARPS=1`, `DS4_CUDA_NO_Q8_MMA_ALIGNED=1`, and
`DS4_CUDA_NO_Q8_MMA_SCALE_PADDING=1` allow independent rollback. The padded
specialization retains the compiled-kernel capability check. No model format,
cache, context or sampling changes.

## Compatibility

Only eligible single-GPU GB10 prefill dispatch changes; existing opt-outs and fallback paths remain available. No model or cache conversion is required.

## Practical impact

This targets eligible GB10 Q8 prefill, so its user-visible benefit depends on how much of a request uses that path; it does not optimize decode. The earlier roughly 10.7% prefill comparisons and separate padding measurements below use their stated baselines. They are not additive percentages or newly measured gains over `f62ca29`. The rebased standalone API and sanitizer checks validate the optimized path's outputs and boundaries.

## Combined runtime context

A [stock/full-stack engine comparison](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/README.md) measures pristine `f62ca29` against the complete integrated runtime on GB10 CUDA and M3 Ultra Metal, including full 262,144-token capacity. The original full sweeps used one process pair per machine and include additional changes beyond these 13 PRs. A [targeted M3 follow-up](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/m3-attribution/README.md) did not reproduce the original short-decode slowdown, using a reversed-order pair, same-process controls and an exact original-executable replay. These results do not isolate this PR’s marginal gain, establish universal speed or quality, or newly benchmark its server/cache workflows. See the [per-PR assessment](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/PR-ASSESSMENT.md) for its supported benefit and limits.

## Validation

The build and runtime checks below ran before upstream’s README-only update. The full PR diff and every other tracked file are byte-identical at this head; `git diff --check` passed again. The documentation-only rebase was not rebuilt.

One standalone commit, `ad19000e06ed`, directly on upstream `f62ca29a3087` (2026-09-07). The public-API fixture covers 28 shapes and all eight optimization combinations: partial blocks/warps/tiles, short batches, grouped strides, width 8192, unaligned-width fallback and artifact presence/absence. Codes, outputs and guards must match exactly.

On the preceding `b6af0ad` base, clean default Metal and CPU builds, `make test-frontends`, session-state, TP-command and vision-image tests, and `git diff --check` passed on M3 Ultra / Darwin 27.0 / Apple clang 21. These portability and host checks load no model or GPU fixture.

Earlier standalone CUDA-object A/B evidence on GB10/CUDA 13/sm_121a, Vision-Exp IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8, 262,144 allocation, 2,048-token chunks and 128 teacher-forced decode tokens:

| Frontier | Before prefill | After prefill | Change |
| ---: | ---: | ---: | ---: |
| 8,192 | 691.47 tok/s | 765.13 tok/s | +10.65% |
| 32,768 | 675.29 tok/s | 747.91 tok/s | +10.75% |

Complete frontier vectors were byte-identical; decode differed by less than 0.6%, with no claimed decode gain. Separate eight-arm padding off/on comparisons on an integration measured +2.51% for 32,768→36,864 and +1.45% for 131,045→135,141; all 30,768,640 compared float values matched. These measurements predate the rebase. That padding comparison precedes the final capability guard/comment cleanup. Historical 28-shape API/eight-combination, numeric boundary and 184-shape padding tests passed memcheck/synccheck. The unrelated raw end-of-allocation bounds repair remains #978.

Before the Metal-only upstream update, the same patch passed checks on NVIDIA DGX Spark / Ubuntu / Linux 6.17.0-1032-nvidia, GCC 13.3 and CUDA 13.0.88: clean `make -j4 cuda-spark` (`sm_121a`), `make CUDA_ARCH=sm_121a test-frontends`, session-state, TP-command and vision-image tests, and a clean `make -j4 cpu` build. These are host tests and compile/link coverage; CUDA execution is recorded separately. The later upstream updates are a five-line GLM SSD change inside a Metal-only guard and a README edit. CUDA source and the PR patch are unchanged; native Linux preprocessing of `ds4.c` was byte-identical for CUDA, CPU and sanitizer builds.

The standalone Q8 prefill fixture passed normally and under Compute Sanitizer memcheck and synccheck (zero errors). All 28 shapes retained byte-identical output across the fixture variants.

No full aggregate model-suite, other-GPU, other-quantization or multi-GPU result is claimed.
