### PR TITLE
cuda: add opt-in ordered KV gathering for indexed decode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@
 /tests/test_quality_api
 /tests/test_cuda_q8_scratch
 /tests/test_cuda_dspark_moe
+/tests/test_cuda_indexed_gather
 /tests/test_session_state
 /tests/test_session_state_gpu
 /tests/test_tp_commands

--- a/Makefile
+++ b/Makefile
@@ -298,8 +298,12 @@ cpu: ds4_cli_cpu.o ds4_server_cpu.o ds4_bench_cpu.o ds4_eval_cpu.o ds4_eval_case
 	$(CC) $(CFLAGS) -o ds4-eval ds4_eval_cpu.o ds4_eval_cases.o ds4_help.o $(CPU_CORE_OBJS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o ds4-agent ds4_agent_cpu.o ds4_help.o ds4_prompt_prefix.o ds4_web.o ds4_kvstore.o linenoise.o ds4_gpu_args_cpu.o $(CPU_CORE_OBJS) $(LDLIBS)
 
-cuda-regression: tests/cuda_long_context_smoke
+cuda-regression: tests/cuda_long_context_smoke tests/test_cuda_indexed_gather
 	./tests/cuda_long_context_smoke
+	./tests/test_cuda_indexed_gather
+
+tests/test_cuda_indexed_gather: tests/test_cuda_indexed_gather.cu ds4_cuda.o ds4_image.o $(MMQ_OBJS)
+	$(NVCC) $(NVCCFLAGS) -std=c++17 -I. -o $@ $^ $(CUDA_LDLIBS)
 
 tests/test_mxfp4_cuda: tests/test_mxfp4_cuda.cu $(MMQ_OBJS)
 	$(NVCC) $(NVCCFLAGS) -std=c++17 $(MMQ_INCLUDES) -o $@ $^ $(CUDA_LDLIBS)
@@ -559,7 +563,7 @@ ds4_rocm_compat.o: ds4_rocm_compat.cu ds4_gpu.h ds4_gpu_mgpu.h ds4_gpu_args.h ds
 ds4_rocm_unavailable.o: ds4_rocm_unavailable.cu
 	$(HIPCC) $(ROCM_CFLAGS) -c -o $@ ds4_rocm_unavailable.cu
 
-tests/cuda_long_context_smoke: tests/cuda_long_context_smoke.o ds4_cuda.o $(MMQ_OBJS)
+tests/cuda_long_context_smoke: tests/cuda_long_context_smoke.o ds4_cuda.o ds4_image.o $(MMQ_OBJS)
 	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(CUDA_LDLIBS)
 
 tests/test_layer_pack.o: tests/test_layer_pack.c ds4_layer_pack.h

--- a/docs/DGX_SPARK.md
+++ b/docs/DGX_SPARK.md
@@ -19,6 +19,15 @@ Do not use `--cuda-tensor-parallel` on a single Spark.
 Stop other inference services before loading a model so they do not compete
 for memory. Restore any services you stopped when finished.
 
+`DS4_CUDA_INDEXED_DECODE_GATHER=1` opts into ordered KV gathering for Flash's
+single-token indexed attention. It copies selected F32 rows once, in their
+existing order, before the original attention kernel reads them across heads.
+It does not change attention arithmetic, KV precision, cache formats or the
+selected rows. Unset, `0` and unrecognized values keep the original path.
+Other shapes, multi-GPU execution and graph capture also keep that path.
+This optimization has been evaluated on GB10; measure it on other CUDA devices
+before using it there. It does not change the Metal or ROCm backends.
+
 ## GLM 5.3 Flash
 
 Q2 is the resident target for one Spark:

--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -9606,6 +9606,38 @@ __device__ __forceinline__ void attention_compact_topk_stable(
     }
 }
 
+/* Preserve KV values and top-k slot order, including duplicates. Moving the
+ * selected rows once avoids repeating scattered memory reads across heads.
+ * The consumer below remains the original attention arithmetic. */
+__global__ static void attention_indexed_decode_gather_kernel(
+        float *staged, int32_t *staged_topk,
+        const float *raw, const float *comp, const int32_t *topk,
+        uint32_t n_raw, uint32_t raw_cap, uint32_t raw_start,
+        uint32_t visible_comp, uint32_t top_k, uint32_t head_dim) {
+    const uint32_t row = blockIdx.x;
+    const float *source = NULL;
+    if (row < n_raw) {
+        source = raw + (uint64_t)((raw_start + row) % raw_cap) * head_dim;
+    } else {
+        const uint32_t slot = row - n_raw;
+        const int32_t original = slot < top_k ? topk[slot] : -1;
+        const bool valid = original >= 0 && (uint32_t)original < visible_comp;
+        if (threadIdx.x == 0) staged_topk[slot] = valid ? (int32_t)slot : -1;
+        if (valid) source = comp + (uint64_t)original * head_dim;
+    }
+    float *dest = staged + (uint64_t)row * head_dim;
+    for (uint32_t d = threadIdx.x; d < head_dim; d += blockDim.x)
+        dest[d] = source ? source[d] : 0.0f;
+}
+
+static bool cuda_tensor_overlaps_single_tmp(const ds4_gpu_tensor *tensor) {
+    if (!g_cuda_tmp || !tensor || !tensor->bytes) return false;
+    const uintptr_t base = (uintptr_t)g_cuda_tmp;
+    const uintptr_t ptr = (uintptr_t)tensor->ptr;
+    return ptr >= base ? ptr - base < g_cuda_tmp_bytes
+                       : base - ptr < tensor->bytes;
+}
+
 __global__ static void attention_indexed_mixed_kernel(
         float *heads,
         const float *sinks,
@@ -18262,6 +18294,46 @@ extern "C" int ds4_gpu_attention_indexed_mixed_batch_heads_tensor(
                                                                  n_head,
                                                                  head_dim);
         return cuda_ok(cudaGetLastError(), "attention indexed heads8 launch");
+    }
+    /* Opt in only for the measured single-token shape. Other shapes and
+     * multi-device/capture calls retain the existing path. Scratch shares
+     * the established ordered allocator; no cross-call activation registry
+     * or retained pointer is introduced. Do not overwrite an input/output
+     * supplied from that slab. */
+    const char *gather = getenv("DS4_CUDA_INDEXED_DECODE_GATHER");
+    if (gather && strcmp(gather, "1") == 0 &&
+        g_n_gpus == 1 && logical_tier == 0 && !g_decode_graph_capturing &&
+        n_tokens == 1u && n_head == 64u && head_dim == 512u &&
+        top_k <= 512u &&
+        n_raw <= 256u && pos0 < UINT32_MAX && n_raw <= pos0 + 1u &&
+        ds4_tensor_device_idx(q) == 0 && ds4_tensor_device_idx(raw_kv) == 0 &&
+        ds4_tensor_device_idx(comp_kv) == 0 && ds4_tensor_device_idx(topk) == 0 &&
+        !cuda_tensor_overlaps_single_tmp(heads) &&
+        !cuda_tensor_overlaps_single_tmp(q) &&
+        !cuda_tensor_overlaps_single_tmp(raw_kv) &&
+        !cuda_tensor_overlaps_single_tmp(comp_kv) &&
+        !cuda_tensor_overlaps_single_tmp(topk)) {
+        const uint64_t kv_bytes = (uint64_t)(n_raw + 512u) * head_dim * sizeof(float);
+        float *staged = (float *)cuda_tmp_alloc_on(
+                logical_tier, kv_bytes + 512u * sizeof(int32_t),
+                "indexed decode KV gather");
+        if (staged) {
+            int32_t *staged_topk = (int32_t *)((char *)staged + kv_bytes);
+            const uint32_t visible = ratio ? std::min(n_comp, (pos0 + 1u) / ratio) : n_comp;
+            attention_indexed_decode_gather_kernel<<<n_raw + 512u, 256>>>(
+                    staged, staged_topk, (const float *)raw_kv->ptr,
+                    (const float *)comp_kv->ptr, topk_ptr, n_raw, raw_cap,
+                    raw_start, visible, top_k, head_dim);
+            if (!cuda_ok(cudaGetLastError(), "indexed decode gather launch")) return 0;
+            attention_indexed_mixed_kernel<<<dim3(1, n_head), 256>>>(
+                    (float *)heads->ptr, sinks, (const float *)q->ptr, staged,
+                    staged + (uint64_t)n_raw * head_dim, staged_topk,
+                    1u, pos0, n_raw, n_raw, 0u, 512u, top_k,
+                    window, 0u, n_head, head_dim);
+            return cuda_ok(cudaGetLastError(), "gathered indexed decode launch");
+        }
+        /* Failure to obtain optional staging must not remove the original
+         * attention implementation's ability to execute this request. */
     }
     dim3 grid(n_tokens, n_head, 1);
     attention_indexed_mixed_kernel<<<grid, 256>>>((float *)heads->ptr,

--- a/tests/test_cuda_indexed_gather.cu
+++ b/tests/test_cuda_indexed_gather.cu
@@ -1,0 +1,225 @@
+#include "ds4_gpu.h"
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <cerrno>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#define CHECK(x) do { if (!(x)) { \
+    fprintf(stderr,"FAIL line %d: %s\n",__LINE__,#x); exit(1); \
+} } while (0)
+
+static float value(size_t i, unsigned seed) {
+    uint32_t x=(uint32_t)i*747796405u+seed*2891336453u;
+    x=((x>>((x>>28u)+4u))^x)*277803737u;
+    x=(x>>22u)^x;
+    return ((int)(x%20001u)-10000)/40961.0f;
+}
+template<class T> static ds4_gpu_tensor *upload(const std::vector<T>& data) {
+    ds4_gpu_tensor *tensor=ds4_gpu_tensor_alloc(data.size()*sizeof(T)); CHECK(tensor);
+    CHECK(ds4_gpu_tensor_write(tensor,0,data.data(),data.size()*sizeof(T)));
+    return tensor;
+}
+struct Shape {
+    uint32_t nt=1,pos=32768,nr=256,cap=2304,start=2133,nc=8192,k=512;
+    uint32_t window=256,ratio=4,nh=64,dim=512,pattern=0;
+};
+struct Case {
+    Shape s;
+    std::vector<float> q,raw,comp,output,reference;
+    std::vector<int32_t> topk;
+    ds4_gpu_tensor *dq,*dr,*dc,*dt,*storage,*dst;
+    Case(Shape shape,unsigned seed):s(shape),
+        q((size_t)s.nt*s.nh*s.dim),raw((size_t)s.cap*s.dim),
+        comp((size_t)std::max(1u,s.nc)*s.dim),output(q.size()+32u,12345.25f),
+        topk((size_t)s.nt*std::max(1u,s.k)) {
+        for(size_t i=0;i<q.size();i++)q[i]=value(i,seed+1);
+        for(size_t i=0;i<raw.size();i++)raw[i]=value(i,seed+2);
+        for(size_t i=0;i<comp.size();i++)comp[i]=value(i,seed+3);
+        if(s.pattern==5) {
+            const uint32_t bits[]={0u,0x80000000u,1u,0x80000001u,
+                0x00800000u,0x80800000u,0x3e000001u,0xbe000001u};
+            for(auto *data:{&q,&raw,&comp})for(size_t i=0;i<data->size();i++)
+                memcpy(&(*data)[i],&bits[(i+seed)%8u],sizeof(float));
+        }
+        for(size_t i=0;i<topk.size();i++) {
+            int32_t index=(int32_t)((i*7919u+seed)%std::max(1u,s.nc));
+            if(s.pattern==1 && i%3u==0)index=-1;
+            if(s.pattern==2 && i%3u==0)index=(int32_t)s.nc+7;
+            if(s.pattern==3)index=i%2u?-1:0;
+            if(s.pattern==4)index=-1;
+            topk[i]=index;
+        }
+        const uint32_t visible=s.ratio?std::min(s.nc,(s.pos+s.nt)/s.ratio):s.nc;
+        for(size_t i=(size_t)visible*s.dim;i<comp.size();i++)comp[i]=NAN;
+        dq=upload(q);dr=upload(raw);dc=upload(comp);dt=upload(topk);storage=upload(output);
+        dst=ds4_gpu_tensor_view(storage,16u*sizeof(float),q.size()*sizeof(float));CHECK(dst);
+    }
+    ~Case() {
+        for(auto *t:{dst,storage,dt,dc,dr,dq})ds4_gpu_tensor_free(t);
+    }
+    Case(const Case&)=delete;
+    Case& operator=(const Case&)=delete;
+    bool eligible(const char *mode="1") const {
+        return !strcmp(mode,"1") && s.k<=512 &&
+            s.nt==1 && s.nh==64 && s.dim==512 && s.nr<=256 &&
+            s.pos<UINT32_MAX && s.nr<=s.pos+1u;
+    }
+    int infer(float *model) {
+        return ds4_gpu_attention_indexed_mixed_batch_heads_tensor(dst,model,4096,0,
+            dq,dr,dc,0,dt,s.nt,s.pos,s.nr,s.cap,s.start,s.nc,s.k,
+            s.window,s.ratio,s.nh,s.dim);
+    }
+    void read() {
+        CHECK(ds4_gpu_tensor_read(storage,0,output.data(),output.size()*sizeof(float)));
+        for(size_t i=0;i<16u;i++) {
+            CHECK(output[i]==12345.25f);
+            CHECK(output[q.size()+16u+i]==12345.25f);
+        }
+        for(size_t i=0;i<q.size();i++)CHECK(std::isfinite(output[i+16u]));
+    }
+    void baseline(float *model) {
+        CHECK(unsetenv("DS4_CUDA_INDEXED_DECODE_GATHER")==0);
+        CHECK(infer(model));read();reference.assign(output.begin()+16,output.end()-16);
+    }
+    void exact() {
+        read();CHECK(!memcmp(reference.data(),output.data()+16,q.size()*sizeof(float)));
+    }
+    // Independent double-precision checks across query/head/dimension ends.
+    void scalar(float *model) {
+        for(uint32_t t:{0u,s.nt-1u})for(uint32_t h:{0u,s.nh-1u}) {
+            const uint32_t pos=s.pos+t,first=s.pos+s.nt-s.nr;
+            const uint32_t visible=s.ratio?std::min(s.nc,(pos+1u)/s.ratio):s.nc;
+            std::vector<const float*> rows;
+            for(uint32_t r=0;r<s.nr && rows.size()<256u;r++) {
+                const uint32_t p=first+r;
+                if(p<=pos && (!s.window || pos+1u<=s.window || p>=pos+1u-s.window))
+                    rows.push_back(raw.data()+(size_t)((s.start+r)%s.cap)*s.dim);
+            }
+            for(uint32_t k=0;k<s.k;k++) {
+                int32_t index=topk[(size_t)t*s.k+k];
+                if(index>=0 && (uint32_t)index<visible)
+                    rows.push_back(comp.data()+(size_t)index*s.dim);
+            }
+            std::vector<double> scores(rows.size());double maximum=model[h];
+            for(size_t r=0;r<rows.size();r++) {
+                double sum=0;
+                for(uint32_t d=0;d<s.dim;d++)sum+=(double)q[((size_t)t*s.nh+h)*s.dim+d]*rows[r][d];
+                scores[r]=sum/sqrt((double)s.dim);maximum=std::max(maximum,scores[r]);
+            }
+            double denom=exp(model[h]-maximum);
+            for(auto &score:scores)denom+=score=exp(score-maximum);
+            for(uint32_t d:{0u,s.dim/2u,s.dim-1u}) {
+                double expected=0;
+                for(size_t r=0;r<rows.size();r++)expected+=rows[r][d]*scores[r]/denom;
+                CHECK(fabs(expected-reference[((size_t)t*s.nh+h)*s.dim+d])<2e-5);
+            }
+        }
+    }
+};
+
+static void churn_scratch() {
+    const uint32_t nc=65536,nt=16,k=2048;
+    std::vector<float> scores((size_t)nc*nt);
+    for(size_t i=0;i<scores.size();i++)scores[i]=(float)(i%nc);
+    std::vector<uint32_t> selected((size_t)nt*k);
+    auto *ds=upload(scores),*di=upload(selected);
+    CHECK(ds4_gpu_indexer_topk_tensor(di,ds,nc,nt,k));
+    CHECK(ds4_gpu_tensor_read(di,0,selected.data(),selected.size()*sizeof(uint32_t)));
+    for(uint32_t t=0;t<nt;t++) {
+        std::vector<uint32_t> row(selected.begin()+t*k,selected.begin()+(t+1u)*k);
+        std::sort(row.begin(),row.end());
+        for(uint32_t j=0;j<k;j++)CHECK(row[j]==nc-k+j);
+    }
+    ds4_gpu_tensor_free(di);ds4_gpu_tensor_free(ds);
+    puts("PASS existing top-k scratch growth/overwrite");
+}
+
+int main(int argc,char **argv) {
+    const bool dispatch_probe=argc==4 && !strcmp(argv[1],"--dispatch-probe");
+    CHECK(argc==1 || dispatch_probe);
+    CHECK(ds4_gpu_init());
+    float *model=NULL;CHECK(cudaMallocHost((void**)&model,4096)==cudaSuccess);
+    for(unsigned i=0;i<1024;i++)model[i]=value(i,99);
+    CHECK(setenv("DS4_CUDA_COPY_MODEL","1",1)==0);
+    CHECK(ds4_gpu_set_model_map(model,4096));CHECK(unsetenv("DS4_CUDA_COPY_MODEL")==0);
+    if(dispatch_probe) {
+        char *end=NULL;errno=0;const unsigned long long pos=strtoull(argv[3],&end,10);
+        CHECK(!errno && end!=argv[3] && !*end && pos<UINT32_MAX);
+        Shape shape;shape.pos=(uint32_t)pos;shape.nr=std::min(256u,shape.pos+1u);
+        shape.nc=std::max(1u,(shape.pos+1u)/4u);
+        {
+            Case c(shape,913);c.baseline(model);c.scalar(model);
+            CHECK(setenv("DS4_CUDA_INDEXED_DECODE_GATHER",argv[2],1)==0);
+            CHECK(c.infer(model));c.exact();
+            printf("PASS dispatch probe mode=%s pos=%u expected_gather_kernel_calls=%u\n",
+                argv[2],shape.pos,c.eligible(argv[2])?1u:0u);
+        }
+        CHECK(cudaDeviceSynchronize()==cudaSuccess);
+        ds4_gpu_cleanup();CHECK(cudaFreeHost(model)==cudaSuccess);
+        return 0;
+    }
+    unsigned cases=0,expected_gather_calls=0;
+    auto run=[&](Shape shape) {
+        Case c(shape,++cases);c.baseline(model);c.scalar(model);
+        size_t before,total,after;CHECK(cudaMemGetInfo(&before,&total)==cudaSuccess);
+        for(const char *mode:{"0","invalid","1"}) {
+            CHECK(setenv("DS4_CUDA_INDEXED_DECODE_GATHER",mode,1)==0);
+            for(int repeat=0;repeat<3;repeat++) {CHECK(c.infer(model));c.exact();}
+            expected_gather_calls+=c.eligible(mode)?3u:0u;
+            printf("dispatch,case,%u,mode,%s,expected_gathers,%u\n",
+                cases,mode,c.eligible(mode)?3u:0u);
+        }
+        CHECK(cudaMemGetInfo(&after,&total)==cudaSuccess);
+        printf("case,%u,eligible,%u,values,%zu,exact,1,scratch_growth_bytes,%zu\n",
+            cases,c.eligible(),c.q.size(),before>after?before-after:0);fflush(stdout);
+    };
+    Shape first;first.nr=1;first.nc=3;first.k=1;run(first);
+    run(Shape{}); // A real growth from ~1 MiB to ~1.5 MiB, not just reuse.
+    Shape extremes;extremes.pattern=5;run(extremes);
+    for(uint32_t pos:{2047u,8191u,16383u,32766u,32767u,32768u,32769u,131045u,262143u}) {
+        Shape boundary;boundary.pos=pos;boundary.nc=(pos+1u)/4u;
+        boundary.pattern=1;run(boundary);
+    }
+    churn_scratch();
+    for(unsigned i=0;i<36;i++) {
+        Shape s;s.nc=i%4u==0?3u:i%4u==1?257u:i%4u==2?8192u:65536u;
+        s.nr=i%3u==0?1u:i%3u==1?255u:256u;
+        s.k=i%4u==0?1u:i%4u==1?31u:i%4u==2?255u:512u;
+        s.ratio=i%7u==0?0u:4u;s.pos=i%5u==0?17u:s.nc*4u-1u;
+        s.nr=std::min(s.nr,s.pos+1u);s.start=i%2u?0u:s.cap-1u;
+        s.window=i%5u==0?0u:i%5u==1?7u:256u;s.pattern=i%5u;
+        if(i==31)s.nh=17;
+        if(i==32)s.dim=128;
+        // Valid multi-token inputs exercise the unchanged prefill fallback;
+        // invalid and invisible selected rows are covered on decode above.
+        if(i==33){s.nt=2;s.nr=2;s.pattern=0;}
+        if(i==34)s.nr=257;
+        run(s);
+    }
+    { // Pending A/B calls share scratch but never conversation outputs.
+        Shape a,b;b.pos=131045;b.nc=32768;b.start=b.cap-1u;b.pattern=3;
+        Case ca(a,701),cb(b,702);ca.baseline(model);cb.baseline(model);
+        for(int repeat=0;repeat<8;repeat++) {
+            CHECK(setenv("DS4_CUDA_INDEXED_DECODE_GATHER","1",1)==0);
+            CHECK(ca.infer(model));CHECK(cb.infer(model));
+            if(repeat==3)churn_scratch();
+            ca.exact();cb.exact();
+        }
+        expected_gather_calls+=16;
+        puts("PASS alternating live buffers and intervening scratch owner");
+        // Existing rejection behavior remains rejection, with no new launch.
+        ca.s.k=513;CHECK(!ca.infer(model));ca.s.k=512;
+        ca.s.nr=0;CHECK(!ca.infer(model));ca.s.nr=256;
+        ca.s.start=ca.s.cap;CHECK(!ca.infer(model));ca.s.start=0;
+        ca.s.nc=0;CHECK(!ca.infer(model));ca.s.nc=8192;
+    }
+    CHECK(unsetenv("DS4_CUDA_INDEXED_DECODE_GATHER")==0);
+    CHECK(cudaDeviceSynchronize()==cudaSuccess);
+    ds4_gpu_cleanup();CHECK(cudaFreeHost(model)==cudaSuccess);
+    printf("PASS %u API cases; expected_gather_kernel_calls=%u; exact floats, guards, scalar oracle, scratch transitions\n",
+        cases,expected_gather_calls);
+}


### PR DESCRIPTION
## Summary

Add `DS4_CUDA_INDEXED_DECODE_GATHER=1`, an opt-in CUDA path that gathers Flash's selected F32 KV rows once before running the existing single-token attention kernel. Default behavior is unchanged.

## Why

Indexed decode makes each of 64 heads read the same scattered KV rows. The selected rows are shared, but their scattered memory access is repeated. This patch copies the raw window and selected compressed rows into contiguous scratch once, then calls the original attention kernel with remapped indices.

The important invariant is **same rows, same slot order, same F32 values, same attention arithmetic**. Duplicate indices stay duplicated; invalid and not-yet-visible rows stay masked. There is no sorting, precision conversion, new reduction or change to model math.

## Compatibility

- Unset, `0` and unrecognized values retain the original path. Only `1` enables gathering.
- Limited to one GPU, single-token decode, 64 heads, dimension 512, at most 256 raw rows and `top_k <= 512`. Other shapes and graph capture retain the original path. Metal and ROCm are unchanged.
- Reuses the existing ordered scratch allocator, with input/output overlap guards and allocation-failure fallback. Maximum staging request is about 1.50 MiB; no per-session registry, cache-format change or retained activation pointer is added.
- The regression target gains a 48-case API test. Its existing smoke target also needs `ds4_image.o` to resolve `ds4_deepseek4_attention_bounds`; the missing prerequisite was reproduced on pristine main and is corrected here as test-link wiring.

This is independent of the indexer optimization in #763 and token-tile prefill fix in #869. The top-k expansion in #478 must retain this path's 512-slot guard; #566's stream override and #628's backend split would need normal integration/rebase work if merged first.

## Practical impact

This opt-in targets long-context indexed decode on the supported CUDA shape. The earlier 8.79–10.55% off/on measurements below isolate gathering within their stated integration; they are not newly measured gains over `f62ca29`, and the short-context path remained flat. The rebased standalone fixture separately validates complete outputs, fallbacks and scratch ownership.

As broader integration evidence, a combined build containing this patch, warp sorting and other changes was validated on two GB10 Sparks on 2026-09-07. Against each host's previous production build, normal-setting decode improved 8.77–10.75% and 9.15–11.19%, respectively, at the measured frontiers from 8,192 through 262,016 tokens; 2K remained flat. Runs used original/candidate/candidate/original process order; each result is the mean of two process medians, with four warm trials per process after two warmups. Both used Vision-Exp IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8 with its encoder and preserved 262,144 context. This supports the combined deployment only: the comparator was not pristine `f62ca29`, and these gains cannot be assigned to this PR or added to its earlier off/on results. The existing adaptive FP16 weight cache confounded long-context prefill and cross-process numerical repeatability; no isolated prefill gain or normal-setting cross-process bitwise guarantee is inferred from that run.

## Combined runtime context

A [stock/full-stack engine comparison](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/README.md) measures pristine `f62ca29` against the complete integrated runtime on GB10 CUDA and M3 Ultra Metal, including full 262,144-token capacity. The original full sweeps used one process pair per machine and include additional changes beyond these 13 PRs. A [targeted M3 follow-up](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/m3-attribution/README.md) did not reproduce the original short-decode slowdown, using a reversed-order pair, same-process controls and an exact original-executable replay. These results do not isolate this PR’s marginal gain, establish universal speed or quality, or newly benchmark its server/cache workflows. See the [per-PR assessment](https://github.com/JordiPosthumus/ds4/blob/6bf1dbe8817f5965528b16fcf995fcbe9befe752/benchmarks/official-vs-full-stack-20260907/PR-ASSESSMENT.md) for its supported benefit and limits.

## Validation

The build and runtime checks below ran before upstream’s README-only update. The full PR diff and every other tracked file are byte-identical at this head; `git diff --check` passed again. The documentation-only rebase was not rebuilt.

One standalone commit, `3518aa9f30fc`, directly on upstream `f62ca29a3087` (2026-09-07). The 48-case public-API fixture checks complete output bytes, a scalar reference, wrapped raw rings, duplicate/invalid/invisible indices, shape fallbacks, overlap guards, scratch growth/reuse and pending A/B calls with an intervening scratch owner.

On the preceding `b6af0ad` base, clean default Metal and CPU builds, `make test-frontends`, session-state, TP-command and vision-image tests, and `git diff --check` passed on M3 Ultra / Darwin 27.0 / Apple clang 21. These portability and host checks load no model or GPU fixture.

Earlier integration evidence, before extraction: GB10, CUDA 13.0.88, driver 580.173.02, Vision-Exp IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8 plus encoder. Six balanced observations per frontier used identical snapshots and 128 teacher-forced tokens. Steady decode off/on measured 15.879/17.555 tok/s at 8K (+10.55%), 15.181/16.584 at 32K (+9.24%), and 13.446/14.628 at 131,045 (+8.79%). All six paired blocks were positive; excluding the first changed the last result to +8.05%. A warmed 2K trace recorded zero gather launches and flat speed. All 30,768,640 saved F32 values matched across baseline/candidate text and image continuations. Private-server restart, image restore, cancellation, tools and shared-prefix isolation passed on that integration. These support the mechanism; they are not a clean-head full-model sweep or proof of unchanged default speed (separate off/off observations differed −0.25% to −2.82%).

Before the Metal-only upstream update, the same patch passed checks on NVIDIA DGX Spark / Ubuntu / Linux 6.17.0-1032-nvidia, GCC 13.3 and CUDA 13.0.88: clean `make -j4 cuda-spark` (`sm_121a`), `make CUDA_ARCH=sm_121a test-frontends`, session-state, TP-command and vision-image tests, and a clean `make -j4 cpu` build. These are host tests and compile/link coverage; CUDA execution is recorded separately. The later upstream updates are a five-line GLM SSD change inside a Metal-only guard and a README edit. CUDA source and the PR patch are unchanged; native Linux preprocessing of `ds4.c` was byte-identical for CUDA, CPU and sanitizer builds.

The standalone 48-case gathered-attention API fixture and CUDA long-context smoke test passed on the isolated PR build. The API fixture also passed Compute Sanitizer memcheck and synccheck with zero errors, retaining complete-output identity, scalar-reference and scratch-transition checks.

No full aggregate model-suite, other-GPU, other-quantization or multi-GPU result is claimed.
