### PR TITLE
rocm: fix strix-halo build, rsqrtf() is device-only under HIP

### DIFF
--- a/rocm/ds4_rocm_deepseek4_vision.cuh
+++ b/rocm/ds4_rocm_deepseek4_vision.cuh
@@ -236,7 +236,8 @@ extern "C" int ds4_gpu_attention_visual_mixed_batch_heads_tensor(
     if (!cuda_ok(cudaGetLastError(), "visual attention KV pack launch"))
         return 0;
 
-    const float alpha = rsqrtf((float)head_dim);
+    /* rsqrtf() is a __device__-only builtin under ROCm/HIP; this is host code. */
+    const float alpha = 1.0f / sqrtf((float)head_dim);
     const float beta = 0.0f;
     cublasStatus_t status = cublasSgemmStridedBatched(
             g_cublas, CUBLAS_OP_T, CUBLAS_OP_N,


### PR DESCRIPTION
`ds4_gpu_attention_visual_mixed_batch_heads_tensor()` in `rocm/ds4_rocm_deepseek4_vision.cuh` is host code, but `rsqrtf()` is declared `__device__`-only in ROCm/HIP's math headers, so `make rocm` / `make strix-halo` fails to compile `ds4_rocm.o`:

```
rocm/ds4_rocm_deepseek4_vision.cuh:239:25: error: no matching function for call to 'rsqrtf'
  239 |     const float alpha = rsqrtf((float)head_dim);
      |                         ^~~~~~
note: candidate function not viable: call to __device__ function from __host__ function
  671 | float rsqrtf(float __x) { return __ocml_rsqrt_f32(__x); }
1 error generated when compiling for gfx1151.
```

`nvcc` accepts `rsqrtf()` on the host, which is why this slipped through the CUDA build. Switch to `1.0f / sqrtf()` — equivalent, and valid on the host for both toolchains.

Introduced by e976a54 ("Add DeepSeek Vision-Exp support to ROCm", 2026-09-01). This is a distinct issue from the `ds4.c` / `ds4_gpu.h` `__APPLE__`-guard errors reported in #980 (different file, fails at a later point in the build).

Tested: `make rocm` now builds clean on Strix Halo (gfx1151, ROCm 7.x), all five binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
