### PR TITLE
Fix agent tool results on text-only DeepSeek engines

### DIFF
--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -8484,6 +8484,22 @@ static bool agent_tool_observation_build(agent_worker *w,
         }
     }
     ds4_tokens_copy(tokens, &w->transcript);
+    /* Text-only tool observations must not require a multimodal engine.
+     * ds4_chat_append_multimodal_message() rejects engines that are
+     * neither GLM nor DeepSeek-with-vision, so on a plain text-only
+     * DeepSeek model every tool result append failed. The failure was
+     * misread as "tool result would exceed context", triggering a
+     * compaction that could never help, and ended with a bogus
+     * "context full after compaction" error that idled the agent.
+     * Use the plain chat append path when there are no images. */
+    if (obs->image_count == 0) {
+        const char *text =
+            (obs->part_count && obs->parts[0].text) ? obs->parts[0].text : "";
+        ds4_chat_append_message(w->engine, tokens, "tool", text);
+        free(parts);
+        *spans_out = NULL;
+        return true;
+    }
     /* GLM grounds image tokens in user turns; keep text-only observations in
      * the native tool-response role used by the rest of the agent protocol. */
     bool ok = ds4_chat_append_multimodal_message(


### PR DESCRIPTION
## Problem

Since 4771329 ("Add GLM 5.3 Flash vision support"), `agent_tool_observation_build()` in `ds4_agent.c` appends every tool observation through `ds4_chat_append_multimodal_message()`. That function rejects any engine that is neither GLM nor DeepSeek-with-vision:

```c
if ((DS4_MODEL_FAMILY != DS4_MODEL_FAMILY_GLM_DSA &&
     e->vision_kind != DS4_VISION_DEEPSEEK4) || (!tool && !user))
    ... return 0;
```

On a plain text-only DeepSeek V4 Flash/Pro engine (no `--vision` encoder loaded), **every** tool result append therefore fails. The failure is swallowed by `agent_tool_observation_fits()` and misread as "tool result would exceed context", which triggers a context compaction that can never help. After compaction the append still fails, and the agent dies with a bogus error:

```
COMPACTING rebuilding context: old=1860 summary+tail=2023 tail=123
ds4-agent: context full after compaction
```

...even with a 1M-token context and only ~2k tokens in use. The agent then sits idle; tool use (bash, web, file edits) is completely broken on text-only DeepSeek models.

## Reproduce

```
./ds4-agent -m <text-only DeepSeek GGUF> --non-interactive \
  -p "Run: echo hello, then tell me the output"
```

The bash call executes, but appending its observation fails and the run ends with the error above.

## Fix

When the observation carries no images, append it through the plain `ds4_chat_append_message()` tool path — the same path used before 4771329. The multimodal path is kept for image-carrying observations (GLM / DeepSeek vision engines).

## Tested

- Apple M3 Ultra, macOS, Metal backend, text-only DeepSeek V4 Flash GGUF
- Non-interactive run with a forced bash tool call now completes the full round trip: tool executes, observation is appended, model answers with the command output, clean exit. No "context full" error.
- `make ds4-agent` builds warning-free.
