### PR TITLE
cuda: reduce long-context visual-attention scratch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,16 @@ tests/test_mxfp4_cuda: tests/test_mxfp4_cuda.cu $(MMQ_OBJS)
 
 test-mxfp4-cuda: tests/test_mxfp4_cuda
 	./tests/test_mxfp4_cuda
+
+tests/test_cuda_visual_attention: tests/test_cuda_visual_attention.cu ds4_cuda.o ds4_image.o $(MMQ_OBJS)
+	$(NVCC) $(NVCCFLAGS) -std=c++17 -I. -o $@ $^ $(CUDA_LDLIBS)
+
+.PHONY: test-cuda-visual-attention
+test-cuda-visual-attention: tests/test_cuda_visual_attention
+	./tests/test_cuda_visual_attention
+	./tests/test_cuda_visual_attention --fractional
+	./tests/test_cuda_visual_attention --boundaries
+	./tests/test_cuda_visual_attention --memory
 endif
 
 ds4.o: ds4.c ds4.h ds4_ssd.h ds4_distributed.h ds4_gpu.h ds4_linux_memory.h
@@ -764,6 +774,7 @@ clean:
 	rm -f tests/test_cuda_q8_scratch
 	rm -f tests/test_cuda_dspark_moe
 	rm -f tests/test_quality_api
+	rm -f tests/test_cuda_visual_attention
 	rm -f tests/test_linux_memory tests/test_rocm_memory
 	rm -f tests/test_glm_attention tests/test_glm_attention_rocm
 	rm -f tests/test_ssd_cache

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -18486,6 +18486,20 @@ extern "C" int ds4_gpu_attention_prefill_masked_mixed_heads_tensor(
                                        n_comp, window, ratio, n_head, head_dim);
 }
 
+__global__ static void attention_visual_unpack_heads_kernel(
+        float *heads, const float *tmp,
+        uint32_t n_tokens, uint32_t n_head, uint32_t head_dim,
+        uint32_t head0, uint32_t head_count) {
+    const uint64_t i = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= (uint64_t)n_tokens * head_count * head_dim) return;
+    const uint32_t d = i % head_dim;
+    const uint64_t row = i / head_dim;
+    const uint32_t h = row % head_count;
+    const uint32_t t = row / head_count;
+    heads[((uint64_t)t * n_head + head0 + h) * head_dim + d] =
+        tmp[((uint64_t)h * n_tokens + t) * head_dim + d];
+}
+
 extern "C" int ds4_gpu_attention_visual_mixed_batch_heads_tensor(
         ds4_gpu_tensor *heads,
         const void *model_map,
@@ -18510,7 +18524,9 @@ extern "C" int ds4_gpu_attention_visual_mixed_batch_heads_tensor(
         uint32_t n_head,
         uint32_t head_dim) {
     if (!heads || !model_map || !q || !raw_kv || !tokens || vocab_size == 0 ||
-        n_tokens == 0 || n_raw == 0 || raw_cap < n_raw || raw_start >= raw_cap ||
+        n_tokens == 0 || n_head == 0 || head_dim == 0 ||
+        n_tokens > INT_MAX || n_head > (uint32_t)INT_MAX / head_dim ||
+        n_raw == 0 || raw_cap < n_raw || raw_start >= raw_cap ||
         (n_comp != 0 && (!comp_kv || ratio == 0)) ||
         (use_comp_mask && !comp_mask) || comp_kv_f16 || !g_cublas_ready ||
         sinks_offset > model_size ||
@@ -18540,11 +18556,21 @@ extern "C" int ds4_gpu_attention_visual_mixed_batch_heads_tensor(
 
     if (n_raw > UINT32_MAX - n_comp) return 0;
     const uint32_t n_keys = n_raw + n_comp;
+    if (n_keys > INT_MAX) return 0;
+    /* Keep small calls unchanged. Large visual prefills otherwise retain a
+     * context-sized score matrix for every head, which can exhaust memory.
+     * Heads are independent, so reuse that workspace across head groups. */
+    const uint64_t scores_per_head = (uint64_t)n_tokens * n_keys;
+    const uint64_t small_scores = UINT64_C(256) * 1024 * 1024 / sizeof(float);
+    const uint32_t head_cap = scores_per_head <= small_scores / n_head
+                           ? n_head : min(n_head, 8u);
+    if ((uint64_t)n_tokens * n_keys >
+        UINT64_MAX / head_cap / sizeof(float)) return 0;
     const uint64_t kv_count = (uint64_t)n_keys * head_dim;
     const uint64_t score_count =
-        (uint64_t)n_head * n_tokens * n_keys;
+        (uint64_t)head_cap * n_tokens * n_keys;
     const uint64_t out_count =
-        (uint64_t)n_head * n_tokens * head_dim;
+        (uint64_t)head_cap * n_tokens * head_dim;
     if (kv_count > UINT64_MAX / sizeof(float) ||
         score_count > UINT64_MAX / sizeof(float) ||
         out_count > UINT64_MAX / sizeof(float)) return 0;
@@ -18584,36 +18610,53 @@ extern "C" int ds4_gpu_attention_visual_mixed_batch_heads_tensor(
 
     const float alpha = rsqrtf((float)head_dim);
     const float beta = 0.0f;
-    cublasStatus_t status = cublasSgemmStridedBatched(
-            cuda_cublas_for_tier(logical_tier), CUBLAS_OP_T, CUBLAS_OP_N,
-            (int)n_keys, (int)n_tokens, (int)head_dim,
-            &alpha, kv, (int)head_dim, 0,
-            (const float *)q->ptr, (int)(n_head * head_dim),
-            (long long)head_dim, &beta, scores, (int)n_keys,
-            (long long)n_keys * n_tokens, (int)n_head);
-    if (!cublas_ok(status, "visual attention score gemm")) return 0;
-    dim3 score_grid(n_tokens, n_head, 1u);
-    attention_visual_mixed_softmax_kernel<<<score_grid, 256u>>>(
-            scores, sinks,
-            use_comp_mask ? (const float *)comp_mask->ptr : NULL,
-            device_bounds, use_comp_mask, n_tokens, pos0, first_raw_pos,
-            n_raw, n_comp, ratio, n_keys);
-    if (!cuda_ok(cudaGetLastError(), "visual attention softmax launch"))
-        return 0;
-
     const float one = 1.0f;
-    status = cublasSgemmStridedBatched(
-            cuda_cublas_for_tier(logical_tier), CUBLAS_OP_N, CUBLAS_OP_N,
-            (int)head_dim, (int)n_tokens, (int)n_keys,
-            &one, kv, (int)head_dim, 0, scores, (int)n_keys,
-            (long long)n_keys * n_tokens, &beta, out_tmp, (int)head_dim,
-            (long long)head_dim * n_tokens, (int)n_head);
-    if (!cublas_ok(status, "visual attention value gemm")) return 0;
-    const uint64_t values = (uint64_t)n_tokens * n_head * head_dim;
-    attention_prefill_unpack_heads_kernel<<<
-        (values + 255u) / 256u, 256u>>>(
-            (float *)heads->ptr, out_tmp, n_tokens, n_head, head_dim);
-    return cuda_ok(cudaGetLastError(), "visual attention unpack launch");
+    for (uint32_t head0 = 0; head0 < n_head;) {
+        const uint32_t remaining = n_head - head0;
+        /* Avoid a singleton tail: cuBLAS treats batchCount=1 differently. */
+        const uint32_t head_count = remaining == head_cap + 1u
+                                  ? head_cap - 1u : min(head_cap, remaining);
+        cublasStatus_t status = cublasSgemmStridedBatched(
+                cuda_cublas_for_tier(logical_tier), CUBLAS_OP_T, CUBLAS_OP_N,
+                (int)n_keys, (int)n_tokens, (int)head_dim,
+                &alpha, kv, (int)head_dim, 0,
+                (const float *)q->ptr + (uint64_t)head0 * head_dim,
+                (int)(n_head * head_dim),
+                (long long)head_dim, &beta, scores, (int)n_keys,
+                (long long)n_keys * n_tokens, (int)head_count);
+        if (!cublas_ok(status, "visual attention score gemm")) return 0;
+        dim3 score_grid(n_tokens, head_count, 1u);
+        attention_visual_mixed_softmax_kernel<<<score_grid, 256u>>>(
+                scores, sinks + head0,
+                use_comp_mask ? (const float *)comp_mask->ptr : NULL,
+                device_bounds, use_comp_mask, n_tokens, pos0, first_raw_pos,
+                n_raw, n_comp, ratio, n_keys);
+        if (!cuda_ok(cudaGetLastError(), "visual attention softmax launch"))
+            return 0;
+
+        status = cublasSgemmStridedBatched(
+                cuda_cublas_for_tier(logical_tier), CUBLAS_OP_N, CUBLAS_OP_N,
+                (int)head_dim, (int)n_tokens, (int)n_keys,
+                &one, kv, (int)head_dim, 0, scores, (int)n_keys,
+                (long long)n_keys * n_tokens, &beta, out_tmp, (int)head_dim,
+                (long long)head_dim * n_tokens, (int)head_count);
+        if (!cublas_ok(status, "visual attention value gemm")) return 0;
+        const uint64_t values = (uint64_t)n_tokens * head_count * head_dim;
+        if (head_count == n_head) {
+            attention_prefill_unpack_heads_kernel<<<
+                (values + 255u) / 256u, 256u>>>(
+                    (float *)heads->ptr, out_tmp, n_tokens, n_head, head_dim);
+        } else {
+            attention_visual_unpack_heads_kernel<<<
+                (values + 255u) / 256u, 256u>>>(
+                    (float *)heads->ptr, out_tmp, n_tokens, n_head, head_dim,
+                    head0, head_count);
+        }
+        if (!cuda_ok(cudaGetLastError(), "visual attention unpack launch"))
+            return 0;
+        head0 += head_count;
+    }
+    return 1;
 }
 extern "C" int ds4_gpu_attention_output_q8_batch_tensor(
         ds4_gpu_tensor       *out,

--- a/tests/test_cuda_visual_attention.cu
+++ b/tests/test_cuda_visual_attention.cu
@@ -1,0 +1,254 @@
+#include "ds4_gpu.h"
+#include "ds4_image.h"
+
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#define CHECK(x) do { if (!(x)) { \
+    fprintf(stderr, "FAIL line %d: %s\n", __LINE__, #x); exit(1); \
+} } while (0)
+
+struct shape {
+    uint32_t nt, pos, nc, nh, dim, mask;
+    bool quality;
+};
+
+static size_t mismatched_cases;
+static bool benchmark;
+static bool fractional;
+
+static float value(size_t i, unsigned seed) {
+    uint32_t x = (uint32_t)i * 747796405u + seed * 2891336453u;
+    x = ((x >> ((x >> 28u) + 4u)) ^ x) * 277803737u;
+    x = (x >> 22u) ^ x;
+    if (fractional) return ((int)(x % 65521u) - 32760) / 65537.0f;
+    return ((int)(x % 31u) - 15) / 32.0f;
+}
+
+static ds4_gpu_tensor *upload(const std::vector<float> &v) {
+    ds4_gpu_tensor *t = ds4_gpu_tensor_alloc(v.size() * sizeof(float));
+    CHECK(t);
+    CHECK(ds4_gpu_tensor_write(t, 0, v.data(), v.size() * sizeof(float)));
+    return t;
+}
+
+static void run_case(const shape &s, float *model, FILE *dump, FILE *oracle,
+                     bool memory_check) {
+    const uint32_t nr = s.nt + std::min(s.pos, 19u);
+    const uint32_t cap = nr + 13u, start = cap - 7u;
+    const uint32_t first = s.pos + s.nt - nr, nk = nr + s.nc;
+    const uint32_t ratio = s.nc ? 4u : 0u, window = 256u, vocab = 128u;
+    const size_t count = (size_t)s.nt * s.nh * s.dim;
+    std::vector<float> q(count), raw((size_t)cap * s.dim);
+    std::vector<float> comp((size_t)std::max(s.nc, 1u) * s.dim);
+    std::vector<float> mask((size_t)s.nt * std::max(s.nc, 1u));
+    std::vector<float> output(count + 32u, 12345.25f);
+    for (size_t i = 0; i < q.size(); i++) q[i] = value(i, 3);
+    for (size_t i = 0; i < raw.size(); i++) raw[i] = value(i, 5);
+    for (size_t i = 0; i < comp.size(); i++) comp[i] = value(i, 7);
+    for (size_t i = 0; i < mask.size(); i++)
+        mask[i] = s.mask == 2 || i % 3u == 0 ? -INFINITY : -0.25f;
+    std::vector<int32_t> tokens(s.nt, 11);
+    if (s.nt >= 7u) {
+        tokens[1] = vocab + DS4_DEEPSEEK4_IMAGE_PAD;
+        tokens[2] = vocab + DS4_DEEPSEEK4_IMAGE_START;
+        tokens[3] = vocab + DS4_DEEPSEEK4_IMAGE;
+        tokens[4] = vocab + DS4_DEEPSEEK4_IMAGE_NEWLINE;
+        tokens[5] = vocab + DS4_DEEPSEEK4_IMAGE;
+        tokens[6] = vocab + DS4_DEEPSEEK4_IMAGE_END;
+    }
+    if (s.nt >= 17u) {
+        tokens[s.nt-4u] = vocab + DS4_DEEPSEEK4_IMAGE_START;
+        tokens[s.nt-3u] = vocab + DS4_DEEPSEEK4_IMAGE;
+        tokens[s.nt-2u] = vocab + DS4_DEEPSEEK4_IMAGE_END;
+    }
+    ds4_gpu_tensor *dq = upload(q), *dr = upload(raw), *dc = upload(comp);
+    ds4_gpu_tensor *dm = upload(mask), *storage = upload(output);
+    ds4_gpu_tensor *dst = ds4_gpu_tensor_view(storage, 16u*sizeof(float), count*sizeof(float));
+    CHECK(dst);
+    ds4_gpu_set_quality(s.quality);
+    size_t free_before = 0, total = 0, free_after = 0;
+    CHECK(cudaMemGetInfo(&free_before, &total) == cudaSuccess);
+    cudaEvent_t begin, end;
+    CHECK(cudaEventCreate(&begin) == cudaSuccess);
+    CHECK(cudaEventCreate(&end) == cudaSuccess);
+    auto infer = [&]() {
+      CHECK(ds4_gpu_attention_visual_mixed_batch_heads_tensor(
+        dst, model, 4096, 0, dq, dr, s.nc ? dc : NULL, 0,
+        s.mask ? dm : NULL, s.mask != 0, tokens.data(), vocab,
+        s.nt, s.pos, nr, cap, start, s.nc, window, ratio, s.nh, s.dim));
+    };
+    CHECK(cudaEventRecord(begin) == cudaSuccess);
+    infer();
+    CHECK(cudaEventRecord(end) == cudaSuccess);
+    CHECK(cudaEventSynchronize(end) == cudaSuccess);
+    float ms = 0;
+    CHECK(cudaEventElapsedTime(&ms, begin, end) == cudaSuccess);
+    if (benchmark) {
+        for (int i = 0; i < 3; i++) infer();
+        CHECK(cudaDeviceSynchronize() == cudaSuccess);
+        std::vector<float> samples;
+        for (int i = 0; i < 10; i++) {
+            CHECK(cudaEventRecord(begin) == cudaSuccess);
+            infer();
+            CHECK(cudaEventRecord(end) == cudaSuccess);
+            CHECK(cudaEventSynchronize(end) == cudaSuccess);
+            CHECK(cudaEventElapsedTime(&ms, begin, end) == cudaSuccess);
+            samples.push_back(ms);
+        }
+        std::sort(samples.begin(), samples.end());
+        ms = (samples[4] + samples[5]) / 2;
+    }
+    CHECK(cudaMemGetInfo(&free_after, &total) == cudaSuccess);
+    CHECK(ds4_gpu_tensor_read(storage, 0, output.data(), output.size()*sizeof(float)));
+    for (size_t i = 0; i < 16; i++) {
+        CHECK(output[i] == 12345.25f);
+        CHECK(output[count+16+i] == 12345.25f);
+    }
+    for (size_t i = 16; i < count+16; i++) CHECK(std::isfinite(output[i]));
+    if (dump) CHECK(fwrite(output.data()+16, sizeof(float), count, dump) == count);
+    if (oracle) {
+        std::vector<float> expected(count);
+        CHECK(fread(expected.data(), sizeof(float), count, oracle) == count);
+        size_t differences = 0;
+        double max_error = 0;
+        for (size_t i = 0; i < count; i++) {
+            differences += memcmp(&expected[i], &output[i+16], sizeof(float)) != 0;
+            max_error = std::max(max_error, fabs((double)expected[i]-output[i+16]));
+        }
+        if (differences) fprintf(stderr, "nt=%u heads=%u dim=%u quality=%d: %zu/%zu differing floats, max %.9g\n",
+            s.nt, s.nh, s.dim, s.quality, differences, count, max_error);
+        if (differences) mismatched_cases++;
+    }
+    /* Independent double-precision oracle: every small output, and selected
+     * rows/components across head-group/image boundaries for large calls.
+     * Exact backend-to-backend comparison above separately covers TF32 mode. */
+    if (s.quality) {
+        const bool sampled = (uint64_t)s.nt*s.nh*nk*s.dim >= 12000000u;
+        std::vector<uint32_t> bounds((size_t)s.nt*2u);
+        CHECK(ds4_deepseek4_attention_bounds((const int *)tokens.data(), s.nt,
+                                            vocab, s.pos, nr, window, bounds.data()));
+        std::vector<double> scores(nk);
+        for (uint32_t t = 0; t < s.nt; t++) for (uint32_t h = 0; h < s.nh; h++) {
+            if (sampled && t != 0 && t != std::min(3u,s.nt-1u) && t != s.nt-1u) continue;
+            if (sampled && h != 0 && h != std::min(7u,s.nh-1u) &&
+                h != std::min(8u,s.nh-1u) && h != s.nh-1u) continue;
+            double maximum = model[h];
+            const uint32_t visible = ratio ? std::min(s.nc, (s.pos+t+1u)/ratio) : 0;
+            for (uint32_t k = 0; k < nk; k++) {
+                const uint32_t c = k-nr;
+                const bool allowed = k < nr
+                    ? first+k >= bounds[t*2u] && first+k <= bounds[t*2u+1u]
+                    : c < visible && (!s.mask || mask[(size_t)t*s.nc+c] > -1e20f);
+                double v = -INFINITY;
+                if (allowed) {
+                    const float *kv = k < nr ? raw.data() + (size_t)((start+k)%cap)*s.dim
+                                            : comp.data() + (size_t)c*s.dim;
+                    v = 0;
+                    for (uint32_t d = 0; d < s.dim; d++)
+                        v += (double)q[((size_t)t*s.nh+h)*s.dim+d] * kv[d];
+                    v /= sqrt((double)s.dim);
+                    if (k >= nr && s.mask) v += mask[(size_t)t*s.nc+c];
+                }
+                scores[k] = v;
+                maximum = std::max(maximum, v);
+            }
+            double denom = exp(model[h]-maximum);
+            for (uint32_t k = 0; k < nk; k++) denom += scores[k] = exp(scores[k]-maximum);
+            for (uint32_t d = 0; d < s.dim; d++) {
+                if (sampled && d != 0 && d != s.dim/2u && d != s.dim-1u) continue;
+                double expected = 0;
+                for (uint32_t k = 0; k < nk; k++) {
+                    const float *kv = k < nr ? raw.data() + (size_t)((start+k)%cap)*s.dim
+                                            : comp.data() + (size_t)(k-nr)*s.dim;
+                    expected += scores[k] * kv[d] / denom;
+                }
+                CHECK(fabs(expected-output[16+((size_t)t*s.nh+h)*s.dim+d]) < 2e-5);
+            }
+        }
+    }
+    const double growth = free_before > free_after ? (free_before-free_after)/1048576.0 : 0;
+    printf("nt=%u pos=%u comp=%u heads=%u dim=%u mask=%u quality=%d %s=%.4f scratch_growth_MiB=%.2f\n",
+           s.nt,s.pos,s.nc,s.nh,s.dim,s.mask,s.quality,
+           benchmark ? "warmed_median_ms" : "ms",ms,growth);
+    fflush(stdout);
+    if (memory_check) CHECK(growth < 160.0);
+    CHECK(cudaEventDestroy(begin) == cudaSuccess);
+    CHECK(cudaEventDestroy(end) == cudaSuccess);
+    ds4_gpu_tensor_free(dst); ds4_gpu_tensor_free(storage);
+    ds4_gpu_tensor_free(dm); ds4_gpu_tensor_free(dc);
+    ds4_gpu_tensor_free(dr); ds4_gpu_tensor_free(dq);
+}
+
+int main(int argc, char **argv) {
+    FILE *dump = NULL, *oracle = NULL;
+    bool memory = false, large = false, boundaries = false;
+    for (int i=1;i<argc;i++) {
+        if (!strcmp(argv[i],"--dump") && i+1<argc) { dump=fopen(argv[++i],"wb"); CHECK(dump); }
+        else if (!strcmp(argv[i],"--compare") && i+1<argc) { oracle=fopen(argv[++i],"rb"); CHECK(oracle); }
+        else if (!strcmp(argv[i],"--memory")) memory=true;
+        else if (!strcmp(argv[i],"--large")) large=true;
+        else if (!strcmp(argv[i],"--boundaries")) boundaries=true;
+        else if (!strcmp(argv[i],"--bench")) benchmark=true;
+        else if (!strcmp(argv[i],"--fractional")) fractional=true;
+        else { fprintf(stderr,"bad argument\n"); return 1; }
+    }
+    int devices=0;
+    CHECK(cudaGetDeviceCount(&devices)==cudaSuccess && devices>0);
+    CHECK(ds4_gpu_init());
+    float *model=NULL;
+    CHECK(cudaMallocHost((void **)&model,4096)==cudaSuccess);
+    for (size_t i=0;i<1024;i++) model[i]=value(i,17);
+    /* This synthetic model is only 4 KiB. Make its sinks device-resident,
+     * avoiding unsupported read-only host registration on integrated GPUs. */
+    CHECK(setenv("DS4_CUDA_COPY_MODEL", "1", 1)==0);
+    CHECK(ds4_gpu_set_model_map(model,4096));
+    CHECK(unsetenv("DS4_CUDA_COPY_MODEL")==0);
+    if (memory) {
+        /* Exclude one-time CUDA/cuBLAS initialization from the scratch delta. */
+        run_case({7,0,0,1,32,0,false},model,NULL,NULL,false);
+        run_case({257,32761,8192,64,512,1,false},model,dump,oracle,true);
+    } else if (boundaries) {
+        for (bool quality : {false,true}) {
+            /* Immediately below, at, and above the 256 MiB score cutoff. */
+            for (uint32_t nc : {32716u,32717u,32718u})
+                run_case({32,129001,nc,64,512,1,quality},model,dump,oracle,false);
+            /* Large calls must also cover incomplete final head groups. */
+            for (uint32_t nh : {9u,17u,63u})
+                run_case({257,129001,32768,nh,512,1,quality},model,dump,oracle,false);
+        }
+    } else if (benchmark) {
+        run_case({1,32767,8192,64,512,1,false},model,dump,oracle,false);
+        run_case({32,129001,32769,64,512,1,false},model,dump,oracle,false);
+        run_case({469,130603,32768,64,512,1,false},model,dump,oracle,false);
+        run_case({1579,137216,35000,64,512,1,false},model,dump,oracle,false);
+        run_case({2048,260096,65536,64,512,1,false},model,dump,oracle,false);
+    } else {
+        for (bool quality : {false,true}) {
+            for (uint32_t nh : {1u,7u,8u,9u,17u,63u,64u}) {
+                run_case({7,0,0,nh,32,0,quality},model,dump,oracle,false);
+                run_case({17,113,37,nh,32,1,quality},model,dump,oracle,false);
+                run_case({31,2047,513,nh,32,2,quality},model,dump,oracle,false);
+            }
+            run_case({1,32767,8192,64,512,1,quality},model,dump,oracle,false);
+            run_case({32,129001,32769,64,512,1,quality},model,dump,oracle,false);
+            if (large) {
+                run_case({469,130603,32768,64,512,1,quality},model,dump,oracle,false);
+                run_case({1579,137216,35000,64,512,1,quality},model,dump,oracle,false);
+                run_case({2048,260096,65536,64,512,1,quality},model,dump,oracle,false);
+            }
+        }
+    }
+    if (dump) CHECK(fclose(dump)==0);
+    if (oracle) { CHECK(fgetc(oracle)==EOF); CHECK(fclose(oracle)==0); }
+    ds4_gpu_cleanup();
+    CHECK(cudaFreeHost(model)==cudaSuccess);
+    CHECK(mismatched_cases == 0);
+    puts("PASS: CUDA visual attention");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Reuse the CUDA visual-attention score/output workspace across groups of up to
eight heads when the full score matrix exceeds 256 MiB. Smaller calls keep
their original cuBLAS batch size and unpack kernel. No model, sampling, attention
mask, KV format or server configuration changes.

## Why

Visual prefill currently materializes `heads × queries × (raw + compressed keys)`
FP32 scores at once. A model can fit comfortably in memory and still request
tens of GiB of temporary storage when it encounters an image late in a conversation.

On GB10 with DeepSeek-V4-Flash-Vision-Exp IQ2XXS/w2-Q2_K and Q8 dense projections,
a 140,127-token request with an image after 136K tokens requested **18.13 GiB**
for this workspace. A test-only allocation guard rejected it before it could
exhaust the host. The patched production-shaped build completed the identical
request with a **2.33 GiB** maximum allocation and about 9 GiB host headroom.
The guard and watchdog exist only in the external diagnostic harness.

Each attention head is independent. This patch keeps each head's complete key
dimension, uses the existing score GEMM, softmax and value GEMM, and scatters
the finished group to its normal output positions before reusing scratch.
It does not truncate attention, change precision or introduce another cache.
The final group avoids a singleton because cuBLAS can select a different
arithmetic path for `batchCount=1`.

## Compatibility

The full key dimension and original arithmetic are retained. Calls below the existing 256 MiB workspace threshold keep their prior dispatch.

## Practical impact

The primary benefit is making long-context image requests fit by reducing temporary attention workspace. The earlier 18.13-to-2.33 GiB reproducer below demonstrates that capacity improvement; the 3.85–6.13% timings cover individual large attention calls. Neither is a whole-model speedup over `f62ca29`. Smaller calls retain their dispatch, and the standalone fixture checks the large-call arithmetic and memory boundaries.

## Combined runtime context

A [stock/full-stack engine comparison](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/README.md) measures pristine `f62ca29` against the complete integrated runtime on GB10 CUDA and M3 Ultra Metal, including full 262,144-token capacity. The original full sweeps used one process pair per machine and include additional changes beyond these 13 PRs. A [targeted M3 follow-up](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/m3-attribution/README.md) did not reproduce the original short-decode slowdown, using a reversed-order pair, same-process controls and an exact original-executable replay. These results do not isolate this PR’s marginal gain, establish universal speed or quality, or newly benchmark its server/cache workflows. See the [per-PR assessment](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/PR-ASSESSMENT.md) for its supported benefit and limits.

## Validation

The build and runtime checks below ran before upstream’s README-only update. The full PR diff and every other tracked file are byte-identical at this head; `git diff --check` passed again. The documentation-only rebase was not rebuilt.

One standalone commit, `78dd9deb5ea7`, directly on upstream `f62ca29a3087` (2026-09-07). The focused CUDA fixture checks independent double-precision references, wrapped raw KV, image boundaries, masks, incomplete head groups, scratch growth and output guards. Large/fractional/boundary modes retain complete-output comparison support.

On the preceding `b6af0ad` base, clean default Metal and CPU builds, `make test-frontends`, session-state, TP-command and vision-image tests, and `git diff --check` passed on M3 Ultra / Darwin 27.0 / Apple clang 21. These portability and host checks load no model or GPU fixture.

Earlier GB10/CUDA 13/sm_121a evidence: 128 full-output cases across two input families, both quality modes and cutoff/262K boundaries were byte-identical to the unchanged backend. Fractional boundary comparisons passed memcheck and synccheck. The scratch fixture fell from 584.56 MiB to 87.99 MiB, excluding initialization. A production-shaped Vision-Exp IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8 comparison matched 4,266,240 full-vocabulary floats after a 36K image prefill and 32 teacher-forced steps; four snapshot/suffix restores per arm also matched. The protected 140K reproducer and these model results predate this rebase. Balanced GPU-event call gains were 3.85–6.13% for the measured large attention shapes; no whole-model or decode gain is inferred.

Before the Metal-only upstream update, the same patch passed checks on NVIDIA DGX Spark / Ubuntu / Linux 6.17.0-1032-nvidia, GCC 13.3 and CUDA 13.0.88: clean `make -j4 cuda-spark` (`sm_121a`), `make CUDA_ARCH=sm_121a test-frontends`, session-state, TP-command and vision-image tests, and a clean `make -j4 cpu` build. These are host tests and compile/link coverage; CUDA execution is recorded separately. The later upstream updates are a five-line GLM SSD change inside a Metal-only guard and a README edit. CUDA source and the PR patch are unchanged; native Linux preprocessing of `ds4.c` was byte-identical for CUDA, CPU and sanitizer builds.

The standalone visual-attention fixture passed its default, fractional, boundary and memory modes. The default mode also passed Compute Sanitizer memcheck and synccheck with zero errors. These are independent-reference and guard checks; the earlier complete-output baseline comparisons above remain separately dated evidence.

No full aggregate model-suite, other-GPU, other-quantization or multi-GPU result is claimed.
