### PR TITLE
kvstore: age the eviction value of unused checkpoints

### DIFF
--- a/ds4_kvstore.c
+++ b/ds4_kvstore.c
@@ -537,15 +537,20 @@ double ds4_kvstore_entry_eviction_score(
     if (!e || e->file_size == 0) return 0.0;
     (void)live;
     double effective_hits = (double)e->hits;
+    double freshness = 1.0;
     uint64_t used_at = e->last_used ? e->last_used : e->created_at;
     if (used_at == 0) {
         effective_hits = 0.0;
+        freshness = 0.0;
     } else if (now > used_at) {
         double elapsed = (double)(now - used_at);
-        effective_hits *= exp2(-elapsed / (double)DS4_KVSTORE_HIT_HALF_LIFE_SECONDS);
+        freshness = exp2(-elapsed / (double)DS4_KVSTORE_HIT_HALF_LIFE_SECONDS);
+        effective_hits *= freshness;
         if (effective_hits < KV_CACHE_MIN_EFFECTIVE_HITS) effective_hits = 0.0;
     }
-    double score = (effective_hits + 1.0) *
+    /* Unused checkpoints must age too. A permanent +1 lets old, denser dumps
+     * evict a just-saved conversation before its first disk lookup. */
+    double score = (effective_hits + freshness) *
                    (double)e->tokens / (double)e->file_size;
     if (kv_cache_reason_is_anchor(e->reason))
         score *= KV_CACHE_ANCHOR_REASON_SCORE_FACTOR;

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -18813,8 +18813,10 @@ static void test_kv_text_stub_file_model(const char *dir, const char *text,
     }
 
     uint8_t h[KV_CACHE_FIXED_HEADER];
+    /* These fixtures exercise identity/prefix policy, not decades of aging. */
+    const uint64_t now = (uint64_t)time(NULL);
     ds4_kvstore_fill_header(h, model_id, 2, reason, 0, tokens, 0,
-                            32768, 100, 100, payload_bytes);
+                            32768, now, now, payload_bytes);
     uint8_t text_len[4];
     le_put32(text_len, (uint32_t)strlen(text));
     TEST_ASSERT(fwrite(h, 1, sizeof(h), fp) == sizeof(h));
@@ -19327,6 +19329,104 @@ static void test_kv_cache_eviction_score_decays_stale_hits(void) {
     /* A fresh entry's score never decays below its (0+1) * tokens/size floor,
      * regardless of how old another entry's hit history is. */
     TEST_ASSERT(f_on == 1.0 * (double)fresh.tokens / (double)fresh.file_size);
+}
+
+static void test_kv_cache_eviction_decays_unused_value(void) {
+    const uint64_t now = 1000u + 16u * KV_CACHE_HIT_HALF_LIFE_SECONDS;
+    kv_entry e = {.tokens = 1024, .file_size = 4096,
+                  .created_at = now, .last_used = now};
+    double fresh = kv_entry_eviction_score(&e, NULL, now, NULL);
+    TEST_ASSERT(fresh == 0.25);
+    e.last_used = now - KV_CACHE_HIT_HALF_LIFE_SECONDS;
+    TEST_ASSERT(kv_entry_eviction_score(&e, NULL, now, NULL) == fresh * 0.5);
+    e.last_used = now - 2u * KV_CACHE_HIT_HALF_LIFE_SECONDS;
+    TEST_ASSERT(kv_entry_eviction_score(&e, NULL, now, NULL) == fresh * 0.25);
+
+    /* Existing hit evidence and anchor preference still matter. */
+    e.hits = 3;
+    TEST_ASSERT(kv_entry_eviction_score(&e, NULL, now, NULL) == fresh);
+    e.reason = KV_REASON_COLD;
+    TEST_ASSERT(kv_entry_eviction_score(&e, NULL, now, NULL) == fresh * 2.0);
+
+    e.hits = 0;
+    e.reason = KV_REASON_UNKNOWN;
+    e.last_used = 0;
+    e.created_at = now - KV_CACHE_HIT_HALF_LIFE_SECONDS;
+    TEST_ASSERT(kv_entry_eviction_score(&e, NULL, now, NULL) == fresh * 0.5);
+    e.created_at = 0;
+    TEST_ASSERT(kv_entry_eviction_score(&e, NULL, now, NULL) == 0.0);
+    e.last_used = UINT64_MAX; /* A future timestamp cannot amplify the score. */
+    TEST_ASSERT(kv_entry_eviction_score(&e, NULL, now, NULL) == fresh);
+    e.last_used = 1;
+    TEST_ASSERT(kv_entry_eviction_score(&e, NULL, UINT64_MAX, NULL) == 0.0);
+}
+
+static void test_kv_cache_eviction_preserves_sequential_shutdown_saves(void) {
+    char tmpl[] = "/tmp/ds4-kv-shutdown-aging-test.XXXXXX";
+    char *dir = mkdtemp(tmpl);
+    TEST_ASSERT(dir != NULL);
+    if (!dir) return;
+    const char *sha[] = {
+        "1111111111111111111111111111111111111111",
+        "2222222222222222222222222222222222222222",
+        "3333333333333333333333333333333333333333",
+        "4444444444444444444444444444444444444444",
+    };
+    char *path[4];
+    for (int i = 0; i < 4; i++) {
+        char name[44];
+        snprintf(name, sizeof(name), "%s.kv", sha[i]);
+        path[i] = path_join(dir, name);
+    }
+    const uint64_t now = (uint64_t)time(NULL);
+    const uint64_t fixed = KV_CACHE_FIXED_HEADER + 4u;
+    /* Scaled-down byte costs from long DeepSeek checkpoints. Older, longer
+     * dumps have slightly better density but have not been used in days. */
+    test_kv_stub_file(dir, sha[0], KV_REASON_EVICT, 159734, 0,
+                     now - 11u * KV_CACHE_HIT_HALF_LIFE_SECONDS, 2120u * 1024u);
+    test_kv_stub_file(dir, sha[1], KV_REASON_EVICT, 185855, 0,
+                     now - 10u * KV_CACHE_HIT_HALF_LIFE_SECONDS, 2463u * 1024u);
+    kv_disk_cache kc = {0};
+    kc.enabled = true;
+    kc.dir = xstrdup(dir);
+    kc.opt = kv_cache_default_options();
+    kc.budget_bytes = 5u * 1024u * 1024u;
+
+    kv_cache_evict(&kc, NULL, fixed + 1410u * 1024u, NULL);
+    test_kv_stub_file(dir, sha[2], KV_REASON_SHUTDOWN, 105662, 0,
+                     now, 1410u * 1024u);
+    TEST_ASSERT(access(path[0], F_OK) != 0);
+    TEST_ASSERT(access(path[1], F_OK) == 0);
+    kv_cache_evict(&kc, NULL, fixed + 2595u * 1024u, NULL);
+    test_kv_stub_file(dir, sha[3], KV_REASON_SHUTDOWN, 195932, 0,
+                     now, 2595u * 1024u);
+    TEST_ASSERT(access(path[2], F_OK) == 0);
+    TEST_ASSERT(access(path[1], F_OK) != 0);
+    kv_cache_close(&kc);
+
+    /* A fresh process sees the same survivors, within the same disk budget. */
+    TEST_ASSERT(ds4_kvstore_open(&kc, dir, 5, false,
+                                kv_cache_default_options(), NULL, NULL, NULL));
+    TEST_ASSERT(kc.len == 2);
+    TEST_ASSERT(access(path[2], F_OK) == 0);
+    TEST_ASSERT(access(path[3], F_OK) == 0);
+    uint64_t total = 0;
+    for (int i = 0; i < kc.len; i++) total += kc.entry[i].file_size;
+    TEST_ASSERT(total <= kc.budget_bytes);
+
+    /* Freshness is not a pin: an insufficient budget still forces eviction. */
+    kc.budget_bytes = 3u * 1024u * 1024u;
+    kv_cache_evict(&kc, NULL, 0, NULL);
+    total = 0;
+    for (int i = 0; i < kc.len; i++) total += kc.entry[i].file_size;
+    TEST_ASSERT(kc.len == 1);
+    TEST_ASSERT(total <= kc.budget_bytes);
+    kv_cache_close(&kc);
+    for (int i = 0; i < 4; i++) {
+        unlink(path[i]);
+        free(path[i]);
+    }
+    rmdir(dir);
 }
 
 static void test_kv_cache_eviction_decayed_hits_tie_break_by_age(void) {
@@ -19877,6 +19977,8 @@ static void ds4_server_unit_tests_run(void) {
     test_kv_cache_eviction_prefers_superseded_continued_prefix();
     test_kv_cache_eviction_keeps_smaller_context_prefix();
     test_kv_cache_eviction_score_decays_stale_hits();
+    test_kv_cache_eviction_decays_unused_value();
+    test_kv_cache_eviction_preserves_sequential_shutdown_saves();
     test_kv_cache_eviction_decayed_hits_tie_break_by_age();
     test_kv_cache_eviction_keeps_aligned_continued_frontiers();
 }


### PR DESCRIPTION
## Summary

Age the eviction score's initial `+1` using the existing six-hour hit decay.
No new setting, cache format or retention pin.

## Why

Under disk-cache pressure, a graceful shutdown saved a 105662-token resident
conversation, then evicted it immediately to save the next slot. Older unused
checkpoints survived instead.

The scorer decays **hits**, but adds a permanent `1` afterward. A never-hit
checkpoint therefore retains its full tokens-per-byte score indefinitely.
Larger dumps with slightly better density can outrank a new checkpoint even
after days without use. Existing pre-eviction prevents a write from evicting
itself; it does not protect that checkpoint from the following write.

This changes `(decayed_hits + 1) * density` to
`(decayed_hits + freshness) * density`, reusing the same six-hour exponential.
Hit clamping, anchor bonuses, superseded-continued-prefix weighting and the
hard byte budget are unchanged. Freshness is a preference, not a guarantee:
fresh entries are still evicted if the cache cannot hold the working set.

The aging issue was also discussed in #444 and @unsaltedbutter-ai's closed #550. Existing half-life, density accounting and role weights are preserved.

Compatibility: existing cache files need no migration. Only eviction ranking
changes; lookup identity, payloads, model math and sampling do not.

## Practical impact

The benefit is retaining more useful recent checkpoints under cache pressure, reducing avoidable cold restarts of conversations. It does not speed up kernels or guarantee retention when the working set exceeds the budget. The controlled old/new-scorer experiment below isolates the retention decision. A latency or throughput benefit over `f62ca29` has not been measured; that benefit depends on workload and cache pressure.

## Combined runtime context

A [stock/full-stack engine comparison](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/README.md) measures pristine `f62ca29` against the complete integrated runtime on GB10 CUDA and M3 Ultra Metal, including full 262,144-token capacity. The original full sweeps used one process pair per machine and include additional changes beyond these 13 PRs. A [targeted M3 follow-up](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/m3-attribution/README.md) did not reproduce the original short-decode slowdown, using a reversed-order pair, same-process controls and an exact original-executable replay. These results do not isolate this PR’s marginal gain, establish universal speed or quality, or newly benchmark its server/cache workflows. See the [per-PR assessment](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/PR-ASSESSMENT.md) for its supported benefit and limits.

## Validation

The build and runtime checks below ran before upstream’s README-only update. The full PR diff and every other tracked file are byte-identical at this head; `git diff --check` passed again. The documentation-only rebase was not rebuilt.

One standalone commit, `ba4b40eeac9a`, directly on upstream `f62ca29a3087` (2026-09-07). Deterministic tests cover unused-entry half-life, timestamp boundaries, sequential shutdown-sized writes, reopen and eviction of fresh entries when the budget is insufficient. The old scorer fails the new assertions.

On the preceding `b6af0ad` base, clean default Metal and CPU builds, `make test-frontends`, session-state, TP-command and vision-image tests, and `git diff --check` passed on M3 Ultra / Darwin 27.0 / Apple clang 21. These portability and host checks load no model or GPU fixture.

On the preceding `b6af0ad` base, fully instrumented host C/Objective-C ASan+UBSan tests also passed on M3 (`-O1`, leak detection off). Earlier controlled GB10/CUDA 13 integration A/B, changing only this scorer, used Vision-Exp IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8 and its encoder, two residents/one active request, 262,144 context and 2,048 prefill. In a private 256 MiB cache with synthetic old metadata, the old scorer lost a fresh 2,071-token conversation; the new scorer reloaded all 2,071 tokens. Both retained the second 6,167-token conversation. Actual payloads were generated and restored by the model; only the pressure fixtures were synthetic. The tiny budget could still evict fresh data later, as intended. This earlier integration result is not a standalone current-head model sweep.

Before the Metal-only upstream update, the same patch passed checks on NVIDIA DGX Spark / Ubuntu / Linux 6.17.0-1032-nvidia, GCC 13.3 and CUDA 13.0.88: clean `make -j4 cuda-spark` (`sm_121a`), `make CUDA_ARCH=sm_121a test-frontends`, session-state, TP-command and vision-image tests, and a clean `make -j4 cpu` build. CPU ASan+UBSan server/session/TP/vision tests passed with leak detection on; agent tests passed with leak detection off for the unchanged upstream fixture leak. These are host tests and compile/link coverage; CUDA execution is recorded separately. The later upstream updates are a five-line GLM SSD change inside a Metal-only guard and a README edit. CUDA source and the PR patch are unchanged; native Linux preprocessing of `ds4.c` was byte-identical for CUDA, CPU and sanitizer builds.

No full aggregate model-suite, other-GPU, other-quantization or multi-GPU result is claimed.
