### PR TITLE
tests: validate complete scorer tables and frontier logits

### DIFF
--- a/gguf-tools/quality-testing/README.md
+++ b/gguf-tools/quality-testing/README.md
@@ -224,3 +224,34 @@ Output fields:
   local top-N for the same position.
 - `api_top_mae`: local-vs-API logprob MAE over mapped API top alternatives.
 - `api_pair_rate`: pairwise ordering agreement among mapped API alternatives.
+
+## 6. Validate regression artifacts
+
+Two standard-library Python tools check saved artifacts without running inference. For matched `score_official` runs with API logprob coverage, require the complete intended manifest and finite, consistent counts and scores:
+
+```sh
+python3 gguf-tools/quality-testing/validate_scores.py \
+  --manifest gguf-tools/quality-testing/data/flash/manifest.tsv \
+  --baseline /tmp/old.tsv --candidate /tmp/new.tsv --strict-identical > /tmp/scores.json
+```
+
+Exit 0 with `--strict-identical` requires every per-case value to match; omit it to report valid differences without deciding their acceptability. Unlike `compare_scores.py`, validation rejects missing/duplicate cases, malformed fields and changed coverage denominators. This stricter mode requires the current four-column manifest and scorer TSV format with nonzero API coverage; use the existing comparator for continuation-only references without API logprobs.
+
+Compare complete vocabulary dumps from `ds4-bench --dump-frontier-logits-dir`:
+
+```sh
+python3 gguf-tools/quality-testing/compare_frontier_logits.py \
+  /tmp/old-logits /tmp/new-logits --frontiers 2048 4096 --ctx 8192 \
+  --model /models/model.gguf --backend rocm --quality false --quant-bits 2 --vocab 129280 \
+  --output /tmp/frontiers.json
+```
+
+Supply the exact expected metadata: `ctx` is allocated capacity; each frontier is total context, and prefill is its increase from the previous frontier (initially zero). Each directory must contain exactly the requested dumps. Exit 0 requires complete finite float32 bit identity; exit 1 reports drift, invalid artifacts or an operational error. JSON distinguishes `identical`, `drift` and `invalid`, with full-vector hashes, differing counts and maximum absolute differences. The output path must be new. The parser follows the writer's nine-significant-digit float format and preserves signed zero.
+
+Matching argmax is insufficient: a measured 8K–64K comparison retained all four argmax IDs while full vectors differed, with maximum absolute difference 7.45228. This is numerical drift, not by itself proof of worse generation quality. Record prompt/weight hashes, source/build identity, settings and successful run completion separately; these tools cannot recover that provenance from score tables or dumps, and do not replace model-quality checks.
+
+Run the host-only positive and negative controls:
+
+```sh
+python3 -m unittest discover -s gguf-tools/quality-testing/tests -v
+```

--- a/gguf-tools/quality-testing/compare_frontier_logits.py
+++ b/gguf-tools/quality-testing/compare_frontier_logits.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Validate complete ds4-bench frontier dumps and require exact finite float32 bits."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+import struct
+import sys
+
+
+FIELDS = {'source', 'model', 'backend', 'quality', 'quant_bits', 'prompt_tokens',
+          'frontier_tokens', 'prefill_tokens', 'ctx', 'vocab', 'argmax_id',
+          'argmax_logit', 'logits'}
+INT_MAX = 2**31 - 1
+
+
+class InvalidDump(ValueError):
+    pass
+
+
+class JSONNumber(str):
+    """Keep decimal spelling, including integer-form -0, until field validation."""
+
+
+def unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise InvalidDump(f'duplicate JSON key: {key}')
+        result[key] = value
+    return result
+
+
+def reject_constant(value):
+    raise InvalidDump(f'non-finite JSON constant: {value}')
+
+
+def integer(value, name, minimum=0):
+    if type(value) is not JSONNumber or not re.fullmatch(r'0|[1-9][0-9]*', value):
+        raise InvalidDump(f'{name}: expected canonical JSON integer, not bool/null/string/float')
+    number = int(value)
+    if not minimum <= number <= INT_MAX:
+        raise InvalidDump(f'{name}: integer out of range')
+    return number
+
+
+def binary32(value, name):
+    if type(value) is not JSONNumber:
+        raise InvalidDump(f'{name}: expected a JSON number, not bool/null/string')
+    try:
+        parsed = float(value)
+        if not math.isfinite(parsed):
+            raise InvalidDump(f'{name}: non-finite number')
+        raw = struct.pack('<f', parsed)
+        rounded = struct.unpack('<f', raw)[0]
+        if not math.isfinite(rounded):
+            raise InvalidDump(f'{name}: non-finite binary32 value')
+    except (OverflowError, ValueError) as exc:
+        raise InvalidDump(f'{name}: invalid finite binary32 number: {exc}') from exc
+    # The C writer promotes float to double and prints %.9g. Re-formatting the
+    # recovered binary32 verifies the source spelling and preserves signed zero.
+    if format(rounded, '.9g') != value:
+        raise InvalidDump(f'{name}: not the writer\'s canonical %.9g binary32 representation')
+    return raw, rounded
+
+
+def validate_expectations(frontiers, ctx, model, backend, quality, quant_bits, vocab):
+    if (not frontiers or any(type(n) is not int or not 0 < n <= INT_MAX for n in frontiers)
+            or frontiers != sorted(set(frontiers))):
+        raise InvalidDump('expected frontiers must be unique, positive, strictly increasing integers')
+    if type(ctx) is not int or not frontiers[-1] < ctx <= INT_MAX:
+        raise InvalidDump('expected ctx must exceed the final frontier and fit a signed C int')
+    if type(model) is not str or not model or '\0' in model:
+        raise InvalidDump('expected model must be a nonempty path string without NUL')
+    if backend not in ('rocm', 'cuda', 'metal', 'cpu') or type(backend) is not str:
+        raise InvalidDump('unsupported expected backend')
+    if type(quality) is not bool or type(quant_bits) is not int or quant_bits not in (0, 2, 4):
+        raise InvalidDump('expected quality must be boolean and quant_bits must be 0, 2, or 4')
+    if type(vocab) is not int or not 0 < vocab <= INT_MAX:
+        raise InvalidDump('expected vocab must be a positive signed C int')
+    return {'source': 'ds4-bench', 'model': model, 'backend': backend,
+            'quality': quality, 'quant_bits': quant_bits, 'ctx': ctx, 'vocab': vocab}
+
+
+def validate_dump(path, expected, frontier, previous):
+    if path.is_symlink() or not path.is_file():
+        raise InvalidDump('dump must be an existing regular file, not a symlink')
+    raw = path.read_bytes()
+    if not raw or not raw.endswith(b'\n'):
+        raise InvalidDump('dump is empty or missing its final newline')
+    try:
+        document = json.loads(raw.decode('utf-8'), object_pairs_hook=unique_object,
+                              parse_int=JSONNumber, parse_float=JSONNumber,
+                              parse_constant=reject_constant)
+    except (ValueError, UnicodeError) as exc:
+        raise InvalidDump(f'invalid JSON: {exc}') from exc
+    if type(document) is not dict or set(document) != FIELDS:
+        raise InvalidDump('dump must have exactly the known ds4-bench metadata and logits fields')
+    for key in ('source', 'model', 'backend'):
+        if type(document[key]) is not str or document[key] != expected[key]:
+            raise InvalidDump(f'{key}: does not match explicit expected metadata')
+    if type(document['quality']) is not bool or document['quality'] != expected['quality']:
+        raise InvalidDump('quality: does not match explicit expected boolean')
+    metadata = {key: document[key] for key in ('source', 'model', 'backend', 'quality')}
+    counts = {key: integer(document[key], key) for key in
+              ('quant_bits', 'prompt_tokens', 'frontier_tokens', 'prefill_tokens', 'ctx', 'vocab', 'argmax_id')}
+    required_counts = {key: expected[key] for key in ('quant_bits', 'ctx', 'vocab')}
+    required_counts.update(prompt_tokens=frontier, frontier_tokens=frontier,
+                           prefill_tokens=frontier - previous)
+    for key, value in required_counts.items():
+        if counts[key] != value:
+            raise InvalidDump(f'{key}: got {counts[key]}, expected {value}')
+    if counts['argmax_id'] >= expected['vocab']:
+        raise InvalidDump('argmax_id: outside vocabulary')
+    if type(document['logits']) is not list or len(document['logits']) != expected['vocab']:
+        raise InvalidDump('logits: vector length must exactly match expected vocabulary')
+    words = bytearray()
+    values = []
+    for index, value in enumerate(document['logits']):
+        word, decoded = binary32(value, f'logits[{index}]')
+        words.extend(word)
+        values.append(decoded)
+    argmax_word, argmax_value = binary32(document['argmax_logit'], 'argmax_logit')
+    argmax = counts['argmax_id']
+    if argmax_word != words[4 * argmax:4 * argmax + 4]:
+        raise InvalidDump('argmax_logit: float32 bits do not match logits[argmax_id]')
+    # Both current CPU argmax implementations retain the lowest ID on ties.
+    if argmax != max(range(len(values)), key=values.__getitem__):
+        raise InvalidDump('argmax_id: not the first maximum of the complete logit vector')
+    metadata.update(counts)
+    metadata['argmax_logit'] = argmax_value
+    return {'metadata': metadata, 'file_sha256': hashlib.sha256(raw).hexdigest(),
+            'logits_float32_sha256': hashlib.sha256(words).hexdigest()}, bytes(words), values
+
+
+def compare_directories(baseline, candidate, frontiers, expected):
+    try:
+        validated = validate_expectations(frontiers, expected['ctx'], expected['model'],
+                                           expected['backend'], expected['quality'],
+                                           expected['quant_bits'], expected['vocab'])
+    except (KeyError, TypeError) as exc:
+        raise InvalidDump(f'incomplete expected metadata: {exc}') from exc
+    if expected != validated:
+        raise InvalidDump('expected metadata does not match the explicit source contract')
+    names = {f'frontier_{frontier:06d}.logits.json' for frontier in frontiers}
+    errors = []
+    for label, directory in (('baseline', baseline), ('candidate', candidate)):
+        try:
+            present = {path.name for path in directory.iterdir()}
+            if present != names:
+                errors.append(f'{label} file coverage: missing={sorted(names - present)}, extra={sorted(present - names)}')
+        except OSError as exc:
+            errors.append(f'{label} directory: {exc}')
+    results = []
+    previous = 0
+    for frontier in frontiers:
+        filename = f'frontier_{frontier:06d}.logits.json'
+        row = {'frontier': frontier, 'filename': filename, 'errors': [],
+               'complete_finite_validation': False, 'strict_float32_identity': False}
+        data = []
+        for label, directory in (('baseline', baseline), ('candidate', candidate)):
+            try:
+                info, words, values = validate_dump(directory / filename, expected, frontier, previous)
+                row[label] = info
+                data.append((words, values))
+            except (OSError, InvalidDump, OverflowError, RecursionError) as exc:
+                row['errors'].append(f'{label}: {exc}')
+        if len(data) == 2:
+            old, new = data
+            count = 0
+            first = None
+            max_abs = 0.0
+            for index, (x, y) in enumerate(zip(old[1], new[1])):
+                offset = 4 * index
+                xb, yb = old[0][offset:offset + 4], new[0][offset:offset + 4]
+                if xb != yb:
+                    count += 1
+                    max_abs = max(max_abs, abs(x - y))
+                    if first is None:
+                        first = {'index': index, 'baseline': x, 'candidate': y,
+                                 'baseline_bits': f'{int.from_bytes(xb, "little"):08x}',
+                                 'candidate_bits': f'{int.from_bytes(yb, "little"):08x}'}
+            row.update(complete_finite_validation=True, strict_float32_identity=count == 0,
+                       values=expected['vocab'], changed_count=count, first_change=first, max_abs=max_abs)
+        results.append(row)
+        previous = frontier
+    complete = not errors and all(row['complete_finite_validation'] for row in results)
+    identical = complete and all(row['strict_float32_identity'] for row in results)
+    return {'format_version': 1, 'status': 'identical' if identical else ('drift' if complete else 'invalid'),
+            'strict_float32_identity': identical, 'complete_finite_coverage': complete,
+            'scope': 'selected prefill frontiers only; no model quality or decode correctness verdict',
+            'expected_frontiers': frontiers, 'expected_metadata': expected,
+            'errors': errors, 'frontiers': results}
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('baseline', type=Path)
+    parser.add_argument('candidate', type=Path)
+    parser.add_argument('--frontiers', type=int, nargs='+', required=True)
+    parser.add_argument('--ctx', type=int, required=True)
+    parser.add_argument('--model', required=True)
+    parser.add_argument('--backend', choices=('rocm', 'cuda', 'metal', 'cpu'), required=True)
+    parser.add_argument('--quality', choices=('true', 'false'), required=True)
+    parser.add_argument('--quant-bits', type=int, choices=(0, 2, 4), required=True)
+    parser.add_argument('--vocab', type=int, required=True)
+    parser.add_argument('--output', type=Path, required=True, help='exclusively create a new JSON report')
+    args = parser.parse_args(argv)
+    try:
+        expected = validate_expectations(args.frontiers, args.ctx, args.model, args.backend,
+                                         args.quality == 'true', args.quant_bits, args.vocab)
+        report = compare_directories(args.baseline, args.candidate, args.frontiers, expected)
+        with args.output.open('x', encoding='utf-8') as output:
+            output.write(json.dumps(report, indent=2, allow_nan=False) + '\n')
+        print(f'{report["status"].upper()}: {len(report["frontiers"])} expected frontiers; {args.output}', file=sys.stderr)
+        return 0 if report['strict_float32_identity'] else 1
+    except (OSError, ValueError, OverflowError, RecursionError) as exc:
+        print(f'INVALID: {exc}', file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/gguf-tools/quality-testing/tests/test_compare_frontier_logits.py
+++ b/gguf-tools/quality-testing/tests/test_compare_frontier_logits.py
@@ -1,0 +1,200 @@
+"""Host-only negative controls for the complete frontier dump gate."""
+
+import json
+from pathlib import Path
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import compare_frontier_logits as gate
+
+
+def f32(value):
+    return struct.unpack('<f', struct.pack('<f', value))[0]
+
+
+def fixture(frontier=2048, previous=0, values=None, **changes):
+    values = [1.0, -2.0, 3.0, 0.0] if values is None else values
+    values = [f32(value) for value in values]
+    best = max(range(len(values)), key=values.__getitem__)
+    document = {'source': 'ds4-bench', 'model': '/models/flash', 'backend': 'rocm',
+                'quality': False, 'quant_bits': 2, 'prompt_tokens': frontier,
+                'frontier_tokens': frontier, 'prefill_tokens': frontier - previous,
+                'ctx': 8192, 'vocab': len(values), 'argmax_id': best,
+                'argmax_logit': '__ARGMAX__', 'logits': '__LOGITS__'}
+    document.update(changes)
+    return (json.dumps(document).replace('"__ARGMAX__"', format(values[best], '.9g'))
+            .replace('"__LOGITS__"', '[' + ','.join(format(value, '.9g') for value in values) + ']') + '\n').encode()
+
+
+class FrontierTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.old, self.new = self.root / 'old', self.root / 'new'
+        self.old.mkdir()
+        self.new.mkdir()
+        self.expected = gate.validate_expectations([2048, 4096], 8192, '/models/flash', 'rocm', False, 2, 4)
+        for directory in (self.old, self.new):
+            (directory / 'frontier_002048.logits.json').write_bytes(fixture())
+            (directory / 'frontier_004096.logits.json').write_bytes(fixture(4096, 2048))
+
+    def compare(self):
+        return gate.compare_directories(self.old, self.new, [2048, 4096], self.expected)
+
+    def assert_bad(self, raw):
+        path = self.new / 'frontier_002048.logits.json'
+        path.write_bytes(raw)
+        report = self.compare()
+        self.assertEqual(report['status'], 'invalid')
+        self.assertFalse(report['strict_float32_identity'])
+        self.assertFalse(report['frontiers'][0]['complete_finite_validation'])
+        self.assertTrue(report['frontiers'][1]['complete_finite_validation'])
+        self.assertTrue(report['frontiers'][0]['errors'])
+
+    def test_complete_identity_and_full_vector_hashes(self):
+        result = self.compare()
+        self.assertEqual(result['status'], 'identical')
+        self.assertTrue(result['complete_finite_coverage'])
+        self.assertEqual(len(result['frontiers']), 2)
+        for row in result['frontiers']:
+            self.assertEqual(row['values'], 4)
+            self.assertEqual(row['changed_count'], 0)
+            self.assertEqual(row['baseline']['logits_float32_sha256'], row['candidate']['logits_float32_sha256'])
+
+    def test_non_argmax_drift_cannot_hide_behind_same_argmax(self):
+        (self.new / 'frontier_002048.logits.json').write_bytes(fixture(values=[1, -1, 3, 0]))
+        (self.new / 'frontier_004096.logits.json').write_bytes(fixture(4096, 2048, values=[1, -2, 3, 1]))
+        result = self.compare()
+        self.assertEqual(result['status'], 'drift')
+        self.assertTrue(result['complete_finite_coverage'])
+        self.assertEqual([row['changed_count'] for row in result['frontiers']], [1, 1])
+        self.assertEqual(result['frontiers'][0]['first_change']['index'], 1)
+        self.assertEqual(result['frontiers'][0]['max_abs'], 1)
+
+    def test_negative_zero_survives_integer_form_json_parsing(self):
+        (self.new / 'frontier_002048.logits.json').write_bytes(fixture(values=[1, -2, 3, -0.0]))
+        row = self.compare()['frontiers'][0]
+        self.assertFalse(row['strict_float32_identity'])
+        self.assertEqual(row['changed_count'], 1)
+        self.assertEqual(row['max_abs'], 0)
+        self.assertEqual(row['first_change']['baseline_bits'], '00000000')
+        self.assertEqual(row['first_change']['candidate_bits'], '80000000')
+
+    def test_writer_nine_digit_numbers_recover_original_float32_bits(self):
+        literals = [('1.00000012', 0x3f800001), ('-0', 0x80000000),
+                    ('1.40129846e-45', 0x00000001), ('3.40282347e+38', 0x7f7fffff),
+                    ('-3.40282347e+38', 0xff7fffff), ('0.100000001', 0x3dcccccd)]
+        for literal, bits in literals:
+            word, _ = gate.binary32(gate.JSONNumber(literal), 'test')
+            self.assertEqual(struct.unpack('<I', word)[0], bits)
+        for literal in ('0.1', '1.0000001192092896', '1.0', '1e0', '1e-999', '1e999', '3.5e38'):
+            with self.subTest(literal=literal), self.assertRaises(gate.InvalidDump):
+                gate.binary32(gate.JSONNumber(literal), 'test')
+
+    def test_null_bool_string_nonfinite_and_overflow_logits_are_rejected(self):
+        good = fixture()
+        for token in ('null', 'true', 'false', '"1"', 'NaN', 'Infinity', '-Infinity', '1e999', '3.5e38', '1e-999'):
+            with self.subTest(token=token):
+                self.assert_bad(good.replace(b'[1,-2,3,0]', ('[1,-2,3,' + token + ']').encode()))
+
+    def test_numeric_metadata_types_and_counts_are_strict(self):
+        numeric = ('quant_bits', 'prompt_tokens', 'frontier_tokens', 'prefill_tokens', 'ctx', 'vocab', 'argmax_id')
+        for key in numeric:
+            for value in (None, True, False, '2', 2.0, -1, 2**31):
+                with self.subTest(key=key, value=value):
+                    self.assert_bad(fixture(**{key: value}))
+        for changes in ({'quant_bits': 4}, {'prompt_tokens': 2047}, {'frontier_tokens': 4096},
+                        {'prefill_tokens': 0}, {'ctx': 4096}, {'vocab': 3}, {'argmax_id': 4}):
+            self.assert_bad(fixture(**changes))
+        for value in (None, 0, 1, 'false', True):
+            self.assert_bad(fixture(quality=value))
+
+    def test_source_model_backend_metadata_must_match_explicit_expectations(self):
+        for key in ('source', 'model', 'backend'):
+            for value in (None, False, 0, '', 'wrong'):
+                with self.subTest(key=key, value=value):
+                    self.assert_bad(fixture(**{key: value}))
+
+    def test_full_lengths_argmax_value_and_tie_break_validation(self):
+        self.assert_bad(fixture().replace(b'[1,-2,3,0]', b'[1,-2,3]'))
+        self.assert_bad(fixture().replace(b'[1,-2,3,0]', b'[1,-2,3,0,4]'))
+        self.assert_bad(fixture(argmax_id=0, argmax_logit=1))
+        self.assert_bad(fixture(argmax_logit=2))
+        self.assert_bad(fixture(argmax_logit=None))
+        self.assert_bad(fixture(argmax_logit=True))
+        self.assert_bad(fixture(values=[3, 3, 0, 0], argmax_id=1))
+        (self.new / 'frontier_002048.logits.json').write_bytes(fixture(values=[3, 3, 0, 0]))
+        self.assertTrue(self.compare()['frontiers'][0]['complete_finite_validation'])
+        # Equality as a Python number must not hide signed-zero argmax corruption.
+        self.assert_bad(fixture(values=[-0.0, -1, -2, -3], argmax_logit=0))
+
+    def test_duplicate_missing_extra_truncated_and_malformed_json_rejected(self):
+        good = fixture()
+        malformed = [b'', good[:-1], good[:-3], good + b'{}\n', b'[]\n',
+                     good.replace(b'{', b'{"source":"ds4-bench",', 1),
+                     good.replace(b'"source": "ds4-bench", ', b''),
+                     good.replace(b'{', b'{"extra":1,', 1),
+                     good.replace(b'"logits": [1,-2,3,0]', b'"logits": null'),
+                     good.replace(b'"logits": [1,-2,3,0]', b'"logits": {"a":1,"a":2}'),
+                     good.replace(b'flash', b'\xff')]
+        for raw in malformed:
+            with self.subTest(raw=raw[:60]):
+                self.assert_bad(raw)
+
+    def test_first_frontier_is_from_zero_and_second_is_an_increment(self):
+        self.assert_bad(fixture(prefill_tokens=1024))
+        (self.new / 'frontier_002048.logits.json').write_bytes(fixture())
+        (self.new / 'frontier_004096.logits.json').write_bytes(fixture(4096, 0))
+        result = self.compare()
+        self.assertEqual(result['status'], 'invalid')
+        self.assertIn('prefill_tokens', result['frontiers'][1]['errors'][0])
+
+    def test_exact_directory_coverage_and_symlink_rejection(self):
+        extra = self.new / 'extra.log'
+        extra.write_text('unselected artifact')
+        self.assertEqual(self.compare()['status'], 'invalid')
+        extra.unlink()
+        path = self.new / 'frontier_002048.logits.json'
+        path.unlink()
+        self.assertEqual(self.compare()['status'], 'invalid')
+        path.symlink_to(self.old / path.name)
+        self.assertEqual(self.compare()['status'], 'invalid')
+
+    def test_expected_frontiers_and_context_require_explicit_sane_contract(self):
+        for frontiers in ([], [0], [-1], [True], [4096, 2048], [2048, 2048]):
+            with self.assertRaises(gate.InvalidDump):
+                gate.validate_expectations(frontiers, 8192, '/models/flash', 'rocm', False, 2, 4)
+            with self.assertRaises(gate.InvalidDump):
+                gate.compare_directories(self.old, self.new, frontiers, self.expected)
+        for ctx in (4095, 4096, True, 2**31):
+            with self.assertRaises(gate.InvalidDump):
+                gate.validate_expectations([2048, 4096], ctx, '/models/flash', 'rocm', False, 2, 4)
+
+    def test_cli_exit_status_and_exclusive_output_for_identity_drift_invalid(self):
+        command = [sys.executable, str(Path(gate.__file__)), str(self.old), str(self.new),
+                   '--frontiers', '2048', '4096', '--ctx', '8192', '--model', '/models/flash',
+                   '--backend', 'rocm', '--quality', 'false', '--quant-bits', '2', '--vocab', '4']
+        output = self.root / 'identity.json'
+        process = subprocess.run(command + ['--output', str(output)], capture_output=True, text=True)
+        self.assertEqual(process.returncode, 0, process.stderr)
+        original = output.read_bytes()
+        self.assertEqual(json.loads(original)['status'], 'identical')
+        self.assertEqual(subprocess.run(command + ['--output', str(output)], capture_output=True).returncode, 1)
+        self.assertEqual(output.read_bytes(), original)
+        (self.new / 'frontier_002048.logits.json').write_bytes(fixture(values=[1, -1, 3, 0]))
+        output = self.root / 'drift.json'
+        self.assertEqual(subprocess.run(command + ['--output', str(output)], capture_output=True).returncode, 1)
+        self.assertEqual(json.loads(output.read_bytes())['status'], 'drift')
+        (self.new / 'frontier_002048.logits.json').write_bytes(fixture(vocab=True))
+        output = self.root / 'invalid.json'
+        self.assertEqual(subprocess.run(command + ['--output', str(output)], capture_output=True).returncode, 1)
+        self.assertEqual(json.loads(output.read_bytes())['status'], 'invalid')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gguf-tools/quality-testing/tests/test_validate_scores.py
+++ b/gguf-tools/quality-testing/tests/test_validate_scores.py
@@ -1,0 +1,219 @@
+"""Fault injection and independently calculated comparator checks; no GPU."""
+
+from decimal import Decimal
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "validate_scores.py"
+SPEC = importlib.util.spec_from_file_location("validate_scores", SCRIPT)
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+# Literal source-format fixtures keep parser/comparator bugs independent of a
+# fixture generator implementing the same arithmetic as the validator.
+HEADER = "id\tprompt_tokens\ttarget_tokens\tnll\tavg_nll\tfirst_match\tgreedy_lcp\tapi_ref_tokens\tapi_target_tokens\tapi_target_mae\tapi_target_mean_delta\tapi_top_items\tapi_top_mapped\tapi_top_coverage\tapi_top1_count\tapi_top1_match\tapi_top1_rate\tapi_topn_ref\tapi_topn_hit\tapi_topn_recall\tapi_top_logprob_count\tapi_top_mae\tapi_top_mean_delta\tapi_pair_total\tapi_pair_agree\tapi_pair_rate"
+ROWS = [
+    "case_000\t10\t4\t4.000000000\t1.000000000\t1\t2\t4\t4\t0.100000000\t-0.050000000\t8\t8\t1.000000000\t4\t3\t0.750000000\t8\t6\t0.750000000\t8\t0.300000000\t-0.100000000\t4\t3\t0.750000000",
+    "case_001\t12\t2\t4.000000000\t2.000000000\t0\t0\t2\t2\t0.400000000\t0.200000000\t6\t6\t1.000000000\t2\t1\t0.500000000\t6\t3\t0.500000000\t6\t0.600000000\t0.200000000\t6\t3\t0.500000000",
+]
+MANIFEST = "# id\tprompt_file\tcontinuation_file\tresponse_file\ncase_000\tp0.txt\tc0.txt\tr0.json\ncase_001\tp1.txt\tc1.txt\tr1.json\n"
+
+
+class ScoresTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.manifest = self.root / "manifest.tsv"
+        self.baseline = self.root / "baseline.tsv"
+        self.candidate = self.root / "candidate.tsv"
+        self.manifest.write_text(MANIFEST)
+        self.valid = HEADER + "\n" + "\n".join(ROWS) + "\n"
+        self.baseline.write_text(self.valid)
+        self.candidate.write_text(self.valid)
+
+    def compare(self):
+        return validator.compare(self.manifest, self.baseline, self.candidate)
+
+    def changed(self, **fields):
+        rows = [line.split("\t") for line in ROWS]
+        for field, value in fields.items():
+            rows[0][HEADER.split("\t").index(field)] = value
+        return HEADER + "\n" + "\n".join("\t".join(row) for row in rows) + "\n"
+
+    def reject(self, text, message=None):
+        self.candidate.write_text(text)
+        with self.assertRaises(validator.ValidationError) as caught:
+            self.compare()
+        if message:
+            self.assertIn(message, str(caught.exception))
+
+    def cli(self, *args):
+        return subprocess.run([sys.executable, str(SCRIPT), "--manifest", str(self.manifest),
+                               "--baseline", str(self.baseline), "--candidate", str(self.candidate),
+                               *args], capture_output=True, text=True)
+
+    def test_complete_identity_and_independent_weighted_metrics(self):
+        result = self.compare()
+        self.assertTrue(result["identical_reported_values"])
+        self.assertEqual(result["cases"], 2)
+        old = result["baseline"]
+        self.assertEqual(old["counts"]["target_tokens"], 6)
+        self.assertEqual(old["nll"], Decimal(8))
+        self.assertAlmostEqual(float(old["avg_nll"]), 8 / 6)
+        self.assertEqual(old["api_target_mae"], Decimal("0.2"))
+        self.assertAlmostEqual(float(old["api_target_mean_delta"]), 0.2 / 6)
+        self.assertAlmostEqual(float(old["api_top_mae"]), 6 / 14)
+        self.assertAlmostEqual(float(old["api_top1_rate"]), 4 / 6)
+        self.assertAlmostEqual(float(old["api_pair_rate"]), 6 / 10)
+
+    def test_paired_difference_sign_denominator_and_case_identity(self):
+        self.candidate.write_text(self.changed(nll="4.400000000", avg_nll="1.100000000"))
+        result = self.compare()
+        self.assertFalse(result["identical_reported_values"])
+        self.assertEqual(result["delta_candidate_minus_baseline"]["nll"], Decimal("0.4"))
+        self.assertAlmostEqual(float(result["delta_candidate_minus_baseline"]["avg_nll"]), .4 / 6)
+        self.assertEqual(result["changed_cases"], [{"id": "case_000", "fields": ["nll", "avg_nll"]}])
+        self.assertEqual(result["per_case"][0]["delta_nll"], Decimal("0.4"))
+        self.assertEqual(result["per_case"][1]["delta_nll"], 0)
+
+    def test_pairing_uses_ids_not_row_positions(self):
+        self.candidate.write_text(HEADER + "\n" + "\n".join(reversed(ROWS)) + "\n")
+        self.assertTrue(self.compare()["identical_reported_values"])
+
+    def test_exact_complete_manifest_coverage(self):
+        for rows in (ROWS[:1], ROWS[1:], [], ROWS + [ROWS[0]], [ROWS[0], ROWS[0]],
+                     ROWS + [ROWS[0].replace("case_000", "case_999")]):
+            with self.subTest(rows=rows):
+                self.reject(HEADER + "\n" + "\n".join(rows) + "\n")
+
+    def test_rejects_all_empty_null_nonfinite_numeric_fields(self):
+        for field in HEADER.split("\t")[1:]:
+            for value in ("", "null", "None", "NaN", "nan", "inf", "-Inf", "Infinity", "1e999", " 1 "):
+                with self.subTest(field=field, value=value):
+                    self.reject(self.changed(**{field: value}))
+
+    def test_rejects_malformed_and_negative_counts(self):
+        for field in validator.COUNT_COLUMNS:
+            for value in ("1.0", "-1", "+1", "01", "1e0", "1_0", "١", str(2**63)):
+                with self.subTest(field=field, value=value):
+                    self.reject(self.changed(**{field: value}))
+
+    def test_rejects_zero_denominators(self):
+        for field in validator.DENOMINATORS:
+            with self.subTest(field=field):
+                self.reject(self.changed(**{field: "0"}))
+
+    def test_finite_looking_decimal_double_overflow_fails(self):
+        self.reject(self.changed(nll="2" + "0" * 308 + ".000000000"), "not finite")
+
+    def test_schema_truncation_and_trailing_junk(self):
+        for text in ("", HEADER + "\n", self.valid[:-1], self.valid[:-8],
+                     self.valid.replace("\t0.750000000\n", "\n", 1),
+                     self.valid.replace("\t0.750000000\n", "\t0.750000000\textra\n", 1),
+                     self.valid + "\n", self.valid + "# done\n", self.valid + "\x00\n",
+                     self.valid.replace("\tnll\t", "\tavg_nll\t", 1),
+                     self.valid.replace("\tnll\tavg_nll", "\tavg_nll\tnll", 1),
+                     self.valid.replace("4.000000000", "4.00000000", 1)):
+            with self.subTest(text=text[:80]):
+                self.reject(text)
+
+    def test_manifest_corruption(self):
+        for text in ("", MANIFEST.splitlines()[0] + "\n", MANIFEST[:-1],
+                     MANIFEST + MANIFEST.splitlines()[1] + "\n",
+                     MANIFEST.replace("\tr0.json", ""),
+                     MANIFEST.replace("\tr0.json", "\t"),
+                     MANIFEST.replace("\tr0.json", "\tnull"),
+                     MANIFEST.replace("case_001", "case_999"),
+                     MANIFEST.replace("# id", "id")):
+            with self.subTest(text=text):
+                self.manifest.write_text(text)
+                with self.assertRaises(validator.ValidationError):
+                    self.compare()
+
+    def test_internal_consistency_faults(self):
+        mutations = [dict(nll="-1.000000000"), dict(avg_nll="1.010000000"),
+                     dict(first_match="2"), dict(first_match="0"), dict(greedy_lcp="0"),
+                     dict(greedy_lcp="5"), dict(api_ref_tokens="3"), dict(api_target_tokens="3"),
+                     dict(api_top_items="7"), dict(api_topn_ref="7"), dict(api_top_logprob_count="7"),
+                     dict(api_top1_count="5"), dict(api_pair_total="253"),
+                     dict(api_top1_match="5"), dict(api_topn_hit="9"), dict(api_pair_agree="5"),
+                     dict(api_top_coverage="0.900000000"), dict(api_top1_rate="1.100000000"),
+                     dict(api_topn_recall="0.700000000"), dict(api_pair_rate="-0.100000000"),
+                     dict(api_target_mae="-0.100000000"), dict(api_target_mean_delta="0.200000000"),
+                     dict(api_top_mean_delta="0.400000000")]
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                self.reject(self.changed(**mutation))
+
+    def test_valid_individual_rows_with_mismatched_pair_denominators_fail(self):
+        mutations = [dict(prompt_tokens="11"),
+                     dict(target_tokens="8", api_ref_tokens="8", api_target_tokens="8",
+                          nll="8.000000000"),
+                     dict(api_top_items="16", api_top_coverage="0.500000000"),
+                     dict(api_top_mapped="7", api_topn_ref="7", api_top_logprob_count="7",
+                          api_top_coverage="0.875000000", api_topn_recall="0.857142857"),
+                     dict(api_top1_count="3", api_top1_rate="1.000000000"),
+                     dict(api_pair_total="5", api_pair_rate="0.600000000")]
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                self.candidate.write_text(self.changed(**mutation))
+                ids, _ = validator.manifest_ids(self.manifest)
+                validator.load_scores(self.candidate, ids)
+                with self.assertRaisesRegex(validator.ValidationError, "baseline/candidate"):
+                    self.compare()
+
+    def test_ratio_rounding_bound_is_serialization_only(self):
+        self.candidate.write_text(self.changed(api_top1_count="3", api_top1_match="1", api_top1_rate="0.333333333"))
+        ids, _ = validator.manifest_ids(self.manifest)
+        validator.load_scores(self.candidate, ids)
+        self.reject(self.changed(api_top1_count="3", api_top1_match="1", api_top1_rate="0.333333334"))
+
+    def test_cli_strict_difference_fails_but_metrics_remain_reviewable(self):
+        success = self.cli("--strict-identical")
+        self.assertEqual(success.returncode, 0, success.stderr)
+        self.assertTrue(json.loads(success.stdout)["requested_check_passed"])
+        self.candidate.write_text(self.changed(nll="4.400000000", avg_nll="1.100000000"))
+        failure = self.cli("--strict-identical")
+        self.assertNotEqual(failure.returncode, 0)
+        self.assertFalse(json.loads(failure.stdout)["requested_check_passed"])
+        self.assertIn("FAIL", failure.stderr)
+        diagnostic = self.cli()
+        self.assertEqual(diagnostic.returncode, 0)
+        self.assertEqual(json.loads(diagnostic.stdout)["quality_verdict"], "not_decided_by_this_tool")
+
+    def test_cli_malformed_inputs_do_not_emit_success_report(self):
+        self.candidate.write_text(self.changed(nll="NaN"))
+        result = self.cli()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("FAIL", result.stderr)
+        self.candidate.unlink()
+        result = self.cli()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_baseline_is_validated_too(self):
+        self.baseline.write_text(self.changed(api_top_mae="NaN"))
+        with self.assertRaises(validator.ValidationError):
+            self.compare()
+
+    def test_same_aggregate_can_hide_per_case_drift_and_strict_catches_it(self):
+        lines = self.valid.splitlines()
+        lines[1] = lines[1].replace("4.000000000\t1.000000000", "4.400000000\t1.100000000")
+        lines[2] = lines[2].replace("4.000000000\t2.000000000", "3.600000000\t1.800000000")
+        self.candidate.write_text("\n".join(lines) + "\n")
+        result = self.compare()
+        self.assertEqual(result["delta_candidate_minus_baseline"]["nll"], 0)
+        self.assertEqual(len(result["changed_cases"]), 2)
+        self.assertNotEqual(self.cli("--strict-identical").returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gguf-tools/quality-testing/validate_scores.py
+++ b/gguf-tools/quality-testing/validate_scores.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Validate complete score_official TSV pairs before reporting differences."""
+
+from __future__ import annotations
+
+import argparse
+from decimal import Decimal, localcontext
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+import sys
+
+
+COLUMNS = (
+    "id prompt_tokens target_tokens nll avg_nll first_match greedy_lcp "
+    "api_ref_tokens api_target_tokens api_target_mae api_target_mean_delta "
+    "api_top_items api_top_mapped api_top_coverage api_top1_count api_top1_match "
+    "api_top1_rate api_topn_ref api_topn_hit api_topn_recall api_top_logprob_count "
+    "api_top_mae api_top_mean_delta api_pair_total api_pair_agree api_pair_rate"
+).split()
+FLOAT_COLUMNS = {
+    "nll", "avg_nll", "api_target_mae", "api_target_mean_delta",
+    "api_top_coverage", "api_top1_rate", "api_topn_recall", "api_top_mae",
+    "api_top_mean_delta", "api_pair_rate",
+}
+COUNT_COLUMNS = set(COLUMNS[1:]) - FLOAT_COLUMNS
+DENOMINATORS = (
+    "prompt_tokens", "target_tokens", "api_ref_tokens", "api_target_tokens",
+    "api_top_items", "api_top_mapped", "api_top1_count", "api_topn_ref",
+    "api_top_logprob_count", "api_pair_total",
+)
+RATIOS = (
+    ("api_top_coverage", "api_top_mapped", "api_top_items"),
+    ("api_top1_rate", "api_top1_match", "api_top1_count"),
+    ("api_topn_recall", "api_topn_hit", "api_topn_ref"),
+    ("api_pair_rate", "api_pair_agree", "api_pair_total"),
+)
+MANIFEST_HEADER = "# id\tprompt_file\tcontinuation_file\tresponse_file"
+HALF_PRINT_UNIT = Decimal("0.0000000005")
+MAX_COUNT = 2**63 - 1
+
+
+class ValidationError(ValueError):
+    """An input or comparison cannot be trusted."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValidationError(message)
+
+
+def read_lines(path: Path) -> tuple[list[str], str]:
+    data = path.read_bytes()
+    require(bool(data), f"{path}: empty file")
+    require(data.endswith(b"\n"), f"{path}: missing final newline (possibly truncated)")
+    require(b"\x00" not in data, f"{path}: NUL byte")
+    text = data.decode("utf-8")
+    # score_official emits LF. Accept CRLF transport without accepting bare CR.
+    text = text.replace("\r\n", "\n")
+    require("\r" not in text, f"{path}: bare carriage return")
+    return text[:-1].split("\n"), hashlib.sha256(data).hexdigest()
+
+
+def manifest_ids(path: Path) -> tuple[tuple[str, ...], str]:
+    lines, digest = read_lines(path)
+    require(lines[0] == MANIFEST_HEADER, f"{path}: unexpected manifest header")
+    ids = []
+    seen = set()
+    for line_number, line in enumerate(lines[1:], 2):
+        cells = line.split("\t")
+        require(len(cells) == 4, f"{path}:{line_number}: expected four manifest fields")
+        require(all(v and v == v.strip() and v.lower() not in {"null", "none"}
+                    for v in cells), f"{path}:{line_number}: empty/null/whitespace manifest field")
+        case_id = cells[0]
+        require(not any(c.isspace() for c in case_id), f"{path}:{line_number}: whitespace in case ID")
+        require(case_id not in seen, f"{path}:{line_number}: duplicate manifest ID {case_id}")
+        seen.add(case_id)
+        ids.append(case_id)
+    require(bool(ids), f"{path}: manifest has no cases")
+    return tuple(ids), digest
+
+
+def parse_number(value: str, field: str, where: str) -> int | Decimal:
+    if field in COUNT_COLUMNS:
+        require(bool(re.fullmatch(r"0|[1-9][0-9]*", value)), f"{where}: {field} is not an unsigned integer")
+        require(len(value) <= 19, f"{where}: {field} exceeds scorer count range")
+        number = int(value)
+        require(number <= MAX_COUNT, f"{where}: {field} exceeds scorer count range")
+        return number
+    # %.9f is the source format. NaN/Inf, blanks, null, whitespace, scientific
+    # notation and truncated decimal fields are deliberately not accepted.
+    require(bool(re.fullmatch(r"-?(?:0|[1-9][0-9]{0,308})\.[0-9]{9}", value)),
+            f"{where}: {field} must be a finite number with nine decimal places")
+    require(math.isfinite(float(value)), f"{where}: {field} is not finite")
+    return Decimal(value)
+
+
+def validate_row(row: dict[str, int | Decimal], where: str) -> None:
+    for field in DENOMINATORS:
+        require(row[field] > 0, f"{where}: {field} must be positive; missing API coverage is not a pass")
+    target = row["target_tokens"]
+    require(row["api_ref_tokens"] == row["api_target_tokens"] == target,
+            f"{where}: API reference/target counts must equal target_tokens")
+    require(row["first_match"] in (0, 1), f"{where}: first_match must be 0 or 1")
+    require(0 <= row["greedy_lcp"] <= target, f"{where}: greedy_lcp outside target length")
+    require(bool(row["first_match"]) == (row["greedy_lcp"] > 0),
+            f"{where}: first_match inconsistent with greedy_lcp")
+    require(row["nll"] >= 0 and row["avg_nll"] >= 0, f"{where}: negative NLL")
+    require(abs(row["nll"] - row["avg_nll"] * target) <= HALF_PRINT_UNIT * (target + 1),
+            f"{where}: nll/avg_nll inconsistent with target_tokens and source print precision")
+    require(row["api_top_mapped"] == row["api_topn_ref"] == row["api_top_logprob_count"],
+            f"{where}: mapped/top-N/logprob counts differ")
+    require(row["api_top1_count"] <= min(target, row["api_top_mapped"]),
+            f"{where}: api_top1_count exceeds target/mapped count")
+    require(row["api_pair_total"] <= row["api_top_mapped"] * 63 // 2,
+            f"{where}: pair count exceeds at-most-64-mapped-alternatives bound")
+    for field, numerator, denominator in RATIOS:
+        require(row[numerator] <= row[denominator], f"{where}: {numerator} exceeds {denominator}")
+        require(0 <= row[field] <= 1, f"{where}: {field} outside [0,1]")
+        expected = Decimal(row[numerator]) / row[denominator]
+        require(abs(row[field] - expected) <= HALF_PRINT_UNIT,
+                f"{where}: {field} inconsistent with counts and source print precision")
+    for prefix in ("api_target", "api_top"):
+        mae = row[f"{prefix}_mae"]
+        signed = row[f"{prefix}_mean_delta"]
+        require(mae >= 0, f"{where}: {prefix}_mae is negative")
+        require(abs(signed) <= mae + 2 * HALF_PRINT_UNIT,
+                f"{where}: absolute signed delta exceeds MAE")
+
+
+def load_scores(path: Path, ids: tuple[str, ...]) -> tuple[dict, str]:
+    lines, digest = read_lines(path)
+    require(lines[0].split("\t") == COLUMNS, f"{path}: unexpected score header/order/duplicate or missing column")
+    rows = {}
+    expected = set(ids)
+    with localcontext() as context:
+        context.prec = 400
+        for line_number, line in enumerate(lines[1:], 2):
+            where = f"{path}:{line_number}"
+            values = line.split("\t")
+            require(len(values) == len(COLUMNS), f"{where}: expected {len(COLUMNS)} fields, got {len(values)}")
+            case_id = values[0]
+            require(case_id in expected, f"{where}: unexpected case ID {case_id!r}")
+            require(case_id not in rows, f"{where}: duplicate case ID {case_id}")
+            row = {field: parse_number(value, field, where)
+                   for field, value in zip(COLUMNS[1:], values[1:])}
+            validate_row(row, where)
+            rows[case_id] = row
+    missing = expected - rows.keys()
+    require(not missing, f"{path}: missing manifest cases: {', '.join(sorted(missing))}")
+    return rows, digest
+
+
+def aggregate(rows: dict, ids: tuple[str, ...]) -> dict:
+    counts = {field: sum(rows[case_id][field] for case_id in ids) for field in COUNT_COLUMNS}
+    nll = sum(rows[case_id]["nll"] for case_id in ids)
+    result = {"counts": counts, "nll": nll, "avg_nll": nll / counts["target_tokens"]}
+    for prefix, denominator in (("api_target", "api_target_tokens"), ("api_top", "api_top_logprob_count")):
+        for suffix in ("mae", "mean_delta"):
+            field = f"{prefix}_{suffix}"
+            result[field] = sum(rows[i][field] * rows[i][denominator] for i in ids) / counts[denominator]
+    for field, numerator, denominator in RATIOS:
+        result[field] = Decimal(counts[numerator]) / counts[denominator]
+    return result
+
+
+def compare(manifest: Path, baseline: Path, candidate: Path) -> dict:
+    ids, manifest_hash = manifest_ids(manifest)
+    old, old_hash = load_scores(baseline, ids)
+    new, new_hash = load_scores(candidate, ids)
+    changed = []
+    per_case = []
+    with localcontext() as context:
+        context.prec = 400
+        for case_id in ids:
+            for field in DENOMINATORS:
+                require(old[case_id][field] == new[case_id][field],
+                        f"{case_id}: baseline/candidate {field} mismatch")
+            fields = [field for field in COLUMNS[1:] if old[case_id][field] != new[case_id][field]]
+            if fields:
+                changed.append({"id": case_id, "fields": fields})
+            per_case.append({"id": case_id, "target_tokens": old[case_id]["target_tokens"],
+                             "delta_nll": new[case_id]["nll"] - old[case_id]["nll"],
+                             "delta_first_match": new[case_id]["first_match"] - old[case_id]["first_match"],
+                             "delta_greedy_lcp": new[case_id]["greedy_lcp"] - old[case_id]["greedy_lcp"]})
+        old_summary = aggregate(old, ids)
+        new_summary = aggregate(new, ids)
+        deltas = {field: new_summary[field] - old_summary[field]
+                  for field in old_summary if field != "counts"}
+    return {
+        "validation": "complete_manifest_finite_consistent_paired_scores",
+        "quality_verdict": "not_decided_by_this_tool",
+        "cases": len(ids), "identical_reported_values": not changed,
+        "sha256": {"manifest": manifest_hash, "baseline": old_hash, "candidate": new_hash},
+        "baseline": old_summary, "candidate": new_summary,
+        "delta_candidate_minus_baseline": deltas,
+        "changed_cases": changed, "per_case": per_case,
+    }
+
+
+def json_number(value):
+    if isinstance(value, Decimal):
+        # Preserve decimal arithmetic; JSON numeric strings are deliberate.
+        with localcontext() as context:
+            context.prec = 18
+            return str(+value)
+    raise TypeError(f"unsupported JSON value: {type(value).__name__}")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--strict-identical", action="store_true",
+                        help="fail if any parsed per-case numeric value differs")
+    args = parser.parse_args(argv)
+    try:
+        result = compare(args.manifest, args.baseline, args.candidate)
+        failed = args.strict_identical and not result["identical_reported_values"]
+        result["strict_identical_requested"] = args.strict_identical
+        result["requested_check_passed"] = not failed
+        print(json.dumps(result, indent=2, default=json_number, allow_nan=False, sort_keys=True))
+        if failed:
+            print("FAIL: reported score values differ in strict-identical mode", file=sys.stderr)
+            return 1
+        return 0
+    except (ValidationError, OSError, UnicodeError, ArithmeticError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds two offline quality checks, with standard-library Python tests and concise usage examples:

- `validate_scores.py`: requires complete manifest coverage, finite/consistent scores and matched API denominators; optionally requires every reported value to match.
- `compare_frontier_logits.py`: validates every vocabulary value and expected frontier, reporting exact float32 differences instead of relying on argmax.

| Check | Existing behaviour / weak check | New result |
|---|---|---|
| Missing case, duplicate case, NaN score | Current comparator exits 0 in all three controls | All rejected |
| Measured 8K–64K frontier pair | All four argmax IDs match | Detects full-vector drift; max absolute difference 7.45228 |
| Complete Flash/Vision score pairs | 100 cases each | Both pass unchanged |

30 host tests pass in under a second. Two utilities, two test files, one README update; no inference changes or GPU dependency.

Score validation requires API-covered `score_official` tables. Numerical drift is reported, not equated with worse model quality; prompt/model/build provenance and generation-quality checks remain separate.
