### PR TITLE
 ROCm: accelerate DeepSeek prefill and DSpark on gfx1151

### DIFF
--- a/cuda/mmq/mmq.cuh
+++ b/cuda/mmq/mmq.cuh
@@ -3696,6 +3696,22 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
     // only write-back is too late: stale or NaN tail blocks can contaminate
     // other values in the same hardware matrix fragment.
     const int valid_y_words = min(mmq_x, tile_y_max_j + 1) * MMQ_TILE_Y_K;
+#if defined(GGML_USE_HIP) && defined(__gfx1151__)
+    // Load scheduling can change fast-math accumulation order. Keep the
+    // established path outside the larger gfx1151 IQ2 prefill templates.
+    constexpr bool fast_y_loads = type == GGML_TYPE_IQ2_XXS && mmq_x >= 32;
+    const bool full_y_tile = tile_y_max_j >= mmq_x - 1;
+    const int linear_tid = threadIdx.y*warp_size + threadIdx.x;
+    constexpr int nthreads = nwarps * warp_size;
+
+    // Seed invalid columns once. Both K stages refresh only the valid prefix,
+    // and the existing barriers keep the suffix zero before every matrix op.
+    if (fast_y_loads && !full_y_tile) {
+        for (int l = valid_y_words + linear_tid; l < mmq_x * MMQ_TILE_Y_K; l += nthreads) {
+            tile_y[l] = 0;
+        }
+    }
+#endif
 
     float sum[mmq_x*mmq_y / (nwarps*warp_size)] = {0.0f};
 
@@ -3725,12 +3741,36 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
         }
         {
             const int * by0 = y + ncols_y * (kb0 * qk / ne_block) * sz;
+#if defined(GGML_USE_HIP) && defined(__gfx1151__)
+            if constexpr (fast_y_loads) {
+                if (full_y_tile) {
+#pragma unroll
+                    for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nthreads) {
+                        const int l = l0 + linear_tid;
+                        tile_y[l] = by0[l];
+                    }
+                } else {
+#pragma unroll
+                    for (int l = linear_tid; l < valid_y_words; l += nthreads) {
+                        tile_y[l] = by0[l];
+                    }
+                }
+            } else {
+#pragma unroll
+                for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
+                    int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+
+                    tile_y[l] = l < valid_y_words ? by0[l] : 0;
+                }
+            }
+#else
 #pragma unroll
             for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
                 int l = l0 + threadIdx.y*warp_size + threadIdx.x;
 
                 tile_y[l] = l < valid_y_words ? by0[l] : 0;
             }
+#endif
         }
 
         __syncthreads();
@@ -3741,12 +3781,36 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 
         {
             const int * by0 = y + ncols_y * ((kb0 * qk / ne_block) * sz + sz);
+#if defined(GGML_USE_HIP) && defined(__gfx1151__)
+            if constexpr (fast_y_loads) {
+                if (full_y_tile) {
+#pragma unroll
+                    for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nthreads) {
+                        const int l = l0 + linear_tid;
+                        tile_y[l] = by0[l];
+                    }
+                } else {
+#pragma unroll
+                    for (int l = linear_tid; l < valid_y_words; l += nthreads) {
+                        tile_y[l] = by0[l];
+                    }
+                }
+            } else {
+#pragma unroll
+                for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
+                    int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+
+                    tile_y[l] = l < valid_y_words ? by0[l] : 0;
+                }
+            }
+#else
 #pragma unroll
             for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
                 int l = l0 + threadIdx.y*warp_size + threadIdx.x;
 
                 tile_y[l] = l < valid_y_words ? by0[l] : 0;
             }
+#endif
         }
 
         __syncthreads();

--- a/docs/SPECULATIVE_DECODING.md
+++ b/docs/SPECULATIVE_DECODING.md
@@ -41,6 +41,8 @@ The scheduler can back off when drafting is unproductive. Defaults select the
 fast paths; diagnostic environment variables are not needed for normal use.
 Recorded comparisons are in [the QA guide](../QA_BEFORE_RELEASES.md).
 
+For the tested Strix Halo coding configuration, use `--dspark --dspark-confidence 0.7` with the default five-token draft cap and scheduler. Client sampling is temperature `1.0`, `top_p=0.95`, `min_p=0`, and `top_k=0`; high reasoning was also checked on coding and tool-use requests. This uses opportunistic sampling as described below; exact-mode throughput is not qualified by these measurements. `--mtp-draft` controls legacy autoregressive MTP, not the DSpark draft width.
+
 ## GLM: built-in MTP
 
 GLM's draft block is already in its main GGUF:

--- a/ds4.c
+++ b/ds4.c
@@ -70317,6 +70317,16 @@ static int ds4_session_eval_dspark_speculative_argmax(
             return n_accept;
         }
     }
+    if (!ignore_eos) {
+        /* Keep the verified state at the same frontier as the returned tokens,
+         * including when a fused seed moves EOS into the draft interior. */
+        for (int i = 0; i < draft_n; i++) {
+            if (drafts[i] == eos_token) {
+                draft_n = i + 1;
+                break;
+            }
+        }
+    }
     if (stats_enabled) {
         s->dspark_stats.proposed_tokens += (uint64_t)(draft_n - seed_tokens);
         ds4_dspark_stats_note_len(s->dspark_stats.draft_len_hist,

--- a/ds4.c
+++ b/ds4.c
@@ -2600,6 +2600,14 @@ static bool ds4_dspark_rocm_gfx1151_fast_path(void) {
 #endif
 }
 
+static bool ds4_dspark_rocm_gfx1151_reference_alignment(void) {
+#if defined(DS4_ROCM_BUILD) && !defined(DS4_NO_GPU)
+    return ds4_gpu_dspark_gfx1151_fast_path() != 0;
+#else
+    return false;
+#endif
+}
+
 typedef struct {
     uint32_t stages;
     uint32_t block_size;
@@ -28272,6 +28280,39 @@ static bool metal_graph_dspark_cache_ends_at(const ds4_gpu_graph *g,
            g->dspark_cache_token_start + g->dspark_cache_len == pos;
 }
 
+/* The physical ring also holds temporary draft rows; only trusted target features belong to this logical window. */
+static bool metal_graph_dspark_cache_merge_target_range(ds4_gpu_graph *g,
+                                                        uint32_t start,
+                                                        uint32_t len) {
+    if (!g || len == 0 || len > g->dspark_cache_cap ||
+        start > UINT32_MAX - len || DS4_N_SWA == 0 ||
+        !metal_graph_dspark_cache_current_window_valid(g)) return false;
+    const uint32_t end = start + len;
+    uint32_t first = start;
+    if (g->dspark_cache_len != 0) {
+        const uint32_t old_start = g->dspark_cache_token_start;
+        const uint32_t old_end = old_start + g->dspark_cache_len;
+        /* Incoming capture is authoritative: retain only an overlapping/adjacent prefix, never its old future. */
+        if (old_start < start && start <= old_end) first = old_start;
+    }
+    uint32_t limit = DS4_N_SWA;
+    if (limit > g->dspark_cache_cap) limit = g->dspark_cache_cap;
+    if (end - first > limit) first = end - limit;
+    return metal_graph_dspark_cache_set_window(g, first, end - first);
+}
+
+static bool metal_graph_dspark_cache_target_prefix(ds4_gpu_graph *g,
+                                                    uint32_t feature_pos) {
+    if (!g || DS4_N_SWA == 0 ||
+        !metal_graph_dspark_cache_crop_to_prefix(g, feature_pos) ||
+        !metal_graph_dspark_cache_ends_at(g, feature_pos)) return false;
+    const uint32_t limit = DS4_N_SWA - 1u;
+    if (g->dspark_cache_len > limit) {
+        return metal_graph_dspark_cache_set_window(g, feature_pos - limit, limit);
+    }
+    return true;
+}
+
 static bool metal_graph_dspark_cache_claim_appended_row(ds4_gpu_graph *g,
                                                         uint32_t pos) {
     if (!g || g->dspark_cache_len == 0 ||
@@ -33058,7 +33099,8 @@ static bool metal_graph_prepare_dspark_setup_block(
     const uint64_t hc_dim = (uint64_t)DS4_N_HC * DS4_N_EMBD;
     const uint64_t hc_bytes = hc_dim * sizeof(float);
     int32_t positions[DS4_DSPARK_MAX_BLOCK_SIZE + 1u];
-    positions[0] = (int32_t)pos;
+    if (ds4_dspark_rocm_gfx1151_reference_alignment() && pos == 0) return false;
+    positions[0] = (int32_t)(ds4_dspark_rocm_gfx1151_reference_alignment() ? pos - 1u : pos);
     for (uint32_t i = 0; i < dw->block_size; i++) {
         positions[i + 1u] = (int32_t)(pos + i);
     }
@@ -33139,7 +33181,8 @@ static bool metal_graph_prepare_dspark_stage0_setup_block(
     const uint64_t hc_dim = (uint64_t)DS4_N_HC * DS4_N_EMBD;
     const uint64_t hc_bytes = hc_dim * sizeof(float);
     int32_t positions[DS4_DSPARK_MAX_BLOCK_SIZE + 1u];
-    positions[0] = (int32_t)pos;
+    if (ds4_dspark_rocm_gfx1151_reference_alignment() && pos == 0) return false;
+    positions[0] = (int32_t)(ds4_dspark_rocm_gfx1151_reference_alignment() ? pos - 1u : pos);
     for (uint32_t i = 0; i < dw->block_size; i++) {
         positions[i + 1u] = (int32_t)(pos + i);
     }
@@ -33401,6 +33444,14 @@ static bool metal_graph_seed_dspark_stage_target_cache(
         return false;
     }
 
+    const bool direct_target_kv = ds4_dspark_rocm_gfx1151_reference_alignment();
+    if (direct_target_kv &&
+        (!metal_graph_batch_ffn_norm(g) ||
+         ds4_gpu_tensor_bytes(metal_graph_batch_ffn_norm(g)) <
+             (uint64_t)n_tokens * DS4_N_EMBD * sizeof(float))) {
+        return false;
+    }
+
     const uint64_t hc_dim = (uint64_t)DS4_N_HC * DS4_N_EMBD;
     const uint64_t mix_hc = 2ull * DS4_N_HC + (uint64_t)DS4_N_HC * DS4_N_HC;
     const ds4_layer_weights *block = &dw->stage[stage].block;
@@ -33428,19 +33479,19 @@ static bool metal_graph_seed_dspark_stage_target_cache(
     const float attn_factor = 1.0f;
 
     if (ok && !commands_open) ok = ds4_gpu_begin_commands() != 0;
-    if (ok) ok = ds4_gpu_rms_norm_plain_rows_tensor(metal_graph_batch_flat_hc(g),
+    if (ok && !direct_target_kv) ok = ds4_gpu_rms_norm_plain_rows_tensor(metal_graph_batch_flat_hc(g),
                                                       metal_graph_batch_cur_hc(g),
                                                       (uint32_t)hc_dim,
                                                       n_tokens,
                                                       DS4_RMS_EPS) != 0;
-    if (ok) ok = metal_graph_matmul_plain_tensor(hc_mix_view,
+    if (ok && !direct_target_kv) ok = metal_graph_matmul_plain_tensor(hc_mix_view,
                                                  dspark_model,
                                                  block->hc_attn_fn,
                                                  hc_dim,
                                                  mix_hc,
                                                  metal_graph_batch_flat_hc(g),
                                                  n_tokens);
-    if (fuse_hc_norm) {
+    if (!direct_target_kv && fuse_hc_norm) {
         if (ok) ok = ds4_gpu_hc_split_weighted_sum_norm_tensor(attn_cur_view,
                                                                  metal_graph_batch_attn_norm(g),
                                                                  hc_split_view,
@@ -33456,7 +33507,7 @@ static bool metal_graph_seed_dspark_stage_target_cache(
                                                                  DS4_N_HC_SINKHORN_ITER,
                                                                  DS4_HC_EPS,
                                                                  DS4_RMS_EPS) != 0;
-    } else {
+    } else if (!direct_target_kv) {
         if (ok) ok = ds4_gpu_hc_split_weighted_sum_tensor(attn_cur_view,
                                                             hc_split_view,
                                                             hc_mix_view,
@@ -33478,12 +33529,15 @@ static bool metal_graph_seed_dspark_stage_target_cache(
                                                           n_tokens,
                                                           DS4_RMS_EPS) != 0;
     }
+    /* DSpark target features already have stage-0 main_proj/main_norm. The reference applies wkv directly; support HC/attn_norm is for drafts. */
     if (ok) ok = metal_graph_matmul_plain_tensor(metal_graph_batch_kv_raw(g),
                                                  dspark_model,
                                                  block->attn_kv,
                                                  DS4_N_EMBD,
                                                  DS4_N_HEAD_DIM,
-                                                 metal_graph_batch_attn_norm(g),
+                                                 direct_target_kv ?
+                                                     metal_graph_batch_ffn_norm(g) :
+                                                     metal_graph_batch_attn_norm(g),
                                                  n_tokens);
     if (ok) ok = ds4_gpu_rms_norm_weight_rows_tensor(metal_graph_batch_kv(g),
                                                       metal_graph_batch_kv_raw(g),
@@ -33574,9 +33628,10 @@ static bool metal_graph_seed_dspark_initial_cache_from_prefill(
         (void)ds4_gpu_synchronize();
         return false;
     }
-    if (!metal_graph_dspark_cache_set_window(g, batch_start, n_tokens)) {
-        return false;
-    }
+    const bool window_ok = ds4_dspark_rocm_gfx1151_reference_alignment() ?
+        metal_graph_dspark_cache_merge_target_range(g, batch_start, n_tokens) :
+        metal_graph_dspark_cache_set_window(g, batch_start, n_tokens);
+    if (!window_ok) return false;
     if (seeded_rows) *seeded_rows = n_tokens;
     return true;
 }
@@ -33656,6 +33711,9 @@ static bool metal_graph_eval_dspark_stage_block(
         return false;
     }
 
+    const bool align_rocm = ds4_dspark_rocm_gfx1151_reference_alignment();
+    if (align_rocm && pos == 0) return false;
+    const uint32_t feature_pos = align_rocm ? pos - 1u : pos;
     const uint32_t draft = dw->block_size;
     const uint32_t rows = draft + 1u;
     if (support_len > g->dspark_cache_cap ||
@@ -33665,7 +33723,7 @@ static bool metal_graph_eval_dspark_stage_block(
     }
     const uint32_t visible_rows = support_len + rows;
     const uint32_t attention_raw_start =
-        support_len ? raw_start : (pos % g->dspark_cache_cap);
+        support_len ? raw_start : (feature_pos % g->dspark_cache_cap);
     const uint32_t append_pos = support_len ?
         (uint32_t)(((uint64_t)raw_start + support_len) %
                    g->dspark_cache_cap) :
@@ -33838,6 +33896,14 @@ static bool metal_graph_eval_dspark_stage_block(
                                            DS4_ROPE_YARN_BETA_SLOW) != 0;
     DS4_DSPARK_PROFILE_STAGE("q_path");
 
+    if (ok && ds4_dspark_rocm_gfx1151_reference_alignment()) {
+        /* Keep every draft row's HC/attn_norm result; only target row zero uses the already-projected main_x shared by all support stages. */
+        ok = ds4_gpu_tensor_copy(metal_graph_batch_attn_norm(g),
+                                  0,
+                                  g->dspark_main_x,
+                                  0,
+                                  (uint64_t)DS4_N_EMBD * sizeof(float)) != 0;
+    }
     if (ok) ok = metal_graph_matmul_plain_tensor(metal_graph_batch_kv_raw(g),
                                                  dspark_model,
                                                  block->attn_kv,
@@ -33858,7 +33924,7 @@ static bool metal_graph_eval_dspark_stage_block(
                                            1,
                                            DS4_N_HEAD_DIM,
                                            DS4_N_ROT,
-                                           pos,
+                                           feature_pos,
                                            0,
                                            false,
                                            freq_base,
@@ -34013,18 +34079,21 @@ static bool metal_graph_eval_dspark_stage_chain(
         return false;
     }
 
+    const bool align_rocm = ds4_dspark_rocm_gfx1151_reference_alignment();
+    if (align_rocm && pos == 0) return false;
+    const uint32_t feature_pos = align_rocm ? pos - 1u : pos;
     const uint32_t rows = dw->block_size + 1u;
     const uint32_t support_len = g->dspark_cache_len;
     const uint32_t raw_start = support_len ? g->dspark_cache_start : 0;
     if (support_len > g->dspark_cache_cap ||
         rows > g->dspark_cache_cap - support_len ||
         (support_len != 0 && raw_start >= g->dspark_cache_cap) ||
-        !metal_graph_dspark_cache_ends_at(g, pos)) {
+        !metal_graph_dspark_cache_ends_at(g, feature_pos)) {
         return false;
     }
     if (cache_start_out) {
         *cache_start_out = support_len ? raw_start :
-            (pos % g->dspark_cache_cap);
+            (feature_pos % g->dspark_cache_cap);
     }
     if (cache_rows_out) *cache_rows_out = support_len + rows;
 
@@ -34085,6 +34154,10 @@ static bool metal_graph_eval_dspark_stage_chain(
         (void)ds4_gpu_synchronize();
         return false;
     }
+    if (align_rocm) {
+        /* Draft rows remain temporary; only the committed target feature joins the history. */
+        return metal_graph_dspark_cache_merge_target_range(g, feature_pos, 1u);
+    }
     return true;
 }
 
@@ -34094,9 +34167,10 @@ static bool metal_graph_dspark_ring_maintain(
         const ds4_model          *dspark_model,
         const ds4_dspark_weights *dw,
         uint32_t                  pos) {
+    const bool align_rocm = ds4_dspark_rocm_gfx1151_reference_alignment();
     if (!g || !dspark_model || !dw ||
         !g->dspark_capture_valid ||
-        g->dspark_cache_len == 0 ||
+        (!align_rocm && g->dspark_cache_len == 0) ||
         !metal_graph_dspark_cache_ends_at(g, pos) ||
         !dspark_stage0_weights_ready(g, dw) ||
         !dspark_stage_cache_ready(g, dw) ||
@@ -34184,7 +34258,11 @@ static bool metal_graph_dspark_ring_maintain(
     else (void)ds4_gpu_synchronize();
     ds4_gpu_tensor_free(kv_view);
     ds4_gpu_tensor_free(kv_raw_view);
-    if (ok) (void)metal_graph_dspark_cache_claim_appended_row(g, pos);
+    if (ok && align_rocm) {
+        ok = metal_graph_dspark_cache_merge_target_range(g, pos, 1u);
+    } else if (ok) {
+        (void)metal_graph_dspark_cache_claim_appended_row(g, pos);
+    }
     return ok;
 }
 
@@ -54312,6 +54390,13 @@ static bool ds4_session_dspark_rocm_gfx1151_fast_path(
            ds4_dspark_rocm_gfx1151_fast_path();
 }
 
+static bool ds4_session_dspark_rocm_gfx1151_reference_alignment(
+        const ds4_session *s) {
+    return s && s->engine &&
+           s->engine->backend == DS4_BACKEND_CUDA &&
+           ds4_dspark_rocm_gfx1151_reference_alignment();
+}
+
 static bool ds4_session_dspark_seed_batch_enabled(
         const ds4_session *s) {
     const char *env = getenv("DS4_DSPARK_SEED_BATCH");
@@ -67908,12 +67993,18 @@ static bool ds4_session_prepare_dspark_draft_impl(ds4_session *s,
     s->dspark_last_confidence0 = 0.0f;
     s->dspark_last_confidence0_valid = false;
     if (scheduler_enabled) s->dspark_last_propose_ms = 0.0;
+    const bool align_rocm = ds4_session_dspark_rocm_gfx1151_reference_alignment(s);
+    if (align_rocm && (pos == 0 || pos != (uint32_t)s->checkpoint.len)) return false;
+    const uint32_t feature_pos = align_rocm ? pos - 1u : pos;
     if (enabled && !fake_argmax_enabled &&
         ds4_session_dspark_scheduler_should_skip(s)) {
+        if (align_rocm) {
+            (void)metal_graph_dspark_cache_target_prefix(&s->graph, feature_pos);
+        }
         (void)metal_graph_dspark_ring_maintain(&s->graph,
                                                &s->engine->mtp_model,
                                                &s->engine->dspark_weights,
-                                               pos);
+                                               feature_pos);
         const double propose_ms =
             time_enabled ? (now_sec() - stats_t0) * 1000.0 : 0.0;
         if (scheduler_enabled) s->dspark_last_propose_ms = propose_ms;
@@ -68007,10 +68098,16 @@ static bool ds4_session_prepare_dspark_draft_impl(ds4_session *s,
             if (initial_cache_ready) {
                 if (!initial_cache_ok) metal_graph_dspark_cache_reset(&s->graph);
                 cache_window_ok = initial_cache_ok;
+                if (cache_window_ok && align_rocm) {
+                    /* The captured batch already includes h[L-1]; overwrite that row instead of duplicating it at L. */
+                    cache_window_ok =
+                        metal_graph_dspark_cache_target_prefix(&s->graph, feature_pos);
+                }
             } else {
-                cache_window_ok =
-                    metal_graph_dspark_cache_crop_to_prefix(&s->graph, pos) &&
-                    metal_graph_dspark_cache_ends_at(&s->graph, pos);
+                cache_window_ok = align_rocm ?
+                    metal_graph_dspark_cache_target_prefix(&s->graph, feature_pos) :
+                    metal_graph_dspark_cache_crop_to_prefix(&s->graph, feature_pos) &&
+                    metal_graph_dspark_cache_ends_at(&s->graph, feature_pos);
             }
         }
         DS4_DSPARK_PROP_ADD(propose_cache_ms, cache_t0);
@@ -74253,11 +74350,18 @@ static int ds4_session_eval_speculative_argmax_impl(
             }
         }
     }
+    const bool align_rocm_dspark =
+        e->support_kind == DS4_SUPPORT_DSPARK &&
+        ds4_session_dspark_rocm_gfx1151_reference_alignment(s);
     const bool seed_batch_dspark =
         can_prepare_support_draft &&
         e->support_kind == DS4_SUPPORT_DSPARK &&
         ds4_session_dspark_seed_batch_enabled(s) &&
         sample_argmax(s->logits, DS4_N_VOCAB) == first_token;
+    if (align_rocm_dspark && can_prepare_support_draft && !seed_batch_dspark) {
+        /* Pair the incoming seed t[L] with the captured target feature h[L-1]. */
+        (void)ds4_session_prepare_dspark_draft(s, first_token, (uint32_t)s->checkpoint.len);
+    }
     if (seed_batch_dspark) {
         s->dspark_draft_valid = false;
         s->dspark_draft_len = 0;
@@ -74291,7 +74395,7 @@ static int ds4_session_eval_speculative_argmax_impl(
                     accepted, accepted_cap, err, errlen);
             if (fused_n != 0) return fused_n;
         }
-        if (e->backend == DS4_BACKEND_METAL) {
+        if (e->backend == DS4_BACKEND_METAL || align_rocm_dspark) {
             /* A declined proposal already consumed this cycle's confidence and
              * scheduler decision. Do not draft the same seed again after decode. */
             if (ds4_session_eval_probe_tp(s, first_token, false, err, errlen) != 0)
@@ -74312,7 +74416,7 @@ static int ds4_session_eval_speculative_argmax_impl(
     }
     if (ds4_session_eval_probe_tp(s,
                                   first_token,
-                                  can_prepare_support_draft,
+                                  can_prepare_support_draft && !align_rocm_dspark,
                                   err,
                                   errlen) != 0) return -1;
     int n_accept = 0;
@@ -75079,8 +75183,13 @@ int ds4_session_eval_speculative(ds4_session *s, int first_token,
 
     s->dspark_sample_temperature = temperature;
     s->dspark_sample_rng = can_prepare ? rng : NULL;
+    const bool align_rocm_dspark =
+        stochastic_dspark && ds4_session_dspark_rocm_gfx1151_reference_alignment(s);
+    if (can_prepare && align_rocm_dspark) {
+        (void)ds4_session_prepare_dspark_draft(s, first_token, (uint32_t)s->checkpoint.len);
+    }
     const int eval_rc = ds4_session_eval_probe_tp(
-        s, first_token, can_prepare, err, errlen);
+        s, first_token, can_prepare && !align_rocm_dspark, err, errlen);
     s->dspark_sample_rng = NULL;
     if (eval_rc != 0) {
         s->dspark_sample_temperature = 0.0f;

--- a/rocm/ds4_rocm_attention_launch.cuh
+++ b/rocm/ds4_rocm_attention_launch.cuh
@@ -1303,7 +1303,18 @@ extern "C" int ds4_gpu_attention_output_q8_batch_tensor(
                 const float alpha = 1.0f;
                 const float beta0 = 0.0f;
                 const float beta1 = 1.0f;
-                cublasStatus_t st = cublasGemmStridedBatchedEx(g_cublas,
+                cublasStatus_t st = (cublasStatus_t)-1;
+#ifdef __HIP_PLATFORM_AMD__
+                if (g_dspark_verify_mode && !g_glm_model && !g_quality_mode &&
+                    n_tokens >= 2u && n_tokens <= 6u &&
+                    rank == 1024u && group_dim == 4096u && n_groups == 8u &&
+                    g_rocblas_f16_solution_set == DS4_ROCBLAS_F16_SOLUTIONS_5_6_8D1AE90E &&
+                    ds4_rocm_is_gfx1151() &&
+                    hipblaslt_dspark_attention_a(low_h, out_a_f16, heads_h, n_tokens)) {
+                    st = CUBLAS_STATUS_SUCCESS;
+                }
+#endif
+                if (st != CUBLAS_STATUS_SUCCESS) st = cublasGemmStridedBatchedEx(g_cublas,
                                                                CUBLAS_OP_T,
                                                                CUBLAS_OP_N,
                                                                (int)rank,

--- a/rocm/ds4_rocm_hipblaslt.cuh
+++ b/rocm/ds4_rocm_hipblaslt.cuh
@@ -212,3 +212,102 @@ static int hipblaslt_gemm_tn_f16_out_f32_prefill(
     __atomic_store_n(&g_hipblaslt_prefill_state, -1, __ATOMIC_RELAXED);
     return 0;
 }
+
+/* Experimental DSpark attention A: five fixed-width plans, independent of
+ * the prefill cache and its failure state. C/D contain eight interleaved groups. */
+static int g_hipblaslt_dspark_a_state;
+static cuda_hipblaslt_gemm_plan g_hipblaslt_dspark_a_plans[5];
+
+static void hipblaslt_dspark_a_plan_destroy(cuda_hipblaslt_gemm_plan &p) {
+    if (p.d_desc) (void)hipblasLtMatrixLayoutDestroy(p.d_desc);
+    if (p.c_desc) (void)hipblasLtMatrixLayoutDestroy(p.c_desc);
+    if (p.b_desc) (void)hipblasLtMatrixLayoutDestroy(p.b_desc);
+    if (p.a_desc) (void)hipblasLtMatrixLayoutDestroy(p.a_desc);
+    if (p.desc) (void)hipblasLtMatmulDescDestroy(p.desc);
+    p = {};
+}
+
+static void hipblaslt_dspark_a_clear(void) {
+    for (auto &p : g_hipblaslt_dspark_a_plans) hipblaslt_dspark_a_plan_destroy(p);
+    __atomic_store_n(&g_hipblaslt_dspark_a_state, 0, __ATOMIC_RELAXED);
+}
+
+/* The caller additionally gates model family, verifier mode and gfx1151. */
+static int hipblaslt_dspark_attention_a(
+        __half *out, const __half *w, const __half *x, uint32_t n_tok) {
+    if (n_tok < 2u || n_tok > 6u || !out || !w || !x ||
+        !g_hipblaslt_ready || !g_cublas_ready ||
+        g_rocblas_f16_solution_set != DS4_ROCBLAS_F16_SOLUTIONS_5_6_8D1AE90E ||
+        __atomic_load_n(&g_hipblaslt_dspark_a_state, __ATOMIC_RELAXED) < 0) return 0;
+    if (__atomic_load_n(&g_hipblaslt_dspark_a_state, __ATOMIC_RELAXED) == 0) {
+        int version = 0;
+        char revision[128] = {0};
+        if (!hipblaslt_ok(hipblasLtGetVersion(g_hipblaslt, &version), "DSpark A version") ||
+            !hipblaslt_ok(hipblasLtGetGitRevision(g_hipblaslt, revision), "DSpark A revision") ||
+            version != 100401 || strcmp(revision, "8d1ae90e") != 0) {
+            __atomic_store_n(&g_hipblaslt_dspark_a_state, -1, __ATOMIC_RELAXED);
+            return 0;
+        }
+        __atomic_store_n(&g_hipblaslt_dspark_a_state, 1, __ATOMIC_RELAXED);
+    }
+    cuda_hipblaslt_gemm_plan &p = g_hipblaslt_dspark_a_plans[n_tok - 2u];
+    const float alpha = 1.0f, beta = 0.0f;
+    if (!p.desc) {
+        int ok = 0;
+        do {
+            if (!hipblaslt_ok(hipblasLtMatmulDescCreate(&p.desc, HIPBLAS_COMPUTE_32F, HIP_R_32F),
+                              "DSpark A matmul desc")) break;
+            const hipblasOperation_t op_a = HIPBLAS_OP_T, op_b = HIPBLAS_OP_N;
+            if (!hipblaslt_ok(hipblasLtMatmulDescSetAttribute(p.desc, HIPBLASLT_MATMUL_DESC_TRANSA,
+                              &op_a, sizeof(op_a)), "DSpark A transA") ||
+                !hipblaslt_ok(hipblasLtMatmulDescSetAttribute(p.desc, HIPBLASLT_MATMUL_DESC_TRANSB,
+                              &op_b, sizeof(op_b)), "DSpark A transB")) break;
+            if (!hipblaslt_ok(hipblasLtMatrixLayoutCreate(&p.a_desc, HIP_R_16F, 4096, 1024, 4096),
+                              "DSpark A weights") ||
+                !hipblaslt_ok(hipblasLtMatrixLayoutCreate(&p.b_desc, HIP_R_16F, 4096, n_tok, 4096),
+                              "DSpark A inputs") ||
+                !hipblaslt_ok(hipblasLtMatrixLayoutCreate(&p.c_desc, HIP_R_16F, 1024, n_tok, 8192),
+                              "DSpark A C") ||
+                !hipblaslt_ok(hipblasLtMatrixLayoutCreate(&p.d_desc, HIP_R_16F, 1024, n_tok, 8192),
+                              "DSpark A D")) break;
+            const int32_t groups = 8;
+            const int64_t strides[] = {INT64_C(4194304), INT64_C(4096) * n_tok, 1024, 1024};
+            const hipblasLtMatrixLayout_t layouts[] = {p.a_desc, p.b_desc, p.c_desc, p.d_desc};
+            bool layouts_ok = true;
+            for (unsigned i = 0; i < 4u && layouts_ok; i++) {
+                layouts_ok = hipblaslt_ok(hipblasLtMatrixLayoutSetAttribute(layouts[i],
+                        HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &groups, sizeof(groups)), "DSpark A batches") &&
+                    hipblaslt_ok(hipblasLtMatrixLayoutSetAttribute(layouts[i],
+                        HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &strides[i], sizeof(strides[i])),
+                        "DSpark A stride");
+            }
+            if (!layouts_ok) break;
+            std::vector<int> indices{2379};
+            std::vector<hipblasLtMatmulHeuristicResult_t> algorithms;
+            if (!hipblaslt_ok(hipblaslt_ext::getAlgosFromIndex(g_hipblaslt, indices, algorithms),
+                              "DSpark A fixed index")) break;
+            if (algorithms.size() != 1 || algorithms[0].state != HIPBLAS_STATUS_SUCCESS ||
+                hipblaslt_ext::getIndexFromAlgo(algorithms[0].algo) != 2379) break;
+            size_t workspace = 0;
+            if (!hipblaslt_ok(hipblaslt_ext::matmulIsAlgoSupported(g_hipblaslt, p.desc,
+                    &alpha, p.a_desc, p.b_desc, &beta, p.c_desc, p.d_desc,
+                    algorithms[0].algo, workspace), "DSpark A support") || workspace != 0) break;
+            p.algo = algorithms[0].algo;
+            ok = 1;
+        } while (0);
+        if (!ok) {
+            hipblaslt_dspark_a_plan_destroy(p);
+            __atomic_store_n(&g_hipblaslt_dspark_a_state, -1, __ATOMIC_RELAXED);
+            return 0;
+        }
+    }
+    hipStream_t stream = nullptr;
+    if (hipblaslt_ok(hipblasGetStream(g_cublas, &stream), "DSpark A stream") &&
+        hipblaslt_ok(hipblasLtMatmul(g_hipblaslt, p.desc, &alpha,
+                w, p.a_desc, x, p.b_desc, &beta, out, p.c_desc, out, p.d_desc,
+                &p.algo, nullptr, 0, stream), "DSpark A matmul")) return 1;
+    /* A synchronous library rejection falls back on the same stream and
+     * overwrites every output. An asynchronous GPU fault is not recoverable. */
+    __atomic_store_n(&g_hipblaslt_dspark_a_state, -1, __ATOMIC_RELAXED);
+    return 0;
+}

--- a/rocm/ds4_rocm_hipblaslt.cuh
+++ b/rocm/ds4_rocm_hipblaslt.cuh
@@ -2,12 +2,18 @@
  * Included from ds4_cuda.cu under __HIP_PLATFORM_AMD__ to keep ROCm
  * planning/cache code out of the CUDA host runtime body. */
 
+#include <hipblaslt/hipblaslt-ext.hpp>
+
 static hipblasLtHandle_t g_hipblaslt;
 static int g_hipblaslt_ready;
+/* Zero is unchecked, one version-matched, minus one disabled until cleanup. */
+static int g_hipblaslt_prefill_state;
 struct cuda_hipblaslt_gemm_plan {
     uint32_t out_dim;
     uint32_t n_tok;
     uint32_t in_dim;
+    hipDataType output_type;
+    int solution_index;
     hipblasLtMatmulDesc_t desc;
     hipblasLtMatrixLayout_t a_desc;
     hipblasLtMatrixLayout_t b_desc;
@@ -27,6 +33,7 @@ static void hipblaslt_gemm_plan_clear(void) {
         if (p.desc) (void)hipblasLtMatmulDescDestroy(p.desc);
     }
     g_hipblaslt_gemm_plans.clear();
+    __atomic_store_n(&g_hipblaslt_prefill_state, 0, __ATOMIC_RELAXED);
 }
 
 static int hipblaslt_ok(hipblasStatus_t st, const char *what) {
@@ -39,10 +46,13 @@ static cuda_hipblaslt_gemm_plan *hipblaslt_gemm_plan_get(
         uint32_t out_dim,
         uint32_t n_tok,
         uint32_t in_dim,
-        const char *label) {
+        const char *label,
+        hipDataType output_type = HIP_R_16F,
+        int solution_index = -1) {
     for (size_t i = 0; i < g_hipblaslt_gemm_plans.size(); i++) {
         cuda_hipblaslt_gemm_plan &p = g_hipblaslt_gemm_plans[i];
-        if (p.out_dim == out_dim && p.n_tok == n_tok && p.in_dim == in_dim) return &p;
+        if (p.out_dim == out_dim && p.n_tok == n_tok && p.in_dim == in_dim &&
+            p.output_type == output_type && p.solution_index == solution_index) return &p;
     }
 
     hipblasLtMatmulDesc_t desc = NULL;
@@ -66,10 +76,27 @@ static cuda_hipblaslt_gemm_plan *hipblaslt_gemm_plan_get(
                           "A layout create")) break;
         if (!hipblaslt_ok(hipblasLtMatrixLayoutCreate(&b_desc, HIP_R_16F, in_dim, n_tok, in_dim),
                           "B layout create")) break;
-        if (!hipblaslt_ok(hipblasLtMatrixLayoutCreate(&c_desc, HIP_R_16F, out_dim, n_tok, out_dim),
+        if (!hipblaslt_ok(hipblasLtMatrixLayoutCreate(&c_desc, output_type, out_dim, n_tok, out_dim),
                           "C layout create")) break;
-        if (!hipblaslt_ok(hipblasLtMatrixLayoutCreate(&d_desc, HIP_R_16F, out_dim, n_tok, out_dim),
+        if (!hipblaslt_ok(hipblasLtMatrixLayoutCreate(&d_desc, output_type, out_dim, n_tok, out_dim),
                           "D layout create")) break;
+        if (solution_index >= 0) {
+            std::vector<int> indices{solution_index};
+            std::vector<hipblasLtMatmulHeuristicResult_t> algorithms;
+            if (!hipblaslt_ok(hipblaslt_ext::getAlgosFromIndex(g_hipblaslt, indices, algorithms),
+                              "prefill fixed index")) break;
+            if (algorithms.size() != 1 || algorithms[0].state != HIPBLAS_STATUS_SUCCESS ||
+                hipblaslt_ext::getIndexFromAlgo(algorithms[0].algo) != solution_index) break;
+            const float alpha = 1.0f, beta = 0.0f;
+            size_t workspace = 0;
+            if (!hipblaslt_ok(hipblaslt_ext::matmulIsAlgoSupported(
+                    g_hipblaslt, desc, &alpha, a_desc, b_desc, &beta, c_desc, d_desc,
+                    algorithms[0].algo, workspace), "prefill fixed index support")) break;
+            if (workspace != 0) break;
+            heur[0] = algorithms[0];
+            ok = 1;
+            break;
+        }
         if (!hipblaslt_ok(hipblasLtMatmulPreferenceCreate(&pref), "preference create")) break;
         const size_t max_workspace = 0;
         if (!hipblaslt_ok(hipblasLtMatmulPreferenceSetAttribute(
@@ -101,6 +128,8 @@ static cuda_hipblaslt_gemm_plan *hipblaslt_gemm_plan_get(
     p.out_dim = out_dim;
     p.n_tok = n_tok;
     p.in_dim = in_dim;
+    p.output_type = output_type;
+    p.solution_index = solution_index;
     p.desc = desc;
     p.a_desc = a_desc;
     p.b_desc = b_desc;
@@ -134,4 +163,52 @@ static int hipblaslt_gemm_tn_f16_out_f16(
                                         &p->algo,
                                         NULL, 0, 0),
                         label ? label : "gemm");
+}
+
+/* gfx1151 prefill selections for hipBLASLt 100401 / 8d1ae90e.
+ * These are Lt algorithm indices; other library revisions retain the fallback. */
+static int hipblaslt_prefill_solution_index(
+        uint32_t out_dim, uint32_t n_tok, uint32_t in_dim) {
+    if (n_tok != 2048u && n_tok != 4096u) return -1;
+    if (out_dim == 24u && in_dim == 16384u) return 2537;
+    if (out_dim == 8192u && in_dim == 1024u) return 2539;
+    if (in_dim == 4096u &&
+        (out_dim == 64u || out_dim == 256u ||
+         out_dim == 512u || out_dim == 1024u)) {
+        return out_dim == 64u && n_tok == 2048u ? 2537 : 2539;
+    }
+    return -1;
+}
+
+/* The caller restricts this path to gfx1151 DS4 with quality mode off;
+ * validate the dimensions here as well before choosing any fixed-index plan. */
+static int hipblaslt_gemm_tn_f16_out_f32_prefill(
+        float *out, const __half *w, const __half *x,
+        uint32_t out_dim, uint32_t n_tok, uint32_t in_dim) {
+    const int solution_index = hipblaslt_prefill_solution_index(out_dim, n_tok, in_dim);
+    if (solution_index < 0 || !g_hipblaslt_ready || !out || !w || !x ||
+        __atomic_load_n(&g_hipblaslt_prefill_state, __ATOMIC_RELAXED) < 0) return 0;
+    if (__atomic_load_n(&g_hipblaslt_prefill_state, __ATOMIC_RELAXED) == 0) {
+        int version = 0;
+        char revision[128] = {0};
+        if (!hipblaslt_ok(hipblasLtGetVersion(g_hipblaslt, &version), "prefill version") ||
+            !hipblaslt_ok(hipblasLtGetGitRevision(g_hipblaslt, revision), "prefill revision") ||
+            version != 100401 || strcmp(revision, "8d1ae90e") != 0) {
+            __atomic_store_n(&g_hipblaslt_prefill_state, -1, __ATOMIC_RELAXED);
+            return 0;
+        }
+        __atomic_store_n(&g_hipblaslt_prefill_state, 1, __ATOMIC_RELAXED);
+    }
+    cuda_hipblaslt_gemm_plan *p = hipblaslt_gemm_plan_get(
+            out_dim, n_tok, in_dim, "prefill F16/F32", HIP_R_32F, solution_index);
+    if (p) {
+        const float alpha = 1.0f, beta = 0.0f;
+        if (hipblaslt_ok(hipblasLtMatmul(g_hipblaslt, p->desc, &alpha,
+                w, p->a_desc, x, p->b_desc, &beta, out, p->c_desc, out, p->d_desc,
+                &p->algo, NULL, 0, 0), "prefill F16/F32")) return 1;
+    }
+    /* Original same-stream fallback overwrites the whole output. This
+     * handles library rejection; asynchronous GPU faults remain fatal. */
+    __atomic_store_n(&g_hipblaslt_prefill_state, -1, __ATOMIC_RELAXED);
+    return 0;
 }

--- a/rocm/ds4_rocm_matmul.cuh
+++ b/rocm/ds4_rocm_matmul.cuh
@@ -1007,6 +1007,17 @@ extern "C" int ds4_gpu_matmul_f16_tensor(ds4_gpu_tensor *out, const void *model_
         if (!xh) return 0;
         f32_to_f16_kernel<<<(xh_count + 255) / 256, 256>>>(xh, (const float *)x->ptr, xh_count);
         if (!cuda_ok(cudaGetLastError(), "f16 activation convert launch")) return 0;
+#ifdef __HIP_PLATFORM_AMD__
+        if ((n_tok == 2048u || n_tok == 4096u) &&
+            hipblaslt_prefill_solution_index((uint32_t)out_dim, (uint32_t)n_tok,
+                                            (uint32_t)in_dim) >= 0 &&
+            !g_glm_model && !g_quality_mode &&
+            g_rocblas_f16_solution_set == DS4_ROCBLAS_F16_SOLUTIONS_5_6_8D1AE90E &&
+            ds4_rocm_is_gfx1151()) {
+            if (hipblaslt_gemm_tn_f16_out_f32_prefill((float *)out->ptr, w, xh,
+                        (uint32_t)out_dim, (uint32_t)n_tok, (uint32_t)in_dim)) return 1;
+        }
+#endif
         if (in_dim == 16384u && out_dim == 24u && n_tok == 2048u &&
             ds4_rocm_gfx1151_flag("DS4_ROCM_F16_TINYM_WMMA")) {
             matmul_f16_tinym24_wmma_kernel<<<32u, 256u>>>((float *)out->ptr, w, xh);

--- a/rocm/ds4_rocm_runtime.cuh
+++ b/rocm/ds4_rocm_runtime.cuh
@@ -5862,6 +5862,7 @@ extern "C" void ds4_gpu_cleanup(void) {
     cuda_stream_cache_stats_print("cleanup");
     cuda_shared_gate_up_async_cleanup();
 #ifdef __HIP_PLATFORM_AMD__
+    hipblaslt_dspark_a_clear();
     hipblaslt_gemm_plan_clear();
 #endif
     if (g_cublas_ready) {

--- a/tests/test_dspark_eos_contract.py
+++ b/tests/test_dspark_eos_contract.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Execute the actual DSpark greedy host function against checked target-state mocks.
+
+Run with Python's standard library and a C compiler; no model or GPU is needed.
+This checks commit/frontier ownership, not backend math or public-call dispatch.
+An optional source path admits a pre-fix negative control without editing it.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import tempfile
+
+
+FUNCTION = 'ds4_session_eval_dspark_speculative_argmax'
+
+
+def extract(source, name=FUNCTION):
+    matches = list(re.finditer(r'static int ' + re.escape(name) + r'\s*\(', source))
+    if len(matches) != 1:
+        raise ValueError('require exactly one production greedy helper')
+    start = matches[0].start()
+    opening = source.index('{', start)
+    # Braces inside comments and strings must not delimit the actual function.
+    token = re.compile(r'/\*.*?\*/|//[^\n]*|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|[{}]', re.S)
+    depth = 0
+    for match in token.finditer(source, opening):
+        if match.group() == '{':
+            depth += 1
+        elif match.group() == '}':
+            depth -= 1
+            if depth == 0:
+                return source[start:match.end()]
+    raise ValueError('unterminated production helper')
+
+
+PRELUDE = r'''
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#define DS4_DSPARK_MAX_BLOCK_SIZE 16
+#define DS4_SPEC_PREFIX_SLOTS 4
+#define DS4_N_VOCAB 16
+#define DS4_TP_VERIFY_COMMIT_FULL 1
+#define DS4_TP_VERIFY_COMMIT_PREFIX 2
+#define DS4_TP_VERIFY_ROLLBACK_REPLAY 3
+enum { DS4_BACKEND_METAL, DS4_BACKEND_CUDA, DS4_BACKEND_CPU };
+typedef int ds4_think_mode;
+typedef struct { int len, data[64]; } ds4_tokens;
+typedef struct { int frontier; } ds4_gpu_graph;
+typedef struct { int model, weights, backend; struct { void *ctx; bool vocab_split; } tp; } ds4_engine;
+typedef struct {
+    double upload_ms, layer_ms, head_ms, read_ms;
+    bool fused_head;
+} ds4_verify_suffix_timing;
+typedef struct {
+    ds4_engine *engine; ds4_tokens checkpoint; ds4_gpu_graph graph;
+    bool dspark_draft_valid, checkpoint_valid; uint32_t dspark_draft_len;
+    int dspark_draft_tokens[16], ctx_size, tp_session_id;
+    float logits[DS4_N_VOCAB], *spec_row_logits;
+    double dspark_last_propose_ms;
+    struct { STATS_FIELDS } dspark_stats;
+} ds4_session;
+typedef struct { int frontier; } ds4_spec_frontier;
+static int verified_width, verified_start, verified_tokens[16], target_next[16];
+static int selected_row, prefix_committed, replayed, capture_notes, mock_errors;
+static int tp_width, tp_tokens[16], tp_commit_kind, tp_commit_count, capture_prefix_calls;
+static bool tp_leader, seed_batch, fail_prefix, fail_read, fail_verify, prefixes_captured;
+static int extra_stop = -1;
+static bool ds4_dspark_stats_enabled(void) { return true; }
+static bool ds4_dspark_scheduler_enabled(ds4_session *s) { (void)s; return false; }
+static bool ds4_dspark_scheduler_timing_enabled(void) { return false; }
+static double now_sec(void) { return 1.0; }
+static void ds4_dspark_stats_note_len(uint64_t *hist, uint32_t n) {
+    if (n >= 17) { mock_errors++; return; } hist[n]++;
+}
+static void ds4_session_dspark_scheduler_note(ds4_session *s,uint32_t n,bool miss,double ms) {
+    (void)s; (void)n; (void)miss; (void)ms;
+}
+static bool ds4_token_is_stop_for_think_mode(ds4_engine *e,int token,ds4_think_mode think) {
+    (void)e; (void)think; return token == 1 || token == extra_stop;
+}
+static int sample_argmax(const float *p,int n) {
+    int best=0; for(int i=1;i<n;i++) if(p[i]>p[best]) best=i; return best;
+}
+static void token_vec_push(ds4_tokens *t,int token) {
+    if(t->len<0 || t->len>=64) { mock_errors++; return; } t->data[t->len++]=token;
+}
+static bool spec_frontier_snapshot(ds4_spec_frontier *f,ds4_session *s) {
+    f->frontier=s->graph.frontier;
+    if(f->frontier != s->checkpoint.len) mock_errors++;
+    return true;
+}
+static void spec_frontier_free(ds4_spec_frontier *f) { (void)f; }
+static bool spec_frontier_restore(ds4_spec_frontier *f,ds4_session *s) {
+    s->graph.frontier=f->frontier; return true;
+}
+static bool ds4_session_tp_leader(ds4_session *s) { (void)s; return tp_leader; }
+static int ds4_tp_send_verify(void *ctx,int id,const int *drafts,uint32_t n) {
+    (void)ctx; (void)id;
+    if(n==0 || n>16) { mock_errors++; return 0; }
+    memcpy(tp_tokens,drafts,(size_t)n*sizeof(*drafts)); tp_width=(int)n; return 1;
+}
+static int ds4_tp_send_verify_commit(void *ctx,int kind,int count) {
+    (void)ctx; tp_commit_kind=kind; tp_commit_count=count; return 1;
+}
+static int ds4_tp_recv_logits_half(void *ctx,float *p,uint32_t n) {
+    (void)ctx; (void)p; (void)n; mock_errors++; return 0;
+}
+static bool metal_graph_verify_suffix_tops(ds4_gpu_graph *g,int *m,int *w,ds4_tokens *tokens,
+        uint32_t start,uint32_t n,bool capture,bool keep,int *tops,void *unused,
+        ds4_verify_suffix_timing *timing) {
+    (void)m; (void)w; (void)keep; (void)unused;
+    if(n==0 || n>16 || tokens->len!=(int)(start+n) || g->frontier!=(int)start) mock_errors++;
+    prefixes_captured=capture;
+    verified_width=(int)n; verified_start=(int)start;
+    for(uint32_t i=0;i<n;i++) {
+        verified_tokens[i]=tokens->data[start+i];
+        if(tops) tops[i]=target_next[i];
+    }
+    g->frontier=(int)(start+n);
+    if(timing) memset(timing,0,sizeof(*timing));
+    return !fail_verify;
+}
+static void row_values(float *p,int frontier) {
+    for(int i=0;i<DS4_N_VOCAB;i++) p[i]=(float)(frontier*100+i);
+}
+static bool metal_graph_read_spec_logits_row(ds4_gpu_graph *g,uint32_t row,float *p) {
+    (void)g;
+    if(row>=(uint32_t)verified_width) { mock_errors++; return false; }
+    selected_row=(int)row;
+    row_values(p,verified_start+(int)row+1);
+    return !fail_read;
+}
+static bool ds4_session_dspark_seed_batch_enabled(ds4_session *s) { (void)s; return seed_batch; }
+static void ds4_session_dspark_capture_invalidate(ds4_session *s) { (void)s; }
+static bool spec_frontier_commit_prefix(ds4_session *s,uint32_t n) {
+    if(n==0 || n>4 || n>=(uint32_t)verified_width) { mock_errors++; return false; }
+    if(fail_prefix || !prefixes_captured) return false;
+    prefix_committed=(int)n; s->graph.frontier=verified_start+(int)n; return true;
+}
+static bool metal_graph_dspark_capture_commit_prefix(ds4_gpu_graph *g,uint32_t n) {
+    if(g->frontier!=verified_start+(int)n) mock_errors++;
+    capture_prefix_calls++; return true;
+}
+static void ds4_session_dspark_capture_note_checkpoint(ds4_session *s) {
+    capture_notes++;
+    if(s->checkpoint.len!=s->graph.frontier) mock_errors++;
+}
+static bool metal_graph_eval_token_raw_swa(ds4_gpu_graph *g,int *m,int *w,int token,uint32_t pos,float *p) {
+    (void)m; (void)w;
+    if(g->frontier!=(int)pos || token<0 || token>=DS4_N_VOCAB) { mock_errors++; return false; }
+    g->frontier++; replayed++; row_values(p,g->frontier); return true;
+}
+static const char *ds4_backend_name(int backend) { (void)backend; return "mock"; }
+'''
+
+
+TESTS = r'''
+static int failures, assertions, cases, observed_negative, unaffected_failures;
+static const char *label;
+#define CHECK(x) do { assertions++; if(!(x)) { failures++; if(failures<=24) \
+    fprintf(stderr,"FAIL %s line %d: %s\n",label,__LINE__,#x); } } while(0)
+static ds4_engine engine;
+static ds4_session session;
+static float output_logits[DS4_N_VOCAB];
+static int accepted[20], start, already;
+static void setup(const int *draft,int n,int seed,int reject) {
+    memset(&engine,0,sizeof(engine)); memset(&session,0,sizeof(session));
+    engine.backend=DS4_BACKEND_CUDA; /* CUDA and ROCm share this public backend. */
+    session.engine=&engine; session.ctx_size=64; session.checkpoint_valid=true;
+    session.checkpoint.data[0]=8; session.checkpoint.data[1]=9; session.checkpoint.len=2;
+    for(int i=0;i<20;i++) accepted[i]=-99;
+    already=seed;
+    if(seed) { session.checkpoint.data[2]=2; session.checkpoint.len++; accepted[0]=2; }
+    start=session.checkpoint.len; session.graph.frontier=start;
+    session.dspark_draft_valid=true; session.dspark_draft_len=(uint32_t)n;
+    memcpy(session.dspark_draft_tokens,draft,(size_t)n*sizeof(int));
+    session.spec_row_logits=output_logits;
+    for(int i=0;i<DS4_N_VOCAB;i++) session.logits[i]=-100;
+    session.logits[(draft[0]>=0 && draft[0]<DS4_N_VOCAB) ? draft[0] : 0]=100;
+    for(int i=0;i<n;i++) target_next[i]=(i+1<n) ? draft[i+1] : 5;
+    if(reject==0) { for(int i=0;i<DS4_N_VOCAB;i++) session.logits[i]=-100; session.logits[15]=100; }
+    if(reject>0) target_next[reject-1]=15;
+    verified_width=verified_start=prefix_committed=replayed=capture_notes=mock_errors=0;
+    tp_width=tp_commit_kind=tp_commit_count=capture_prefix_calls=0;
+    selected_row=-1; seed_batch=(seed==0); tp_leader=false;
+    fail_prefix=fail_read=fail_verify=prefixes_captured=false; extra_stop=-1;
+}
+static int invoke(int max_tokens,int cap,bool ignore) {
+    char err[256]={0};
+    return ds4_session_eval_dspark_speculative_argmax(&session,already,max_tokens,1,ignore,0,accepted,cap,err,sizeof(err));
+}
+static void check_frontier(int returned,int expected,int width,const int *draft,int cap) {
+    CHECK(returned==already+expected);
+    CHECK(session.checkpoint.len==start+expected);
+    CHECK(session.graph.frontier==start+expected);
+    CHECK(verified_width==width);
+    CHECK(mock_errors==0);
+    CHECK(session.checkpoint_valid);
+    CHECK(!session.dspark_draft_valid && session.dspark_draft_len==0);
+    for(int i=0;i<expected;i++) {
+        CHECK(accepted[already+i]==draft[i]);
+        CHECK(session.checkpoint.data[start+i]==draft[i]);
+    }
+    CHECK(accepted[cap]==-99 && accepted[19]==-99);
+    if(expected) {
+        for(int i=0;i<DS4_N_VOCAB;i++) CHECK(isfinite(session.logits[i]) && session.logits[i]==(float)((start+expected)*100+i));
+        CHECK(capture_notes==1);
+    }
+    if(tp_leader) {
+        CHECK(tp_width==width);
+        for(int i=0;i<width;i++) CHECK(tp_tokens[i]==draft[i]);
+        if(expected==width && width) CHECK(tp_commit_kind==DS4_TP_VERIFY_COMMIT_FULL);
+        if(expected<width && expected && prefix_committed) {
+            CHECK(tp_commit_kind==DS4_TP_VERIFY_COMMIT_PREFIX && tp_commit_count==expected);
+        }
+        if(expected<width && expected && !prefix_committed) {
+            CHECK(tp_commit_kind==DS4_TP_VERIFY_ROLLBACK_REPLAY && tp_commit_count==expected);
+        }
+    }
+    cases++;
+}
+int main(void) {
+    /* Old source retains three evaluated rows but exposes only two tokens. */
+    const int regression[]={2,1,1}; label="interior-EOS full commit";
+    setup(regression,3,0,-1);
+    int returned=invoke(8,8,false);
+    printf("{\"probe\":\"interior_eos\",\"returned\":%d,\"advanced\":%d,\"verified\":%d}\n",returned,session.checkpoint.len-start,verified_width);
+    observed_negative=(returned==2 && session.checkpoint.len-start==3);
+    check_frontier(returned,2,2,regression,8);
+
+    /* Distinct target rows exercise full/partial acceptance, including a
+       rejection only AFTER EOS. The old partial branch can hide extra state
+       behind a shortened checkpoint; graph frontier/logits reveal that. */
+    for(int seed=0;seed<=1;seed++) for(int n=1;n<=16;n++) for(int eos=-1;eos<n;eos++)
+    for(int ignore=0;ignore<=1;ignore++) for(int reject=-1;reject<n;reject++) {
+        int draft[16]; for(int i=0;i<n;i++) draft[i]=3+(i%12);
+        if(eos>=0) draft[eos]=1;
+        setup(draft,n,seed,reject);
+        tp_leader=(seed==1 && (reject%2)==0);
+        int bounded=eos<0 ? n : eos+(ignore ? 0 : 1);
+        int expected=(reject>=0 && reject<bounded) ? reject : bounded;
+        int width=(bounded==0 || reject==0) ? 0 : bounded;
+        label="EOS positions, seed/ordinary, ignore, partial and TP";
+        int previous_failures=failures;
+        returned=invoke(18,18,ignore!=0);
+        check_frontier(returned,expected,width,draft,18);
+        if(expected==width && width) CHECK(selected_row==expected-1);
+        if(eos<0 || ignore) unaffected_failures+=failures-previous_failures;
+    }
+    for(int seed=0;seed<=1;seed++) for(int first=0;first<15;first++) {
+        int draft[16]; for(int i=0;i<16;i++) draft[i]=3+(i%12);
+        draft[first]=1; draft[first+1]=1;
+        setup(draft,16,seed,-1); label="multiple EOS";
+        returned=invoke(18,18,false); check_frontier(returned,first+1,first+1,draft,18);
+    }
+    const int bounded_draft[]={3,4,1,6,7,8};
+    for(int seed=0;seed<=1;seed++) for(int slots=0;slots<=6;slots++) for(int limit=0;limit<3;limit++) {
+        setup(bounded_draft,6,seed,-1);
+        int max=8,cap=8;
+        if(limit==0) max=already+slots;
+        if(limit==1) cap=already+slots;
+        if(limit==2) session.ctx_size=start+slots+1;
+        int expected=slots<3 ? slots : 3;
+        label="generation, output capacity and context room budgets";
+        returned=invoke(max,cap,false); check_frontier(returned,expected,expected,bounded_draft,cap);
+    }
+    const int invalid_after_eos[]={3,1,99};
+    setup(invalid_after_eos,3,0,-1); label="invalid suffix still rejected before EOS clipping";
+    returned=invoke(8,8,false); check_frontier(returned,0,0,invalid_after_eos,8);
+    CHECK(session.dspark_stats.invalid_draft==1);
+    setup(invalid_after_eos,3,0,-1); label="out of budget invalid token remains uninspected";
+    returned=invoke(2,8,false); check_frontier(returned,2,2,invalid_after_eos,8);
+
+    const int stop_draft[]={3,7,4};
+    setup(stop_draft,3,0,-1); extra_stop=7; label="ignore EOS still excludes other think-mode stop tokens";
+    returned=invoke(8,8,true); check_frontier(returned,1,1,stop_draft,8);
+    setup(stop_draft,3,0,-1); extra_stop=7; label="normal EOS handling does not truncate other tokens";
+    returned=invoke(8,8,false); check_frontier(returned,3,3,stop_draft,8);
+
+    setup(bounded_draft,6,0,1); fail_prefix=true; label="partial commit failure restores and replays bounded prefix";
+    returned=invoke(8,8,false); check_frontier(returned,1,3,bounded_draft,8); CHECK(replayed==1);
+    setup(bounded_draft,6,0,-1); fail_read=true; label="full logits read failure restores and replays through EOS";
+    returned=invoke(8,8,false); check_frontier(returned,3,3,bounded_draft,8); CHECK(replayed==3);
+    setup(bounded_draft,6,0,-1); fail_verify=true; label="verifier failure restores original state";
+    returned=invoke(8,8,false); check_frontier(returned,0,3,bounded_draft,8);
+    const int extended[]={3,4,5,6,7,8};
+    setup(extended,6,0,5); label="four-prefix plus ordinary fifth row remains aligned";
+    returned=invoke(8,8,false); check_frontier(returned,5,6,extended,8); CHECK(prefix_committed==4 && replayed==1);
+
+    printf("{\"cases\":%d,\"assertions\":%d,\"failures\":%d,\"no_eos_or_ignore_eos_failures\":%d,\"observed_old_advance3_return2\":%s}\n",
+        cases,assertions,failures,unaffected_failures,observed_negative?"true":"false");
+    return failures ? 1 : 0;
+}
+'''
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source', type=Path, default=Path(__file__).resolve().parents[1] / 'ds4.c')
+    parser.add_argument('--output', type=Path, help='exclusive-new report directory with emitted C, build and run evidence')
+    args = parser.parse_args()
+    raw = args.source.read_bytes()
+    function = extract(raw.decode('utf-8'))
+    if not re.search(r'^#define DS4_DSPARK_MAX_BLOCK_SIZE 16$', raw.decode('utf-8'), re.M):
+        raise ValueError('production block capacity changed; update this checked host fixture explicitly')
+    fields = sorted(set(re.findall(r's->dspark_stats\.([a-z_]+)', function)))
+    declarations = '\n'.join(('uint64_t ' + f + '[17];') if f.endswith('_hist') else
+                             ('double ' if f.endswith('_ms') else 'uint64_t ') + f + ';' for f in fields)
+    code = PRELUDE.replace('STATS_FIELDS', declarations) + '\n' + function + '\n' + TESTS
+    compiler = shlex.split(os.environ.get('CC', 'cc'))
+    if not compiler:
+        raise ValueError('empty CC')
+    if args.output:
+        args.output.mkdir(parents=True, exist_ok=False)
+    with tempfile.TemporaryDirectory(prefix='ds4-eos-contract-') as temporary:
+        root = args.output or Path(temporary)
+        c, binary = root / 'contract.c', root / 'ds4-host-eos-contract'
+        c.write_text(code)
+        command = compiler + ['-std=c11', '-O0', '-fno-fast-math', '-Wall', '-Wextra', '-Werror', str(c), '-lm', '-o', str(binary)]
+        build = subprocess.run(command, capture_output=True, text=True, timeout=60)
+        report = {'scope': 'actual extracted greedy verifier function; checked host target/TP mocks, no model or GPU arithmetic',
+                  'tested_draft_widths': [1, 16], 'production_max_block_size': 16,
+                  'coverage_limits': 'Public caller selection, proposal kernels, GPU arithmetic, physical KV state, actual TP worker execution and stochastic helper execution are not mocked as proven.',
+                  'source': str(args.source.resolve()), 'source_sha256': hashlib.sha256(raw).hexdigest(),
+                  'helper_sha256': hashlib.sha256(function.encode()).hexdigest(),
+                  'test_sha256': hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+                  'emitted_c_sha256': hashlib.sha256(code.encode()).hexdigest(),
+                  'build_command': command, 'build_returncode': build.returncode,
+                  'build_stdout': build.stdout, 'build_stderr': build.stderr,
+                  'compiler_version': subprocess.run(compiler + ['--version'], capture_output=True, text=True, timeout=10).stdout,
+                  'returncode': build.returncode}
+        if build.returncode == 0:
+            # Diagnostic environment changes must not affect this deterministic host fixture.
+            env = {k: v for k, v in os.environ.items() if not k.startswith('DS4_')}
+            run = subprocess.run([str(binary.resolve())], capture_output=True, text=True, env=env, timeout=30)
+            report.update(returncode=run.returncode, stdout=run.stdout, stderr=run.stderr,
+                          binary_sha256=hashlib.sha256(binary.read_bytes()).hexdigest(),
+                          results=[json.loads(line) for line in run.stdout.splitlines()])
+        if args.output:
+            (root / 'report.json').write_text(json.dumps(report, indent=2) + '\n')
+        print(json.dumps(report))
+        return report['returncode']
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_dspark_window.py
+++ b/tests/test_dspark_window.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Exercise the production DSpark target-window helpers with checked row ranges.
+
+Requires Python and a C compiler; no model or GPU is needed. Optional --output retains the emitted C and build/run evidence; otherwise temporary files are removed.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import tempfile
+
+
+HELPERS = (
+    "metal_graph_dspark_cache_reset",
+    "metal_graph_dspark_cache_window_valid",
+    "metal_graph_dspark_cache_current_window_valid",
+    "metal_graph_dspark_cache_set_window",
+    "metal_graph_dspark_cache_crop_to_prefix",
+    "metal_graph_dspark_cache_ends_at",
+    "metal_graph_dspark_cache_merge_target_range",
+    "metal_graph_dspark_cache_target_prefix",
+)
+
+
+def extract(source, name):
+    matches = list(re.finditer(r"static (?:void|bool) " + re.escape(name) + r"\s*\(", source))
+    if len(matches) != 1:
+        raise ValueError("require exactly one production helper: " + name)
+    start = matches[0].start()
+    opening = source.index("{", start)
+    token = re.compile(r'/\*.*?\*/|//[^\n]*|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|[{}]', re.S)
+    depth = 0
+    for match in token.finditer(source, opening):
+        if match.group() == "{":
+            depth += 1
+        elif match.group() == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:match.end()]
+    raise ValueError("unterminated production helper: " + name)
+
+
+PRELUDE = r'''
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+static uint32_t model_window = 128;
+#define DS4_N_SWA model_window
+typedef struct {
+    uint32_t dspark_cache_cap, dspark_cache_start;
+    uint32_t dspark_cache_token_start, dspark_cache_len;
+} ds4_gpu_graph;
+'''
+
+TESTS = r'''
+static unsigned checks = 0;
+#define REQUIRE(x) do { checks++; assert(x); } while (0)
+static void expect(const ds4_gpu_graph *g, uint32_t first, uint32_t len) {
+    REQUIRE(g->dspark_cache_token_start == (len ? first : 0));
+    REQUIRE(g->dspark_cache_len == len);
+    REQUIRE(g->dspark_cache_start == (len ? first % g->dspark_cache_cap : 0));
+    REQUIRE(metal_graph_dspark_cache_current_window_valid(g));
+}
+int main(void) {
+    ds4_gpu_graph g = {.dspark_cache_cap = 4352};
+    /* Cold prefill clips visibility, retaining the physical raw-cap modulus. */
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 0, 4096));
+    expect(&g, 3968, 128);
+    REQUIRE(metal_graph_dspark_cache_target_prefix(&g, 4095));
+    expect(&g, 3968, 127);
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 4095, 1));
+    expect(&g, 3968, 128);
+    /* Overlapping accepted verifier capture preserves the preceding history. */
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 4095, 7));
+    expect(&g, 3974, 128);
+    REQUIRE(metal_graph_dspark_cache_target_prefix(&g, 4101));
+    expect(&g, 3974, 127);
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 4101, 1));
+    expect(&g, 3974, 128);
+    /* A declined proposal followed by an ordinary seed retains its target row. */
+    REQUIRE(metal_graph_dspark_cache_target_prefix(&g, 4102));
+    expect(&g, 3975, 127);
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 4102, 1));
+    expect(&g, 3975, 128);
+    /* Repeated/overlapping capture never retains the old speculative future. */
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 4098, 3));
+    expect(&g, 3975, 126);
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 4101, 2));
+    expect(&g, 3975, 128);
+    /* A gap resets; one successfully written target initializes an empty ring. */
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 4110, 4));
+    expect(&g, 4110, 4);
+    REQUIRE(metal_graph_dspark_cache_target_prefix(&g, 4120));
+    expect(&g, 0, 0);
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 4120, 1));
+    expect(&g, 4120, 1);
+    /* Rewind past the retained prefix cannot bridge to stale future features. */
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 50, 4));
+    expect(&g, 50, 4);
+    REQUIRE(metal_graph_dspark_cache_target_prefix(&g, 52));
+    expect(&g, 50, 2);
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 52, 1));
+    expect(&g, 50, 3);
+    /* Physical wrap and temporary draft exclusion: only claimed target is visible. */
+    g = (ds4_gpu_graph){.dspark_cache_cap = 256};
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 190, 128));
+    expect(&g, 190, 128);
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 317, 7));
+    expect(&g, 196, 128);
+    REQUIRE(metal_graph_dspark_cache_target_prefix(&g, 323));
+    expect(&g, 196, 127);
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 323, 1));
+    expect(&g, 196, 128);
+    REQUIRE(g.dspark_cache_token_start + g.dspark_cache_len == 324);
+    /* Simulate physical writes across a small ring, including scratch draft rows. */
+    {
+        int row[8] = {0};
+        model_window = 4;
+        g = (ds4_gpu_graph){.dspark_cache_cap = 8};
+        for (int p = 5; p < 9; p++) row[p % 8] = p;
+        REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 5, 4));
+        for (int p = 8; p < 11; p++) row[p % 8] = p;
+        REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 8, 3));
+        expect(&g, 7, 4);
+        for (uint32_t p = 7; p < 11; p++) REQUIRE(row[p % 8] == (int)p);
+        for (int p = 11; p < 19; p++) row[p % 8] = p;
+        REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 11, 8));
+        expect(&g, 15, 4);
+        for (uint32_t p = 15; p < 19; p++) REQUIRE(row[p % 8] == (int)p);
+        REQUIRE(metal_graph_dspark_cache_target_prefix(&g, 18));
+        expect(&g, 15, 3);
+        row[18 % 8] = 18;
+        for (int p = 19; p < 22; p++) row[p % 8] = -p;
+        REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 18, 1));
+        expect(&g, 15, 4);
+        for (uint32_t p = 15; p < 19; p++) REQUIRE(row[p % 8] == (int)p);
+    }
+    /* Model window is dynamic, including the W=1 boundary. */
+    g = (ds4_gpu_graph){.dspark_cache_cap = 256};
+    model_window = 128;
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 196, 128));
+    model_window = 32;
+    REQUIRE(metal_graph_dspark_cache_target_prefix(&g, 324));
+    expect(&g, 293, 31);
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 324, 1));
+    expect(&g, 293, 32);
+    model_window = 1;
+    REQUIRE(metal_graph_dspark_cache_target_prefix(&g, 325));
+    expect(&g, 0, 0);
+    REQUIRE(metal_graph_dspark_cache_merge_target_range(&g, 325, 1));
+    expect(&g, 325, 1);
+    ds4_gpu_graph saved = g;
+    REQUIRE(!metal_graph_dspark_cache_merge_target_range(&g, UINT32_MAX, 1));
+    REQUIRE(!metal_graph_dspark_cache_merge_target_range(&g, 0, 257));
+    REQUIRE(!metal_graph_dspark_cache_merge_target_range(&g, 0, 0));
+    REQUIRE(memcmp(&saved, &g, sizeof(g)) == 0);
+    model_window = 0;
+    REQUIRE(!metal_graph_dspark_cache_target_prefix(&g, 326));
+    REQUIRE(!metal_graph_dspark_cache_merge_target_range(&g, 326, 1));
+    REQUIRE(memcmp(&saved, &g, sizeof(g)) == 0);
+    printf("PASS %u metadata assertions\n", checks);
+    return 0;
+}
+'''
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=Path(__file__).resolve().parents[1] / "ds4.c")
+    parser.add_argument("--output", type=Path, help="exclusive-new report directory; temporary files are removed when omitted")
+    args = parser.parse_args()
+    raw = args.source.read_bytes()
+    helpers = "\n\n".join(extract(raw.decode("utf-8"), name) for name in HELPERS)
+    code = PRELUDE + helpers + TESTS
+    compiler = shlex.split(os.environ.get("CC", "cc"))
+    if not compiler:
+        raise ValueError("empty CC")
+    if args.output:
+        args.output.mkdir(parents=True, exist_ok=False)
+    with tempfile.TemporaryDirectory(prefix="ds4-window-contract-") as temporary:
+        root = (args.output or Path(temporary)).resolve()
+        native_path, binary = root / "metadata.c", root / "ds4-host-window-contract"
+        native_path.write_text(code)
+        command = compiler + ["-std=c99", "-O2", "-UNDEBUG", "-fno-fast-math", "-Wall", "-Wextra", "-Werror", str(native_path), "-o", str(binary)]
+        build = subprocess.run(command, capture_output=True, text=True, timeout=60)
+        report = {
+            "scope": "CPU execution of extracted production metadata helpers and simulated physical row tags; no GPU arithmetic or model inference",
+            "source": str(args.source.resolve()),
+            "source_sha256": hashlib.sha256(raw).hexdigest(),
+            "extracted_helpers": list(HELPERS),
+            "emitted_c_sha256": hashlib.sha256(code.encode()).hexdigest(),
+            "test_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+            "compile_command": command,
+            "build_returncode": build.returncode,
+            "build_stdout": build.stdout,
+            "build_stderr": build.stderr,
+            "exit_code": build.returncode,
+        }
+        if build.returncode == 0:
+            run = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+            report.update(exit_code=run.returncode, result=run.stdout.strip(), stderr=run.stderr,
+                          binary_sha256=hashlib.sha256(binary.read_bytes()).hexdigest())
+        if args.output:
+            (root / "report.json").write_text(json.dumps(report, indent=2) + "\n")
+        print(json.dumps(report, indent=2))
+        return report["exit_code"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
ROCm: accelerate DeepSeek prefill and DSpark on gfx1151

Improves prefill ~15% and sampled DSpark coding continuation 70–77% versus [main](https://github.com/antirez/ds4/commit/9ab705347c1775e7599ede7eb81a6255ec7dccb5).

Framework Desktop, AMD Strix Halo, 128 GB unified memory/up to 124 GB iGPU GTT; ROCm 10.0; mixed IQ2 weights. Native `ds4-bench`, tokens/s; 16K appends 8K. Vision timing uses text prompts.

| Workload | Prefill: main → PR | Decode: main → PR |
|---|---:|---:|
| Flash 16K, greedy 64¹ | 262.64 → 301.30 | 14.23 → 14.23 |
| Vision 16K, greedy 64 | 263.25 → 302.37 | 14.22 → 14.23 |
| Vision DSpark 16K, greedy 64 | 263.40 → 302.55 | 12.48 → 20.19 |
| Flash DSpark 8K, sampled 512² | 236.85 → 266.05 | 14.17 → 25.10 |
| Flash DSpark 16K, sampled 512 | 262.06 → 301.86 | 14.38 → 24.46 |
| Flash DSpark 64K, greedy 128³ | 219.31 → 245.47 | 13.10 → 22.61 |

¹Two samples/arm; other rows one pair. ²Cold prefill. ³32K append, saved matched control. Sampled rows use a fixed-sampling harness on coding-source continuation. Separate chat coding: 13.59 → 22.91 tokens/s, natural EOS at 110/155 tokens; not full agentic throughput.

- Optimize IQ2 activation staging, preserving tail zeroing and scratch lifetime.
- Use **hipBLASLt** 2537/2539 for prefill and 2379 for verifier widths 2–6. Require Lt 100401/revision 8d1ae90e and rocBLAS 5.6.0.8d1ae90e; retain original fallback elsewhere.
- Correct DSpark feature/seed alignment, target KV and rolling 128-feature history; retain the EOS frontier fix.

| Validation | Result |
|---|---|
| Operators | IQ2: 46 shapes exact. Lt: finite outputs, intact canaries/inputs; rounding differs. |
| Official scorer | Flash/Vision: 100 cases and 2,313 targets each; unchanged NLL 0.401858465/0.531075809. Short target-path coverage. |
| Coding / tools / images | Long coding 24/24; sampled 7/7; actual tool round trip passes. Images: 8/8 facts, strict grader 3/8 due JSON fencing. |
| Regressions | 64K continuation completes; 162 cache assertions and 7,217 EOS cases pass; GLM/SSD: 10 cases each unchanged; five binary smokes pass. |

Bulk-Lt long-prompt NLL: 0.474619 → 0.477711 (+0.65%) at default 4K chunks; −0.49% at 2K. Practical checks support retention; broad quality equivalence remains unproven. Terminal Bench and shared-EOS CUDA/Metal/TP hardware checks remain pending. New paths exclude GLM and require gfx1151.

Settings: `--dspark --dspark-confidence 0.7`, default five drafts/scheduler; temperature 1, top_p 0.95, min_p/top_k 0. Opportunistic sampling changes the target distribution; exact-mode speed remains unqualified.
