### PR TITLE
server: auto-discard reload-loop checkpoints (frontier-contradicted)

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -9188,6 +9188,8 @@ struct server_slot {
     live_tool_state anthropic_live;
     visible_live_state thinking_live;
     int continued_last_store_tokens;
+    char disk_reload_path[128];       /* last disk-restored file (repeat-loop guard) */
+    int disk_reload_frontier;         /* its frontier; same file+depth twice = dead tail */
 
     job *assigned;
     job *running;
@@ -10509,6 +10511,27 @@ static void kv_cache_slot_restore_suppressed(server_slot *slot,
         slot->continued_last_store_tokens == suppressed_tokens) {
         slot->continued_last_store_tokens = old_tokens;
     }
+}
+
+/* Reload-loop guard: a disk checkpoint restored twice by the same slot at
+ * the same frontier proves its tail can never match future prompts'
+ * re-tokenizations (text-keyed tiers validate text, not tokens). Discard it
+ * exactly like the prefill-failed path does and let the retry land on the
+ * next candidate or a cold rebuild, which rewrites fresh under the key. */
+static bool kv_cache_reload_repeat(server *s, server_slot *slot,
+                                   const char *path, int frontier) {
+    if (!slot || !path || !slot->disk_reload_path[0]) return false;
+    if (slot->disk_reload_frontier != frontier ||
+        strcmp(slot->disk_reload_path, path) != 0) return false;
+    server_log(DS4_LOG_KVCACHE,
+               "ds4-server: kv cache discarded reason=frontier-contradicted file=%s",
+               path);
+    pthread_mutex_lock(&s->kv_mu);
+    unlink(path);
+    pthread_mutex_unlock(&s->kv_mu);
+    slot->disk_reload_path[0] = '\0';
+    slot->disk_reload_frontier = 0;
+    return true;
 }
 
 static void kv_cache_discard_failed_disk_entry(server *s, server_slot *slot,
@@ -12435,6 +12458,10 @@ static void generate_job_inner(server *s, server_slot *slot, job *j) {
                    j->req.image_count, cached, prompt_for_sync->len);
     }
     if (cached == 0) slot->continued_last_store_tokens = 0;
+    if (cached > 0 && cache_source && cache_source[0] != 'd') {
+        slot->disk_reload_path[0] = '\0';
+        slot->disk_reload_frontier = 0;
+    }
     if (!multimodal && s->kv.enabled && cached == 0 &&
         old_pos >= s->kv.opt.min_tokens) {
         /* Loading a disk snapshot replaces the live Metal session.  Persist the
@@ -12443,10 +12470,23 @@ static void generate_job_inner(server *s, server_slot *slot, job *j) {
         kv_cache_store_current(s, slot, "evict");
     }
     if (!multimodal && cached == 0) {
-        disk_cached = kv_cache_try_load(s, slot, &j->req, &effective_prompt,
-                                        &disk_cache_path,
-                                        &disk_cache_ext_flags);
+        for (int kv_reload_try = 0; kv_reload_try < 2; kv_reload_try++) {
+            disk_cached = kv_cache_try_load(s, slot, &j->req, &effective_prompt,
+                                            &disk_cache_path,
+                                            &disk_cache_ext_flags);
+            if (disk_cached > 0 && kv_reload_try == 0 &&
+                kv_cache_reload_repeat(s, slot, disk_cache_path, disk_cached)) {
+                free(disk_cache_path);
+                disk_cache_path = NULL;
+                disk_cached = 0;
+                continue;
+            }
+            break;
+        }
         if (disk_cached > 0) {
+            snprintf(slot->disk_reload_path, sizeof(slot->disk_reload_path),
+                     "%s", disk_cache_path ? disk_cache_path : "");
+            slot->disk_reload_frontier = disk_cached;
             cached = disk_cached;
             cache_source = "disk-text";
             prompt_for_sync = &effective_prompt;


### PR DESCRIPTION
**Problem.** The text-keyed disk tier validates text, not tokens. When a checkpoint's stored tail diverges from how future prompts re-tokenize the same bytes (BPE boundary variants across sampled thinking/DSML regions - the familiar two-variant equilibrium), the file restores fine, misses again next turn, and re-restores forever: pinned `reason=token-mismatch` at the same `common=` on every following turn, growing re-prefill each time. Production evidence from my fork running this same tier: clusters at common=118557 (43 turns), 273833 (18), 451784, 325177 - the only cure observed was a manual turn-abort, which routes through the existing prefill-failed discard and lets the fallback chain land on a lower valid file.

**Fix.** Same recovery, automated and provable: each slot remembers its last disk-restored (file, frontier). A second consecutive restore of the **same file at the same depth** means the session cannot have advanced between restores - the tail is dead weight by construction. Unlink it under `kv_mu` (exactly the prefill-failed discard semantics already in this file), log `reason=frontier-contradicted`, and retry the load once: the refresh pass walks to the next candidate or a cold rebuild, which rewrites fresh under the key. Any successful memory-tier continuation clears the tracker, so legitimate re-restores of the same correct file after real progress are never punished; disagreement falls back to today's behavior verbatim.

**Blast radius:** ~40 lines, one helper beside `kv_cache_discard_failed_disk_entry`, one two-attempt loop at the existing call site, one clear on memory-tier success. No format, no key, no session-state changes; worst case is one wasted reload per poisoned file instead of an unbounded loop.

**Validation:** optimized build clean (0 errors/0 warnings, M5 Max); ds4-server unit suite green on this head; the mechanism it automates (unlink + invalidate + fallback walk + fresh re-store) is the same one two production manual-abort recoveries exercised end-to-end, and the fork build with the automated detection self-healed two live loops on its first day (discarded at frontier 322155 -> adopted 321371 same second; 338690 -> 331026 same second).