### PR TITLE
Fix CUDA long-context smoke test linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -626,7 +626,7 @@ ds4_rocm_compat.o: ds4_rocm_compat.cu ds4_gpu.h ds4_gpu_mgpu.h ds4_gpu_args.h ds
 ds4_rocm_unavailable.o: ds4_rocm_unavailable.cu
 	$(HIPCC) $(ROCM_CFLAGS) -c -o $@ ds4_rocm_unavailable.cu
 
-tests/cuda_long_context_smoke: tests/cuda_long_context_smoke.o ds4_cuda.o $(MMQ_OBJS)
+tests/cuda_long_context_smoke: tests/cuda_long_context_smoke.o ds4_cuda.o ds4_image.o $(MMQ_OBJS)
 	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(CUDA_LDLIBS)
 
 tests/test_layer_pack.o: tests/test_layer_pack.c ds4_layer_pack.h


### PR DESCRIPTION
## Summary
- link `ds4_image.o` into `tests/cuda_long_context_smoke`
- resolve `ds4_deepseek4_attention_bounds` for `cuda-regression`

Requested by @GiorgioOppo in #952.

## Test plan
- [x] `make clean && make CUDA_ARCH=sm_121 cuda-regression`
- [x] `make -j4 cuda-spark`
- [x] DGX Spark GB10, CUDA 13.0, sm_121a